### PR TITLE
fix local_group::erase_subscriber

### DIFF
--- a/libcaf_core/caf/intrusive_ptr.hpp
+++ b/libcaf_core/caf/intrusive_ptr.hpp
@@ -232,6 +232,17 @@ bool operator<(const intrusive_ptr<T>& x, const intrusive_ptr<T>& y) {
   return x.get() < y.get();
 }
 
+/// @relates intrusive_ptr
+template <class T>
+bool operator<(const intrusive_ptr<T>& x, const T* y) {
+  return x.get() < y;
+}
+/// @relates intrusive_ptr
+template <class T>
+bool operator<(const T* x, const intrusive_ptr<T>& y) {
+  return x < y.get();
+}
+
 template <class T>
 std::string to_string(const intrusive_ptr<T>& x) {
   auto v = reinterpret_cast<uintptr_t>(x.get());


### PR DESCRIPTION
Fixes #574.

This PR makes use of a functionnality introduced in C++14: the ability to use a type that "compares equivalent" to the keys of an` std::set<>` in its `find()` method.

I added the `operator<` to compare an `intrusive_ptr<T>` to a raw `T*`

As an added bonus, the deletion is now O(log(N)), instead of O(N)