### PR TITLE
Add kill exit reason

### DIFF
--- a/libcaf_core/caf/exit_reason.hpp
+++ b/libcaf_core/caf/exit_reason.hpp
@@ -67,6 +67,11 @@ static constexpr uint32_t out_of_workers = 0x00007;
 static constexpr uint32_t user_shutdown = 0x00010;
 
 /**
+ * Indicates that the actor was killed unconditionally.
+ */
+static constexpr uint32_t kill = 0x00011;
+
+/**
  * Indicates that an actor finishied execution because a connection
  * to a remote link was closed unexpectedly.
  */

--- a/libcaf_core/src/exit_reason.cpp
+++ b/libcaf_core/src/exit_reason.cpp
@@ -40,6 +40,7 @@ const char* as_string(uint32_t value) {
   }
   switch (value) {
     case user_shutdown: return "user_shutdown";
+    case kill: return "kill";
     case remote_link_unreachable: return "remote_link_unreachable";
     default:
       if (value < user_defined) {


### PR DESCRIPTION
The kill exit reason kill actors unconditionally, even if they
trap exit messages.