### PR TITLE
Fix unit tests with OpenSSL 1.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ if(CAF_BUILD_STATIC_RUNTIME)
       endif()
     endif()
   endforeach()
+else()
+  set(CAF_BUILD_STATIC_RUNTIME no)
 endif()
 
 # add helper target that simplifies re-running configure
@@ -537,7 +539,7 @@ if(NOT CAF_NO_OPENSSL)
     # Check OpenSSL version >= 1.0.1
     if (OPENSSL_VERSION VERSION_LESS 1.0.1)
       message(STATUS
-              "Disable OpenSSL. Required >= 1.0.1 due to TLSv2 support.")
+              "Disable OpenSSL. Required >= 1.0.1 due to TLSv1.2 support.")
       set(CAF_NO_OPENSSL yes)
     else()
       # Check if openssl headers and library versions match
@@ -552,7 +554,7 @@ if(NOT CAF_NO_OPENSSL)
           }
           return -1;
         }
-      " OPENSSL_CORRECT_VERSION_NUMBER )
+      " OPENSSL_CORRECT_VERSION_NUMBER)
       if (NOT OPENSSL_CORRECT_VERSION_NUMBER)
         message(FATAL_ERROR
           "OpenSSL library version does not match headers")

--- a/libcaf_core/caf/config.hpp
+++ b/libcaf_core/caf/config.hpp
@@ -236,5 +236,4 @@
   throw std::runtime_error(msg)
 #endif // CAF_NO_EXCEPTIONS
 
-
 #endif // CAF_CONFIG_HPP

--- a/libcaf_openssl/caf/openssl/session.hpp
+++ b/libcaf_openssl/caf/openssl/session.hpp
@@ -33,6 +33,11 @@ CAF_POP_WARNINGS
 #include "caf/io/network/native_socket.hpp"
 #include "caf/io/network/default_multiplexer.hpp"
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+# define CAF_SSL_HAS_SECURITY_LEVEL
+# define CAF_SSL_HAS_NON_VERSIONED_TLS_FUN
+#endif
+
 namespace caf {
 namespace openssl {
 


### PR DESCRIPTION
With OpenSSL 1.1.0 a security level specifier was introduced.
By default its set to 1. Our default settings does not fulfill level 1.

With this patch we don't use a specific curve anymore. OpenSSL will
select a curve automatically. In OpenSSL 1.1.0 and higher this is
already the default.

closes #625