### PR TITLE
Fix compatible problems with ASIO in boost 1.66

### DIFF
--- a/libcaf_io/caf/io/network/asio_multiplexer.hpp
+++ b/libcaf_io/caf/io/network/asio_multiplexer.hpp
@@ -52,6 +52,10 @@ using asio_tcp_socket = boost::asio::ip::tcp::socket;
 /// Low-level socket type used as default.
 using asio_tcp_socket_acceptor = boost::asio::ip::tcp::acceptor;
 
+class multiplexer_backend : public io_service {
+  // nop
+};
+
 /// A wrapper for the boost::asio multiplexer
 class asio_multiplexer : public multiplexer {
 public:
@@ -86,14 +90,14 @@ public:
 
   void run() override;
 
-  boost::asio::io_service* pimpl() override;
+  multiplexer_backend* pimpl() override;
 
   inline boost::asio::io_service& service() {
     return service_;
   }
 
 private:
-  io_service service_;
+  multiplexer_backend service_;
 };
 
 template <class T>

--- a/libcaf_io/caf/io/network/asio_multiplexer_impl.hpp
+++ b/libcaf_io/caf/io/network/asio_multiplexer_impl.hpp
@@ -308,7 +308,7 @@ void asio_multiplexer::run() {
     CAF_RAISE_ERROR(ec.message());
 }
 
-boost::asio::io_service* asio_multiplexer::pimpl() {
+multiplexer_backend* asio_multiplexer::pimpl() {
   return &service_;
 }
 

--- a/libcaf_io/caf/io/network/multiplexer.hpp
+++ b/libcaf_io/caf/io/network/multiplexer.hpp
@@ -37,15 +37,11 @@
 #include "caf/io/network/protocol.hpp"
 #include "caf/io/network/native_socket.hpp"
 
-namespace boost {
-namespace asio {
-class io_service;
-} // namespace asio
-} // namespace boost
-
 namespace caf {
 namespace io {
 namespace network {
+
+class multiplexer_backend;
 
 /// Low-level backend for IO multiplexing.
 class multiplexer : public execution_unit {
@@ -136,7 +132,7 @@ public:
 
   /// Retrieves a pointer to the implementation or `nullptr` if CAF was
   /// compiled using the default backend.
-  virtual boost::asio::io_service* pimpl();
+  virtual multiplexer_backend* pimpl();
 
   inline const std::thread::id& thread_id() const {
     return tid_;

--- a/libcaf_io/src/multiplexer.cpp
+++ b/libcaf_io/src/multiplexer.cpp
@@ -28,16 +28,12 @@ multiplexer::multiplexer(actor_system* sys) : execution_unit(sys) {
   // nop
 }
 
-boost::asio::io_service* pimpl() {
-  return nullptr;
-}
-
 multiplexer_ptr multiplexer::make(actor_system& sys) {
   CAF_LOG_TRACE("");
   return multiplexer_ptr{new default_multiplexer(&sys)};
 }
 
-boost::asio::io_service* multiplexer::pimpl() {
+multiplexer_backend* multiplexer::pimpl() {
   return nullptr;
 }
 


### PR DESCRIPTION
ASIO of Boost 1.66 used `io_context` instead of `io_service` and added a typedef for backwards compatibility. So the forward declaration at [multiplexer.hpp](https://github.com/actor-framework/actor-framework/blob/master/libcaf_io/caf/io/network/multiplexer.hpp#L42) lead compilation errors when using ASIO of Boost 1.66.