### PR TITLE
remove OSX/Clang specific pthread code

### DIFF
--- a/libcaf_core/caf/config.hpp
+++ b/libcaf_core/caf/config.hpp
@@ -101,6 +101,9 @@
 #  define CAF_ANNOTATE_FALLTHROUGH [[clang::fallthrough]]
 #  define CAF_COMPILER_VERSION                                                 \
     (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
+#  if !__has_feature(cxx_thread_local)
+#    define CAF_NO_THREAD_LOCAL
+#  endif
 #elif defined(__GNUC__)
 #  define CAF_GCC
 #  define CAF_DEPRECATED __attribute__((__deprecated__))

--- a/libcaf_core/src/logger.cpp
+++ b/libcaf_core/src/logger.cpp
@@ -62,19 +62,7 @@ constexpr const char* log_level_name[] = {
 static_assert(CAF_LOG_LEVEL >= 0 && CAF_LOG_LEVEL <= 4,
               "assertion: 0 <= CAF_LOG_LEVEL <= 4");
 
-#ifdef CAF_MSVC
-
-thread_local intrusive_ptr<logger> current_logger;
-
-inline void set_current_logger(logger* x) {
-  current_logger.reset(x);
-}
-
-inline logger* get_current_logger() {
-  return current_logger.get();
-}
-
-#else // CAF_MSVC
+#if defined(CAF_NO_THREAD_LOCAL)
 
 pthread_key_t s_key;
 pthread_once_t s_key_once = PTHREAD_ONCE_INIT;
@@ -102,7 +90,19 @@ logger* get_current_logger() {
   return reinterpret_cast<logger*>(pthread_getspecific(s_key));
 }
 
-#endif // CAF_MSVC
+#else // !CAF_NO_THREAD_LOCAL
+
+thread_local intrusive_ptr<logger> current_logger;
+
+inline void set_current_logger(logger* x) {
+  current_logger.reset(x);
+}
+
+inline logger* get_current_logger() {
+  return current_logger.get();
+}
+
+#endif // CAF_NO_THREAD_LOCAL
 
 #else // CAF_LOG_LEVEL
 

--- a/libcaf_core/src/memory.cpp
+++ b/libcaf_core/src/memory.cpp
@@ -17,6 +17,7 @@
  * http://www.boost.org/LICENSE_1_0.txt.                                      *
  ******************************************************************************/
 
+#include "caf/config.hpp"
 #include "caf/detail/memory.hpp"
 
 #include <vector>
@@ -43,7 +44,8 @@ using cache_map = std::map<const std::type_info*, std::unique_ptr<memory_cache>>
 
 } // namespace <anonymous>
 
-#if defined(CAF_CLANG) || defined(CAF_MACOS)
+#if defined(CAF_NO_THREAD_LOCAL)
+
 namespace {
 
 pthread_key_t s_key;
@@ -72,7 +74,7 @@ cache_map& get_cache_map() {
   return *cache;
 }
 
-#else // !CAF_CLANG && !CAF_MACOS
+#else // !CAF_NO_THREAD_LOCAL
 
 namespace {
 
@@ -90,7 +92,7 @@ cache_map& get_cache_map() {
   return *s_key;
 }
 
-#endif
+#endif // !CAF_NO_THREAD_LOCAL
 
 memory_cache::~memory_cache() {
   // nop


### PR DESCRIPTION
The compiler shipped with XCode 8 now supports the `thread_local` specifier, this PR drops the workaround code that was previously required.

The only caveat to this PR is that the minimum compiler for OSX will need to be upgraded ( but I am unaware of any breaking reason that would block this ). 