### PR TITLE
Announcement mechanisms for C-style arrays.

### DIFF
--- a/libcaf_core/caf/announce.hpp
+++ b/libcaf_core/caf/announce.hpp
@@ -32,6 +32,7 @@
 #include "caf/detail/safe_equal.hpp"
 #include "caf/detail/type_traits.hpp"
 #include "caf/detail/default_uniform_type_info.hpp"
+#include "caf/detail/array_uniform_type_info.hpp"
 
 namespace caf {
 
@@ -110,7 +111,7 @@ compound_member(const std::pair<GRes (Parent::*)() const,
 
 /// Adds a new type mapping for `T` to the type system using `tname`
 /// as its uniform name and the list of member pointers `xs`.
-/// @warning `announce` is **not** thead-safe!
+/// @warning `announce` is **not** thread-safe!
 template <class T, class... Ts>
 inline const uniform_type_info* announce(std::string tname, const Ts&... xs) {
   static_assert(std::is_pod<T>::value || std::is_empty<T>::value
@@ -118,6 +119,18 @@ inline const uniform_type_info* announce(std::string tname, const Ts&... xs) {
                 "T is neither a POD, nor empty, nor comparable with '=='");
   auto ptr = new detail::default_uniform_type_info<T>(std::move(tname), xs...);
   return announce(typeid(T), uniform_type_info_ptr{ptr});
+}
+
+/// Adds a new type mapping for a C-style array `T[N]` to the type system
+/// using `tname` as its uniform name.
+/// @warning `announce_array_type` is **not** thread-safe!
+template <typename T, size_t N>
+inline const uniform_type_info* announce(std::string tname) {
+  static_assert(std::is_pod<T>::value || std::is_empty<T>::value
+                || detail::is_comparable<T, T>::value,
+                "T is neither a POD, nor empty, nor comparable with '=='");
+  auto ptr = new detail::array_uniform_type_info<T,N>(std::move(tname));
+  return announce(typeid(T[N]), uniform_type_info_ptr{ptr});
 }
 
 /// @}

--- a/libcaf_core/caf/detail/array_uniform_type_info.hpp
+++ b/libcaf_core/caf/detail/array_uniform_type_info.hpp
@@ -1,0 +1,37 @@
+#ifndef CAF_ARRAY_UNIFORM_TYPE_INFO_HPP
+#define CAF_ARRAY_UNIFORM_TYPE_INFO_HPP
+#include "caf/abstract_uniform_type_info.hpp"
+
+namespace caf {
+
+namespace detail {
+
+template <typename T, size_t N>
+class array_uniform_type_info : public abstract_uniform_type_info<T[N]> {
+public:
+  array_uniform_type_info(std::string name)
+      : abstract_uniform_type_info<T[N]>(std::move(name)) {
+    // nop
+  }
+
+protected:
+  void serialize(const void* ptr, serializer* sink) const {
+    auto array_ptr = reinterpret_cast<const T*>(ptr);
+    for (size_t i = 0; i < N; i++) {
+        sink->write_value(array_ptr[i]);
+    }
+  }
+
+  void deserialize(void* ptr, deserializer* source) const {
+    auto array_ptr = reinterpret_cast<T*>(ptr);
+    for (size_t i = 0; i < N; i++) {
+        array_ptr[i] = source->read<T>();
+    }
+  }
+};
+
+} //namespace detail
+
+} //namespace caf
+
+#endif

--- a/libcaf_core/caf/uniform_type_info.hpp
+++ b/libcaf_core/caf/uniform_type_info.hpp
@@ -71,6 +71,30 @@ private:
   T value_;
 };
 
+// A specialization for c style arrays.
+template <class T, size_t N>
+class uniform_value_impl<T[N]> : public uniform_value_t {
+public:
+  uniform_value_impl(const uniform_type_info* ptr)
+      : uniform_value_t(ptr, &value_) {
+    //nop, equivalent of calling the default constructor
+  }
+
+  uniform_value_impl(const uniform_type_info* ptr, T const arg[N])
+      : uniform_value_t(ptr, &value_) {
+    //copying a c style array to initialize it
+    std::copy(&arg[0], &arg[N], &value_[0]);
+  }
+
+  uniform_value copy() override {
+    return uniform_value{new uniform_value_impl(ti, value_)};
+  }
+
+private:
+  T value_[N];
+};
+
+
 /// Creates a uniform value of type `T`.
 template <class T, class... Ts>
 uniform_value make_uniform_value(const uniform_type_info* uti, Ts&&... xs) {

--- a/libcaf_core/test/serialization.cpp
+++ b/libcaf_core/test/serialization.cpp
@@ -106,16 +106,23 @@ enum class test_enum {
   c
 };
 
+struct test_array_wrapper {
+    int value[4];
+};
+
 struct fixture {
   int32_t i32 = -345;
   test_enum te = test_enum::b;
   string str = "Lorem ipsum dolor sit amet.";
   raw_struct rs;
+  test_array_wrapper aw{{0, 1, 2, 3}};
   message msg;
 
   fixture() {
     announce<test_enum>("test_enum");
     announce(typeid(raw_struct), uniform_type_info_ptr{new raw_struct_type_info});
+    announce<int,4>("int_array_4");
+    announce<test_array_wrapper>("test_array_wrapper", &test_array_wrapper::value);
     rs.str.assign(string(str.rbegin(), str.rend()));
     msg = make_message(i32, te, str, rs);
   }
@@ -243,6 +250,15 @@ CAF_TEST(test_enum_serialization) {
   test_enum x;
   binary_util::deserialize(buf, &x);
   CAF_CHECK(te == x);
+}
+
+CAF_TEST(test_array_wrapper) {
+  auto buf = binary_util::serialize(aw);
+  test_array_wrapper x;
+  binary_util::deserialize(buf, &x);
+  for (size_t i = 0; i < 4; i++) {
+      CAF_CHECK(aw.value[i] == x.value[i]);
+  }
 }
 
 CAF_TEST(test_string) {


### PR DESCRIPTION
See #350 and #351 for the issues addressed. Since this is my first commit to the project, let me know if there are things that are not as they should be. As far as I can figure out, C-style arrays require a non-default uniform_type_info. Trying to announce an array type with default_uniform_type_info appears to create an infinite loop... 