### PR TITLE
Make the maximum message size configurable.

### DIFF
--- a/cppa/cppa.hpp
+++ b/cppa/cppa.hpp
@@ -446,6 +446,18 @@ namespace cppa {
  */
 
 /**
+ * @brief Sets the maximum size of a message.
+ * @param size The maximum number of bytes a message may occupy.
+ */
+void max_msg_size(size_t size);
+
+/**
+ * @brief Retrieves the maximum size of messages.
+ * @returns The number maximum number of bytes a message may occupy.
+ */
+size_t max_msg_size();
+
+/**
  * @brief Sends a message to @p whom.
  *
  * <b>Usage example:</b>

--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -28,10 +28,12 @@
 \******************************************************************************/
 
 
+#include <atomic>
 #include <ios>      // std::ios_base::failure
 #include <cstring>
 #include <utility>
 
+#include "cppa/cppa.hpp"
 #include "cppa/util/buffer.hpp"
 #include "cppa/io/input_stream.hpp"
 
@@ -40,13 +42,12 @@ namespace cppa { namespace util {
 namespace {
 
 const size_t default_chunk_size = 512;
-const size_t default_max_size   = 16 * 1024 * 1024;
 
 } // namespace anonymous
 
 buffer::buffer()
 : m_data(nullptr), m_written(0), m_allocated(0), m_final_size(0)
-, m_chunk_size(default_chunk_size), m_max_buffer_size(default_max_size) { }
+, m_chunk_size(default_chunk_size), m_max_buffer_size(max_msg_size()) { }
 
 buffer::buffer(size_t chunk_size, size_t max_buffer_size)
 : m_data(nullptr), m_written(0), m_allocated(0), m_final_size(0)
@@ -62,7 +63,7 @@ buffer::buffer(buffer&& other)
 
 buffer::buffer(const buffer& other)
 : m_data(nullptr), m_written(0), m_allocated(0), m_final_size(0)
-, m_chunk_size(default_chunk_size), m_max_buffer_size(default_max_size) {
+, m_chunk_size(default_chunk_size), m_max_buffer_size(max_msg_size()) {
     write(other, grow_if_needed);
 }
 

--- a/src/middleman.cpp
+++ b/src/middleman.cpp
@@ -388,4 +388,22 @@ void middleman_loop(middleman_impl* impl) {
     CPPA_LOGF_DEBUG("middleman loop done");
 }
 
-} } // namespace cppa::detail
+} // namespace io
+
+namespace {
+
+std::atomic<size_t> default_max_msg_size{16 * 1024 * 1024};
+
+} // namespace <anonymous>
+
+void max_msg_size(size_t size)
+{
+  default_max_msg_size = size;
+}
+
+size_t max_msg_size()
+{
+  return default_max_msg_size;
+}
+
+} // namespace cppa


### PR DESCRIPTION
This patch gives libcppa users the ability to set the maximum message size. The maximum message size still defaults to 16MB, but can now be adjusted with the function `max_msg_size(size_t)`.

A few points that came to mind whilst adding this feature:
- There also exists a message chunk size parameter, which I purposefully left untouched for now. One could imagine scaling it as function of the maximum message size. This may be too low-level to be part of the public API, but one could imagine adding a similar function for the chunk size of message buffers.
- Why does the copy constructor of `util::buffer` does not inherit the maximum size of the other buffer, but instead uses the default values?
- Although you mentioned to put the implementation of `max_msg_size` in `middleman.cpp`, it may as well fit into `util/buffer.cpp` to be close to the chunk size parameter.
