### PR TITLE
Add "--with-openssl" option to the "configure" script

### DIFF
--- a/configure
+++ b/configure
@@ -43,6 +43,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --with-clang=FILE           path to clang++ executable
     --with-gcc=FILE             path to g++ executable
     --with-qt-prefix=PATH       prefix path for Qt5 cmake modules
+    --with-openssl=PATH         path to OpenSSL library and headers
     --dual-build                build using both gcc and clang
     --build-static              build as static and shared library
     --build-static-only         build as static library only
@@ -306,6 +307,9 @@ while [ $# -ne 0 ]; do
             ;;
         --with-qt-prefix=*)
             append_cache_entry CAF_QT_PREFIX_PATH STRING "$optarg"
+            ;;
+        --with-openssl=*)
+            append_cache_entry OPENSSL_ROOT_DIR PATH $optarg
             ;;
         --build-type=*)
             append_cache_entry CMAKE_BUILD_TYPE STRING $optarg


### PR DESCRIPTION
Added a new option "--with-openssl" to the "configure" script so
that a user can specify the location of the OpenSSL library and
headers.  This is needed in cases where OpenSSL is not found
automatically or if the wrong version is found.  For example, in order
to build CAF on macOS, we need to specify "--with-openssl=/opt/local"
when using MacPorts, or "--with-openssl=/usr/local/opt/openssl" when
using Homebrew.