### PR TITLE
Remove duplicate .add_message_type<>() from middleman::init()

### DIFF
--- a/libcaf_io/src/middleman.cpp
+++ b/libcaf_io/src/middleman.cpp
@@ -439,11 +439,7 @@ void middleman::init(actor_system_config& cfg) {
      .add_message_type<acceptor_closed_msg>("@acceptor_closed_msg")
      .add_message_type<connection_closed_msg>("@connection_closed_msg")
      .add_message_type<accept_handle>("@accept_handle")
-     .add_message_type<acceptor_closed_msg>("@acceptor_closed_msg")
-     .add_message_type<connection_closed_msg>("@connection_closed_msg")
      .add_message_type<connection_handle>("@connection_handle")
-     .add_message_type<new_connection_msg>("@new_connection_msg")
-     .add_message_type<new_data_msg>("@new_data_msg")
      .add_message_type<connection_passivated_msg>("@connection_passivated_msg")
      .add_message_type<acceptor_passivated_msg>("@acceptor_passivated_msg");
   // compute and set ID for this network node


### PR DESCRIPTION
Removes 4 duplicate messages from middleman::init().