### PR TITLE
Improve `policy::work_stealing::try_steal()`

### DIFF
--- a/libcaf_core/caf/policy/work_stealing.hpp
+++ b/libcaf_core/caf/policy/work_stealing.hpp
@@ -91,12 +91,10 @@ public:
       // you can't steal from yourself, can you?
       return nullptr;
     }
-    size_t victim;
-    do {
-      // roll the dice to pick a victim other than ourselves
-      victim = d(self).rengine() % p->num_workers();
-    }
-    while (victim == self->id());
+    // roll the dice to pick a victim other than ourselves
+    size_t victim = d(self).rengine() % (p->num_workers() - 1);
+    if (victim == self->id())
+      victim = p->num_workers() - 1;
     // steal oldest element from the victim's queue
     return d(p->worker_by_id(victim)).queue.take_tail();
   }


### PR DESCRIPTION
Victim selection is made collision-free. A try-loop is no longer needed. In previous version, with two workers, the probability of collision is 50%!