### PR TITLE
Typed stateful broker

### DIFF
--- a/libcaf_core/caf/infer_handle.hpp
+++ b/libcaf_core/caf/infer_handle.hpp
@@ -126,6 +126,24 @@ struct infer_handle_from_fun_impl<Result,
   static constexpr spawn_mode mode = spawn_mode::function_with_selfptr;
 };
 
+// statically typed stateful broker with self pointer
+template <class Result, class State, class... Sigs>
+struct infer_handle_from_fun_impl<Result,
+                                  experimental::stateful_actor<
+                                    State,
+                                    io::experimental::typed_broker<Sigs...>
+                                  >*,
+                                  true> {
+  using type = typed_actor<Sigs...>;
+  using impl =
+    experimental::stateful_actor<
+      State,
+      io::experimental::typed_broker<Sigs...>
+    >;
+  using behavior_type = typed_behavior<Sigs...>;
+  static constexpr spawn_mode mode = spawn_mode::function_with_selfptr;
+};
+
 template <class F, class Trait = typename detail::get_callable_trait<F>::type>
 struct infer_handle_from_fun {
   using result_type = typename Trait::result_type;

--- a/libcaf_core/caf/typed_actor.hpp
+++ b/libcaf_core/caf/typed_actor.hpp
@@ -104,6 +104,16 @@ class typed_actor : detail::comparable<typed_actor<Sigs...>>,
   template <class State>
   using stateful_pointer = experimental::stateful_actor<State, base>*;
 
+  /// Identifies the broker_base class for this kind of actor with actor.
+  template <class State>
+  using stateful_broker_base =
+    experimental::stateful_actor<State, broker_base>;
+
+  /// Identifies the broker_base class for this kind of actor with actor.
+  template <class State>
+  using stateful_broker_pointer =
+    experimental::stateful_actor<State, broker_base>*;
+
   typed_actor() = default;
   typed_actor(typed_actor&&) = default;
   typed_actor(const typed_actor&) = default;


### PR DESCRIPTION
Add necessary template aliases and template specialization, so that we can
implement typed_stateful_broker using stateful_actor.
```C++
using foo = typed_actor<...>;

class foo_state {
  ...
};

foo::behavior_type foo_impl(foo::stateful_broker_pointer<foo_state> self, ...) {
  ...
}
```