### PR TITLE
Fix `typed_response_promise`

### DIFF
--- a/libcaf_core/caf/detail/ctm.hpp
+++ b/libcaf_core/caf/detail/ctm.hpp
@@ -60,9 +60,9 @@ struct ctm_cmp<typed_mpi<In, Out, empty_type_list>,
                typed_mpi<In, type_list<typed_continue_helper<Out>>, empty_type_list>>
     : std::true_type { };
 
-template <class In, class Out>
-struct ctm_cmp<typed_mpi<In, Out, empty_type_list>,
-               typed_mpi<In, type_list<typed_response_promise<Out>>, empty_type_list>>
+template <class In, class... Ts>
+struct ctm_cmp<typed_mpi<In, type_list<Ts...>, empty_type_list>,
+               typed_mpi<In, type_list<typed_response_promise<Ts...>>, empty_type_list>>
     : std::true_type { };
 
 template <class In, class L, class R>

--- a/libcaf_core/caf/typed_response_promise.hpp
+++ b/libcaf_core/caf/typed_response_promise.hpp
@@ -25,7 +25,7 @@
 
 namespace caf {
 
-template <class T>
+template <class... Ts>
 class typed_response_promise {
 public:
   typed_response_promise(response_promise promise) : promise_(promise) {
@@ -37,8 +37,8 @@ public:
     return static_cast<bool>(promise_);
   }
 
-  void deliver(T what) const {
-    promise_.deliver(make_message(std::move(what)));
+  void deliver(Ts... what) const {
+    promise_.deliver(make_message(std::move(what)...));
   }
 
 


### PR DESCRIPTION
Fix the compilation error in the code as follow:
```C++
using foo_type = typed_actor<replies_to<foo_atom>::with<bar_atom>>;
foo_type::behavior_type foo_action(foo_type::pointer self) {
  return {
    [=](foo_atom) {
      return typed_response_promise<bar_atom>{self->make_response_promise()};
    }
  };
}
```