### PR TITLE
Add check for `result` type to `deliver`

### DIFF
--- a/libcaf_core/caf/detail/type_traits.hpp
+++ b/libcaf_core/caf/detail/type_traits.hpp
@@ -607,6 +607,12 @@ constexpr bool can_insert_elements() {
   return can_insert_elements_impl<T>(static_cast<T*>(nullptr));
 }
 
+template <class Test, template <class...> class Ref>
+struct is_specialization : std::false_type { };
+
+template <template <class...> class Ref, class... Args>
+struct is_specialization<Ref<Args...>, Ref> : std::true_type { };
+
 } // namespace detail
 } // namespace caf
 

--- a/libcaf_core/caf/response_promise.hpp
+++ b/libcaf_core/caf/response_promise.hpp
@@ -57,6 +57,11 @@ public:
     response_promise
   >::type
   deliver(T&&x, Ts&&... xs) {
+    static_assert(!detail::is_specialization<T, result>::value
+                  && !detail::disjunction<
+                       detail::is_specialization<Ts, result>::value...
+                     >::value,
+                  "it is not possible to deliver objects of type result<...>");
     return deliver_impl(make_message(std::forward<T>(x),
                                      std::forward<Ts>(xs)...));
   }


### PR DESCRIPTION
This commit adds a `static_assert` to `response_promise::deliver` which
prevents faulty usage of `result<...>` and `deliver`.

closes #592