### PR TITLE
Logging enhancements

### DIFF
--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -123,7 +123,7 @@ public:
   actor_id thread_local_aid(actor_id aid);
 
   /// Writes an entry to the log file.
-  void log(int level, const std::string& class_name,
+  void log(int level, const char* component, const std::string& class_name,
            const char* function_name, const char* file_name,
            int line_num, const std::string& msg);
 
@@ -133,13 +133,15 @@ public:
 
   class trace_helper {
   public:
-    trace_helper(std::string class_name, const char* fun_name,
-                 const char* file_name, int line_num, const std::string& msg);
+    trace_helper(const char* component, std::string class_name,
+                 const char* fun_name, const char* file_name, int line_num,
+                 const std::string& msg);
 
     ~trace_helper();
 
   private:
     logger* parent_;
+    const char* component_;
     std::string class_;
     const char* fun_name_;
     const char* file_name_;
@@ -150,9 +152,11 @@ public:
 
   static logger* current_logger();
 
-  static void log_static(int level, const std::string& class_name,
-                         const char* function_name, const char* file_name,
-                         int line_num, const std::string& msg);
+  static void log_static(int level, const char* component,
+                         const std::string& class_name,
+                         const char* function_name,
+                         const char* file_name, int line_num,
+                         const std::string& msg);
 
   /** @endcond */
 
@@ -229,9 +233,13 @@ inline caf::actor_id caf_set_aid_dummy() { return 0; }
 
 #else // CAF_LOG_LEVEL
 
+#ifndef CAF_LOG_COMPONENT
+#define CAF_LOG_COMPONENT "caf"
+#endif
+
 #define CAF_LOG_IMPL(loglvl, message)                                          \
-  caf::logger::log_static(loglvl, CAF_GET_CLASS_NAME, __func__,                \
-                          __FILE__, __LINE__,                                  \
+  caf::logger::log_static(loglvl, CAF_LOG_COMPONENT, CAF_GET_CLASS_NAME,       \
+                          __func__, __FILE__, __LINE__,                        \
                           (caf::logger::line_builder{} << message).get())
 
 #define CAF_PUSH_AID(aarg)                                                     \

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -88,6 +88,17 @@ public:
     line_builder();
 
     template <class T>
+    line_builder& operator<<(const T& x) {
+      if (! str_.empty())
+        str_ += " ";
+      std::stringstream ss;
+      ss << x;
+      str_ += ss.str();
+      behind_arg_ = false;
+      return *this;
+    }
+
+    template <class T>
     line_builder& operator<<(const arg_wrapper<T>& x) {
       if (behind_arg_)
         str_ += ", ";
@@ -99,6 +110,8 @@ public:
       behind_arg_ = true;
       return *this;
     }
+
+    line_builder& operator<<(const std::string& str);
 
     line_builder& operator<<(const char* str);
 

--- a/libcaf_core/src/logger.cpp
+++ b/libcaf_core/src/logger.cpp
@@ -136,6 +136,14 @@ logger::line_builder::line_builder() : behind_arg_(false) {
   // nop
 }
 
+logger::line_builder& logger::line_builder::operator<<(const std::string& str) {
+  if (! str_.empty())
+    str_ += " ";
+  str_ += str;
+  behind_arg_ = false;
+  return *this;
+}
+
 logger::line_builder& logger::line_builder::operator<<(const char* str) {
   if (! str_.empty())
     str_ += " ";


### PR DESCRIPTION
This change set adds a new column to the log file that represents the *component*. It is a static variable that users can change by defining `CAF_LOG_COMPONENT` prior to including `caf/logger.hpp`. If not defined, the logger will use the default component `caf`.

Moreover, one can now log any type that provides `operator<<` compatible with a `std::ostream`. The semantics are the same as with the arg wrappers: when using `<<` to stream into the log, elements are white-space separated.