### PR TITLE
Fix and improve sync response handling of `local_actor`

### DIFF
--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -24,7 +24,7 @@
 #include <cstdint>
 #include <exception>
 #include <functional>
-#include <forward_list>
+#include <list>
 
 #include "caf/fwd.hpp"
 
@@ -646,7 +646,8 @@ protected:
   message_id last_request_id_;
 
   // identifies all IDs of sync messages waiting for a response
-  std::forward_list<pending_response> pending_responses_;
+  // arranged in chronological order, and used as a FIFO queue
+  std::list<pending_response> pending_responses_;
 
   // points to dummy_node_ if no callback is currently invoked,
   // points to the node under processing otherwise

--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -599,7 +599,10 @@ public:
 
   message_id new_request_id(message_priority mp);
 
-  void mark_arrived(message_id response_id);
+  // sync response handler invokation follows a chronological FIFO order
+  // the handler to remove should be at the front the of list
+  // call `pending_responses_.pop_front()` directly
+  // void mark_arrived(message_id response_id);
 
   bool awaits_response() const;
 

--- a/libcaf_core/src/local_actor.cpp
+++ b/libcaf_core/src/local_actor.cpp
@@ -495,11 +495,11 @@ message_id local_actor::new_request_id(message_priority mp) {
   return mp == message_priority::normal ? result : result.with_high_priority();
 }
 
-void local_actor::mark_arrived(message_id mid) {
-  CAF_ASSERT(mid.is_response());
-  pending_response_predicate predicate{mid};
-  pending_responses_.remove_if(predicate);
-}
+//void local_actor::mark_arrived(message_id mid) {
+//  CAF_ASSERT(mid.is_response());
+//  pending_response_predicate predicate{mid};
+//  pending_responses_.remove_if(predicate);
+//}
 
 bool local_actor::awaits_response() const {
   return ! pending_responses_.empty();
@@ -515,9 +515,13 @@ bool local_actor::awaits(message_id mid) const {
 maybe<local_actor::pending_response&>
 local_actor::find_pending_response(message_id mid) {
   pending_response_predicate predicate{mid};
-  auto last = pending_responses_.end();
-  auto i = std::find_if(pending_responses_.begin(), last, predicate);
-  if (i == last) {
+  // due to common usage pattern and the principle of locality, the match, if
+  // any, is more likely to be recently added, and thus reside to the rear of
+  // the list; so search backward
+  auto rbegin = pending_responses_.rbegin();
+  auto rend = pending_responses_.rend();
+  auto i = std::find_if(rbegin, rend, predicate);
+  if (i == rend) {
     return none;
   }
   return *i;


### PR DESCRIPTION
In the previous version, handling of sync responses by `local_actor` is done in reverse order of their corresponding `sync_send()` calls. For example,

~~~~~C++
void exp_behavior(caf::event_based_actor* self,
                  const caf::actor& responder_1,
                  const caf::actor& responder_2) {
  ...
  self->sync_send(responder_1, ...).then(handler_1);
  self->sync_send(responder_2, ...).then(handler_2);
}
~~~~~

Regardless of the order response messages are enqueued to the mailbox, `handler_2` is going to be invoked before `handler_1`. I don't think this is correct `sync_send()` semantics. This PR fixes this issue, and makes sure that handling of sync responses follows the order of their corresponding `sync_send()` calls.

It turns out that this issue only exists among sync responses. The behavior between sync and async responses is correct. For example,

~~~~~C++
caf::behavior exp_behavior(caf::event_based_actor* self,
                           const caf::actor& responder_1,
                           const caf::actor& responder_2) {
  ...
  self->sync_send(responder_1, ...).then(handler_1);
  self->send(responder_2, ...);
  return handler_2;
}
~~~~~

It's guaranteed that `handler_1` be invoked before `handler_2`, even when the async response arrived before the sync one.

Besides the fix, an improvement is also made to the removal of invoked sync response handlers. Now the removal takes constant time instead of linear time to the number of pending sync response handlers.
