### PR TITLE
Serialize vector<bool> efficiently

### DIFF
--- a/libcaf_core/caf/data_processor.hpp
+++ b/libcaf_core/caf/data_processor.hpp
@@ -228,36 +228,61 @@ public:
 
   // Special case to avoid using 1 byte per bool
   error apply(std::vector<bool>& x) {
-    uint64_t len = x.size();
-    auto err = begin_sequence(len);
-    if (err || len == 0)
+    // Convert vector<bool> to a vector<uint64>,
+    // by packing each block of 64 booleans on a 64-bits integer.
+    // To not waste up to 63 bits, the last uint64_t
+    // (ie. the last 'remainder' booleans) is encoded as a var-int
+    auto remainder = static_cast<uint8_t>(x.size() % 64);
+    auto err = apply_builtin(u8_v, &remainder);
+    if (err)
       return err;
     struct {
-      size_t len;
-      void operator()(std::vector<bool>& lhs, std::vector<uint8_t>& rhs) const {
-        lhs.resize(len, false);
+      void operator()(std::vector<bool>& lhs, std::vector<uint64_t>& rhs) const {
+        lhs.resize(rhs.size() * 64, false);
         size_t cpt = 0;
         for (auto v: rhs) {
-          for (int k = 0; k < 8; ++k) {
-            lhs[cpt] = ((v & (1 << k)) != 0);
-            if (++cpt >= len)
-              return;
+          for (int k = 0; k < 64; ++k) {
+            lhs[cpt++] = ((v & (1ul << k)) != 0);
           }
         }
       }
-      void operator()(std::vector<uint8_t>& lhs, std::vector<bool>& rhs) const {
-        size_t k = 0;
-        lhs.resize((rhs.size() - 1) / 8 + 1, 0);
-        for (bool b: rhs) {
+      void operator()(std::vector<uint64_t>& lhs, std::vector<bool>& rhs) const {
+        if (rhs.empty())
+          return;
+        size_t len = rhs.size() - rhs.size() % 64;
+        lhs.resize(len / 64, 0);
+        for (size_t k = 0; k < len; ++k) {
+          auto b = rhs[k];
           if (b)
-            lhs[k / 8] |= (1 << (k % 8));
-          ++k;
+            lhs[k / 64] |= (1ul << (k % 64));
         }
       }
     } assign;
-    assign.len = len;
-    std::vector<uint8_t> tmp;
-    return convert_apply(dref(), x, tmp, assign);
+    std::vector<uint64_t> tmp;
+    err = convert_apply(dref(), x, tmp, assign);
+    if (err || !remainder)
+      return err;
+    // the last uint64_t for 'remainder' bits
+    if (Derived::reads_state) {
+      uint64_t encoded = 0;
+      auto len = x.size();
+      for (int k = 0; k < remainder; ++k) {
+        auto b = x[len - remainder + k];
+        if (b)
+          encoded |= (1ul << k);
+      }
+      return begin_sequence(encoded);
+    } else {
+      uint64_t encoded = 0;
+      err = begin_sequence(encoded);
+      if (err)
+        return err;
+      x.reserve(x.size() + remainder);
+      for (int k = 0; k < remainder; ++k) {
+        x.push_back((bool) (encoded & (1ul << k)));
+      }
+      return none;
+    }
   }
 
   template <class T>


### PR DESCRIPTION
This is a more efficient serialization for vector<bool>; it is transformed to a vector<uint8>, each boolean encoded on a single bit (see #540)
At worst, 7 bits will be unused, when (size() % 8 == 1).

Note that the size of the vector is written ~twice (the size of the original vector<bool>, then the size of the vector<uint8_t>), because we need to know the number of unused bits in the last uint8_t. I guess it could still be optimized: instead of writing the full (uint64_t) size, we could only write its value mod. 8, shaving a few more bytes.
