### PR TITLE
Change remote_actor interface to use a std::string has first argument

### DIFF
--- a/cppa/cppa.hpp
+++ b/cppa/cppa.hpp
@@ -688,7 +688,7 @@ void publish(actor_ptr whom, std::uint16_t port);
  * @returns An {@link actor_ptr} to the proxy instance
  *          representing a remote actor.
  */
-actor_ptr remote_actor(const char* host, std::uint16_t port);
+actor_ptr remote_actor(const std::string& host, std::uint16_t port);
 
 } // namespace cppa
 

--- a/src/unicast_network.cpp
+++ b/src/unicast_network.cpp
@@ -140,7 +140,7 @@ void publish(actor_ptr whom, std::uint16_t port) {
     detail::post_office_publish(sockfd, whom);
 }
 
-actor_ptr remote_actor(const char* host, std::uint16_t port) {
+actor_ptr remote_actor(const std::string& host, std::uint16_t port) {
     detail::native_socket_type sockfd;
     struct sockaddr_in serv_addr;
     struct hostent* server;
@@ -148,10 +148,10 @@ actor_ptr remote_actor(const char* host, std::uint16_t port) {
     if (sockfd == detail::invalid_socket) {
         throw network_error("socket creation failed");
     }
-    server = gethostbyname(host);
+    server = gethostbyname(host.data());
     if (!server) {
         std::string errstr = "no such host: ";
-        errstr += host;
+        errstr += host.data();
         throw network_error(std::move(errstr));
     }
     memset(&serv_addr, 0, sizeof(serv_addr));


### PR DESCRIPTION
This commit introduces a transparent interface change to `cppa::remote_actor`, whose first argument used to be a `const char*`. I changed it into `std::string`, because _(i)_ many application manage strings as this data type, and _(ii)_ a `const char*` can be implicitly converted to a std::string.
