### PR TITLE
Patch empty() method for MSVC v140_clang_c2

### DIFF
--- a/libcaf_core/caf/detail/double_ended_queue.hpp
+++ b/libcaf_core/caf/detail/double_ended_queue.hpp
@@ -202,7 +202,7 @@ public:
   // does not lock
   bool empty() const {
     // atomically compares first and last pointer without locks
-    return head_ == tail_;
+    return head_.load() == tail_.load();
   }
 
 private:


### PR DESCRIPTION
Without this patch, when compiling on Windows with MSVC v140_clang_c2 toolset we got the error reported below. The reason why this PR is done on topic/latency branch is that the error only happens on this branch.

After having a look at _std::atomic<>_ standard specifications, I believe that the proposed _load()_ comparison just behaves as the original _atomic<>_ value comparison, provided that _std::atomic<>_ does not implement an explicit _operator==_ and original comparison seems to rely on an implicit cast.

Furthermore, I am not sure if the function behaviour matches the comment expectations ("_atomically compares first and last pointer without locks_") as the comparison itself is not atomic in neither versions of the code. And, if it does not match, if this represents a problem for the work stealing algorithm.

Follows the error on v140_clang_c2:

```
  In file included from D:\Users\Tulmenga\Projects\prj_0lf\factory_0lf\actor-framework\libcaf_core\caf/policy/work_stealing.hpp:36:
D:\Users\Tulmenga\Projects\prj_0lf\factory_0lf\actor-framework\libcaf_core\caf/detail/double_ended_queue.hpp(205,18): error : use of overloaded operator '==' is ambiguous (with operand types 'const std::atomic<node *>' and 'const std::atom
ic<node *>') [D:\Users\Tulmenga\Projects\prj_0lf\factory_0lf\actor-framework\build\libcaf_core\libcaf_core_static.vcxproj]
      return head_ == tail_;
             ~~~~~ ^  ~~~~~
  D:\Users\Tulmenga\Projects\prj_0lf\factory_0lf\actor-framework\libcaf_core\caf/policy/work_stealing.hpp(191,54) :  note: in instantiation of member function 'caf::detail::double_ended_queue<caf::resumable>::empty' requested here
                           [&] { return !d(self).queue.empty(); }))
                                                       ^
  D:\Users\Tulmenga\Projects\prj_0lf\factory_0lf\actor-framework\libcaf_core\caf/scheduler/worker.hpp(113,26) :  note: in instantiation of function template specialization 'caf::policy::work_stealing::dequeue<caf::scheduler::worker<caf::po
  licy::work_stealing> >' requested here
        auto job = policy_.dequeue(this);
                           ^
  ... ... ...
  D:\Users\Tulmenga\Projects\prj_0lf\factory_0lf\actor-framework\libcaf_core\caf/detail/double_ended_queue.hpp(205,18) :  note: built-in candidate operator==(const class caf::detail::double_ended_queue<class caf::resumable>::node *, const
  class caf::detail::double_ended_queue<class caf::resumable>::node *)
  D:\Users\Tulmenga\Projects\prj_0lf\factory_0lf\actor-framework\libcaf_core\caf/detail/double_ended_queue.hpp(205,18) :  note: built-in candidate operator==(void *, void *)
  D:\Users\Tulmenga\Projects\prj_0lf\factory_0lf\actor-framework\libcaf_core\caf/detail/double_ended_queue.hpp(205,18) :  note: built-in candidate operator==(const void *, const void *)
  1 error generated.
```