### PR TITLE
Add flare actor

### DIFF
--- a/libcaf_io/CMakeLists.txt
+++ b/libcaf_io/CMakeLists.txt
@@ -12,6 +12,8 @@ set (LIBCAF_IO_SRCS
      src/broker.cpp
      src/default_multiplexer.cpp
      src/doorman.cpp
+     src/flare.cpp
+     src/flare_actor.cpp
      src/middleman.cpp
      src/middleman_actor.cpp
      src/hook.cpp

--- a/libcaf_io/caf/io/detail/flare.hpp
+++ b/libcaf_io/caf/io/detail/flare.hpp
@@ -1,0 +1,66 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright (C) 2011 - 2016                                                  *
+ * Dominik Charousset <dominik.charousset (at) haw-hamburg.de>                *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#ifndef CAF_IO_DETAIL_FLARE_HPP
+#define CAF_IO_DETAIL_FLARE_HPP
+
+namespace caf {
+namespace io {
+namespace detail {
+
+/// An object that can be used to signal a "ready" status via a file descriptor
+/// that may be integrated with select(), poll(), etc. Though it may be used to
+/// signal availability of a resource across threads, both access to that
+/// resource and the use of the fire/extinguish functions must be performed in
+/// a thread-safe manner in order for that to work correctly.
+class flare {
+public:
+  /// Constructs a flare by opening a UNIX pipe.
+  flare();
+
+  flare(const flare&) = delete;
+  flare& operator=(const flare&) = delete;
+
+  /// Retrieves a file descriptor that will become ready if the flare has been
+  /// "fired" and not yet "extinguishedd."
+  int fd() const;
+
+  /// Puts the object in the "ready" state by writing one byte into the
+  /// underlying pipe.
+  void fire();
+
+  // Takes the object out of the "ready" state by consuming all bytes from the
+  // underlying pipe.
+  void extinguish();
+
+  /// Attempts to consume only one byte from the pipe, potentially leaving the
+  /// flare in "ready" state.
+  /// @returns `true` if one byte was read successfully from the pipe and
+  ///          `false` if the pipe had no data to be read.
+  bool extinguish_one();
+
+private:
+  int fds_[2];
+};
+
+} // namespace detail
+} // namespace io
+} // namespace caf
+
+#endif // CAF_IO_DETAIL_FLARE_HPP

--- a/libcaf_io/caf/io/detail/flare_actor.hpp
+++ b/libcaf_io/caf/io/detail/flare_actor.hpp
@@ -1,0 +1,81 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright (C) 2011 - 2016                                                  *
+ * Dominik Charousset <dominik.charousset (at) haw-hamburg.de>                *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#ifndef CAF_IO_DETAIL_FLARE_ACTOR_HPP
+#define CAF_IO_DETAIL_FLARE_ACTOR_HPP
+
+#include <type_traits>
+
+#include "caf/blocking_actor.hpp"
+
+#include "caf/io/detail/flare.hpp"
+
+namespace caf {
+namespace io {
+namespace detail {
+
+class flare_actor;
+
+} // namespace detail
+} // namespace io
+} // namespace caf
+
+namespace caf {
+namespace mixin {
+
+template <>
+struct is_blocking_requester<caf::io::detail::flare_actor> : std::true_type { };
+
+} // namespace mixin
+} // namespace caf
+
+namespace caf {
+namespace io {
+namespace detail {
+
+class flare_actor : public blocking_actor {
+public:
+  flare_actor(actor_config& sys);
+
+  void launch(execution_unit*, bool, bool) override;
+
+  void act() override;
+
+  void await_data() override;
+
+  bool await_data(timeout_type timeout) override;
+
+  void enqueue(mailbox_element_ptr ptr, execution_unit*) override;
+
+  mailbox_element_ptr dequeue() override;
+
+  const char* name() const override;
+
+  int descriptor() const;
+
+private:
+  flare flare_;
+  bool await_flare_;
+};
+
+} // namespace detail
+} // namespace io
+} // namespace caf
+
+#endif // CAF_IO_DETAIL_FLARE_ACTOR_HPP

--- a/libcaf_io/src/flare.cpp
+++ b/libcaf_io/src/flare.cpp
@@ -1,0 +1,77 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright (C) 2011 - 2016                                                  *
+ * Dominik Charousset <dominik.charousset (at) haw-hamburg.de>                *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <exception>
+
+#include "caf/io/detail/flare.hpp"
+
+namespace caf {
+namespace io {
+namespace detail {
+
+flare::flare() {
+  if (::pipe(fds_) == -1)
+    std::terminate();
+  ::fcntl(fds_[0], F_SETFD, ::fcntl(fds_[0], F_GETFD) | FD_CLOEXEC);
+  ::fcntl(fds_[1], F_SETFD, ::fcntl(fds_[1], F_GETFD) | FD_CLOEXEC);
+  ::fcntl(fds_[0], F_SETFL, ::fcntl(fds_[0], F_GETFL) | O_NONBLOCK);
+  ::fcntl(fds_[1], F_SETFL, ::fcntl(fds_[1], F_GETFL) | O_NONBLOCK);
+}
+
+int flare::fd() const {
+  return fds_[0];
+}
+
+void flare::fire() {
+  char tmp = 0;
+  for (;;) {
+    auto n = ::write(fds_[1], &tmp, 1);
+    if (n > 0)
+      break; // Success -- wrote a byte to pipe.
+    if (n < 0 && errno == EAGAIN)
+      break; // Success -- pipe is full and just need at least one byte in it.
+    // Loop, because either the byte wasn't written or we got EINTR.
+  }
+}
+
+void flare::extinguish() {
+  char tmp[256];
+  for (;;)
+    if (::read(fds_[0], tmp, sizeof(tmp)) == -1 && errno == EAGAIN)
+      break; // Pipe is now drained.
+}
+
+bool flare::extinguish_one() {
+  char tmp = 0;
+  for (;;) {
+    auto n = ::read(fds_[0], &tmp, 1);
+    if (n == 1)
+      return true; // Read one byte.
+    if (n < 0 && errno == EAGAIN)
+      return false; // No data available to read.
+  }
+}
+
+} // namespace detail
+} // namespace io
+} // namespace caf

--- a/libcaf_io/src/flare_actor.cpp
+++ b/libcaf_io/src/flare_actor.cpp
@@ -1,0 +1,129 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright (C) 2011 - 2016                                                  *
+ * Dominik Charousset <dominik.charousset (at) haw-hamburg.de>                *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include <poll.h>
+
+#include <exception>
+
+#include "caf/detail/sync_request_bouncer.hpp"
+
+#include "caf/io/detail/flare_actor.hpp"
+
+namespace caf {
+namespace io {
+namespace detail {
+
+flare_actor::flare_actor(actor_config& sys)
+    : blocking_actor{sys},
+      await_flare_{true} {
+  // Ensure that the first enqueue operation returns unblocked_reader.
+  mailbox().try_block();
+}
+
+void flare_actor::launch(execution_unit*, bool, bool) {
+  // Nothing todo here since we only extract messages via receive() calls.
+}
+
+void flare_actor::act() {
+  // Usually called from launch(). But should never happen in our
+  // implementation.
+  CAF_ASSERT(! "act() of flare_actor called");
+}
+
+void flare_actor::await_data() {
+  CAF_LOG_DEBUG("awaiting data");
+  if (! await_flare_)
+    return;
+  pollfd p = {flare_.fd(), POLLIN, 0};
+  for (;;) {
+    CAF_LOG_DEBUG("polling");
+    auto n = ::poll(&p, 1, -1);
+    if (n < 0 && errno != EAGAIN)
+      std::terminate();
+    if (n == 1) {
+      CAF_ASSERT(p.revents & POLLIN);
+      CAF_ASSERT(has_next_message());
+      await_flare_ = false;
+      return;
+    }
+  }
+}
+
+bool flare_actor::await_data(timeout_type timeout) {
+  CAF_LOG_DEBUG("awaiting data with timeout");
+  if (! await_flare_)
+    return true;
+  auto delta = timeout - timeout_type::clock::now();
+  if (delta.count() <= 0)
+    return false;
+  pollfd p = {flare_.fd(), POLLIN, 0};
+  auto n = ::poll(&p, 1, delta.count());
+  if (n < 0 && errno != EAGAIN)
+    std::terminate();
+  if (n == 1) {
+    CAF_ASSERT(p.revents & POLLIN);
+    CAF_ASSERT(has_next_message());
+    await_flare_ = false;
+    return true;
+  }
+  return false;
+}
+
+void flare_actor::enqueue(mailbox_element_ptr ptr, execution_unit*) {
+  auto mid = ptr->mid;
+  auto sender = ptr->sender;
+  switch (mailbox().enqueue(ptr.release())) {
+    case caf::detail::enqueue_result::unblocked_reader: {
+      CAF_LOG_DEBUG("firing flare");
+      flare_.fire();
+      break;
+    }
+    case caf::detail::enqueue_result::queue_closed:
+      if (mid.is_request()) {
+        caf::detail::sync_request_bouncer bouncer{exit_reason()};
+        bouncer(sender, mid);
+      }
+      break;
+    case caf::detail::enqueue_result::success:
+      break;
+  }
+}
+
+mailbox_element_ptr flare_actor::dequeue() {
+  auto msg = next_message();
+  if (!has_next_message() && mailbox().try_block()) {
+    auto extinguished = flare_.extinguish_one();
+    CAF_ASSERT(extinguished);
+    await_flare_ = true;
+  }
+  return msg;
+}
+
+const char* flare_actor::name() const {
+  return "flare_actor";
+}
+
+int flare_actor::descriptor() const {
+  return flare_.fd();
+}
+
+} // namespace detail
+} // namespace io
+} // namespace caf
+

--- a/libcaf_io/test/flare_actor.cpp
+++ b/libcaf_io/test/flare_actor.cpp
@@ -1,0 +1,116 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright (C) 2011 - 2016                                                  *
+ * Dominik Charousset <dominik.charousset (at) haw-hamburg.de>                *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include <poll.h>
+
+#include <chrono>
+
+#include "caf/config.hpp"
+
+#define CAF_SUITE flare_actor
+#include "caf/test/unit_test.hpp"
+
+#include "caf/actor_system.hpp"
+#include "caf/actor_system_config.hpp"
+#include "caf/scoped_actor.hpp"
+#include "caf/event_based_actor.hpp"
+
+#include "caf/io/detail/flare_actor.hpp"
+
+using namespace std;
+using namespace caf;
+
+namespace {
+
+bool is_ready(io::detail::flare_actor* a, long secs = 1) {
+  pollfd p = {a->descriptor(), POLLIN, 0};
+  auto n = ::poll(&p, 1, secs * 1000);
+  if (n < 0)
+    terminate();
+  return n == 1 && p.revents & POLLIN;
+}
+
+behavior dispatcher(event_based_actor* self, actor sink) {
+  return [=](int i) {
+    this_thread::sleep_for(chrono::milliseconds{100}); // simulate work
+    self->send(sink, i);
+  };
+}
+
+} // namespace <anonymous>
+
+CAF_TEST(direct) {
+  actor_system_config cfg;
+  actor_system sys{cfg};
+  scoped_actor self{sys};
+  auto a = sys.spawn<io::detail::flare_actor>();
+  auto f = actor_cast<io::detail::flare_actor*>(a);
+  CAF_MESSAGE("one message");
+  CAF_CHECK(!is_ready(f, 0));
+  self->send(a, 42);
+  CAF_CHECK(is_ready(f));
+  f->receive([&](int i) { CAF_CHECK_EQUAL(i, 42); });
+  CAF_CHECK(!is_ready(f, 0));
+  CAF_MESSAGE("three messages");
+  self->send(a, 42);
+  self->send(a, 43);
+  self->send(a, 44);
+  CAF_CHECK(is_ready(f));
+  CAF_CHECK(!f->mailbox().empty());
+  f->receive([&](int i) { CAF_CHECK_EQUAL(i, 42); });
+  CAF_CHECK(is_ready(f));
+  CAF_CHECK(!f->mailbox().empty());
+  f->receive([&](int i) { CAF_CHECK_EQUAL(i, 43); });
+  CAF_CHECK(is_ready(f));
+  CAF_CHECK(!f->mailbox().empty());
+  f->receive([&](int i) { CAF_CHECK_EQUAL(i, 44); });
+  CAF_CHECK(!is_ready(f, 0));
+  CAF_CHECK(f->mailbox().empty());
+}
+
+CAF_TEST(indirect) {
+  actor_system_config cfg;
+  actor_system sys{cfg};
+  scoped_actor self{sys};
+  auto a = self->spawn<io::detail::flare_actor, linked>();
+  auto b = self->spawn<linked>(dispatcher, a);
+  auto c = self->spawn<linked>(dispatcher, b);
+  auto d = self->spawn<linked>(dispatcher, c);
+  auto f = actor_cast<io::detail::flare_actor*>(a);
+  CAF_MESSAGE("one message");
+  self->send(d, 42);
+  CAF_CHECK(is_ready(f, 1));
+  f->receive([&](int i) { CAF_CHECK_EQUAL(i, 42); });
+  CAF_CHECK(!is_ready(f, 0));
+  CAF_MESSAGE("three messages");
+  self->send(d, 42);
+  self->send(d, 43);
+  self->send(d, 44);
+  CAF_CHECK(is_ready(f, 1));
+  CAF_CHECK(!f->mailbox().empty());
+  f->receive([&](int i) { CAF_CHECK_EQUAL(i, 42); });
+  CAF_CHECK(is_ready(f));
+  CAF_CHECK(!f->mailbox().empty());
+  f->receive([&](int i) { CAF_CHECK_EQUAL(i, 43); });
+  CAF_CHECK(is_ready(f));
+  CAF_CHECK(!f->mailbox().empty());
+  f->receive([&](int i) { CAF_CHECK_EQUAL(i, 44); });
+  CAF_CHECK(!is_ready(f, 0));
+  CAF_CHECK(f->mailbox().empty());
+}


### PR DESCRIPTION
This change set introduces a "flare", a UNIX pipe that exposes a file descriptor to signal readiness, as well as a "flare actor", which is a blocking actor that exposes the flare's descriptor for testing mailbox emptiness. This enables use of blocking actors in combination with existing descriptor-based event loops, e.g.,:

```cpp
auto fd = get_descriptor_from_flare_actor();
pollfd p = {fd, POLLIN, {}};
auto n = ::poll(&p, 1, -1); // block until a message arrives
if (n == 1)
  assert(p.revents & POLLIN);
```