### PR TITLE
Add reuse_addr argument in publish_local_groups

### DIFF
--- a/libcaf_io/caf/io/publish_local_groups.hpp
+++ b/libcaf_io/caf/io/publish_local_groups.hpp
@@ -30,7 +30,8 @@ namespace io {
 ///          chooses a random high-level port.
 /// @throws bind_failure
 /// @throws network_error
-uint16_t publish_local_groups(uint16_t port, const char* addr = nullptr);
+uint16_t publish_local_groups(uint16_t port, const char* addr = nullptr,
+                              bool reuse_addr = false);
 
 } // namespace io
 } // namespace caf

--- a/libcaf_io/src/publish_local_groups.cpp
+++ b/libcaf_io/src/publish_local_groups.cpp
@@ -26,7 +26,8 @@
 namespace caf {
 namespace io {
 
-uint16_t publish_local_groups(uint16_t port, const char* addr) {
+uint16_t publish_local_groups(uint16_t port, const char* addr,
+                              bool reuse_addr) {
   auto group_nameserver = []() -> behavior {
     return {
       [](get_atom, const std::string& name) {
@@ -37,7 +38,7 @@ uint16_t publish_local_groups(uint16_t port, const char* addr) {
   auto gn = spawn<hidden>(group_nameserver);
   uint16_t result;
   try {
-    result = publish(gn, port, addr);
+    result = publish(gn, port, addr, reuse_addr);
   }
   catch (std::exception&) {
     anon_send_exit(gn, exit_reason::user_shutdown);


### PR DESCRIPTION
Enable setting socket option SO_REUSEADDR also when
publish_local_groups is used.