### PR TITLE
Implement true uniform random work stealing

### DIFF
--- a/libcaf_core/caf/policy/scheduler_policy.hpp
+++ b/libcaf_core/caf/policy/scheduler_policy.hpp
@@ -21,6 +21,7 @@
 #define CAF_POLICY_SCHEDULER_POLICY_HPP
 
 #include "caf/fwd.hpp"
+#include "caf/scheduler/abstract_coordinator.hpp"
 
 namespace caf {
 namespace policy {
@@ -30,10 +31,14 @@ namespace policy {
 class scheduler_policy {
 public:
   /// Policy-specific data fields for the coordinator.
-  struct coordinator_data { };
+  struct coordinator_data {
+    explicit coordinator_data(scheduler::abstract_coordinator*);
+  };
 
   /// Policy-specific data fields for the worker.
-  struct worker_data { };
+  struct worker_data {
+    explicit worker_data(scheduler::abstract_coordinator*);
+  };
 
   /// Enqueues a new job to coordinator.
   template <class Coordinator>

--- a/libcaf_core/caf/policy/unprofiled.hpp
+++ b/libcaf_core/caf/policy/unprofiled.hpp
@@ -20,6 +20,8 @@
 #ifndef CAF_POLICY_UNPROFILED_HPP
 #define CAF_POLICY_UNPROFILED_HPP
 
+#include "caf/scheduler/abstract_coordinator.hpp"
+
 namespace caf {
 namespace policy {
 
@@ -33,10 +35,18 @@ public:
   virtual ~unprofiled() = default;
 
   /// Policy-specific data fields for the coordinator.
-  struct coordinator_data { };
+  struct coordinator_data {
+    inline explicit coordinator_data(scheduler::abstract_coordinator*) {
+      // nop
+    }
+  };
 
   /// Policy-specific data fields for the worker.
-  struct worker_data { };
+  struct worker_data {
+    inline explicit worker_data(scheduler::abstract_coordinator*) {
+      // nop
+    }
+  };
 
   /// Performs cleanup action before a shutdown takes place.
   template <class Worker>

--- a/libcaf_core/caf/policy/work_sharing.hpp
+++ b/libcaf_core/caf/policy/work_sharing.hpp
@@ -38,6 +38,10 @@ public:
   using queue_type = std::list<resumable*>;
 
   struct coordinator_data {
+    inline explicit coordinator_data(scheduler::abstract_coordinator*) {
+      // nop
+    }
+
     queue_type queue;
     std::mutex lock;
     std::condition_variable cv;

--- a/libcaf_core/caf/scheduler/coordinator.hpp
+++ b/libcaf_core/caf/scheduler/coordinator.hpp
@@ -41,7 +41,7 @@ public:
 
   using policy_data = typename Policy::coordinator_data;
 
-  coordinator(actor_system& sys) : super(sys) {
+  coordinator(actor_system& sys) : super(sys), data_(this) {
     // nop
   }
 

--- a/libcaf_core/caf/scheduler/worker.hpp
+++ b/libcaf_core/caf/scheduler/worker.hpp
@@ -46,7 +46,8 @@ public:
       : execution_unit(&worker_parent->system()),
         max_throughput_(throughput),
         id_(worker_id),
-        parent_(worker_parent) {
+        parent_(worker_parent),
+        data_(worker_parent) {
     // nop
   }
 


### PR DESCRIPTION
In general, `rand() % n` does not generate a true discrete uniform random distribution among `[0..(n - 1)]`, unless `(RAND_MAX + 1) % n == 0`. As a result, in the previous version, workers with smaller indices are more likely to be victims.