### PR TITLE
Update simple_broker.cpp

### DIFF
--- a/examples/brokers/simple_broker.cpp
+++ b/examples/brokers/simple_broker.cpp
@@ -191,7 +191,7 @@ int main(int argc, char** argv) {
     {"server,s", "run in server mode"},
     {"client,c", "run in client mode"},
     {"port,p", "set port", port},
-    {"host,H", "set host (client mode only"}
+    {"host,H", "set host (client mode only)", host}
   });
   if (! res.error.empty()) {
     cerr << res.error << endl;


### PR DESCRIPTION
fixed bug: examples/simple_broker client isn't able to specify server host with CLI option '-H'