### PR TITLE
Fix the return type of `add_tcp_doorman`

### DIFF
--- a/libcaf_io/caf/io/experimental/typed_broker.hpp
+++ b/libcaf_io/caf/io/experimental/typed_broker.hpp
@@ -184,7 +184,7 @@ public:
     return super::add_tcp_scribe(fd);
   }
 
-  maybe<std::pair<accept_handle, uint16_t>>
+  std::pair<accept_handle, uint16_t>
   add_tcp_doorman(uint16_t port = 0,
                   const char* in = nullptr,
                   bool reuse_addr = false) {


### PR DESCRIPTION
The function with the same name and parameters in `abstract_broker` return a
`std::pair<accept_handle, uint16_t>` object.