### PR TITLE
Fix building libcppa as a submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ endif (HAVE_VALGRIND_H)
 # check for g++ >= 4.7 or clang++ > = 3.2
 try_run(ProgramResult
         CompilationSucceeded
-        ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/get_compiler_version.cpp
+	${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/get_compiler_version.cpp
         RUN_OUTPUT_VARIABLE CompilerVersion)
 if (NOT CompilationSucceeded OR NOT ProgramResult EQUAL 0)
   message(FATAL_ERROR "Cannot determine compiler version")
@@ -327,7 +327,7 @@ endif ()
 # check for doxygen and add custom "doc" target to Makefile
 find_package(Doxygen)
 if (DOXYGEN_FOUND)
-  configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in ${CMAKE_SOURCE_DIR}/Doxyfile
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile
                  @ONLY)
   add_custom_target(doc ${DOXYGEN_EXECUTABLE} ${CMAKE_HOME_DIRECTORY}/Doxyfile
                     WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}


### PR DESCRIPTION
when trying to build libcppa with add_subdirectory, cmake fails to find get_compiler_version.cpp and doxyfile. 
Using CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR fixes that. 
