### PR TITLE
Make logger more configurable

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -34,6 +34,7 @@ set (LIBCAF_CORE_SRCS
      src/behavior_impl.cpp
      src/blocking_actor.cpp
      src/blocking_behavior.cpp
+     src/color.cpp
      src/concatenated_tuple.cpp
      src/config_option.cpp
      src/continue_helper.cpp

--- a/libcaf_core/caf/actor_system_config.hpp
+++ b/libcaf_core/caf/actor_system_config.hpp
@@ -252,6 +252,13 @@ public:
   size_t work_stealing_relaxed_steal_interval;
   size_t work_stealing_relaxed_sleep_duration_us;
 
+  // -- config parameters for the logger ---------------------------------------
+
+  std::string logger_filename;
+  std::string logger_verbosity;
+  bool logger_console;
+  bool logger_colorize;
+
   // -- config parameters of the middleman -------------------------------------
 
   atom_value middleman_network_backend;

--- a/libcaf_core/caf/actor_system_config.hpp
+++ b/libcaf_core/caf/actor_system_config.hpp
@@ -255,9 +255,8 @@ public:
   // -- config parameters for the logger ---------------------------------------
 
   std::string logger_filename;
-  std::string logger_verbosity;
-  bool logger_console;
-  bool logger_colorize;
+  atom_value logger_verbosity;
+  atom_value logger_console;
 
   // -- config parameters of the middleman -------------------------------------
 

--- a/libcaf_core/caf/actor_system_config.hpp
+++ b/libcaf_core/caf/actor_system_config.hpp
@@ -257,6 +257,7 @@ public:
   std::string logger_filename;
   atom_value logger_verbosity;
   atom_value logger_console;
+  std::string logger_filter;
 
   // -- config parameters of the middleman -------------------------------------
 

--- a/libcaf_core/caf/color.hpp
+++ b/libcaf_core/caf/color.hpp
@@ -1,0 +1,46 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright (C) 2011 - 2016                                                  *
+ * Dominik Charousset <dominik.charousset (at) haw-hamburg.de>                *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#ifndef CAF_COLOR_HPP
+#define CAF_COLOR_HPP
+
+namespace caf {
+
+enum color_face {
+  normal,
+  bold
+};
+
+enum color_value {
+  reset,
+  black,
+  red,
+  green,
+  yellow,
+  blue,
+  magenta,
+  cyan,
+  white
+};
+
+const char* color(color_value value, color_face face = normal);
+
+} // namespace caf
+
+#endif // CAF_COLOR_HPP

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -190,18 +190,6 @@ private:
 #define CAF_LOG_LEVEL_DEBUG 3
 #define CAF_LOG_LEVEL_TRACE 4
 
-#define CAF_PRINT_ERROR_IMPL(nclass, nfun, message)                            \
-  do {                                                                         \
-    caf::logger::line_builder lb;                                              \
-    lb << message;                                                             \
-    if (nclass.empty())                                                        \
-      printf("[ERROR] in %s:%d %s::%s: %s\n", __FILE__, __LINE__,              \
-             nclass.c_str(), nfun, lb.get().c_str());                          \
-    else                                                                       \
-      printf("[ERROR] in %s:%d %s: %s\n", __FILE__, __LINE__,                  \
-             nfun, lb.get().c_str());                      \
-  } while (false)
-
 #define CAF_ARG(argument) caf::logger::make_arg_wrapper(#argument, argument)
 
 #ifdef CAF_MSVC
@@ -289,6 +277,8 @@ inline caf::actor_id caf_set_aid_dummy() { return 0; }
 #  define CAF_LOG_WARNING(output) CAF_LOG_IMPL(CAF_LOG_LEVEL_WARNING, output)
 #endif
 
+#define CAF_LOG_ERROR(output) CAF_LOG_IMPL(CAF_LOG_LEVEL_ERROR, output)
+
 #endif // CAF_LOG_LEVEL
 
 #ifndef CAF_LOG_INFO
@@ -303,11 +293,9 @@ inline caf::actor_id caf_set_aid_dummy() { return 0; }
 #  define CAF_LOG_WARNING(output) CAF_VOID_STMT
 #endif
 
-#define CAF_LOG_ERROR(output)                                                  \
-  do {                                                                         \
-    CAF_PRINT_ERROR_IMPL(CAF_GET_CLASS_NAME, __func__, output);                \
-    CAF_LOG_IMPL(CAF_LOG_LEVEL_ERROR, output);                                 \
-  } while (false)
+#ifndef CAF_LOG_ERROR
+#  define CAF_LOG_ERROR(output) CAF_VOID_STMT
+#endif
 
 #ifdef CAF_LOG_LEVEL
 

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -64,8 +64,10 @@ public:
   struct event {
     event* next;
     event* prev;
+    int level;
+    std::string prefix;
     std::string msg;
-    explicit event(std::string log_message = "");
+    explicit event(int l = 0, std::string p = "", std::string m = "");
   };
 
   template <class T>
@@ -167,6 +169,7 @@ private:
   void stop();
 
   actor_system& system_;
+  int level_;
   detail::shared_spinlock aids_lock_;
   std::unordered_map<std::thread::id, actor_id> aids_;
   std::thread thread_;

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -65,9 +65,11 @@ public:
     event* next;
     event* prev;
     int level;
+    const char* component;
     std::string prefix;
     std::string msg;
-    explicit event(int l = 0, std::string p = "", std::string m = "");
+    explicit event(int l = 0, char const* c = "", std::string p = "",
+                   std::string m = "");
   };
 
   template <class T>

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -17,8 +17,8 @@
  * http://www.boost.org/LICENSE_1_0.txt.                                      *
  ******************************************************************************/
 
