### PR TITLE
Replace echo with portable version.

### DIFF
--- a/configure
+++ b/configure
@@ -192,7 +192,7 @@ else
     configure $compiler "" $bindir $libdir $CMakeGenerator
 fi
 
-echo -e "DIRS :=$workdirs\n" > $sourcedir/Makefile
+printf "DIRS := %s\n\n" $workdirs > $sourcedir/Makefile
 makefile=$(cat <<'EOT'
 all:
 	@for i in $(DIRS); do $(MAKE) -C $$i $@; done


### PR DESCRIPTION
It turns out that the echo shell built-in is not portable when using it to
print special characters like "\n". For this purpose, the community encourages
the use of printf instead.
