### PR TITLE
Fix exception handling in `local_actor::resume()`

### DIFF
--- a/libcaf_core/src/local_actor.cpp
+++ b/libcaf_core/src/local_actor.cpp
@@ -650,7 +650,8 @@ resumable::resume_result local_actor::resume(execution_unit* eu,
     }
     if (eptr) {
       auto opt_reason = self->handle(eptr);
-      rsn = *opt_reason;
+      rsn = opt_reason ? *opt_reason
+                       : exit_reason::unhandled_exception;
     }
     self->planned_exit_reason(rsn);
     try {


### PR DESCRIPTION
The previous version does not correctly handle the case when the call to `self->act()` throws an exception that is not successfully handled by the call to `self->handle(eptr)`.