### PR TITLE
Improve typed/untyped response promise cast

### DIFF
--- a/libcaf_core/caf/all.hpp
+++ b/libcaf_core/caf/all.hpp
@@ -77,7 +77,6 @@
 #include "caf/abstract_channel.hpp"
 #include "caf/may_have_timeout.hpp"
 #include "caf/message_priority.hpp"
-#include "caf/response_promise.hpp"
 #include "caf/binary_serializer.hpp"
 #include "caf/event_based_actor.hpp"
 #include "caf/primitive_variant.hpp"
@@ -86,6 +85,7 @@
 #include "caf/binary_deserializer.hpp"
 #include "caf/scoped_execution_unit.hpp"
 #include "caf/typed_continue_helper.hpp"
+#include "caf/typed_response_promise.hpp"
 #include "caf/typed_event_based_actor.hpp"
 
 #include "caf/decorator/adapter.hpp"

--- a/libcaf_core/caf/typed_response_promise.hpp
+++ b/libcaf_core/caf/typed_response_promise.hpp
@@ -35,8 +35,8 @@ public:
   /// Constructs an invalid response promise.
   typed_response_promise() = default;
 
-  inline typed_response_promise(response_promise promise)
-      : promise_(std::move(promise)) {
+  inline typed_response_promise(local_actor* self, mailbox_element& src)
+      : promise_(self, src) {
     // nop
   }
 
@@ -44,6 +44,11 @@ public:
   typed_response_promise(const typed_response_promise&) = default;
   typed_response_promise& operator=(typed_response_promise&&) = default;
   typed_response_promise& operator=(const typed_response_promise&) = default;
+
+  /// Implicitly convertible to untyped response promise.
+  inline operator response_promise& () {
+    return promise_;
+  }
 
   /// Satisfies the promise by sending a non-error response message.
   template <class U, class... Us>
@@ -63,11 +68,6 @@ public:
   /// For non-requests, nothing is done.
   inline void deliver(error x) {
     promise_.deliver(std::move(x));
-  }
-
-  /// Returns `*this` as an untyped response promise.
-  inline operator response_promise& () {
-    return promise_;
   }
 
   /// Queries whether this promise is a valid promise that is not satisfied yet.

--- a/libcaf_core/src/local_actor.cpp
+++ b/libcaf_core/src/local_actor.cpp
@@ -997,16 +997,6 @@ void local_actor::delayed_send_impl(message_id mid, const channel& dest,
                                     mid, std::move(msg));
 }
 
-response_promise local_actor::make_response_promise() {
-  auto& ptr = current_element_;
-  if (! ptr)
-    return {};
-  auto& mid = ptr->mid;
-  if (mid.is_answered())
-    return {};
-  return {this, *ptr};
-}
-
 const char* local_actor::name() const {
   return "actor";
 }

--- a/libcaf_core/test/typed_response_promise.cpp
+++ b/libcaf_core/test/typed_response_promise.cpp
@@ -68,7 +68,7 @@ public:
         });
         send(calculator, next_id_, x);
         auto& entry = promises_[next_id_++];
-        entry = make_response_promise();
+        entry = make_response_promise<foo_promise>();
         return entry;
       },
       [=](get_atom, int x, int y) -> foo2_promise {
@@ -82,7 +82,7 @@ public:
         });
         send(calculator, next_id_, x, y);
         auto& entry = promises2_[next_id_++];
-        entry = make_response_promise();
+        entry = make_response_promise<foo2_promise>();
         // verify move semantics
         CAF_CHECK(entry.pending());
         foo2_promise tmp(std::move(entry));
@@ -94,7 +94,7 @@ public:
         return entry;
       },
       [=](get_atom, double) -> foo3_promise {
-        foo3_promise resp = make_response_promise();
+        auto resp = make_response_promise<double>();
         resp.deliver(make_error(sec::unexpected_message));
         return resp;
       },
@@ -147,8 +147,6 @@ CAF_TEST_FIXTURE_SCOPE(typed_spawn_tests, fixture)
 CAF_TEST(typed_response_promise) {
   typed_response_promise<int> resp;
   resp.deliver(1); // delivers on an invalid promise has no effect
-  CAF_CHECK_EQUAL(static_cast<void*>(&static_cast<response_promise&>(resp)),
-                  static_cast<void*>(&resp));
   self->request(foo, get_atom::value, 42).receive(
     [](int x) {
       CAF_CHECK_EQUAL(x, 84);


### PR DESCRIPTION
Implicit conversion from untyped promise to typed promise is forbidden. Use `response_promise_cast` to cast between typed and untyped promises explicitly. To cast from typed to untyped, do
~~~C++
auto y = response_promise_cast(std::move(x));
~~~
To cast from untyped to typed, do
~~~C++
auto y = response_promise_cast<int, int>(std::move(x));
~~~
or equivalently
~~~C++
auto y = response_promise_cast<typed_response_promise<int, int>>(std::move(x));
~~~
The second form is to accommodate usage like
~~~C++
using typed_promise = typed_response_promise<int, int>;
auto y = response_promise_cast<typed_promise>(std::move(x));
~~~
Added an `local_actor::make_response_promise()` overload to return typed promise. To return untyped promise, do
~~~C++
auto x = make_response_promise();
~~~
To return typed promise, do
~~~C++
auto x = make_response_promise<int, int>();
~~~
or equivalently
~~~C++
auto x = make_response_promise<typed_response_promise<int, int>>();
~~~