### PR TITLE
Enhance serialization framework

### DIFF
--- a/libcaf_core/caf/detail/delegate_serialize.hpp
+++ b/libcaf_core/caf/detail/delegate_serialize.hpp
@@ -52,9 +52,19 @@ namespace detail {
 // to enable both ADL and picking up existing boost code.
 
 template <class Processor, class U>
-void delegate_serialize(Processor& proc, U& x) {
+auto delegate_serialize(Processor& proc, U& x)
+  -> decltype(serialize(proc, x, 0)) {
   using namespace boost::serialization;
   serialize(proc, x, 0);
+}
+
+// Calls `serialize(...)` without the unused version argument, which CAF
+// ignores anyway.
+
+template <class Processor, class U>
+auto delegate_serialize(Processor& proc, U& x)
+  -> decltype(serialize(proc, x)) {
+  serialize(proc, x);
 }
 
 } // namespace detail

--- a/libcaf_core/test/serialization.cpp
+++ b/libcaf_core/test/serialization.cpp
@@ -74,7 +74,7 @@ struct raw_struct {
 };
 
 template <class Processor>
-void serialize(Processor& proc, raw_struct& x, const unsigned int) {
+void serialize(Processor& proc, raw_struct& x) {
   proc & x.str;
 }
 


### PR DESCRIPTION
This patch makes the version parameter in the serialization API optional. CAF doesn't use it anyway right now and the majority of use cases won't need it either. It currently exists only for Boost compatibility, which this patch doesn't affect.