### PR TITLE
Simplify obs-commit-version.sh

### DIFF
--- a/scripts/obs-commit-version.sh
+++ b/scripts/obs-commit-version.sh
@@ -7,17 +7,15 @@
 #
 #     $ make
 #     $ make test
-#     $ make doc                          <-- this is a necessary step!
-#     $ obs-commit-version.sh --release   <-- for release build
-#     -or-
-#     $ obs-commit-version.sh --nightly   <-- for nightly build
+#     $ make doc                       <-- this is a necessary step!
+#     $ scripts/obs-commit-version.sh
 #
 # In brief, it performs the following steps:
 #
 #  1. Determines current version from <caf/config.h> header. It's crucial to
 #     have this version set correctly for script to operate properly.
-#  2. If was run in '--nightly' mode, ask Git to describe current position on
-#     the revision tree related to determined stable version.
+#  2. Determines current branch. If it's 'master' then rebuild stable
+#     packages, if it's 'develop' then rebuild nightly.
 #  3. Checks out OBS project using "osc" tool. It uses default credentials
 #     specified in ~/.oscrc configuration file.
 #  4. Puts new source tarball into OBS project.
@@ -25,6 +23,7 @@
 #  6. Commits changes files to trigger new OBS build.
 #
 # Copyright (c) 2015, Pavel Kretov <firegurafiku@gmail.com>
+# Copyright (c) 2015, Dominik Charousset <dominik.charousset@haw-hamburg.de>
 #
 # Distributed under the terms and conditions of the BSD 3-Clause License or
 # (at your option) under the terms and conditions of the Boost Software
@@ -37,69 +36,87 @@
 set -o nounset
 set -o errexit
 
-# check for `osc` command
-type osc > /dev/null 2>&1 || {
+# Script configuration (yet unlikely to change in the future).
+confReleaseBranch="master"
+confNightlyBranch="develop"
+confReleaseProject="devel:libraries:caf"
+confNightlyProject="devel:libraries:caf:nightly"
+confReleasePackage="caf"
+confNightlyPackage="caf"
+
+# Check for 'osc' command.
+type osc >/dev/null 2>&1 || {
   echo "This script requires 'osc', please install it first." >&2
   exit 1
 }
 
-# check if header exists
-if [ ! -f "libcaf_core/caf/config.hpp" ] ; then
+sourceDir="$PWD"
+
+# Check if header exists.
+if [ ! -f "$sourceDir/libcaf_core/caf/config.hpp" ] ; then
   echo "This script must be called from the root directly of CAF." >&2
   exit 1
 fi
 
-# check arguments
-if [ $# -ne 2 ] || [ $1 != "--release" -a $1 != "--nightly" ] ; then
-  echo "Usage: $0 (--release|--nightly) NAMESPACE:PROJECT/PACKAGE" >&2
+if [ ! -d "$sourceDir/html" \
+  -o ! -f "$sourceDir/manual/manual.html"\
+  -o ! -f "$sourceDir/manual/manual.pdf" ] ; then
+  echo "Documentation must be generated before calling this script." >&2
   exit 1
 fi
 
-operatingMode="$1"
-packageFqn="$2"
-projectName="$(dirname "$packageFqn")"
-packageName="$(basename "$packageFqn")"
-
-sourceDir="$PWD"
-
-# 1.
+# Extract version information from header file.
 versionAsInt=$(grep "#define CAF_VERSION" libcaf_core/caf/config.hpp | awk '{print $3'})
 versionMajor=$(echo "$versionAsInt / 10000" | bc)
 versionMinor=$(echo "( $versionAsInt / 100 ) % 100" | bc)
 versionPatch=$(echo "$versionAsInt % 100" | bc)
 versionAsStr="$versionMajor.$versionMinor.$versionPatch"
 
-# 2.
-version=$versionAsStr
-if [ "$operatingMode" = "--nightly" ] ; then
-  version="${versionAsStr}_$(date +%Y%m%d)"
+# Retrieve current branch from git.
+gitBranch=`git rev-parse --abbrev-ref HEAD`
+
+if [ "$gitBranch" = "$confReleaseBranch" ] ; then 
+  projectName="$confReleaseProject"
+  packageName="$confReleasePackage"
+  packageVersion="${versionAsStr}"
+elif [ "$gitBranch" = "$confNightlyBranch" ] ; then
+  projectName="$confNightlyProject"
+  packageName="$confNightlyPackage"
+  packageVersion="${versionAsStr}_$(date +%Y%m%d)"
+else
+  # Don't prevent other branches from building, but issue a warning.
+  echo "Not on '$confReleaseBranch' or '$confNightlyBranch' branch. Exitting." >&2
+  exit
 fi
 
-# 3, 4
+packageFqn="$projectName/$packageName"
+sourceTarball="${versionAsStr}.tar.gz"
 buildDir="$sourceDir/build"
 obsDir="$buildDir/obs-temp"
-if [ -d "$obsDir" ]; then
-  rm -rf "$obsDir"
-fi
+
+# Prepare a directory for checkout.
+[ -d "$obsDir" ] && rm -rf "$obsDir"
 mkdir -p "$obsDir"
 cd "$obsDir"
+
+# Checkout the project from OBS into a newly created directory.
+echo "[obs-commit-version] Checking out"
 osc checkout "$packageFqn"
+
+# Remove old tarball.
 cd "$packageFqn"
 osc remove *.tar.gz
 
+# And generate a new tarball.
 cd "$sourceDir"
-
-echo "generate tarball: ${version}.tar.gz"
-
-sourceTarball="${version}.tar.gz"
+echo "[obs-commit-version] Generating tarball: ${versionAsStr}.tar.gz"
 tar czf "$obsDir/$packageFqn/$sourceTarball" --exclude ".git" --exclude "build" *
-cd -
+cd - >/dev/null
 
 osc add "$sourceTarball"
 
-# 5.
-sed -i.bk -E -e "s/^Version:([ ]+).+/Version:\1$version/g" "$packageName.spec"
-
-# 6.
-osc commit -m "Automatic commit: $version, $operatingMode"
+# Fix package version and commit.
+sed -i.bk -E -e "s/^Version:([ ]+).+/Version:\1$packageVersion/g" "$packageName.spec"
+echo "[obs-commit-version] Comitting: $packageVersion, $gitBranch"
+osc commit -m "Automatic commit: $packageVersion, $gitBranch"
 


### PR DESCRIPTION
I've noticed that current Jenkins setup issues builds onto wrong OBS repository, thus breaking stable builds. In order to completely separate release packages and nightly packages, I've modified `obs-commit-version.sh` to take no parameters and be as much self-contained as possible. New behaviour is the following:

* if branch is 'master', then trigger release build to 'devel:libraries:caf/caf' with version like '15.0.1''
* if branch is 'develop', then trigger nightly build to 'devel:libraries:caf:nightly/caf' with long version '15.0.1_20170325`
* on other branches do nothing.

So, Jenkins should just issue the same command sequence regardless the build type:
```text
$ make
$ make doc
$ scripts/obs-commit-version.sh
```
