### PR TITLE
Add templated put/get registry methods

### DIFF
--- a/libcaf_core/caf/actor_registry.hpp
+++ b/libcaf_core/caf/actor_registry.hpp
@@ -29,6 +29,7 @@
 
 #include "caf/fwd.hpp"
 #include "caf/actor.hpp"
+#include "caf/actor_cast.hpp"
 #include "caf/abstract_actor.hpp"
 #include "caf/actor_control_block.hpp"
 
@@ -49,10 +50,16 @@ public:
   ~actor_registry();
 
   /// Returns the local actor associated to `key`.
-  strong_actor_ptr get(actor_id key) const;
+  template<class T = strong_actor_ptr>
+  T get(actor_id key) const {
+      return actor_cast<T>(get_impl(key));
+  }
 
   /// Associates a local actor with its ID.
-  void put(actor_id key, strong_actor_ptr val);
+  template<class T>
+  void put(actor_id key, const T& val) {
+      put_impl(key, actor_cast<strong_actor_ptr>(val));
+  }
 
   /// Removes an actor from this registry,
   /// leaving `reason` for future reference.
@@ -72,10 +79,17 @@ public:
   void await_running_count_equal(size_t expected) const;
 
   /// Returns the actor associated with `key` or `invalid_actor`.
-  strong_actor_ptr get(atom_value key) const;
+  template<class T = strong_actor_ptr>
+  T get(atom_value key) const {
+      return actor_cast<T>(get_impl(key));
+  }
 
   /// Associates given actor to `key`.
-  void put(atom_value key, strong_actor_ptr value);
+  template<class T>
+  void put(atom_value key, const T& value) {
+      // using reference here and before to allow putting a scoped_actor without calling .ptr()
+      put_impl(key, actor_cast<strong_actor_ptr>(value));
+  }
 
   /// Removes a name mapping.
   void erase(atom_value key);
@@ -90,6 +104,18 @@ private:
 
   // Stops this component.
   void stop();
+
+  /// Returns the local actor associated to `key`.
+  strong_actor_ptr get_impl(actor_id key) const;
+
+  /// Associates a local actor with its ID.
+  void put_impl(actor_id key, strong_actor_ptr val);
+
+  /// Returns the actor associated with `key` or `invalid_actor`.
+  strong_actor_ptr get_impl(atom_value key) const;
+
+  /// Associates given actor to `key`.
+  void put_impl(atom_value key, strong_actor_ptr value);
 
   using entries = std::unordered_map<actor_id, strong_actor_ptr>;
 

--- a/libcaf_core/src/actor_registry.cpp
+++ b/libcaf_core/src/actor_registry.cpp
@@ -28,7 +28,6 @@
 #include "caf/sec.hpp"
 #include "caf/locks.hpp"
 #include "caf/logger.hpp"
-#include "caf/actor_cast.hpp"
 #include "caf/attachable.hpp"
 #include "caf/exit_reason.hpp"
 #include "caf/actor_system.hpp"
@@ -56,7 +55,7 @@ actor_registry::actor_registry(actor_system& sys) : running_(0), system_(sys) {
   // nop
 }
 
-strong_actor_ptr actor_registry::get(actor_id key) const {
+strong_actor_ptr actor_registry::get_impl(actor_id key) const {
   shared_guard guard(instances_mtx_);
   auto i = entries_.find(key);
   if (i != entries_.end())
@@ -65,7 +64,7 @@ strong_actor_ptr actor_registry::get(actor_id key) const {
   return nullptr;
 }
 
-void actor_registry::put(actor_id key, strong_actor_ptr val) {
+void actor_registry::put_impl(actor_id key, strong_actor_ptr val) {
   CAF_LOG_TRACE(CAF_ARG(key));
   if (!val)
     return;
@@ -119,7 +118,7 @@ void actor_registry::await_running_count_equal(size_t expected) const {
   }
 }
 
-strong_actor_ptr actor_registry::get(atom_value key) const {
+strong_actor_ptr actor_registry::get_impl(atom_value key) const {
   shared_guard guard{named_entries_mtx_};
   auto i = named_entries_.find(key);
   if (i == named_entries_.end())
@@ -127,10 +126,10 @@ strong_actor_ptr actor_registry::get(atom_value key) const {
   return i->second;
 }
 
-void actor_registry::put(atom_value key, strong_actor_ptr value) {
+void actor_registry::put_impl(atom_value key, strong_actor_ptr value) {
   if (value)
     value->get()->attach_functor([=] {
-      system_.registry().put(key, nullptr);
+      system_.registry().put_impl(key, nullptr);
     });
   exclusive_guard guard{named_entries_mtx_};
   named_entries_.emplace(key, std::move(value));


### PR DESCRIPTION
If I understand this right, we need to cast actors to and from `strong_actor_ptr` when working with the registry. I think it could be moved to the registry itself to make the code more readable. Now when I put I use this:
```cpp
system.registry().put(main_loop_atom::value, actor_cast<strong_actor_ptr>(self));
```
and when I get I have to cast again:
```cpp
auto ml = actor_cast<actor>(self->system().registry().get(main_loop_atom::value));
```
Casting on put seems to be inevitable anyway so better make `put` a template that accepts any type and casts it to `strong_actor_ptr` internally and allow specifying the desired result type in `get`. The type information is lost anyway thus we need to know what type to cast the result to. Now the syntax is a bit shorter and more intuitive (`get` without the template parameter still returns just `strong_actor_ptr` to retain compatibility):
```cpp
self->system().registry().put(main_loop_atom::value, self);
auto ml = self->system().registry().get<actor>(main_loop_atom::value);
```
This must work for all types of actors, I tried with scoped_actor, dynamically and statically typed ones. Please take a look at the `put` signature, I'm getting the value by reference so that putting `scoped_actor` to the registry isn't any different from other actor types. If it would be by value, we'd need to use something like `self.ptr()` for scoped actors which is ugly. I'm a bit worried about reference counting in that case, please check if it works fine. I suppose since these operations are synchronous and we're calling the other `put` method that accepts by value (incrementing ref) it shouldn't be a problem. Also the reference prevents calling this templated version from the regular `put()` (which results in compile error because `actor_cast` doesn't work on `nullptr`) when it clears the entry in the functor:
```cpp
  if (value)
    value->get()->attach_functor([=] {
      system_.registry().put(key, nullptr);
    });
```

...or else we'd need to cast `nullptr` to `strong_actor_ptr`. So we're killing two birds with one stone.