### PR TITLE
Cleanup `actor_factory` test code

### DIFF
--- a/libcaf_core/test/actor_factory.cpp
+++ b/libcaf_core/test/actor_factory.cpp
@@ -62,21 +62,12 @@ struct fixture {
 };
 
 struct test_actor_no_args : event_based_actor {
-  test_actor_no_args(actor_config& conf) : event_based_actor(conf) {
-    // nop
-  }
-
-  behavior make_behavior() override {
-    return {};
-  }
+  using event_based_actor::event_based_actor;
 };
 
 struct test_actor_one_arg : event_based_actor {
   test_actor_one_arg(actor_config& conf, int value) : event_based_actor(conf) {
     CAF_CHECK_EQUAL(value, 42);
-  }
-  behavior make_behavior() override {
-    return {};
   }
 };
 


### PR DESCRIPTION
- Remove redundant code which gives readers the false impression that a user-defined `make_behavior()` is required;
- Use [inheriting constructor](http://en.cppreference.com/w/cpp/language/using_declaration#Inheriting_constructors) (a C++11 feature) to make code cleaner.