### PR TITLE
Respect CAF_LOG_LEVEL

### DIFF
--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -274,11 +274,32 @@ inline caf::actor_id caf_set_aid_dummy() { return 0; }
 
 #endif // CAF_LOG_LEVEL < CAF_LOG_LEVEL_TRACE
 
+#if CAF_LOG_LEVEL >= CAF_LOG_LEVEL_DEBUG
+#  define CAF_LOG_DEBUG(output) CAF_LOG_IMPL(CAF_LOG_LEVEL_DEBUG, output)
+#endif
+
+#if CAF_LOG_LEVEL >= CAF_LOG_LEVEL_INFO
+#  define CAF_LOG_INFO(output) CAF_LOG_IMPL(CAF_LOG_LEVEL_INFO, output)
+#endif
+
+#if CAF_LOG_LEVEL >= CAF_LOG_LEVEL_WARNING
+#  define CAF_LOG_WARNING(output) CAF_LOG_IMPL(CAF_LOG_LEVEL_WARNING, output)
+#endif
+
 #endif // CAF_LOG_LEVEL
 
-#define CAF_LOG_DEBUG(output) CAF_LOG_IMPL(CAF_LOG_LEVEL_DEBUG, output)
-#define CAF_LOG_INFO(output) CAF_LOG_IMPL(CAF_LOG_LEVEL_INFO, output)
-#define CAF_LOG_WARNING(output) CAF_LOG_IMPL(CAF_LOG_LEVEL_WARNING, output)
+#ifndef CAF_LOG_INFO
+#  define CAF_LOG_INFO(output) CAF_VOID_STMT
+#endif
+
+#ifndef CAF_LOG_DEBUG
+#  define CAF_LOG_DEBUG(output) CAF_VOID_STMT
+#endif
+
+#ifndef CAF_LOG_WARNING
+#  define CAF_LOG_WARNING(output) CAF_VOID_STMT
+#endif
+
 #define CAF_LOG_ERROR(output)                                                  \
   do {                                                                         \
     CAF_PRINT_ERROR_IMPL(CAF_GET_CLASS_NAME, __func__, output);                \

--- a/libcaf_core/src/logger.cpp
+++ b/libcaf_core/src/logger.cpp
@@ -294,22 +294,22 @@ void logger::run() {
 }
 
 void logger::start() {
-# ifdef CAF_LOG_LEVEL
+#if CAF_LOG_LEVEL >= CAF_LOG_LEVEL_INFO
   const char* log_level_table[] = {"ERROR", "WARN", "INFO", "DEBUG", "TRACE"};
   thread_ = std::thread{[this] { this->run(); }};
   std::string msg = "ENTRY log level = ";
   msg += log_level_table[global_log_level];
-  log(4, "caf", "caf::logger", "run", __FILE__, __LINE__, msg);
-# endif
+  log(CAF_LOG_LEVEL_INFO, "caf", "caf::logger", "run", __FILE__, __LINE__, msg);
+#endif
 }
 
 void logger::stop() {
-# ifdef CAF_LOG_LEVEL
-  log(4, "caf", "caf::logger", "run", __FILE__, __LINE__, "EXIT");
+#if CAF_LOG_LEVEL >= CAF_LOG_LEVEL_INFO
+  log(CAF_LOG_LEVEL_INFO, "caf", "caf::logger", "run", __FILE__, __LINE__, "EXIT");
   // an empty string means: shut down
   queue_.synchronized_enqueue(queue_mtx_, queue_cv_, new event{""});
   thread_.join();
-# endif
+#endif
 }
 
 } // namespace caf


### PR DESCRIPTION
This should fix issue #488 

Wrt logger start/stop log entries, I think INFO is a more appropriate log level there instead of TRACE.