### PR TITLE
Make the operator << of actor_ostream call caf::to_string automatically.

### DIFF
--- a/examples/aout.cpp
+++ b/examples/aout.cpp
@@ -15,16 +15,16 @@ using std::endl;
 int main() {
   for (int i = 1; i <= 50; ++i) {
     spawn<blocking_api>([i](blocking_actor* self) {
-      aout(self) << "Hi there! This is actor nr. "
-                 << i << "!" << endl;
+      aout(self) << "Hi there! This is actor nr. " << i << "! "
+                 << "Actor address: " << self->address() << endl;
       std::random_device rd;
       std::default_random_engine re(rd());
       std::chrono::milliseconds tout{re() % 10};
       self->delayed_send(self, tout, 42);
       self->receive(
         [i, self](int) {
-          aout(self) << "Actor nr. "
-                     << i << " says goodbye!" << endl;
+          aout(self) << "Actor nr. " << i << " says goodbye! "
+                     << "Current message: " << self->current_message() << endl;
         }
       );
     });

--- a/libcaf_core/caf/actor_ostream.hpp
+++ b/libcaf_core/caf/actor_ostream.hpp
@@ -51,10 +51,6 @@ class actor_ostream {
     return write(std::move(arg));
   }
 
-  inline actor_ostream& operator<<(const message& arg) {
-    return write(caf::to_string(arg));
-  }
-
   // disambiguate between conversion to string and to message
   inline actor_ostream& operator<<(const char* arg) {
     return *this << std::string{arg};
@@ -62,10 +58,10 @@ class actor_ostream {
 
   template <class T>
   inline typename std::enable_if<
-    !std::is_convertible<T, std::string>::value &&
-    !std::is_convertible<T, message>::value, actor_ostream&
+    !std::is_convertible<T, std::string>::value, actor_ostream&
   >::type operator<<(T&& arg) {
-    return write(std::to_string(std::forward<T>(arg)));
+	using std::to_string;
+	return write(to_string(std::forward<T>(arg)));
   }
 
   inline actor_ostream& operator<<(actor_ostream::fun_type f) {


### PR DESCRIPTION
After this change, we can print some caf types using caf::aout without calling caf::to_string.

such as:

from:
```C++
caf::aout(self) << caf::to_string(self->current_message()) << std::endl;
```
to:
```C++
caf::aout(self) << self->current_message() << std::endl;
```

from:
```C++
caf::aout(self) << caf::to_string(self->address()) << std::endl;
```
to:
```C++
caf::aout(self) << self->address() << std::endl;
```

and so on.