### PR TITLE
Avoid CMake pain when using custom Boost prefix.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,10 @@ if (NOT DISABLE_CONTEXT_SWITCHING)
   )
 endif ()
 
+if (BOOST_ROOT)
+  # Prevent falling back to system paths when using a custom Boost prefix.
+  set(Boost_NO_SYSTEM_PATHS true)
+endif ()
 find_package(Boost REQUIRED)
 find_package(PTHREAD REQUIRED)
 


### PR DESCRIPTION
If there exist multiple Boost installations, both in a custom prefix and system-wide, CMake mixes and matches from what it finds as opposed to sticking with one version. For example, CMake may pick the debug built from the system-wide installation and the release build from a custom prefix when libcppa has been configured with `--with-boost=/path/to/prefix`.
