### PR TITLE
Fixes a signature bug in default_multiplexer.cpp

### DIFF
--- a/libcaf_io/src/default_multiplexer.cpp
+++ b/libcaf_io/src/default_multiplexer.cpp
@@ -351,8 +351,8 @@ namespace network {
     return poll_once(false);
   }
 
-  bool default_multiplexer::run_once() {
-    return poll_once(true);
+  void default_multiplexer::run_once() {
+    poll_once(true);
   }
 
   void default_multiplexer::run() {


### PR DESCRIPTION
This fixes a signature bug in default_multiplexer.cpp that prevented compiling on gcc4.8.4