### PR TITLE
Deprecate .unsafe functions of typed_actor

### DIFF
--- a/libcaf_core/caf/function_view.hpp
+++ b/libcaf_core/caf/function_view.hpp
@@ -135,9 +135,7 @@ class function_view {
 public:
   using type = Actor;
 
-  function_view(duration rel_timeout = infinite)
-      : timeout(rel_timeout),
-        impl_(unsafe_actor_handle_init) {
+  function_view(duration rel_timeout = infinite) : timeout(rel_timeout) {
     // nop
   }
 
@@ -164,7 +162,7 @@ public:
   function_view& operator=(function_view&& x) {
     timeout = x.timeout;
     assign(x.impl_);
-    x.assign(unsafe_actor_handle_init);
+    x.reset();
     return *this;
   }
 
@@ -195,16 +193,21 @@ public:
   }
 
   void assign(type x) {
-    if (impl_.unsafe() && !x.unsafe())
+    if (!impl_ && x)
       new_self(x);
-    if (!impl_.unsafe() && x.unsafe())
+    if (impl_ && !x)
       self_.~scoped_actor();
     impl_.swap(x);
   }
 
+  void reset() {
+    self_.~scoped_actor();
+    impl_ = type();
+  }
+
   /// Checks whether this function view has an actor assigned to it.
   explicit operator bool() const {
-    return !impl_.unsafe();
+    return static_cast<bool>(impl_);
   }
 
   duration timeout;

--- a/libcaf_core/caf/typed_actor.hpp
+++ b/libcaf_core/caf/typed_actor.hpp
@@ -125,6 +125,7 @@ class typed_actor : detail::comparable<typed_actor<Sigs...>>,
   using stateful_broker_pointer =
     stateful_actor<State, broker_base>*;
 
+  typed_actor() = default;
   typed_actor(typed_actor&&) = default;
   typed_actor(const typed_actor&) = default;
   typed_actor& operator=(typed_actor&&) = default;
@@ -165,7 +166,7 @@ class typed_actor : detail::comparable<typed_actor<Sigs...>>,
     return *this;
   }
 
-  typed_actor(const unsafe_actor_handle_init_t&) {
+  explicit typed_actor(const unsafe_actor_handle_init_t&) CAF_DEPRECATED {
     // nop
   }
 
@@ -206,7 +207,7 @@ class typed_actor : detail::comparable<typed_actor<Sigs...>>,
 
   /// Queries whether this object was constructed using
   /// `unsafe_actor_handle_init` or is in moved-from state.
-  bool unsafe() const {
+  bool unsafe() const CAF_DEPRECATED {
     return !ptr_;
   }
 
@@ -250,8 +251,6 @@ class typed_actor : detail::comparable<typed_actor<Sigs...>>,
   /// @endcond
 
 private:
-  typed_actor() = default;
-
   actor_control_block* get() const noexcept {
     return ptr_.get();
   }

--- a/libcaf_io/src/middleman.cpp
+++ b/libcaf_io/src/middleman.cpp
@@ -101,9 +101,7 @@ actor_system::module* middleman::make(actor_system& sys, detail::type_list<>) {
   return new impl(sys);
 }
 
-middleman::middleman(actor_system& sys)
-    : system_(sys),
-      manager_(unsafe_actor_handle_init) {
+middleman::middleman(actor_system& sys) : system_(sys) {
   // nop
 }
 

--- a/libcaf_io/test/remote_spawn.cpp
+++ b/libcaf_io/test/remote_spawn.cpp
@@ -89,7 +89,7 @@ void run_client(int argc, char** argv, uint16_t port) {
   auto f1 = make_function_view(*calc);
   CAF_REQUIRE_EQUAL(f1(add_atom::value, 10, 20), 30);
   CAF_REQUIRE_EQUAL(f1(sub_atom::value, 10, 20), -10);
-  f1.assign(unsafe_actor_handle_init);
+  f1.reset();
   anon_send_exit(*calc, exit_reason::kill);
   mm.close(port);
 }


### PR DESCRIPTION
@Neverlord it seems that you forgot `typed_actor`. ;)