### PR TITLE
Port to Cygwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lib/*
 manual
 *.swp
 bii/*
+.idea/
 libcaf_core/caf/detail/build_config.hpp
 .ycm_extra_conf.pyc
 blog_release_note.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.4)
 project(caf C CXX)
 
 # be nice to vim users
@@ -266,7 +266,7 @@ endif(CAF_ENABLE_ADDRESS_SANITIZER)
 if(NOT APPLE AND NOT WIN32)
   set(EXTRA_FLAGS "${EXTRA_FLAGS} -pthread")
 endif()
-# -fPIC generates warnings on MinGW plus extra setup steps needed on MinGW
+# -fPIC generates warnings on MinGW and Cygwin plus extra setup steps needed on MinGW
 if(MINGW)
   add_definitions(-D_WIN32_WINNT=0x0600)
   add_definitions(-DWIN32)
@@ -274,6 +274,8 @@ if(MINGW)
   set(LD_FLAGS "ws2_32 -liphlpapi")
   # build static to avoid runtime dependencies to GCC libraries
   set(EXTRA_FLAGS "${EXTRA_FLAGS} -static")
+elseif(CYGWIN)
+  set(EXTRA_FLAGS "${EXTRA_FLAGS} -U__STRICT_ANSI__")
 else()
   set(EXTRA_FLAGS "${EXTRA_FLAGS} -fPIC")
 endif()

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -106,7 +106,9 @@ if (NOT CAF_BUILD_STATIC_ONLY)
                         SOVERSION ${CAF_VERSION}
                         VERSION ${CAF_VERSION}
                         OUTPUT_NAME caf_core)
-  if(NOT WIN32)
+  if (CYGWIN)
+    install(TARGETS libcaf_core_shared RUNTIME DESTINATION bin)
+  elseif (NOT WIN32)
     install(TARGETS libcaf_core_shared LIBRARY DESTINATION lib)
   endif()
   add_dependencies(libcaf_core_shared libcaf_core)

--- a/libcaf_core/caf/config.hpp
+++ b/libcaf_core/caf/config.hpp
@@ -170,12 +170,14 @@
 #  endif
 #elif defined(__FreeBSD__)
 #  define CAF_BSD
+#elif defined(__CYGWIN__)
+#  define CAF_CYGWIN
 #elif defined(WIN32) || defined(_WIN32)
 #  define CAF_WINDOWS
 #else
 #  error Platform and/or compiler not supportet
 #endif
-#if defined(CAF_MACOS) || defined(CAF_LINUX) || defined(CAF_BSD)
+#if defined(CAF_MACOS) || defined(CAF_LINUX) || defined(CAF_BSD) || defined(CAF_CYGWIN)
 #  define CAF_POSIX
 #endif
 

--- a/libcaf_core/caf/scheduler/profiled_coordinator.hpp
+++ b/libcaf_core/caf/scheduler/profiled_coordinator.hpp
@@ -110,6 +110,11 @@ public:
       m.mem = pmc.PeakWorkingSetSize / 1024;
       m.usr = to_usec(user_time);
       m.sys = to_usec(kernel_time);
+#     elif defined(CAF_CYGWIN)
+      // TODO - decide what to do here instead of zeros
+      m.usr = usec::zero();
+      m.sys = usec::zero();
+      m.mem = 0;
 #     else
       ::rusage ru;
       ::getrusage(RUSAGE_THREAD, &ru);

--- a/libcaf_core/src/get_mac_addresses.cpp
+++ b/libcaf_core/src/get_mac_addresses.cpp
@@ -76,7 +76,7 @@ std::vector<iface_info> get_mac_addresses() {
 } // namespace detail
 } // namespace caf
 
-#elif defined(CAF_LINUX) || defined(CAF_ANDROID)
+#elif defined(CAF_LINUX) || defined(CAF_ANDROID) || defined(CAF_CYGWIN)
 
 #include <vector>
 #include <string>

--- a/libcaf_core/src/get_root_uuid.cpp
+++ b/libcaf_core/src/get_root_uuid.cpp
@@ -61,7 +61,7 @@ std::string get_root_uuid() {
 } // namespace detail
 } // namespace caf
 
-#elif defined(CAF_LINUX) || defined(CAF_BSD)
+#elif defined(CAF_LINUX) || defined(CAF_BSD) || defined(CAF_CYGWIN)
 
 #include <vector>
 #include <string>

--- a/libcaf_io/CMakeLists.txt
+++ b/libcaf_io/CMakeLists.txt
@@ -39,7 +39,9 @@ if (NOT CAF_BUILD_STATIC_ONLY)
                         SOVERSION ${CAF_VERSION}
                         VERSION ${CAF_VERSION}
                         OUTPUT_NAME caf_io)
-  if(NOT WIN32)
+  if (CYGWIN)
+    install(TARGETS libcaf_io_shared RUNTIME DESTINATION bin)
+  elseif (NOT WIN32)
     install(TARGETS libcaf_io_shared LIBRARY DESTINATION lib)
   endif()
   add_dependencies(libcaf_io_shared libcaf_io)

--- a/libcaf_io/src/default_multiplexer.cpp
+++ b/libcaf_io/src/default_multiplexer.cpp
@@ -135,7 +135,7 @@ expected<uint16_t> remote_port_of_fd(native_socket fd);
   }
 
   expected<void> allow_sigpipe(native_socket fd, bool new_value) {
-#   ifndef CAF_LINUX
+#   if !defined(CAF_LINUX) && !defined(CAF_CYGWIN)
     int value = new_value ? 0 : 1;
     CALL_CFUN(res, cc_zero, "setsockopt",
               setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &value,


### PR DESCRIPTION
Added Cygwin support for #517 

I tested with `./configure` and no options.

There is one TODO so far - in `profiled_coordinator.hpp` I hacked around the fact that Cygwin doesn't have an `RUSAGE_THREAD`.  I haven't looked in detail into what that class is doing and how best to handle the Cygwin situation.

