### PR TITLE
Tweaks to optional<T>.

### DIFF
--- a/cppa/optional.hpp
+++ b/cppa/optional.hpp
@@ -144,6 +144,22 @@ class optional {
     /**
      * @brief Returns the value.
      */
+    inline const T* operator->() const {
+        CPPA_REQUIRE(valid());
+        return &m_value;
+    }
+
+    /**
+     * @brief Returns the value.
+     */
+    inline T* operator->() {
+        CPPA_REQUIRE(valid());
+        return &m_value;
+    }
+
+    /**
+     * @brief Returns the value.
+     */
     inline T& get() {
         CPPA_REQUIRE(valid());
         return m_value;


### PR DESCRIPTION
In order to comply with the interface of `std::optional<T>`, we should make it possible to default-construct optional objects. The post-condition shall be the same as in the standard: the object is an a _disengaged_ state. Achieving this involves either adding an explicit default constructor or providing a default argument for the `none_t` overload. I used the latter technique.

Moreover, `std::optional<T>` provides an `operator->` to access the contained value. I added the missing operator overloads.
