### PR TITLE
Scoped_actor loses messages after skipping them

### DIFF
--- a/libcaf_core/src/blocking_actor.cpp
+++ b/libcaf_core/src/blocking_actor.cpp
@@ -396,13 +396,16 @@ void blocking_actor::receive_impl(receive_cond& rcc,
         }
       }
     } while (skipped && !timed_out);
-    if (timed_out)
+    if (timed_out) {
       bhvr.handle_timeout();
-    else
-      seq.erase_and_advance();
-    // check loop post condition
-    if (!rcc.post())
-      return;
+      if (!rcc.post())
+        return;
+    } else {
+      if (rcc.post())
+        seq.erase_and_advance();
+      else
+        return;
+    }
   }
 }
 

--- a/libcaf_core/test/blocking_actor.cpp
+++ b/libcaf_core/test/blocking_actor.cpp
@@ -81,4 +81,112 @@ CAF_TEST(timeout_in_scoped_actor) {
   CAF_CHECK(timeout_called);
 }
 
+// -- scoped_actors using skip -------------------------------------------------
+
+using msg_t = int; 
+// send_order_t contains messages which are send to an actor in the same order
+// as in vector
+using send_order_t = std::vector<msg_t>;
+// sequence_t contains a number of messages for processing by an actor with
+// the information to skip the current message for later processing
+using sequence_t = std::vector<std::pair<msg_t, bool>>;
+using check_order_t = std::pair<send_order_t, sequence_t>;
+
+behavior check_order_behavior_factory(local_actor* self,
+                                      sequence_t::const_iterator* seq_it_ptr) {
+  return {
+    [=](int i) -> result<void> {
+      auto& seq_it = *seq_it_ptr;
+      CAF_CHECK_EQUAL(i, seq_it->first);
+      if (seq_it->second) {
+        CAF_MESSAGE("current: " << i << "; awaiting: " << seq_it->first
+                                << "; inbox size: " << self->mailbox().count()
+                                << " SKIPPED");
+        ++seq_it;
+        return skip(); 
+      } else {
+        CAF_MESSAGE("current: " << i << "; awaiting: " << seq_it->first
+                                << "; inbox size: " << self->mailbox().count()
+                                << " OK");
+        ++seq_it;
+        return unit; 
+      }
+    }
+  };
+}
+
+void check_order_event_based_actor(const check_order_t& corder) {
+  actor_system_config cfg;
+  actor_system system{cfg};
+  auto& send_order = corder.first;
+  auto& sequence = corder.second;
+  auto seq_it = sequence.cbegin();
+  {
+    auto tmp = system.spawn(
+      [=](event_based_actor* self) mutable {
+        self->set_default_handler(skip);
+        for(auto i : send_order) {
+          self->send(self, i);
+        }
+        self->become(
+          check_order_behavior_factory(self, &seq_it));
+      }
+    );
+
+  }
+  system.await_all_actors_done();
+}
+
+void check_order_scoped_actor(const check_order_t& corder) {
+  actor_system_config cfg;
+  actor_system system{cfg};
+  auto& send_order = corder.first;
+  auto& sequence = corder.second;
+  auto seq_it = begin(sequence);
+  scoped_actor self{system};
+  auto check_order_behavior =
+    check_order_behavior_factory(actor_cast<local_actor*>(self), &seq_it);
+  for(auto i : send_order) {
+    self->send(self, i);
+  }
+  while (seq_it != end(sequence)) {
+    self->receive(check_order_behavior);
+  }
+}
+
+CAF_TEST(skip_message) {
+  check_order_t a = {
+    {0, 1, 2, 3}, //recv_order = 0,1,2,3
+    {{0, false}, {1, false}, {2, false}, {3, false}}
+  };
+  check_order_t b = {
+    {3, 2, 1, 0}, //recv_order = 0,1,2,3
+    {{3, true}, {2, true}, {1, true}, {0, false},
+    {3, true}, {2, true}, {1, false},
+    {3, true}, {2, false},
+    {3, false}}    
+  };
+  check_order_t c = {
+    {1, 0, 2}, //recv_order = 0,1,2
+    {{1, true}, {0, false}, 
+    {1, false}, 
+    {2, false}}    
+  };
+  check_order_t d = {
+    {3, 1, 2, 0}, //recv_order = 0,1,2,3
+    {{3, true}, {1, true}, {2, true}, {0, false},
+    {3, true}, {1, false},
+    {3, true}, {2, false},
+    {3, false}}
+  };
+  check_order_event_based_actor(a);
+  check_order_event_based_actor(b);
+  check_order_event_based_actor(c);
+  check_order_event_based_actor(d);
+  check_order_scoped_actor(a);
+  check_order_scoped_actor(b);
+  check_order_scoped_actor(c);
+  check_order_scoped_actor(d);
+}
+
 CAF_TEST_FIXTURE_SCOPE_END()


### PR DESCRIPTION
A scoped_actor seems to lose messages under certain circumstances.

For example: 
Messages 3, 1, 2 and then 0 are send to a scoped_actor and it is necessary to receive them in order 0, 1, 2, 3. All messages, which don't match the receive order are skipped for later processing.
In this example the scoped_actor loses message 2 and 3.

I added a unit test to identify the problem and proposed a solution.