### PR TITLE
Provide two missing includes.

### DIFF
--- a/cppa/detail/uniform_type_info_map.hpp
+++ b/cppa/detail/uniform_type_info_map.hpp
@@ -39,6 +39,8 @@
 
 #include "cppa/cppa_fwd.hpp"
 
+#include "cppa/atom.hpp"
+#include "cppa/process_information.hpp"
 #include "cppa/util/duration.hpp"
 #include "cppa/util/type_list.hpp"
 


### PR DESCRIPTION
This pull request simply adds two missing headers that become relevant when using a different include path through `cppa/util/abstract_uniform_type_info.hpp`, which I use in to implement custom serialization routines.

Below an exemplary error message, which this fix eradicates.

```
In file included from /opt/prefix-clang/include/cppa/util/abstract_uniform_type_info.hpp:38:
/opt/prefix-clang/include/cppa/detail/uniform_type_info_map.hpp:54:5: error: use of undeclared identifier 'atom_value'
    atom_value,
    ^
/opt/prefix-clang/include/cppa/detail/uniform_type_info_map.hpp:69:38: error: expected ';' after alias declaration
    std::map<std::string,std::string>
                                     ^
                                     ;
/opt/prefix-clang/include/cppa/detail/uniform_type_info_map.hpp:72:50: error: use of undeclared identifier 'mapped_type_list'
using zipped_type_list = util::tl_zip_with_index<mapped_type_list>::type;
                                                 ^
/opt/prefix-clang/include/cppa/detail/uniform_type_info_map.hpp:72:69: error: expected ';' after alias declaration
using zipped_type_list = util::tl_zip_with_index<mapped_type_list>::type;
                                                                    ^
                                                                    ;
/opt/prefix-clang/include/cppa/detail/uniform_type_info_map.hpp:79:48: error: use of undeclared identifier 'zipped_type_list'
    return mapped_type_names[util::tl_index_of<zipped_type_list,T>::value][1];
                                               ^
/opt/prefix-clang/include/cppa/detail/uniform_type_info_map.hpp:79:67: error: expected ']'
    return mapped_type_names[util::tl_index_of<zipped_type_list,T>::value][1];
                                                                  ^
/opt/prefix-clang/include/cppa/detail/uniform_type_info_map.hpp:79:29: note: to match this '['
    return mapped_type_names[util::tl_index_of<zipped_type_list,T>::value][1];
                            ^
/opt/prefix-clang/include/cppa/detail/uniform_type_info_map.hpp:78:23: error: no return statement in constexpr function
constexpr const char* mapped_name() {
                      ^
7 errors generated.
make[3]: *** [src/vast/CMakeFiles/libvast.dir/configuration.cc.o] Error 1
make[3]: *** Waiting for unfinished jobs....
```
