### PR TITLE
Fix configure script and print build summary.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,9 @@ set(CMAKE_CXX_FLAGS_RELEASE        "-O4")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
 if (ENABLE_DEBUG)
     set(CMAKE_BUILD_TYPE Debug)
-    add_definitions("-DCPPA_DEBUG")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCPPA_DEBUG")
+else ()
+    set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif ()
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
@@ -203,3 +205,24 @@ add_dependencies(mailbox_performance libcppa)
 add_dependencies(mixed_case libcppa)
 add_dependencies(distributed libcppa)
 add_dependencies(matching libcppa)
+
+string(TOUPPER ${CMAKE_BUILD_TYPE} build_type)
+message(
+    "\n====================|  Build Summary  |===================="
+    "\n"
+    "\nLibcppa version:  ${LIBRARY_VERSION}"
+    "\n"
+    "\nSource directory: ${CMAKE_SOURCE_DIR}"
+    "\nBuild directory:  ${CMAKE_BINARY_DIR}"
+    "\nExecutable path:  ${EXECUTABLE_OUTPUT_PATH}"
+    "\nLibrary path:     ${LIBRARY_OUTPUT_PATH}"
+    "\nInstall prefix:   ${CMAKE_INSTALL_PREFIX}"
+    "\nDebug mode:       ${ENABLE_DEBUG}"
+    "\n"
+    "\nCXX:              ${CMAKE_CXX_COMPILER}"
+    "\nCXXFLAGS:         ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${build_type}}"
+    "\n"
+    "\nBoost:            ${Boost_INCLUDE_DIR}"
+    "\n"
+    "\n===========================================================\n"
+)

--- a/configure
+++ b/configure
@@ -59,15 +59,10 @@ append_cache_entry ()
 #   $5 is the CMake generator.
 configure ()
 {
-    CMakeCacheEntries=""
-
-    echo "-------------------------------------------------"
+    CMakeCacheEntries=$CMakeDefaultCache
 
     if [ -n "$1" ]; then
         append_cache_entry CMAKE_CXX_COMPILER FILEPATH $1
-		echo "compiler:                    $1"
-	else
-		echo "compiler:                    system default"
     fi
 
     if [ -n "$2" ]; then
@@ -76,25 +71,18 @@ configure ()
         workdir=$builddir
     fi
     workdirs="$workdirs $workdir"
-    echo "build directory:             $workdir"
 
     if [ -n "$3" ]; then
         append_cache_entry EXECUTABLE_OUTPUT_PATH PATH $3
-		echo "executable output directory: $3"
     else
         append_cache_entry EXECUTABLE_OUTPUT_PATH PATH "$workdir/bin"
-		echo "executable output directory: $workdir/bin"
     fi
 
     if [ -n "$4" ]; then
         append_cache_entry LIBRARY_OUTPUT_PATH PATH $4
-		echo "library output directory:    $4"
     else
         append_cache_entry LIBRARY_OUTPUT_PATH PATH "$workdir/lib"
-		echo "library output directory:    $workdir/lib"
     fi
-
-    echo "-------------------------------------------------"
 
     if [ -d $workdir ]; then
         # If a build directory exists, check if it has a CMake cache.
@@ -175,6 +163,10 @@ while [ $# -ne 0 ]; do
     esac
     shift
 done
+
+# At this point we save the global CMake variables so that configure() can
+# later use them.
+CMakeDefaultCache=$CMakeCacheEntries
 
 if [ -n "$dualbuild" ]; then
     # Use what we got in $PATH if --with-clang or --with-gcc is not specified.


### PR DESCRIPTION
Some small fixes for the new configure script plus a new build summary.

Moreover, if `--enable-debug` is not specified, the build type defaults to `RelWithDebInfo`.
