### PR TITLE
Add stream `<<` support for types with `to_string()`

### DIFF
--- a/libcaf_core/caf/all.hpp
+++ b/libcaf_core/caf/all.hpp
@@ -35,6 +35,7 @@
 #include "caf/channel.hpp"
 #include "caf/message.hpp"
 #include "caf/node_id.hpp"
+#include "caf/utility.hpp"
 #include "caf/anything.hpp"
 #include "caf/behavior.hpp"
 #include "caf/duration.hpp"

--- a/libcaf_core/caf/utility.hpp
+++ b/libcaf_core/caf/utility.hpp
@@ -17,75 +17,24 @@
  * http://www.boost.org/LICENSE_1_0.txt.                                      *
  ******************************************************************************/
 
-#include <sstream>
-#include <stdlib.h>
+#ifndef CAF_UTILITY_HPP
+#define CAF_UTILITY_HPP
 
-#include "caf/config.hpp"
-#include "caf/utility.hpp"
-#include "caf/exception.hpp"
-
-#ifdef CAF_WINDOWS
-#include <winerror.h>
-#else
-#include <errno.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-#endif
-
-namespace {
-
-std::string ae_what(caf::exit_reason reason) {
-  std::ostringstream oss;
-  oss << "actor exited with reason " << reason;
-  return oss.str();
-}
-
-} // namespace <anonymous>
+#include <ostream>
+#include <type_traits>
 
 namespace caf {
 
-caf_exception::~caf_exception() noexcept {
-  // nop
-}
-
-caf_exception::caf_exception(std::string x) : what_(std::move(x)) {
-  // nop
-}
-
-const char* caf_exception::what() const noexcept {
-  return what_.c_str();
-}
-
-actor_exited::~actor_exited() noexcept {
-  // nop
-}
-
-actor_exited::actor_exited(exit_reason x) : caf_exception(ae_what(x)) {
-  reason_ = x;
-}
-
-network_error::network_error(const std::string& x) : caf_exception(x) {
-  // nop
-}
-
-network_error::network_error(std::string&& x) : caf_exception(std::move(x)) {
-  // nop
-}
-
-network_error::~network_error() noexcept {
-  // nop
-}
-
-bind_failure::bind_failure(const std::string& x) : network_error(x) {
-  // nop
-}
-
-bind_failure::bind_failure(std::string&& x) : network_error(std::move(x)) {
-  // nop
-}
-
-bind_failure::~bind_failure() noexcept {
-  // nop
+/// Inserts `x` into stream `os`.
+/// Attempts `os << x` first and then `os << to_string(x)`.
+/// ADL will pull in namespace `std` and that of `T`.
+template <class CharT, class Traits, class T>
+typename std::enable_if<std::is_same<CharT, char>::value,
+                        std::basic_ostream<CharT, Traits>&>::type
+operator<<(std::basic_ostream<CharT, Traits>& os, const T& x) {
+  return os << to_string(x);
 }
 
 } // namespace caf
+
+#endif // CAF_UTILITY_HPP

--- a/libcaf_core/src/logger.cpp
+++ b/libcaf_core/src/logger.cpp
@@ -37,6 +37,7 @@
 #include "caf/string_algorithms.hpp"
 
 #include "caf/locks.hpp"
+#include "caf/utility.hpp"
 #include "caf/actor_proxy.hpp"
 #include "caf/actor_system.hpp"
 
@@ -282,7 +283,7 @@ logger::logger(actor_system& sys) : system_(sys) {
 void logger::run() {
   std::ostringstream fname;
   fname << "actor_log_" << detail::get_process_id() << "_" << time(0)
-        << "_" << to_string(system_.node())
+        << "_" << system_.node()
         << ".log";
   std::fstream out(fname.str().c_str(), std::ios::out | std::ios::app);
   std::unique_ptr<event> event;

--- a/libcaf_core/test/dynamic_spawn.cpp
+++ b/libcaf_core/test/dynamic_spawn.cpp
@@ -114,7 +114,7 @@ actor spawn_event_testee2(scoped_actor& parent) {
     behavior wait4timeout(int remaining) {
       return {
         after(chrono::milliseconds(1)) >> [=] {
-          CAF_MESSAGE("remaining: " << to_string(remaining));
+          CAF_MESSAGE("remaining: " << remaining);
           if (remaining == 1) {
             send(parent, ok_atom::value);
             quit();

--- a/libcaf_core/test/request.cpp
+++ b/libcaf_core/test/request.cpp
@@ -237,7 +237,7 @@ behavior server(event_based_actor* self) {
           return skip_message();
         },
         others >> [=] {
-          CAF_ERROR("Unexpected message:" << to_string(self->current_message()));
+          CAF_ERROR("Unexpected message:" << self->current_message());
           die();
         }
       );
@@ -246,7 +246,7 @@ behavior server(event_based_actor* self) {
       return skip_message();
     },
     others >> [=] {
-      CAF_ERROR("Unexpected message:" << to_string(self->current_message()));
+      CAF_ERROR("Unexpected message:" << self->current_message());
       die();
     }
   };
@@ -350,8 +350,7 @@ CAF_TEST(request) {
       CAF_CHECK_EQUAL(dm.reason, exit_reason::user_shutdown);
     },
     others >> [&] {
-      CAF_ERROR("Unexpected message: "
-                << to_string(self->current_message()));
+      CAF_ERROR("Unexpected message: " << self->current_message());
     }
   );
   auto mirror = system.spawn<sync_mirror>();
@@ -377,7 +376,7 @@ CAF_TEST(request) {
         if (dm.reason == exit_reason::normal) {
           return skip_message();
         }
-        CAF_ERROR("A exited for reason " << to_string(dm.reason));
+        CAF_ERROR("A exited for reason " << dm.reason);
         return none;
       }
     );
@@ -416,8 +415,7 @@ CAF_TEST(request) {
                 "synchronous request message\"");
     },
     others >> [&] {
-      CAF_ERROR("Unexpected message: "
-                     << to_string(self->current_message()));
+      CAF_ERROR("Unexpected message: " << self->current_message());
     },
     after(milliseconds(0)) >> [] {
       CAF_ERROR("Unexpected timeout");
@@ -426,8 +424,7 @@ CAF_TEST(request) {
   // mailbox should be empty now
   self->receive(
     others >> [&] {
-      CAF_ERROR("Unexpected message: "
-                << to_string(self->current_message()));
+      CAF_ERROR("Unexpected message: " << self->current_message());
     },
     after(milliseconds(0)) >> [] {
       CAF_MESSAGE("Mailbox is empty, all good");
@@ -503,8 +500,7 @@ CAF_TEST(request) {
       CAF_CHECK_EQUAL(dm.reason, exit_reason::user_shutdown);
     },
     others >> [&] {
-      CAF_ERROR("Unexpected message: "
-                << to_string(self->current_message()));
+      CAF_ERROR("Unexpected message: " << self->current_message());
     }
   );
 }

--- a/libcaf_core/test/typed_response_promise.cpp
+++ b/libcaf_core/test/typed_response_promise.cpp
@@ -166,8 +166,7 @@ CAF_TEST(typed_response_promise) {
       CAF_CHECK_EQUAL(y, 3.14 * 2);
     },
     [](const error& err) {
-      CAF_ERROR("unexpected error response message received: "
-                << to_string(err));
+      CAF_ERROR("unexpected error response message received: " << err);
     }
   );
 }
@@ -179,8 +178,7 @@ CAF_TEST(typed_response_promise_chained) {
       CAF_CHECK_EQUAL(v, 8);
     },
     [](const error& err) {
-      CAF_ERROR("unexpected error response message received: "
-                << to_string(err));
+      CAF_ERROR("unexpected error response message received: " << err);
     }
   );
 }

--- a/libcaf_io/caf/io/basp.hpp
+++ b/libcaf_io/caf/io/basp.hpp
@@ -29,6 +29,7 @@
 
 #include "caf/fwd.hpp"
 #include "caf/node_id.hpp"
+#include "caf/utility.hpp"
 #include "caf/callback.hpp"
 #include "caf/actor_addr.hpp"
 #include "caf/serializer.hpp"

--- a/libcaf_io/src/basp.cpp
+++ b/libcaf_io/src/basp.cpp
@@ -54,11 +54,11 @@ std::string to_string(message_type x) {
 std::string to_string(const header &hdr) {
   std::ostringstream oss;
   oss << "{"
-      << to_string(hdr.operation) << ", "
+      << hdr.operation << ", "
       << hdr.payload_len << ", "
       << hdr.operation_data << ", "
-      << to_string(hdr.source_node) << ", "
-      << to_string(hdr.dest_node) << ", "
+      << hdr.source_node << ", "
+      << hdr.dest_node << ", "
       << hdr.source_actor << ", "
       << hdr.dest_actor
       << "}";

--- a/libcaf_io/test/basp.cpp
+++ b/libcaf_io/test/basp.cpp
@@ -39,18 +39,12 @@
 
 namespace std {
 
-ostream& operator<<(ostream& out, const caf::io::basp::message_type& x) {
-  return out << to_string(x);
-}
-
 template <class T>
 ostream& operator<<(ostream& out, const caf::variant<caf::anything, T>& x) {
-  using std::to_string;
-  using caf::to_string;
-  using caf::io::basp::to_string;
+  using caf::operator<<;
   if (get<caf::anything>(&x) != nullptr)
     return out << "*";
-  return out << to_string(get<T>(x));
+  return out << get<T>(x);
 }
 
 } // namespace std
@@ -115,7 +109,7 @@ public:
     auto hdl = mm.named_broker<basp_broker>(atom("BASP"));
     aut_ = static_cast<basp_broker*>(actor_cast<abstract_actor*>(hdl));
     this_node_ = system.node();
-    CAF_MESSAGE("this node: " << to_string(this_node_));
+    CAF_MESSAGE("this node: " << this_node_);
     self_.reset(new scoped_actor{system});
     ahdl_ = accept_handle::from_int(1);
     mpx_->assign_tcp_doorman(aut_.get(), ahdl_);
@@ -409,7 +403,7 @@ public:
   mock_t mock(connection_handle hdl, basp::header hdr, const Ts&... xs) {
     buffer buf;
     to_buf(buf, hdr, nullptr, xs...);
-    CAF_MESSAGE("virtually send " << to_string(hdr.operation)
+    CAF_MESSAGE("virtually send " << hdr.operation
                 << " with " << (buf.size() - basp::header_size)
                 << " bytes payload");
     mpx()->virtual_send(hdl, buf);
@@ -538,7 +532,7 @@ CAF_TEST(publish_and_connect) {
 
 CAF_TEST(remote_actor_and_send) {
   constexpr const char* lo = "localhost";
-  CAF_MESSAGE("self: " << to_string(self()->address()));
+  CAF_MESSAGE("self: " << self()->address());
   mpx()->provide_scribe(lo, 4242, remote_hdl(0));
   CAF_REQUIRE(mpx()->pending_scribes().count(make_pair(lo, 4242)) == 1);
   auto mm1 = system.middleman().actor_handle();
@@ -663,7 +657,7 @@ CAF_TEST(actor_serialize_and_deserialize) {
 CAF_TEST(indirect_connections) {
   // jupiter [remote hdl 0] -> mars [remote hdl 1] -> earth [this_node]
   // (this node receives a message from jupiter via mars and responds via mars)
-  CAF_MESSAGE("self: " << to_string(self()->address()));
+  CAF_MESSAGE("self: " << self()->address());
   auto ax = accept_handle::from_int(4242);
   mpx()->provide_acceptor(4242, ax);
   system.middleman().publish(self(), 4242);
@@ -718,7 +712,7 @@ CAF_TEST(automatic_connection) {
   //  but then also establishes a connection to jupiter directly)
   mpx()->provide_scribe("jupiter", 8080, remote_hdl(0));
   CAF_CHECK(mpx()->pending_scribes().count(make_pair("jupiter", 8080)) == 1);
-  CAF_MESSAGE("self: " << to_string(self()->address()));
+  CAF_MESSAGE("self: " << self()->address());
   auto ax = accept_handle::from_int(4242);
   mpx()->provide_acceptor(4242, ax);
   system.middleman().publish(self(), 4242);

--- a/libcaf_io/test/dynamic_broker.cpp
+++ b/libcaf_io/test/dynamic_broker.cpp
@@ -79,7 +79,7 @@ void pong(event_based_actor* self) {
           return std::make_tuple(pong_atom::value, val);
         },
         [=](const down_msg& dm) {
-          CAF_MESSAGE("received down_msg{" << to_string(dm.reason) << "}");
+          CAF_MESSAGE("received down_msg{" << dm.reason << "}");
           self->quit(dm.reason);
         },
         others >> [=] {
@@ -127,20 +127,20 @@ void peer_fun(broker* self, connection_handle hdl, const actor& buddy) {
       self->send(buddy, type, value);
     },
     [=](ping_atom, int value) {
-      CAF_MESSAGE("received: " << to_string(self->current_message()));
+      CAF_MESSAGE("received: " << self->current_message());
       write(ping_atom::value, value);
     },
     [=](pong_atom, int value) {
-      CAF_MESSAGE("received: " << to_string(self->current_message()));
+      CAF_MESSAGE("received: " << self->current_message());
       write(pong_atom::value, value);
     },
     [=](const down_msg& dm) {
-      CAF_MESSAGE("received: " << to_string(self->current_message()));
+      CAF_MESSAGE("received: " << self->current_message());
       if (dm.source == buddy)
         self->quit(dm.reason);
     },
     others >> [=] {
-      CAF_MESSAGE("unexpected: " << to_string(self->current_message()));
+      CAF_MESSAGE("unexpected: " << self->current_message());
     }
   );
 }

--- a/libcaf_io/test/remote_actor.cpp
+++ b/libcaf_io/test/remote_actor.cpp
@@ -120,8 +120,7 @@ void reflector(event_based_actor* self) {
   self->become(
     others >> [=] {
       CAF_LOG_TRACE("");
-      CAF_MESSAGE("reflect and quit; sender was: "
-                  << to_string(self->current_sender()));
+      CAF_MESSAGE("reflect and quit; sender was: " << self->current_sender());
       self->quit();
       return self->current_message();
   });
@@ -147,7 +146,7 @@ void spawn5_server_impl(event_based_actor* self, actor client, group grp) {
         CAF_MESSAGE("remote client did not spawn five reflectors!");
       }
       for (auto& a : vec) {
-        CAF_MESSAGE("monitor actor: " << to_string(a));
+        CAF_MESSAGE("monitor actor: " << a);
         self->monitor(a);
       }
       CAF_MESSAGE("wait for reflected messages");
@@ -157,7 +156,7 @@ void spawn5_server_impl(event_based_actor* self, actor client, group grp) {
         [=](const std::string& x0, double x1) {
           CAF_MESSAGE((self->node() == self->current_sender()->node()
                        ? "local" : "remote")
-                      << " answer from " << to_string(self->current_sender()));
+                      << " answer from " << self->current_sender());
           CAF_CHECK_EQUAL(x0, "Hello reflectors!");
           CAF_CHECK_EQUAL(x1, 5.0);
           if (++*replies == 7) {
@@ -220,8 +219,8 @@ void spawn5_server(event_based_actor* self, actor client, bool inverted) {
         CAF_REQUIRE(remote_group != invalid_group);
         CAF_REQUIRE(self->current_sender() != invalid_actor_addr);
         CAF_CHECK(self->node() != self->current_sender()->node());
-        CAF_MESSAGE("got group: " << to_string(remote_group)
-                    << " from " << to_string(self->current_sender()));
+        CAF_MESSAGE("got group: " << remote_group
+                    << " from " << self->current_sender());
         spawn5_server_impl(self, client, remote_group);
       }
     );
@@ -239,7 +238,7 @@ void spawn5_client(event_based_actor* self) {
     [=](spawn5_atom, const group& grp) -> message {
       CAF_LOG_TRACE(CAF_ARG(grp));
       CAF_REQUIRE(grp != invalid_group);
-      CAF_MESSAGE("received: " << to_string(self->current_message()));
+      CAF_MESSAGE("received: " << self->current_message());
       actor_vector vec;
       for (int i = 0; i < 5; ++i)
         vec.push_back(self->system().spawn_in_group(grp, reflector));
@@ -426,7 +425,7 @@ private:
     return {
       [=](sync_msg_atom, float f) -> atom_value {
         CAF_LOG_TRACE("");
-        CAF_MESSAGE("received: " << to_string(current_message()));
+        CAF_MESSAGE("received: " << current_message());
         CAF_CHECK_EQUAL(f, 4.2f);
         become(await_foobars());
         return ok_atom::value;

--- a/libcaf_io/test/typed_broker.cpp
+++ b/libcaf_io/test/typed_broker.cpp
@@ -88,7 +88,7 @@ behavior pong(event_based_actor* self) {
           return std::make_tuple(pong_atom::value, val);
         },
         [=](const down_msg& dm) {
-          CAF_MESSAGE("received down_msg{" << to_string(dm.reason) << "}");
+          CAF_MESSAGE("received down_msg{" << dm.reason << "}");
           self->quit(dm.reason);
         },
         others >> [=] {

--- a/libcaf_test/caf/test/unit_test.hpp
+++ b/libcaf_test/caf/test/unit_test.hpp
@@ -33,6 +33,7 @@
 
 #include "caf/fwd.hpp"
 #include "caf/maybe.hpp"
+#include "caf/utility.hpp"
 
 #include "caf/deep_to_string.hpp"
 


### PR DESCRIPTION
Now, you can `os << x` instead of `os << to_string(x)`. What's more, in the future, you implement `to_string()` only, and you will have `os << x` support for free :-)