### PR TITLE
Refine memory order on `monitorable_actor::exit_reason_`

### DIFF
--- a/libcaf_core/caf/monitorable_actor.hpp
+++ b/libcaf_core/caf/monitorable_actor.hpp
@@ -51,11 +51,19 @@ public:
 
   size_t detach(const attachable::token& what) override;
 
+  /// Returns the exit reason of this actor or
+  /// `exit_reason::not_exited` if it is still alive.
+  inline exit_reason get_exit_reason() const {
+    return exit_reason_.load(std::memory_order_relaxed);
+  }
+
   /// @cond PRIVATE
 
-  // Returns `exit_reason_ != exit_reason::not_exited`.
+  // returns `exit_reason_ != exit_reason::not_exited`;
+  // it's possible for user code to call this method
+  // without acquiring `mtx_`
   inline bool exited() const {
-    return exit_reason_ != exit_reason::not_exited;
+    return get_exit_reason() != exit_reason::not_exited;
   }
 
   /// @endcond
@@ -72,6 +80,8 @@ protected:
 
   /// Called by the runtime system to perform cleanup actions for this actor.
   /// Subtypes should always call this member function when overriding it.
+  /// This member function is thread-safe, and if the actor has already exited
+  /// upon invocation, nothing is done.
   virtual void cleanup(exit_reason reason, execution_unit* host);
 
   /****************************************************************************
@@ -91,19 +101,25 @@ protected:
   // tries to run a custom exception handler for `eptr`
   maybe<exit_reason> handle(const std::exception_ptr& eptr);
 
+  // precondition: `mtx_` is acquired
   inline void attach_impl(attachable_ptr& ptr) {
     ptr->next.swap(attachables_head_);
     attachables_head_.swap(ptr);
   }
 
+  // precondition: `mtx_` is acquired
   static size_t detach_impl(const attachable::token& what,
                             attachable_ptr& ptr,
                             bool stop_on_first_hit = false,
                             bool dry_run = false);
 
+  // handles only `exit_msg` and `sys_atom` messages;
+  // returns true if the message is handled
   bool handle_system_message(mailbox_element& node, execution_unit* context,
                              bool trap_exit);
 
+  // handles `exit_msg`, `sys_atom` messages, and additionally `down_msg`
+  // with `down_msg_handler`; returns true if the message is handled
   template <class F>
   bool handle_system_message(mailbox_element& node, execution_unit* context,
                              bool trap_exit, F& down_msg_handler) {
@@ -115,7 +131,9 @@ protected:
     return handle_system_message(node, context, trap_exit);
   }
 
-  // initially set to exit_reason::not_exited
+  // initially set to exit_reason::not_exited;
+  // can only be stored with `mtx_` acquired;
+  // may be read without acquiring `mtx_`
   std::atomic<exit_reason> exit_reason_;
 
   // guards access to exit_reason_, attachables_, links_,

--- a/libcaf_core/src/adapter.cpp
+++ b/libcaf_core/src/adapter.cpp
@@ -50,7 +50,7 @@ adapter::adapter(actor_addr decorated, message msg)
 void adapter::enqueue(mailbox_element_ptr what, execution_unit* host) {
   if (! what)
     return; // not even an empty message
-  auto reason = exit_reason_.load();
+  auto reason = get_exit_reason();
   if (reason != exit_reason::not_exited) {
     // actor has exited
     auto& mid = what->mid;

--- a/libcaf_core/src/local_actor.cpp
+++ b/libcaf_core/src/local_actor.cpp
@@ -69,7 +69,7 @@ local_actor::local_actor(actor_system* sys, actor_id aid,
 
 local_actor::~local_actor() {
   if (! mailbox_.closed()) {
-    detail::sync_request_bouncer f{exit_reason_};
+    detail::sync_request_bouncer f{get_exit_reason()};
     mailbox_.close(f);
   }
 }

--- a/libcaf_core/src/sequencer.cpp
+++ b/libcaf_core/src/sequencer.cpp
@@ -47,7 +47,7 @@ sequencer::sequencer(actor_addr f, actor_addr g, message_types_set msg_types)
 void sequencer::enqueue(mailbox_element_ptr what, execution_unit* context) {
   if (! what)
     return; // not even an empty message
-  auto reason = exit_reason_.load();
+  auto reason = get_exit_reason();
   if (reason != exit_reason::not_exited) {
     // actor has exited
     auto& mid = what->mid;

--- a/libcaf_core/src/splitter.cpp
+++ b/libcaf_core/src/splitter.cpp
@@ -83,7 +83,7 @@ splitter::splitter(std::vector<actor_addr> workers, message_types_set msg_types)
 void splitter::enqueue(mailbox_element_ptr what, execution_unit* context) {
   if (! what)
     return; // not even an empty message
-  auto reason = exit_reason_.load();
+  auto reason = get_exit_reason();
   if (reason != exit_reason::not_exited) {
     // actor has exited
     auto& mid = what->mid;


### PR DESCRIPTION
May improve performance on certain architectures.