### PR TITLE
Solve issue #103: Does not build on Linux <2.6.17, issue #108: unused_result warning on g++-4.8.1

### DIFF
--- a/cppa/config.hpp
+++ b/cppa/config.hpp
@@ -93,6 +93,11 @@
 #ifdef CPPA_WINDOWS
 #else
 #   include <unistd.h>
+
+#	include <linux/version.h>
+#	if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,16)
+#		define CPPA_POLL_IMPL
+#	endif // LINUX_VERSION
 #endif
 
 namespace cppa {

--- a/src/middleman.cpp
+++ b/src/middleman.cpp
@@ -108,7 +108,8 @@ class middleman_impl {
         atomic_thread_fence(memory_order_seq_cst);
         uint8_t dummy = 0;
         // ignore result; write error only means middleman already exited
-        static_cast<void>(write(m_pipe_write, &dummy, sizeof(dummy)));
+		auto unused_ret = write(m_pipe_write, &dummy, sizeof(dummy));
+		static_cast<void>(unused_ret);
     }
 
     void continue_writer(continuable* ptr) {


### PR DESCRIPTION
Solve issue #103: Does not build on Linux <2.6.17, issue #108: unused_result warning on g++-4.8.1