-#ifndef CAF_DETAIL_LOGGING_HPP
-#define CAF_DETAIL_LOGGING_HPP
+#ifndef CAF_LOGGER_HPP
+#define CAF_LOGGER_HPP
 
 #include <thread>
 #include <cstring>
@@ -320,4 +320,4 @@ inline caf::actor_id caf_set_aid_dummy() { return 0; }
 
 #endif // CAF_LOG_LEVEL
 
-#endif // CAF_DETAIL_LOGGING_HPP
+#endif // CAF_LOGGER_HPP

--- a/libcaf_core/src/actor_system.cpp
+++ b/libcaf_core/src/actor_system.cpp
@@ -242,12 +242,13 @@ actor_system::actor_system(actor_system_config& cfg)
     if (mod)
       mod->init(cfg);
   groups_.init(cfg);
+  // start logger before spawning actors (since that uses the logger)
+  logger_.start();
   // spawn config and spawn servers (lazily to not access the scheduler yet)
   static constexpr auto Flags = hidden + lazy_init;
   spawn_serv_ = actor_cast<strong_actor_ptr>(spawn<Flags>(spawn_serv_impl));
   config_serv_ = actor_cast<strong_actor_ptr>(spawn<Flags>(config_serv_impl));
   // fire up remaining modules
-  logger_.start();
   registry_.start();
   registry_.put(atom("SpawnServ"), spawn_serv_);
   registry_.put(atom("ConfigServ"), config_serv_);

--- a/libcaf_core/src/actor_system_config.cpp
+++ b/libcaf_core/src/actor_system_config.cpp
@@ -137,7 +137,9 @@ actor_system_config::actor_system_config()
   .add(logger_verbosity, "verbosity",
        "sets the verbosity (QUIET|ERROR|WARNING|INFO|DEBUG|TRACE)")
   .add(logger_console, "console",
-       "enables logging to the console via std::clog");
+       "enables logging to the console via std::clog")
+  .add(logger_filter, "filter",
+       "sets a component filter for console log messages");
   opt_group{options_, "middleman"}
   .add(middleman_network_backend, "network-backend",
        "sets the network backend to either 'default' or 'asio' (if available)")

--- a/libcaf_core/src/actor_system_config.cpp
+++ b/libcaf_core/src/actor_system_config.cpp
@@ -19,7 +19,6 @@
 
 #include "caf/actor_system_config.hpp"
 
-#include <ctime>
 #include <limits>
 #include <thread>
 #include <fstream>
@@ -27,7 +26,6 @@
 
 #include "caf/message_builder.hpp"
 
