### PR TITLE
Fix "Libcaf" casing issue in FindLibcaf.cmake.

### DIFF
--- a/cmake/FindLibcaf.cmake
+++ b/cmake/FindLibcaf.cmake
@@ -87,7 +87,7 @@ endforeach ()
 
 # final steps to tell CMake we're done
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(libcaf
+find_package_handle_standard_args(Libcaf
                                   DEFAULT_MSG
                                   LIBCAF_LIBRARIES
                                   LIBCAF_INCLUDE_DIRS)


### PR DESCRIPTION
find_package_handle_standard_args() expects the first argument to be the
name of the Find-module in original casing.  If it's not, it may fail to
do things like abort with a FATAL_ERROR message if REQUIRED was supplied
to the original find_package().
