### PR TITLE
Fix bug.

### DIFF
--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -633,6 +633,9 @@ class local_actor : public abstract_actor, public resumable {
   // set by quit
   uint32_t m_planned_exit_reason;
 
+  // used to resume the last exit reason
+  uint32_t m_last_exit_reason;
+
   // identifies the timeout messages we are currently waiting for
   uint32_t m_timeout_id;
 

--- a/libcaf_core/src/local_actor.cpp
+++ b/libcaf_core/src/local_actor.cpp
@@ -586,7 +586,7 @@ resumable::resume_result local_actor::resume(execution_unit* eu,
     on_exit();
     if (has_behavior()) {
       CAF_LOG_DEBUG("on_exit did set a new behavior");
-	  // if the actor still has behaviors, we should record the current exit reason
+      // if the actor still has behaviors, we should record the current exit reason
       if (planned_exit_reason() != exit_reason::not_exited) {
         m_last_exit_reason = planned_exit_reason();
       }

--- a/libcaf_core/src/local_actor.cpp
+++ b/libcaf_core/src/local_actor.cpp
@@ -583,15 +583,23 @@ resumable::resume_result local_actor::resume(execution_unit* eu,
     CAF_LOG_TRACE("");
     bhvr_stack().clear();
     bhvr_stack().cleanup();
+    auto responses = std::move(m_pending_responses);
     on_exit();
     if (has_behavior()) {
       CAF_LOG_DEBUG("on_exit did set a new behavior");
-      // if the actor still has behaviors, we should record the current exit reason
-      if (planned_exit_reason() != exit_reason::not_exited) {
-        m_last_exit_reason = planned_exit_reason();
-      }
+      m_last_exit_reason = exit_reason::normal;
       planned_exit_reason(exit_reason::not_exited);
       return false; // on_exit did set a new behavior
+    } else if (!responses.empty()) {
+      // the actor still has pending responses and on_exit didn't set a new
+      // behavior, we should record the current exit reason
+      auto rsn = planned_exit_reason();
+      if (rsn != exit_reason::not_exited) {
+        m_last_exit_reason = rsn;
+      }
+      m_pending_responses = std::move(responses);
+      planned_exit_reason(exit_reason::not_exited);
+      return false;
     }
     auto rsn = planned_exit_reason();
     if (rsn == exit_reason::not_exited) {

--- a/libcaf_core/src/local_actor.cpp
+++ b/libcaf_core/src/local_actor.cpp
@@ -35,6 +35,7 @@ namespace caf {
 // e.g., when calling address() in the ctor of a derived class
 local_actor::local_actor()
     : m_planned_exit_reason(exit_reason::not_exited),
+      m_last_exit_reason(exit_reason::normal),
       m_timeout_id(0) {
   // nop
 }
@@ -585,12 +586,17 @@ resumable::resume_result local_actor::resume(execution_unit* eu,
     on_exit();
     if (has_behavior()) {
       CAF_LOG_DEBUG("on_exit did set a new behavior");
+	  // if the actor still has behaviors, we should record the current exit reason
+      if (planned_exit_reason() != exit_reason::not_exited) {
+        m_last_exit_reason = planned_exit_reason();
+      }
       planned_exit_reason(exit_reason::not_exited);
       return false; // on_exit did set a new behavior
     }
     auto rsn = planned_exit_reason();
     if (rsn == exit_reason::not_exited) {
-      rsn = exit_reason::normal;
+      // the actor has no behavior, resume the last recorded exit reason
+      rsn = m_last_exit_reason;
       planned_exit_reason(rsn);
     }
     cleanup(rsn);


### PR DESCRIPTION
After the calling of local_actor::quit, if m_pending_responses is not
empty or on_exit did set a new behavior, no matter what the exit reason
was, it will be changed to exit_reason::normal at last. So I think we
should record the exit reason at right time and resume it after the
behaviors and responses are all handled.