### PR TITLE
Fix reset of flags in config file

### DIFF
--- a/libcaf_core/src/message.cpp
+++ b/libcaf_core/src/message.cpp
@@ -324,7 +324,7 @@ message::cli_arg::cli_arg(std::string nstr, std::string tstr, bool& arg)
   : name(std::move(nstr)),
     text(std::move(tstr)),
     flag(&arg) {
-  arg = false;
+  // nop
 }
 
 message::cli_arg::cli_arg(std::string nstr, std::string tstr, consumer f)


### PR DESCRIPTION
Based on a comment in gitter: 
I only change the value of parameter enable-automatic-connections to true. Then the value of this parameter will be still false when debug into fuction void caf_main(actor_system& system, const config& cfg).; when loading io::middleman
[middleman]
; configures whether MMs try to span a full mesh
enable-automatic-connections=false

This pull request fixes the problem.