-#include "caf/detail/get_process_id.hpp"
 #include "caf/detail/parse_ini.hpp"
 
 namespace caf {
@@ -98,14 +96,8 @@ actor_system_config::actor_system_config()
   work_stealing_moderate_sleep_duration_us = 50;
   work_stealing_relaxed_steal_interval = 1;
   work_stealing_relaxed_sleep_duration_us = 10000;
-  std::ostringstream default_filename;
-  default_filename << "actor_log_" << detail::get_process_id()
-                   << "_" << time(0)
-                   << "_[NODE]" // dynamic placeholder for the node ID
-                   << ".log";
-  logger_filename = default_filename.str();
-  logger_console = false;
-  logger_colorize = false;
+  logger_filename = "actor_log_[PID]_[TIMESTAMP]_[NODE].log";
+  logger_console = atom("NONE");
   middleman_network_backend = atom("default");
   middleman_enable_automatic_connections = false;
   middleman_max_consecutive_reads = 50;
@@ -145,9 +137,7 @@ actor_system_config::actor_system_config()
   .add(logger_verbosity, "verbosity",
        "sets the verbosity (QUIET|ERROR|WARNING|INFO|DEBUG|TRACE)")
   .add(logger_console, "console",
-       "enables logging to the console via std::clog")
-  .add(logger_colorize, "colorize",
-       "colorizes console output (ignored on Windows)");
+       "enables logging to the console via std::clog");
   opt_group{options_, "middleman"}
   .add(middleman_network_backend, "network-backend",
        "sets the network backend to either 'default' or 'asio' (if available)")

--- a/libcaf_core/src/actor_system_config.cpp
+++ b/libcaf_core/src/actor_system_config.cpp
@@ -19,12 +19,15 @@
 
 #include "caf/actor_system_config.hpp"
 
+#include <ctime>
 #include <limits>
 #include <thread>
 #include <fstream>
+#include <sstream>
 
 #include "caf/message_builder.hpp"
 
+#include "caf/detail/get_process_id.hpp"
 #include "caf/detail/parse_ini.hpp"
 
 namespace caf {
@@ -95,6 +98,14 @@ actor_system_config::actor_system_config()
   work_stealing_moderate_sleep_duration_us = 50;
   work_stealing_relaxed_steal_interval = 1;
   work_stealing_relaxed_sleep_duration_us = 10000;
+  std::ostringstream default_filename;
+  default_filename << "actor_log_" << detail::get_process_id()
+                   << "_" << time(0)
+                   << "_[NODE]" // dynamic placeholder for the node ID
+                   << ".log";
+  logger_filename = default_filename.str();
+  logger_console = false;
+  logger_colorize = false;
   middleman_network_backend = atom("default");
   middleman_enable_automatic_connections = false;
   middleman_max_consecutive_reads = 50;
@@ -128,6 +139,15 @@ actor_system_config::actor_system_config()
        "sets the frequency of steal attempts during relaxed polling")
   .add(work_stealing_relaxed_sleep_duration_us, "relaxed-sleep-duration",
        "sets the sleep interval between poll attempts during relaxed polling");
+  opt_group{options_, "logger"}
+  .add(logger_filename, "filename",
+       "sets the filesystem path of the log file")
+  .add(logger_verbosity, "verbosity",
+       "sets the verbosity (QUIET|ERROR|WARNING|INFO|DEBUG|TRACE)")
+  .add(logger_console, "console",
+       "enables logging to the console via std::clog")
+  .add(logger_colorize, "colorize",
+       "colorizes console output (ignored on Windows)");
   opt_group{options_, "middleman"}
   .add(middleman_network_backend, "network-backend",
        "sets the network backend to either 'default' or 'asio' (if available)")

--- a/libcaf_core/src/color.cpp
+++ b/libcaf_core/src/color.cpp
@@ -1,0 +1,45 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright (C) 2011 - 2016                                                  *
+ * Dominik Charousset <dominik.charousset (at) haw-hamburg.de>                *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/color.hpp"
+
+#include "caf/config.hpp"
+
+namespace caf {
+
+const char* color(color_value value, color_face face) {
+#ifdef CAF_MSVC
+  return "";
+#else
+  const char* colors[9][2] = {
+    {"\033[0m", "\033[0m"},          // reset
+    {"\033[30m", "\033[1m\033[30m"}, // black
+    {"\033[31m", "\033[1m\033[31m"}, // red
+    {"\033[32m", "\033[1m\033[32m"}, // green
+    {"\033[33m", "\033[1m\033[33m"}, // yellow
+    {"\033[34m", "\033[1m\033[34m"}, // blue
+    {"\033[35m", "\033[1m\033[35m"}, // magenta
+    {"\033[36m", "\033[1m\033[36m"}, // cyan
+    {"\033[37m", "\033[1m\033[37m"}  // white
+  };
+  return colors[static_cast<size_t>(value)][static_cast<size_t>(face)];
+#endif
+}
+
+} // namespace caf

