### PR TITLE
Fix null pointer exception

### DIFF
--- a/libcaf_core/caf/actor_control_block.hpp
+++ b/libcaf_core/caf/actor_control_block.hpp
@@ -216,8 +216,8 @@ typename Inspector::result_type inspect(Inspector& f, strong_actor_ptr& x) {
     aid = x->aid;
     nid = x->nid;
   }
-  auto load = [&] { return load_actor(x, context_of(&f), aid, nid); };
-  auto save = [&] { return save_actor(x, context_of(&f), aid, nid); };
+  auto load = [&f, &x, aid, nid] { return load_actor(x, context_of(&f), aid, nid); };
+  auto save = [&f, &x, aid, nid] { return save_actor(x, context_of(&f), aid, nid); };
   return f(meta::type_name("actor"), aid,
            meta::omittable_if_none(), nid,
            meta::load_callback(load), meta::save_callback(save));


### PR DESCRIPTION
As described in Issue #542, there is a null pointer exception in the inspect method.
The exception was caused by capturing a local variable as reference in a lambda and passing that lambda as a callback to another function. At the time the lambda was called, the captured references are allready gone.

Never capture local variables by ref, if you pass the lambda lives longer than the scope it is created in.