### PR TITLE
Support for listenting on a specific IP address.

### DIFF
--- a/cppa/cppa.hpp
+++ b/cppa/cppa.hpp
@@ -751,9 +751,11 @@ inline void await_all_others_done() {
  * The connection is automatically closed if the lifetime of @p whom ends.
  * @param whom Actor that should be published at @p port.
  * @param port Unused TCP port.
+ * @param addr The IP address to listen to, or @p INADDR_ANY if @p addr is
+ *             @p nullptr.
  * @throws bind_failure
  */
-void publish(actor_ptr whom, std::uint16_t port);
+void publish(actor_ptr whom, std::uint16_t port, const char* addr = nullptr);
 
 /**
  * @brief Publishes @p whom using @p acceptor to handle incoming connections.

--- a/cppa/detail/ipv4_acceptor.hpp
+++ b/cppa/detail/ipv4_acceptor.hpp
@@ -42,7 +42,8 @@ class ipv4_acceptor : public util::acceptor {
 
  public:
 
-    static std::unique_ptr<util::acceptor> create(std::uint16_t port);
+    static std::unique_ptr<util::acceptor> create(std::uint16_t port,
+                                                  const char* addr);
 
     ~ipv4_acceptor();
 

--- a/cppa/group.hpp
+++ b/cppa/group.hpp
@@ -195,11 +195,12 @@ class group : public channel {
 typedef intrusive_ptr<group> group_ptr;
 
 /**
- * @brief Makes *all* local groups accessible via network on @p port.
+ * @brief Makes *all* local groups accessible via network on address @p addr
+ *        and @p port.
  * @throws bind_failure
  * @throws network_error
  */
-void publish_local_groups_at(std::uint16_t port);
+void publish_local_groups_at(std::uint16_t port, const char* addr = nullptr);
 
 } // namespace cppa
 

--- a/examples/group_server.cpp
+++ b/examples/group_server.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
         return 2;
     }
     if (!args_valid) return 1;
-    publish_local_groups_at(port);
+    publish_local_groups_at(port, "127.0.0.1");
     cout << "type 'quit' to shutdown the server" << endl;
     string line;
     while (getline(cin, line)) {

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -107,10 +107,10 @@ struct group_nameserver : event_based_actor {
     }
 };
 
-void publish_local_groups_at(std::uint16_t port) {
+void publish_local_groups_at(std::uint16_t port, const char* addr) {
     auto gn = spawn_hidden<group_nameserver>();
     try {
-        publish(gn, port);
+        publish(gn, port, addr);
     }
     catch (std::exception&) {
         gn->enqueue(nullptr, make_any_tuple(atom("SHUTDOWN")));

--- a/src/unicast_network.cpp
+++ b/src/unicast_network.cpp
@@ -89,8 +89,8 @@ actor_ptr remote_actor(util::io_stream_ptr_pair peer) {
                                                       pinfptr->node_id());
 }
 
-void publish(actor_ptr whom, std::uint16_t port) {
-    if (whom) publish(whom, detail::ipv4_acceptor::create(port));
+void publish(actor_ptr whom, std::uint16_t port, const char* addr) {
+    if (whom) publish(whom, detail::ipv4_acceptor::create(port, addr));
 }
 
 actor_ptr remote_actor(const char* host, std::uint16_t port) {

--- a/unit_testing/test__remote_actor.cpp
+++ b/unit_testing/test__remote_actor.cpp
@@ -236,7 +236,7 @@ int main(int argc, char** argv) {
     bool success = false;
     do {
         try {
-            publish(self, port);
+            publish(self, port, "127.0.0.1");
             success = true;
         }
         catch (bind_failure&) {


### PR DESCRIPTION
Due to security considerations, it is often practically infeasible to deploy an
application that listens on IP addresses by default. This branch includes
changes which allow the user to explicitly specify an IP address when
publishing actors or groups.
