### PR TITLE
Fix compile error

### DIFF
--- a/libcaf_core/caf/mixin/sender.hpp
+++ b/libcaf_core/caf/mixin/sender.hpp
@@ -71,7 +71,7 @@ public:
                   "statically typed actors; use anon_send() or request() when "
                   "communicating with dynamically typed actors");
     static_assert(res_t::valid, "receiver does not accept given message");
-    static_assert(std::is_same<typename res_t::type, type_list<>>::value
+    static_assert(is_void_response<typename res_t::type>::value
                   || response_type_unbox<
                        signatures_of_t<Subtype>,
                        typename res_t::type

--- a/libcaf_core/test/typed_spawn.cpp
+++ b/libcaf_core/test/typed_spawn.cpp
@@ -260,6 +260,8 @@ maybe_string_delegator(maybe_string_actor::pointer self, maybe_string_actor x) {
 
 using int_actor = typed_actor<replies_to<int>::with<int>>;
 
+using float_actor = typed_actor<reacts_to<float>>;
+
 int_actor::behavior_type int_fun() {
   return {
     [](int i) { return i * i; }
@@ -293,6 +295,25 @@ behavior foo2(event_based_actor* self) {
     [=](int i, int_actor server) {
       self->delegate(server, i);
       self->quit();
+    }
+  };
+}
+
+float_actor::behavior_type float_fun(float_actor::pointer self) {
+  return {
+    [=](float a) {
+      CAF_CHECK_EQUAL(a, 1.0f);
+      self->quit(exit_reason::user_shutdown);
+    }
+  };
+}
+
+int_actor::behavior_type foo3(int_actor::pointer self) {
+  auto b = self->spawn<linked>(float_fun);
+  self->send(b, 1.0f);
+  return {
+    [=](int) {
+      return 0;
     }
   };
 }
@@ -452,6 +473,7 @@ CAF_TEST(sending_typed_actors) {
       CAF_CHECK_EQUAL(i, 100);
     }
   );
+  self->spawn(foo3);
 }
 
 CAF_TEST(sending_typed_actors_and_down_msg) {


### PR DESCRIPTION
The compile error could be reproduced using the code fragment below:
```C++
using foo_handle = caf::typed_actor<caf::reacts_to<std::string>>;

using bar_handle = caf::typed_actor<caf::reacts_to<int>>;

foo_handle::behavior_type foo(foo_handle::pointer self) {
  return {
    [=](const std::string& str) {
      caf::aout(self) << str << std::endl;
      self->quit();
    }
  };
}

bar_handle::behavior_type bar(bar_handle::pointer self) {
  auto f = self->spawn<caf::linked>(foo);
  self->send(f, "Hello, world!");
  return {
    [=](int) {
      // nop
    }
  };
}
```