### PR TITLE
Enhance remote_actor() unit tests

### DIFF
--- a/unit_testing/test_remote_actor.cpp
+++ b/unit_testing/test_remote_actor.cpp
@@ -326,6 +326,9 @@ int main(int argc, char** argv) {
                 {
                     auto server2 = remote_actor("localhost", port);
                     CPPA_CHECK(serv == server2);
+                    std::string localhost("127.0.0.1");
+                    auto server3 = remote_actor(localhost, port);
+                    CPPA_CHECK(serv == server3);
                 }
                 auto c = spawn<client, monitored>(serv);
                 receive (


### PR DESCRIPTION
This pull request adds a test for the function `remote_actor` when using the `std::string` overload.
