### PR TITLE
Add support for CAF_TEST_NO_MAIN (issue #305)

### DIFF
--- a/libcaf_test/README.md
+++ b/libcaf_test/README.md
@@ -2,6 +2,8 @@ CAF Unit Testing Framework
 ==========================
 
 The CAF unit testing framework offers a simple API to write unit tests.
+It offers features in a way compliant to Boost.Test library, with similar
+concepts and API.
 
 Concepts
 --------
@@ -14,7 +16,7 @@ Example
 -------
 
 ```cpp
-#include <caf/test/unit_test.h>
+#include <caf/test/unit_test.hpp>
 
 CAF_SUITE("core")
 
@@ -30,3 +32,7 @@ CAF_TEST("divide")
   CAF_CHECK(1 / 1 == 0);  // fails
 }
 ```
+
+You can provide your own `main` function by defining `CAF_TEST_NO_MAIN`
+before including `unit_test.hpp`. In this case you may refer to the default
+test-runner function as `caf::test::main`.

--- a/libcaf_test/caf/test/unit_test.hpp
+++ b/libcaf_test/caf/test/unit_test.hpp
@@ -36,6 +36,15 @@ class message;
 namespace test {
 
 /**
+ * Default test-running function.
+ * This function will be called automatically unless you define
+ * `CAF_TEST_NO_MAIN` before including `caf/test/unit_test.hpp`. In
+ * the latter case you will have to provide you own `main` function,
+ * where you may want to call `caf::test::main` from.
+ */
+int main(int argc, char** argv);
+
+/**
  * A sequence of *checks*.
  */
 class test {

--- a/libcaf_test/caf/test/unit_test_impl.hpp
+++ b/libcaf_test/caf/test/unit_test_impl.hpp
@@ -478,26 +478,9 @@ std::string engine::render(std::chrono::microseconds t) {
       : (std::to_string(t.count()) + " us");
 }
 
-namespace detail {
-
-expr::expr(test* parent, const char* filename, size_t lineno,
-           bool should_fail, const char* expression)
-    : m_test{parent},
-      m_filename{filename},
-      m_line{lineno},
-      m_should_fail{should_fail},
-      m_expr{expression} {
-  assert(m_test != nullptr);
-}
-
-} // namespace detail
-} // namespace test
-} // namespace caf
-
 int main(int argc, char** argv) {
-  using namespace caf;
   // set path of executable
-  test::engine::path(argv[0]);
+  engine::path(argv[0]);
   // default values.
   int verbosity_console = 3;
   int verbosity_file = 3;
@@ -539,7 +522,7 @@ int main(int argc, char** argv) {
   }
   if (res.opts.count("available-suites") > 0) {
     std::cout << "available suites:" << std::endl;
-    for (auto& s : test::engine::available_suites()) {
+    for (auto& s : engine::available_suites()) {
       std::cout << "  - " << s << std::endl;
     }
     return 0;
@@ -551,12 +534,34 @@ int main(int argc, char** argv) {
   }
   auto colorize = res.opts.count("no-colors") == 0;
   if (divider < argc) {
-    test::engine::args(argc - divider - 1, argv + divider + 1);
+    engine::args(argc - divider - 1, argv + divider + 1);
   }
-  auto result = test::engine::run(colorize, log_file, verbosity_console,
+  auto result = engine::run(colorize, log_file, verbosity_console,
                                   verbosity_file, max_runtime, suites,
                                   not_suites, tests, not_tests);
   return result ? 0 : 1;
 }
+
+namespace detail {
+
+expr::expr(test* parent, const char* filename, size_t lineno,
+           bool should_fail, const char* expression)
+    : m_test{parent},
+      m_filename{filename},
+      m_line{lineno},
+      m_should_fail{should_fail},
+      m_expr{expression} {
+  assert(m_test != nullptr);
+}
+
+} // namespace detail
+} // namespace test
+} // namespace caf
+
+#ifndef CAF_TEST_NO_MAIN
+int main(int argc, char** argv) {
+  return caf::test::main(argc, argv);
+}
+#endif
 
 #endif // CAF_TEST_UNIT_TEST_IMPL_HPP


### PR DESCRIPTION
Implements issue #305.

To test this locally, I created a new file named `test-main.cpp` with the following content:
```cpp
#define CAF_TEST_NO_MAIN
#include "caf/test/unit_test.hpp"
#include "caf/test/unit_test_impl.hpp"

int main(int argc, char** argv) {
  caf::test::main(argc, argv);
}
```
Then I've issued a pair of commands to test if it compiles:
```
$ ./configure --no-riac --no-nexus --no-cash --no-opencl
$ make
$ g++ -std=c++11 -o test-main -Ilibcaf_core/ -Ilibcaf_test/ -Lbuild/lib -lcaf_core \
        test-main.cpp libcaf_core/test/*.cpp
$ LD_LIBRARY_PATH=build/lib ./test-main
```