### PR TITLE
Make message::extract_opts more flexible

### DIFF
--- a/examples/qtsupport/qt_group_chat.cpp
+++ b/examples/qtsupport/qt_group_chat.cpp
@@ -35,11 +35,16 @@ int main(int argc, char** argv) {
     {"name,n", "set chat name", name},
     {"group,g", "join chat group", group_id}
   });
+  if (!res.error.empty()) {
+    cerr << res.error << endl;
+    return 1;
+  }
   if (!res.remainder.empty()) {
     std::cerr << res.helptext << std::endl;
     return 1;
   }
   if (res.opts.count("help") > 0) {
+    cout << res.helptext << endl;
     return 0;
   }
   group gptr;

--- a/examples/remote_actors/distributed_calculator.cpp
+++ b/examples/remote_actors/distributed_calculator.cpp
@@ -241,8 +241,12 @@ int main(int argc, char** argv) {
     {"server,s", "run in server mode"},
     {"client,c", "run in client mode"}
   });
+  if (!res.error.empty()) {
+    cerr << res.error << endl;
+    return 1;
+  }
   if (res.opts.count("help") > 0) {
-    // help text has already been printed
+    cout << res.helptext << endl;
     return 0;
   }
   if (!res.remainder.empty()) {

--- a/examples/remote_actors/group_chat.cpp
+++ b/examples/remote_actors/group_chat.cpp
@@ -71,11 +71,16 @@ int main(int argc, char** argv) {
     {"name,n", "set name", name},
     {"group,g", "join group", group_id}
   });
+  if (!res.error.empty()) {
+    cerr << res.error << endl;
+    return 1;
+  }
   if (!res.remainder.empty()) {
     std::cout << res.helptext << std::endl;
     return 1;
   }
   if (res.opts.count("help") > 0) {
+    cout << res.helptext << endl;
     return 0;
   }
   while (name.empty()) {

--- a/libcaf_core/caf/message.hpp
+++ b/libcaf_core/caf/message.hpp
@@ -273,9 +273,13 @@ class message {
    *     {"host,H", "set host (default: localhost)", host},
    *     {"verbose,v", "enable verbose mode"}
    *   });
+   *   if (!res.error.empty()) {
+   *     cerr << res.error << endl;
+   *     return 1;
+   *   }
    *   if (res.opts.count("help") > 0) {
    *     // CLI arguments contained "-h", "--help", or "-?" (builtin);
-   *     // note: the help text has already been printed to stdout
+   *     cout << res.helptext << endl;
    *     return 0;
    *   }
    *   if (!res.remainder.empty()) {
@@ -418,6 +422,11 @@ struct message::cli_res {
    * Stores the automatically generated help text.
    */
   std::string helptext;
+
+  /**
+   * Stores errors during option parsing.
+   */
+  std::string error;
 };
 
 /**


### PR DESCRIPTION
This commit adds a third argument to `message::extract_opts` to control console output of the function. When set to false, the function no longer uses cout and cerr to disply help text and errors.

Moreover, this commit also fixes a bug when users specified their own `-h` or `-?` option, but not `--help`. In this case `extract_opts` would override it with the default help arg. This no longer happens.

Another extension concerns handling of values for single options: it is now possible to omit the space between a value and the single option, e.g., `-v2` is equivalent to `-v 2`.