### PR TITLE
Compile fix for DISABLE_CONTEXT_SWITCHING build.

### DIFF
--- a/src/thread_pool_scheduler.cpp
+++ b/src/thread_pool_scheduler.cpp
@@ -292,8 +292,8 @@ actor_ptr thread_pool_scheduler::spawn(void_function what, scheduling_hint sh) {
 }
 
 actor_ptr thread_pool_scheduler::spawn(void_function what,
-                                       scheduling_hint sh,
-                                       init_callback init_cb) {
+                                       init_callback init_cb,
+                                       scheduling_hint sh) {
     return spawn_as_thread(std::move(what),
                            std::move(init_cb),
                            sh == detached_and_hidden);


### PR DESCRIPTION
When configured with `--disable-context-switching`, I could not build `unstable`:

```
/home/matthias/libcppa/src/thread_pool_scheduler.cpp:294:11: error: prototype for ‘cppa::actor_ptr cppa::detail::thread_pool_scheduler::spawn(cppa::void_function, cppa::scheduling_hint, cppa::init_callback)’ does not match any in class ‘cppa::detail::thread_pool_scheduler’
In file included from /home/matthias/libcppa/src/thread_pool_scheduler.cpp:42:0:
/home/matthias/libcppa/./cppa/detail/thread_pool_scheduler.hpp:68:15: error: candidates are: virtual cppa::actor_ptr cppa::detail::thread_pool_scheduler::spawn(cppa::void_function, cppa::init_callback, cppa::scheduling_hint)
/home/matthias/libcppa/src/thread_pool_scheduler.cpp:288:11: error:                 virtual cppa::actor_ptr cppa::detail::thread_pool_scheduler::spawn(cppa::void_function, cppa::scheduling_hint)
/home/matthias/libcppa/src/thread_pool_scheduler.cpp:247:11: error:                 virtual cppa::actor_ptr cppa::detail::thread_pool_scheduler::spawn(cppa::scheduled_actor*, cppa::init_callback, cppa::scheduling_hint)
/home/matthias/libcppa/src/thread_pool_scheduler.cpp:240:11: error:                 virtual cppa::actor_ptr cppa::detail::thread_pool_scheduler::spawn(cppa::scheduled_actor*, cppa::scheduling_hint)
```

The reason was a signature mismatch between a header and implementation file.
