### PR TITLE
Minor fixes on Windows.

### DIFF
--- a/cmake/FindCAF.cmake
+++ b/cmake/FindCAF.cmake
@@ -67,7 +67,8 @@ foreach (comp ${CAF_FIND_COMPONENTS})
       endif ()
       find_library(CAF_LIBRARY_${UPPERCOMP}
                    NAMES
-                     "caf_${comp}"
+                      "caf_${comp}"
+                      "caf_${comp}_static"
                    HINTS
                      ${library_hints}
                      /usr/lib

--- a/libcaf_core/caf/optional.hpp
+++ b/libcaf_core/caf/optional.hpp
@@ -162,7 +162,7 @@ class optional {
   }
 
   bool m_valid;
-  union { T m_value; };
+  struct { T m_value; };
 };
 
 /// Template specialization to allow `optional` to hold a reference

--- a/libcaf_core/caf/optional.hpp
+++ b/libcaf_core/caf/optional.hpp
@@ -162,7 +162,7 @@ class optional {
   }
 
   bool m_valid;
-  struct { T m_value; };
+  union { T m_value; };
 };
 
 /// Template specialization to allow `optional` to hold a reference


### PR DESCRIPTION
FindCAF.cmake: Fix to also find static only libs.
optional.hpp: Replace union with struct to avoid msvc "implict destructor call" error in conjunction with ue4.