### PR TITLE
obs-commit-version.sh: fix source tarball name

### DIFF
--- a/scripts/obs-commit-version.sh
+++ b/scripts/obs-commit-version.sh
@@ -90,7 +90,7 @@ else
 fi
 
 packageFqn="$projectName/$packageName"
-sourceTarball="${versionAsStr}.tar.gz"
+sourceTarball="${packageVersion}.tar.gz"
 buildDir="$sourceDir/build"
 obsDir="$buildDir/obs-temp"
 

--- a/scripts/obs-commit-version.sh
+++ b/scripts/obs-commit-version.sh
@@ -116,7 +116,11 @@ cd - >/dev/null
 osc add "$sourceTarball"
 
 # Fix package version and commit.
-sed -i.bk -E -e "s/^Version:([ ]+).+/Version:\1$packageVersion/g" "$packageName.spec"
+sed -i.bk -E \
+  -e "s/^Version:([ ]+).+/Version:\1$packageVersion/g" \
+  "$packageName.spec" \
+  "$packageName.dsc"
+
 echo "[obs-commit-version] Comitting: $packageVersion, $gitBranch"
 osc commit -m "Automatic commit: $packageVersion, $gitBranch"
 


### PR DESCRIPTION
Make tarball file name include date suffix, thus making nightly builds
operating again.