### PR TITLE
Allow socket creation on IPv4 only hosts

### DIFF
--- a/libcaf_io/caf/io/network/interfaces.hpp
+++ b/libcaf_io/caf/io/network/interfaces.hpp
@@ -72,6 +72,11 @@ public:
   /// Returns a native IPv4 or IPv6 translation of `host`.
   static optional<std::pair<std::string, protocol>>
   native_address(const std::string& host, optional<protocol> preferred = none);
+
+  /// Returns the host and protocol available for a local server socket
+  static std::vector<std::pair<std::string, protocol>>
+  server_address(uint16_t port, const char* host,
+                 optional<protocol> preferred = none);
 };
 
 } // namespace network

--- a/libcaf_io/src/interfaces.cpp
+++ b/libcaf_io/src/interfaces.cpp
@@ -239,6 +239,42 @@ interfaces::native_address(const std::string& host,
   return none;
 }
 
+std::vector<std::pair<std::string, protocol>>
+interfaces::server_address(uint16_t port, const char* host,
+                           optional<protocol> preferred) {
+  using addr_pair = std::pair<std::string, protocol>;
+  addrinfo hint;
+  memset(&hint, 0, sizeof(hint));
+  hint.ai_socktype = SOCK_STREAM;
+  if (preferred)
+    hint.ai_family = *preferred == protocol::ipv4 ? AF_INET : AF_INET6;
+  else
+    hint.ai_family = AF_UNSPEC;
+  if (host == nullptr)
+    hint.ai_flags = AI_PASSIVE;
+  auto port_str = std::to_string(port);
+  addrinfo* tmp = nullptr;
+  if (getaddrinfo(host, port_str.c_str(), &hint, &tmp) != 0)
+    return {};
+  std::unique_ptr<addrinfo, decltype(freeaddrinfo)*> addrs{tmp, freeaddrinfo};
+  char buffer[INET6_ADDRSTRLEN];
+  // Take the first ipv6 address or the first available address otherwise
+  std::vector<addr_pair> results;
+  for (auto i = addrs.get(); i != nullptr; i = i->ai_next) {
+    auto family = fetch_addr_str(true, true, buffer, i->ai_addr);
+    if (family != AF_UNSPEC) {
+      results.emplace_back(std::string{buffer},
+                           family == AF_INET ? protocol::ipv4
+                                             : protocol::ipv6);
+    }
+  }
+  std::stable_sort(std::begin(results), std::end(results),
+                   [](const addr_pair& lhs, const addr_pair& rhs) {
+                     return lhs.second > rhs.second;
+                   });
+  return results;
+}
+
 } // namespace network
 } // namespace io
 } // namespace caf


### PR DESCRIPTION
Use `getaddrinfo` to discover available ip version and address info instead of direct socket creation. This (hopefully) addresses the failure to create server sockets on hosts that only have IPv4 available, [see mailing list](https://groups.google.com/d/msg/actor-framework/lcbPO4JtHkk/pLAUqmk7AQAJ).

Adding `ipv6.disable=1` to the `GRUB_CMDLINE_LINUX_DEFAULT` options in `/etc/default/grub` disabled IPv6 on my test machine ([related post](https://askubuntu.com/questions/440649/how-to-disable-ipv6-in-ubuntu-14-04), don't forget to update the config `sudo update-grub` and reboot).
