### PR TITLE
Make configure script POSIX compliant

### DIFF
--- a/configure
+++ b/configure
@@ -193,7 +193,7 @@ else
 fi
 
 echo "DIRS :=$workdirs\n" > $sourcedir/Makefile
-read -d '' makefile <<"EOT"
+makefile=$(cat<<'EOT'
 all:
 	@for i in $(DIRS); do $(MAKE) -C $$i $@; done
 
@@ -214,5 +214,6 @@ distclean:
 
 .PHONY: all test install uninstall clean distclean
 EOT
+)
 
 echo "$makefile" >> $sourcedir/Makefile


### PR DESCRIPTION
The script used a Bash built-in to store a multi-line string into a variable
(read -d), which is not POSIX compliant. Fixed by using cat.
