### PR TITLE
Disable the invalid error report

### DIFF
--- a/libcaf_core/src/local_actor.cpp
+++ b/libcaf_core/src/local_actor.cpp
@@ -679,6 +679,7 @@ void local_actor::launch(execution_unit* eu, bool lazy, bool hide) {
         auto this_ptr = ptr->get();
         CAF_ASSERT(dynamic_cast<blocking_actor*>(this_ptr) != 0);
         auto self = static_cast<blocking_actor*>(this_ptr);
+        CAF_SET_LOGGER_SYS(&self->system());
         error rsn;
         std::exception_ptr eptr = nullptr;
         try {


### PR DESCRIPTION
The message below will be printed in the console when calling `delayed_send` if the log is enabled.
```
[ERROR] CAF_PUSH_AID called in file
/home/ubuntu/Softwares/actor-framework/libcaf_core/src/local_actor.cpp
on line 726 without thread-local logger pointer
```