### PR TITLE
Patch empty() method for MSVC v140_clang_c2

### DIFF
--- a/libcaf_core/caf/detail/double_ended_queue.hpp
+++ b/libcaf_core/caf/detail/double_ended_queue.hpp
@@ -202,7 +202,7 @@ public:
   // does not lock
   bool empty() const {
     // atomically compares first and last pointer without locks
-    return head_ == tail_;
+    return head_.load() == tail_.load();
   }
 
 private:


### PR DESCRIPTION
Same as already merged PR #623, but on `master` branch.
