### PR TITLE
Record CC and CXX in config.status.

### DIFF
--- a/configure
+++ b/configure
@@ -130,6 +130,14 @@ configure ()
     fi
 
     echo "# This is the command used to configure this build" > config.status
+    if [ -n "$CC" ]; then
+      printf "CC=%s" $CC >> config.status
+      printf ' ' >> config.status
+    fi
+    if [ -n "$CXX" ]; then
+      printf "CXX=%s" $CXX >> config.status
+      printf ' ' >> config.status
+    fi
     echo $command >> config.status
     chmod u+x config.status
 }


### PR DESCRIPTION
This patch also adds the `CC` and `CXX` environment variables to the config.status
command in the build directory. When invoking `./build/config.status` without
this extra environment variable, one might not end up with the same build
environment as in the first build.
