### PR TITLE
actor_system_config::options_ member access

### DIFF
--- a/libcaf_core/caf/actor_system_config.hpp
+++ b/libcaf_core/caf/actor_system_config.hpp
@@ -359,6 +359,7 @@ private:
 
   std::string extract_config_file_name(message& args);
 
+protected:
   option_vector options_;
 };
 


### PR DESCRIPTION
The option_ member was moved from private to protected, in order to enable derived class access (e.g. for dump purposes).
Maybe a better solution would be to have a proper const accessor function.