--- a/libcaf_core/src/logger.cpp
+++ b/libcaf_core/src/logger.cpp
@@ -19,7 +19,6 @@
 
 #include "caf/logger.hpp"
 
-#include <ctime>
 #include <thread>
 #include <cstring>
 #include <fstream>
@@ -39,8 +38,8 @@
 #include "caf/locks.hpp"
 #include "caf/actor_proxy.hpp"
 #include "caf/actor_system.hpp"
+#include "caf/actor_system_config.hpp"
 
-#include "caf/detail/get_process_id.hpp"
 #include "caf/detail/single_reader_queue.hpp"
 
 namespace caf {
@@ -55,11 +54,34 @@ constexpr const char* log_level_name[] = {
   "TRACE"
 };
 
+#ifndef CAF_MSVC
+namespace color {
+
+// UNIX terminal color codes
+constexpr char reset[]        = "\033[0m";
+constexpr char black[]        = "\033[30m";
+constexpr char red[]          = "\033[31m";
+constexpr char green[]        = "\033[32m";
+constexpr char yellow[]       = "\033[33m";
+constexpr char blue[]         = "\033[34m";
+constexpr char magenta[]      = "\033[35m";
+constexpr char cyan[]         = "\033[36m";
+constexpr char white[]        = "\033[37m";
+constexpr char bold_black[]   = "\033[1m\033[30m";
+constexpr char bold_red[]     = "\033[1m\033[31m";
+constexpr char bold_green[]   = "\033[1m\033[32m";
+constexpr char bold_yellow[]  = "\033[1m\033[33m";
+constexpr char bold_blue[]    = "\033[1m\033[34m";
+constexpr char bold_magenta[] = "\033[1m\033[35m";
+constexpr char bold_cyan[]    = "\033[1m\033[36m";
+constexpr char bold_white[]   = "\033[1m\033[37m";
+
+} // namespace color
+#endif
+
 #ifdef CAF_LOG_LEVEL
 static_assert(CAF_LOG_LEVEL >= 0 && CAF_LOG_LEVEL <= 4,
               "assertion: 0 <= CAF_LOG_LEVEL <= 4");
-
-constexpr int global_log_level = CAF_LOG_LEVEL;
 
 #ifdef CAF_MSVC
 thread_local
@@ -125,10 +147,12 @@ void prettify_type_name(std::string& class_name, const char* c_class_name) {
 
 } // namespace <anonymous>
 
-logger::event::event(std::string x)
+logger::event::event(int l, std::string p, std::string m)
     : next(nullptr),
       prev(nullptr),
-      msg(std::move(x)) {
+      level(l),
+      prefix(std::move(p)),
+      msg(std::move(m)) {
   // nop
 }
 
@@ -223,7 +247,9 @@ void logger::log(int level, const char* component,
                  const std::string& class_name, const char* function_name,
                  const char* c_full_file_name, int line_num,
                  const std::string& msg) {
-  CAF_ASSERT(level >= 0 && level <= 4);
+  CAF_ASSERT(level <= 4);
+  if (level > level_)
+    return;
   std::string file_name;
   std::string full_file_name = c_full_file_name;
   auto ri = find(full_file_name.rbegin(), full_file_name.rend(), '/');
@@ -238,12 +264,13 @@ void logger::log(int level, const char* component,
   }
   auto t0 = std::chrono::high_resolution_clock::now().time_since_epoch();
   auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t0).count();
-  std::ostringstream line;
-  line << ms << " " << component << " " << log_level_name[level] << " "
-       << "actor" << thread_local_aid() << " " << std::this_thread::get_id()
-       << " " << class_name << " " << function_name << " " << file_name << ":"
-       << line_num << " " << msg << std::endl;
-  queue_.synchronized_enqueue(queue_mtx_, queue_cv_, new event{line.str()});
+  std::ostringstream prefix;
+  prefix << ms << " " << component << " " << log_level_name[level] << " "
+         << "actor" << thread_local_aid() << " " << std::this_thread::get_id()
+         << " " << class_name << " " << function_name
+         << " " << file_name << ":" << line_num;
+  queue_.synchronized_enqueue(queue_mtx_, queue_cv_,
+                              new event{level, prefix.str(), msg});
 }
 
 void logger::set_current_actor_system(actor_system* x) {
@@ -273,11 +300,15 @@ logger::logger(actor_system& sys) : system_(sys) {
 }
 
 void logger::run() {
-  std::ostringstream fname;
-  fname << "actor_log_" << detail::get_process_id() << "_" << time(0)
-        << "_" << to_string(system_.node())
-        << ".log";
-  std::fstream out(fname.str().c_str(), std::ios::out | std::ios::app);
+  auto filename = system_.config().logger_filename;
+  // Replace node ID placeholder.
+  auto placeholder = std::string{"[NODE]"};
+  auto i = filename.find(placeholder);
+  if (i != std::string::npos) {
+    auto nid = to_string(system_.node());
+    filename.replace(i, placeholder.size(), nid);
+  }
+  std::fstream out(filename, std::ios::out | std::ios::app);
   std::unique_ptr<event> ptr;
   for (;;) {
     // make sure we have data to read
@@ -289,25 +320,71 @@ void logger::run() {
       out.close();
       return;
     }
-    out << ptr->msg << std::flush;
+    out << ptr->prefix << ' ' << ptr->msg << std::endl;
+    if (system_.config().logger_console) {
+#ifndef CAF_MSVC
+      if (system_.config().logger_colorize) {
+        switch (ptr->level) {
+          default:
+            break;
+          case CAF_LOG_LEVEL_ERROR:
+            std::clog << color::red;
+            break;
+          case CAF_LOG_LEVEL_WARNING:
+            std::clog << color::yellow;
+            break;
+          case CAF_LOG_LEVEL_INFO:
+            std::clog << color::green;
+            break;
+          case CAF_LOG_LEVEL_DEBUG:
+            std::clog << color::cyan;
+            break;
+          case CAF_LOG_LEVEL_TRACE:
+            std::clog << color::blue;
+            break;
+        }
+        std::clog << ptr->msg << color::reset << std::endl;
+      } else {
+#endif
+        std::clog << ptr->msg << std::endl;
+#ifndef CAF_MSVC
+      }
+#endif
+    }
   }
 }
 
 void logger::start() {
-#if defined(CAF_LOG_LEVEL) && CAF_LOG_LEVEL >= CAF_LOG_LEVEL_INFO
-  const char* log_level_table[] = {"ERROR", "WARN", "INFO", "DEBUG", "TRACE"};
+#if defined(CAF_LOG_LEVEL)
+  const char* levels[] = {"ERROR", "WARNING", "INFO", "DEBUG", "TRACE"};
+  auto& lvl = system_.config().logger_verbosity;
+  if (lvl == "QUIET")
+    return;
+  if (lvl.empty()) {
+    level_ = CAF_LOG_LEVEL;
+  } else {
+    auto i = std::find(std::begin(levels), std::end(levels), lvl);
+    if (i == std::end(levels))
+      level_ = CAF_LOG_LEVEL; // ignore invalid log levels
+    else
+      level_ = static_cast<int>(std::distance(std::begin(levels), i));
+    CAF_ASSERT(level_ >= CAF_LOG_LEVEL_ERROR && level_ <= CAF_LOG_LEVEL_TRACE);
+  }
   thread_ = std::thread{[this] { this->run(); }};
   std::string msg = "ENTRY log level = ";
-  msg += log_level_table[global_log_level];
+  msg += levels[level_];
   log(CAF_LOG_LEVEL_INFO, "caf", "caf::logger", "run", __FILE__, __LINE__, msg);
 #endif
 }
 
 void logger::stop() {
-#if defined(CAF_LOG_LEVEL) && CAF_LOG_LEVEL >= CAF_LOG_LEVEL_INFO
-  log(CAF_LOG_LEVEL_INFO, "caf", "caf::logger", "run", __FILE__, __LINE__, "EXIT");
+#if defined(CAF_LOG_LEVEL)
+  if (!thread_.joinable())
+    return;
+  log(CAF_LOG_LEVEL_INFO, "caf", "caf::logger", "run", __FILE__, __LINE__,
+      "EXIT");
   // an empty string means: shut down
-  queue_.synchronized_enqueue(queue_mtx_, queue_cv_, new event{""});
+  queue_.synchronized_enqueue(queue_mtx_, queue_cv_, new event{});
   thread_.join();
 #endif
 }

--- a/libcaf_test/caf/test/unit_test.hpp
+++ b/libcaf_test/caf/test/unit_test.hpp
@@ -32,6 +32,7 @@
 #include <iostream>
 
 #include "caf/fwd.hpp"
+#include "caf/color.hpp"
 #include "caf/optional.hpp"
 
 #include "caf/deep_to_string.hpp"
@@ -213,23 +214,6 @@ private:
   std::mutex file_mtx_;
 };
 
-enum color_face {
-  normal,
-  bold
-};
-
-enum color_value {
-  reset,
-  black,
-  red,
-  green,
-  yellow,
-  blue,
-  magenta,
-  cyan,
-  white
-};
-
 /// Drives unit test execution.
 class engine {
 public:
@@ -310,17 +294,7 @@ private:
   int argc_ = 0;
   char** argv_ = nullptr;
   char*  path_ = nullptr;
-  const char* colors_[9][2] = {
-    {"\033[0m", "\033[0m"},          // reset
-    {"\033[30m", "\033[1m\033[30m"}, // black
-    {"\033[31m", "\033[1m\033[31m"}, // red
-    {"\033[32m", "\033[1m\033[32m"}, // green
-    {"\033[33m", "\033[1m\033[33m"}, // yellow
-    {"\033[34m", "\033[1m\033[34m"}, // blue
-    {"\033[35m", "\033[1m\033[35m"}, // magenta
-    {"\033[36m", "\033[1m\033[36m"}, // cyan
-    {"\033[37m", "\033[1m\033[37m"}  // white
-  };
+  bool colorize_ = false;
   const char* check_file_ = "<none>";
   size_t check_line_ = 0;
   test* current_test_ = nullptr;
@@ -413,8 +387,8 @@ using caf_test_case_auto_fixture = caf::test::dummy_fixture;
 
 #define CAF_TEST_PRINT(level, msg, colorcode)                                  \
   (::caf::test::logger::instance(). level ()                                   \
-    << ::caf::test::engine::color(::caf::test:: colorcode )                    \
-    << "  -> " << ::caf::test::engine::color(::caf::test::reset) << msg        \
+    << ::caf::test::engine::color(::caf:: colorcode )                          \
+    << "  -> " << ::caf::test::engine::color(::caf::reset) << msg              \
     << " [line " << __LINE__ << "]\n")
 
 #define CAF_TEST_PRINT_ERROR(msg)   CAF_TEST_PRINT(info, msg, red)

--- a/libcaf_test/caf/test/unit_test_impl.hpp
+++ b/libcaf_test/caf/test/unit_test_impl.hpp
@@ -316,13 +316,7 @@ bool engine::run(bool colorize,
     // nothing to do
     return true;
   }
-  if (!colorize) {
-    for (size_t i = 0; i <= static_cast<size_t>(white); ++i) {
-      for (size_t j = 0; j <= static_cast<size_t>(bold); ++j) {
-        instance().colors_[i][j] = "";
-      }
-    }
-  }
+  instance().colorize_ = colorize;
   if (!logger::init(verbosity_console, verbosity_file, log_file)) {
     return false;
   }
@@ -475,7 +469,7 @@ bool engine::run(bool colorize,
 }
 
 const char* engine::color(color_value v, color_face t) {
-  return instance().colors_[static_cast<size_t>(v)][static_cast<size_t>(t)];
+  return instance().colorize_ ? caf::color(v, t) : "";
 }
 
 const char* engine::last_check_file() {


### PR DESCRIPTION
With this patch, users can change the following aspects of the logger via `actor_system_config`:

1. Set the name of the logger log file (`--caf#logger.filename=/path/to/file`)
2. Adjust the logger verbosity (`--caf#logger.verbosity=1`)
3. Redirect message to `std::clog`  (`--caf#logger.console=true`)
4. Colorize output according to severity level (ignored on Windows) (`--caf#logger.colorize=true`)