### PR TITLE
Fix memory leak in scoped_actor.

### DIFF
--- a/libcaf_core/src/scoped_actor.cpp
+++ b/libcaf_core/src/scoped_actor.cpp
@@ -49,7 +49,7 @@ blocking_actor* alloc() {
 } // namespace <anonymous>
 
 void scoped_actor::init(bool hide_actor) {
-  m_self.reset(alloc());
+  m_self.reset(alloc(), false);
   if (!hide_actor) {
     m_prev = CAF_SET_AID(m_self->id());
   }


### PR DESCRIPTION
local_actor seems to start off with ref count of 1 and intrusive_ptr::reset will increment that by default, so ~scoped_actor still left the ref count at 1 and so leaks.