### PR TITLE
Ubuntu x64_86 g++-4.8 build error with opencl support (V0.9.0 PRERELEASE 2)

### DIFF
--- a/src/opencl/opencl_metainfo.cpp
+++ b/src/opencl/opencl_metainfo.cpp
@@ -93,13 +93,18 @@ void opencl_metainfo::initialize()
         throw runtime_error(oss.str());
     }
 
-    auto pfn_notify = [this](const char *errinfo,
+    auto pfn_notify = [](const char *errinfo,
                          const void *,
                          size_t,
                          void *) {
-        CPPA_LOG_ERROR("\n##### Error message via pfn_notify #####\n" +
-                       string(errinfo) +
-                       "\n########################################");
+        std::cerr << "[" << "ERROR" << "] " << "opencl_metainfo::" << __func__ << ": "
+                  << "\n##### Error message via pfn_notify #####\n"
+                     + string(errinfo)
+                     + "\n########################################"
+                  << "\nStack trace:\n";
+        void *array[10];
+        size_t size = backtrace(array, 10);
+        backtrace_symbols_fd(array, size, 2);
     };
 
     // create a context


### PR DESCRIPTION
I configured with opencl and I got a build error here:

```
./configure --with-opencl
make
```

error message:

```
Building CXX object CMakeFiles/libcppa.dir/src/opencl/opencl_metainfo.cpp.o
In file included from /files/SOURCE_code/libcppa/libcppa/./cppa/policy/no_scheduling.hpp:39:0,
                 from /files/SOURCE_code/libcppa/libcppa/./cppa/policy.hpp:37,
                 from /files/SOURCE_code/libcppa/libcppa/./cppa/spawn.hpp:36,
                 from /files/SOURCE_code/libcppa/libcppa/./cppa/cppa.hpp:44,
                 from /files/SOURCE_code/libcppa/libcppa/./cppa/opencl/opencl_metainfo.hpp:40,
                 from /files/SOURCE_code/libcppa/libcppa/src/opencl/opencl_metainfo.cpp:31:
/files/SOURCE_code/libcppa/libcppa/src/opencl/opencl_metainfo.cpp: In lambda function:
/files/SOURCE_code/libcppa/libcppa/./cppa/logging.hpp:196:58: error: ‘this’ was not captured for this lambda function
 #define CPPA_CLASS_NAME ::cppa::detail::demangle(typeid(*this)).c_str()
                                                          ^
/files/SOURCE_code/libcppa/libcppa/./cppa/logging.hpp:166:48: note: in definition of macro ‘CPPA_PRINT_ERROR_IMPL’
         std::cerr << "[" << lvlname << "] " << classname << "::"               \
                                                ^
/files/SOURCE_code/libcppa/libcppa/./cppa/logging.hpp:199:5: note: in expansion of macro ‘CPPA_LOG_IMPL’
     CPPA_LOG_IMPL(lvlname, classname, funname, msg)
     ^
/files/SOURCE_code/libcppa/libcppa/./cppa/logging.hpp:151:24: note: in expansion of macro ‘CPPA_PRINT0’
 #define CPPA_CAT(a, b) a ## b
                        ^
/files/SOURCE_code/libcppa/libcppa/./cppa/logging.hpp:263:5: note: in expansion of macro ‘CPPA_LOGC’
     CPPA_LOGC(level, CPPA_CLASS_NAME, __func__, msg)
     ^
/files/SOURCE_code/libcppa/libcppa/./cppa/logging.hpp:263:22: note: in expansion of macro ‘CPPA_CLASS_NAME’
     CPPA_LOGC(level, CPPA_CLASS_NAME, __func__, msg)
                      ^
/files/SOURCE_code/libcppa/libcppa/./cppa/logging.hpp:298:31: note: in expansion of macro ‘CPPA_LOGMF’
 #define CPPA_LOG_ERROR(msg)   CPPA_LOGMF(CPPA_ERROR,   msg)
                               ^
/files/SOURCE_code/libcppa/libcppa/src/opencl/opencl_metainfo.cpp:100:9: note: in expansion of macro ‘CPPA_LOG_ERROR’
         CPPA_LOG_ERROR("\n##### Error message via pfn_notify #####\n" +
         ^
make[3]: *** [CMakeFiles/libcppa.dir/src/opencl/opencl_metainfo.cpp.o] Error 1
```

I checked the file and found that the macro used uncaptured `this` to generate the classname.

So in pull-request I expanded the macro and filled in the classname manually.
- something might be useful to you \* : 
- a lambda with captured variables cannot be converted into C function pointers
- std::function is also hard to convert to C function pointers

(Maybe you have better solution for this. Hope it helps!)
