### PR TITLE
Fix caf::io::remote_actor free function

### DIFF
--- a/libcaf_io/caf/io/remote_actor.hpp
+++ b/libcaf_io/caf/io/remote_actor.hpp
@@ -39,9 +39,7 @@ namespace io {
 template <class ActorHandle = actor>
 expected<ActorHandle> remote_actor(actor_system& sys, std::string host,
                                    uint16_t port) {
-  detail::type_list<ActorHandle> tk;
-  return sys.middleman().remote_actor(sys, sys.message_types(tk),
-                                      std::move(host), port);
+  return sys.middleman().remote_actor<ActorHandle>(std::move(host), port);
 }
 
 } // namespace io


### PR DESCRIPTION
The remote_actor() method of the middleman probably has been refactored some time ago and the corresponding free function wasn't, so I fixed that.