### PR TITLE
Improve the use of random distributions

### DIFF
--- a/libcaf_core/src/actor_pool.cpp
+++ b/libcaf_core/src/actor_pool.cpp
@@ -78,13 +78,14 @@ actor_pool::policy actor_pool::random() {
     }
     void operator()(actor_system&, uplock& guard, const actor_vec& vec,
                     mailbox_element_ptr& ptr, execution_unit* host) {
-      std::uniform_int_distribution<size_t> dis(0, vec.size() - 1);
       upgrade_to_unique_lock<detail::shared_spinlock> unique_guard{guard};
-      actor selected = vec[dis(rd_)];
+      auto selected =
+          vec[dis_(rd_, decltype(dis_)::param_type(0, vec.size() - 1))];
       unique_guard.unlock();
       selected->enqueue(std::move(ptr), host);
     }
     std::random_device rd_;
+    std::uniform_int_distribution<size_t> dis_;
   };
   return impl{};
 }


### PR DESCRIPTION
As per [this](http://stackoverflow.com/a/36048705/1348273), we should store a random distribution object and reuse it if possible. This is the intended usage. Otherwise, the facility would have been designed as free functions instead of classes.