### PR TITLE
Fix and improve response promise

### DIFF
--- a/libcaf_core/caf/detail/split_join.hpp
+++ b/libcaf_core/caf/detail/split_join.hpp
@@ -58,7 +58,7 @@ public:
           this->send(x.first, std::move(x.second));
         this->become(
           // collect results
-          others >> [=] {
+          others >> [=]() mutable {
             join_(value_, this->current_message());
             if (--awaited_results_ == 0) {
               rp.deliver(make_message(value_));

--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <exception>
 #include <functional>
+#include <type_traits>
 #include <forward_list>
 #include <unordered_map>
 
@@ -55,6 +56,7 @@
 #include "caf/check_typed_input.hpp"
 #include "caf/monitorable_actor.hpp"
 #include "caf/invoke_message_result.hpp"
+#include "caf/typed_response_promise.hpp"
 
 #include "caf/detail/disposer.hpp"
 #include "caf/detail/behavior_stack.hpp"
@@ -340,6 +342,16 @@ public:
 
   /// Creates a `response_promise` to response to a request later on.
   response_promise make_response_promise();
+
+  /// Creates a `response_promise` and responds immediately.
+  /// Non-requests do not get an error response message.
+  template <class... Ts>
+  typed_response_promise<typename std::decay<Ts>::type...>
+  response(Ts&&... xs) {
+    auto promise = make_response_promise();
+    promise.deliver(std::forward<Ts>(xs)...);
+    return promise;
+  }
 
   /// Sets a custom exception handler for this actor. If multiple handlers are
   /// defined, only the functor that was added *last* is being executed.

--- a/libcaf_core/caf/typed_response_promise.hpp
+++ b/libcaf_core/caf/typed_response_promise.hpp
@@ -22,27 +22,57 @@
 
 #include "caf/response_promise.hpp"
 
+#include "caf/detail/type_list.hpp"
+
 namespace caf {
 
+/// A response promise can be used to deliver a uniquely identifiable
+/// response message from the server (i.e. receiver of the request)
+/// to the client (i.e. the sender of the request).
 template <class... Ts>
 class typed_response_promise {
 public:
+  /// Constructs an invalid response promise.
   typed_response_promise() = default;
-  typed_response_promise(const typed_response_promise&) = default;
-  typed_response_promise& operator=(const typed_response_promise&) = default;
 
-  typed_response_promise(response_promise promise) : promise_(promise) {
+  inline typed_response_promise(response_promise promise)
+      : promise_(std::move(promise)) {
     // nop
   }
 
-  explicit operator bool() const {
-    // handle is valid if it has a receiver
-    return static_cast<bool>(promise_);
+  typed_response_promise(typed_response_promise&&) = default;
+  typed_response_promise(const typed_response_promise&) = default;
+  typed_response_promise& operator=(typed_response_promise&&) = default;
+  typed_response_promise& operator=(const typed_response_promise&) = default;
+
+  /// Satisfies the promise by sending a non-error response message.
+  template <class U, class... Us>
+  typename std::enable_if<
+    (sizeof...(Us) > 0) || ! std::is_convertible<U, error>::value
+  >::type
+  deliver(U&& x, Us&&... xs) {
+    static_assert(
+      std::is_same<detail::type_list<Ts...>,
+                   detail::type_list<typename std::decay<U>::type,
+                                     typename std::decay<Us>::type...>>::value,
+      "typed_response_promise: message type mismatched");
+    promise_.deliver(std::forward<U>(x), std::forward<Us>(xs)...);
   }
 
-  template <class... Us>
-  void deliver(Us&&... xs) const {
-    promise_.deliver(make_message(std::forward<Us>(xs)...));
+  /// Satisfies the promise by sending an error response message.
+  /// For non-requests, nothing is done.
+  inline void deliver(error x) {
+    promise_.deliver(std::move(x));
+  }
+
+  /// Returns `*this` as an untyped response promise.
+  inline operator response_promise& () {
+    return promise_;
+  }
+
+  /// Queries whether this promise is a valid promise that is not satisfied yet.
+  inline bool pending() const {
+    return promise_.pending();
   }
 
 private:

--- a/libcaf_core/src/response_promise.cpp
+++ b/libcaf_core/src/response_promise.cpp
@@ -18,23 +18,17 @@
  ******************************************************************************/
 
 #include <utility>
+#include <algorithm>
 
 #include "caf/local_actor.hpp"
 #include "caf/response_promise.hpp"
 
 namespace caf {
 
-/*
-response_promise::response_promise(local_actor* self, actor_addr source,
-                                   forwarding_stack stages,
-                                   message_id id)
-    : self_(self),
-      source_(std::move(source)),
-      stages_(std::move(stages)),
-      id_(id) {
-  CAF_ASSERT(id.is_response() || ! id.valid());
+response_promise::response_promise()
+    : self_(nullptr) {
+  // nop
 }
-*/
 
 response_promise::response_promise(local_actor* self, mailbox_element& src)
     : self_(self),
@@ -44,24 +38,30 @@ response_promise::response_promise(local_actor* self, mailbox_element& src)
   src.mid.mark_as_answered();
 }
 
-void response_promise::deliver_impl(message msg) const {
-  if (! valid())
-    return;
-  if (stages_.empty()) {
-    source_->enqueue(self_->address(), id_.response_id(),
-                     std::move(msg), self_->context());
-    return;
-  }
-  auto next = std::move(stages_.back());
-  stages_.pop_back();
-  next->enqueue(mailbox_element::make(std::move(source_), id_,
-                                      std::move(stages_), std::move(msg)),
-                self_->context());
-}
-
-void response_promise::deliver(error x) const {
+void response_promise::deliver(error x) {
   if (id_.valid())
     deliver_impl(make_message(std::move(x)));
+}
+
+void response_promise::deliver_impl(message msg) {
+  if (! stages_.empty()) {
+    auto next = std::move(stages_.back());
+    stages_.pop_back();
+    next->enqueue(mailbox_element::make(std::move(source_), id_,
+                                        std::move(stages_), std::move(msg)),
+                  self_->context());
+    return;
+  }
+  if (source_) {
+    source_->enqueue(self_->address(), id_.response_id(),
+                     std::move(msg), self_->context());
+    source_ = invalid_actor_addr;
+    return;
+  }
+  if (self_)
+    CAF_LOG_ERROR("response promise already satisfied");
+  else
+    CAF_LOG_ERROR("invalid response promise");
 }
 
 } // namespace caf

--- a/libcaf_core/test/typed_response_promise.cpp
+++ b/libcaf_core/test/typed_response_promise.cpp
@@ -30,13 +30,18 @@ using namespace caf;
 
 namespace {
 
-using foo_actor = typed_actor<replies_to<get_atom, int>::with<int>,
+using foo_actor = typed_actor<replies_to<int>::with<int>,
+                              replies_to<get_atom, int>::with<int>,
                               replies_to<get_atom, int, int>::with<int, int>,
+                              replies_to<get_atom, double>::with<double>,
+                              replies_to<get_atom, double, double>
+                              ::with<double, double>,
                               reacts_to<put_atom, int, int>,
                               reacts_to<put_atom, int, int, int>>;
 
 using foo_promise = typed_response_promise<int>;
 using foo2_promise = typed_response_promise<int, int>;
+using foo3_promise = typed_response_promise<double>;
 
 class foo_actor_impl : public foo_actor::base {
 public:
@@ -46,6 +51,12 @@ public:
 
   behavior_type make_behavior() override {
     return {
+      [=](int x) -> foo_promise {
+         auto resp = response(x * 2);
+         CAF_CHECK(! resp.pending());
+         resp.deliver(x * 4); // has no effect
+         return resp;
+      },
       [=](get_atom, int x) -> foo_promise {
         auto calculator = spawn([](event_based_actor* self) -> behavior {
           return {
@@ -72,7 +83,23 @@ public:
         send(calculator, next_id_, x, y);
         auto& entry = promises2_[next_id_++];
         entry = make_response_promise();
+        // verify move semantics
+        CAF_CHECK(entry.pending());
+        foo2_promise tmp(std::move(entry));
+        CAF_CHECK(! entry.pending());
+        CAF_CHECK(tmp.pending());
+        entry = std::move(tmp);
+        CAF_CHECK(entry.pending());
+        CAF_CHECK(! tmp.pending());
         return entry;
+      },
+      [=](get_atom, double) -> foo3_promise {
+        foo3_promise resp = make_response_promise();
+        resp.deliver(make_error(sec::unexpected_message));
+        return resp;
+      },
+      [=](get_atom, double x, double y) {
+        return response(x * 2, y * 2);
       },
       [=](put_atom, int promise_id, int x) {
         auto i = promises_.find(promise_id);
@@ -98,7 +125,19 @@ private:
 };
 
 struct fixture {
+  fixture()
+      : self(system, true),
+        foo(system.spawn<foo_actor_impl>()) {
+    // nop
+  }
+
+  ~fixture() {
+    self->send_exit(foo, exit_reason::kill);
+  }
+
   actor_system system;
+  scoped_actor self;
+  foo_actor foo;
 };
 
 } // namespace <anonymous>
@@ -106,8 +145,10 @@ struct fixture {
 CAF_TEST_FIXTURE_SCOPE(typed_spawn_tests, fixture)
 
 CAF_TEST(typed_response_promise) {
-  scoped_actor self{system};
-  auto foo = self->spawn<foo_actor_impl>();
+  typed_response_promise<int> resp;
+  resp.deliver(1); // delivers on an invalid promise has no effect
+  CAF_CHECK_EQUAL(static_cast<void*>(&static_cast<response_promise&>(resp)),
+                  static_cast<void*>(&resp));
   self->request(foo, get_atom::value, 42).receive(
     [](int x) {
       CAF_CHECK_EQUAL(x, 84);
@@ -119,7 +160,67 @@ CAF_TEST(typed_response_promise) {
       CAF_CHECK_EQUAL(y, 104);
     }
   );
-  self->send_exit(foo, exit_reason::user_shutdown);
+  self->request(foo, get_atom::value, 3.14, 3.14).receive(
+    [](double x, double y) {
+      CAF_CHECK_EQUAL(x, 3.14 * 2);
+      CAF_CHECK_EQUAL(y, 3.14 * 2);
+    },
+    [](const error& err) {
+      CAF_ERROR("unexpected error response message received: "
+                << to_string(err));
+    }
+  );
+}
+
+CAF_TEST(typed_response_promise_chained) {
+  auto composed = foo * foo * foo;
+  self->request(composed, 1).receive(
+    [](int v) {
+      CAF_CHECK_EQUAL(v, 8);
+    },
+    [](const error& err) {
+      CAF_ERROR("unexpected error response message received: "
+                << to_string(err));
+    }
+  );
+}
+
+// verify that only requests get an error response message
+CAF_TEST(error_response_message) {
+  self->request(foo, get_atom::value, 3.14).receive(
+    [](double) {
+      CAF_ERROR("unexpected ordinary response message received");
+    },
+    [](const error& err) {
+      CAF_CHECK_EQUAL(err.code(), static_cast<uint8_t>(sec::unexpected_message));
+    }
+  );
+  self->send(foo, get_atom::value, 3.14);
+  self->send(foo, get_atom::value, 42);
+  self->receive(
+    [](int x) {
+      CAF_CHECK_EQUAL(x, 84);
+    },
+    [](double x) {
+      CAF_ERROR("unexpected ordinary response message received: " << x);
+    }
+  );
+}
+
+// verify that delivering to a satisfied promise has no effect
+CAF_TEST(satisfied_promise) {
+  self->send(foo, 1);
+  self->send(foo, get_atom::value, 3.14, 3.14);
+  int i = 0;
+  self->receive_for(i, 2) (
+    [](int x) {
+      CAF_CHECK_EQUAL(x, 1 * 2);
+    },
+    [](double x, double y) {
+      CAF_CHECK_EQUAL(x, 3.14 * 2);
+      CAF_CHECK_EQUAL(y, 3.14 * 2);
+    }
+  );
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()


### PR DESCRIPTION
1) Fix issue that promise doesn't get invalidated after delivering in non-chained cases
2) Fix issue that typed promise delivers error response message to non-request senders
3) Add move semantics to typed promise
4) Add `typed_response_promise::valid()`
5) Add `local_actor::make_ready_response_promise()`
6) Improve unit test

IMHO, `pending()` would be a better name than `valid()`. I also thought about the name `make_fulfilled_response_promise()`. But then, I realised that the standard library has been using the term `ready` (see [here](http://en.cppreference.com/w/cpp/thread/promise)), and we should follow existing practice. There is `std::future::valid()`, but no similar things for `std::promise`. The name `valid()` seems a little bit odd and counter-intuitive on response promise. A fulfilled promise should be a valid promise. It's just closed an no longer pending. Users are even tempted to expect a valid promise to be a fulfilled promise, given the semantics of `std::future::valid()`.

Relates to #353