### PR TITLE
Fix asio multiplexer compilation with UDP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,7 +632,7 @@ if(NOT CAF_NO_UNIT_TESTS)
     set(caf_test ${EXECUTABLE_OUTPUT_PATH}/caf-test)
     add_test(${test_name} ${caf_test} -n -v 5 -s "${suite}" ${ARGN})
     # add some extra unit testing options when testing ASIO as well
-    if(CAF_USE_ASIO AND "${suite}" MATCHES "^io_.+$")
+    if(CAF_USE_ASIO AND "${suite}" MATCHES "^io_.+$" AND NOT "${suite}" MATCHES ".+_udp$")
       add_test(${test_name}_asio ${caf_test} -n -v 5 -s
                "${suite}" ${ARGN} -- "--caf#middleman.network-backend=asio")
     endif()

--- a/libcaf_io/caf/io/network/asio_multiplexer.hpp
+++ b/libcaf_io/caf/io/network/asio_multiplexer.hpp
@@ -76,6 +76,19 @@ public:
   expected<doorman_ptr> new_tcp_doorman(uint16_t port, const char* in,
                                         bool reuse_addr) override;
 
+  datagram_servant_ptr new_datagram_servant(native_socket fd) override;
+
+  datagram_servant_ptr
+  new_datagram_servant_for_endpoint(native_socket fd,
+                                    const ip_endpoint& ep) override;
+
+  expected<datagram_servant_ptr>
+  new_remote_udp_endpoint(const std::string& host, uint16_t port) override;
+
+  expected<datagram_servant_ptr>
+  new_local_udp_endpoint(uint16_t port, const char* in = nullptr,
+                         bool reuse_addr = false) override;
+
   void exec_later(resumable* ptr) override;
 
   asio_multiplexer(actor_system* sys);

--- a/libcaf_io/caf/io/network/asio_multiplexer_impl.hpp
+++ b/libcaf_io/caf/io/network/asio_multiplexer_impl.hpp
@@ -248,6 +248,30 @@ asio_multiplexer::new_tcp_doorman(uint16_t port, const char* in, bool rflag) {
   return new_doorman(std::move(fd));
 }
 
+datagram_servant_ptr asio_multiplexer::new_datagram_servant(native_socket) {
+  CAF_RAISE_ERROR("UDP is not implemented for asio");
+  return nullptr;
+}
+
+datagram_servant_ptr
+asio_multiplexer::new_datagram_servant_for_endpoint(native_socket,
+                                                    const ip_endpoint&) {
+  CAF_RAISE_ERROR("UDP is not implemented for asio");
+  return nullptr;
+}
+
+expected<datagram_servant_ptr>
+asio_multiplexer::new_remote_udp_endpoint(const std::string&, uint16_t) {
+  CAF_RAISE_ERROR("UDP is not implemented for asio");
+  return sec::bad_function_call;
+}
+
+expected<datagram_servant_ptr>
+asio_multiplexer::new_local_udp_endpoint(uint16_t, const char*, bool) {
+  CAF_RAISE_ERROR("UDP is not implemented for asio");
+  return sec::bad_function_call;
+}
+
 void asio_multiplexer::exec_later(resumable* rptr) {
   auto mt = system().config().scheduler_max_throughput;
   switch (rptr->subtype()) {

--- a/libcaf_io/test/remote_actor_udp.cpp
+++ b/libcaf_io/test/remote_actor_udp.cpp
@@ -19,7 +19,7 @@
 
 #include "caf/config.hpp"
 
-#define CAF_SUITE io_dynamic_remote_actor_tcp
+#define CAF_SUITE io_dynamic_remote_actor_udp
 #include "caf/test/unit_test.hpp"
 
 #include <vector>
@@ -40,6 +40,7 @@ class config : public actor_system_config {
 public:
   config() {
     load<io::middleman>();
+    set("middleman.enable-udp", true);
     add_message_type<std::vector<int>>("std::vector<int>");
     actor_system_config::parse(test::engine::argc(),
                                test::engine::argv());
@@ -130,55 +131,112 @@ behavior linking_actor(event_based_actor* self, const actor& buddy) {
 
 } // namespace <anonymous>
 
-CAF_TEST_FIXTURE_SCOPE(dynamic_remote_actor_tests, fixture)
+CAF_TEST_FIXTURE_SCOPE(dynamic_remote_actor_tests_udp, fixture)
 
-CAF_TEST(identity_semantics_tcp) {
+CAF_TEST(identity_semantics_udp) {
   // server side
   auto server = server_side.spawn(make_pong_behavior);
-  CAF_EXP_THROW(port1, server_side_mm.publish(server, 0, local_host));
-  CAF_EXP_THROW(port2, server_side_mm.publish(server, 0, local_host));
+  CAF_EXP_THROW(port1, server_side_mm.publish_udp(server, 0, local_host));
+  CAF_EXP_THROW(port2, server_side_mm.publish_udp(server, 0, local_host));
   CAF_REQUIRE_NOT_EQUAL(port1, port2);
-  CAF_EXP_THROW(same_server, server_side_mm.remote_actor(local_host, port2));
+  CAF_EXP_THROW(same_server, server_side_mm.remote_actor_udp(local_host, port2));
   CAF_REQUIRE_EQUAL(same_server, server);
   CAF_CHECK_EQUAL(same_server->node(), server_side.node());
-  CAF_EXP_THROW(server1, client_side_mm.remote_actor(local_host, port1));
-  CAF_EXP_THROW(server2, client_side_mm.remote_actor(local_host, port2));
-  CAF_CHECK_EQUAL(server1, client_side_mm.remote_actor(local_host, port1));
-  CAF_CHECK_EQUAL(server2, client_side_mm.remote_actor(local_host, port2));
+  CAF_EXP_THROW(server1, client_side_mm.remote_actor_udp(local_host, port1));
+  CAF_EXP_THROW(server2, client_side_mm.remote_actor_udp(local_host, port2));
+  CAF_CHECK_EQUAL(server1, client_side_mm.remote_actor_udp(local_host, port1));
+  CAF_CHECK_EQUAL(server2, client_side_mm.remote_actor_udp(local_host, port2));
   anon_send_exit(server, exit_reason::user_shutdown);
 }
 
-CAF_TEST(ping_pong_tcp) {
+CAF_TEST(ping_pong_udp) {
   // server side
   CAF_EXP_THROW(port,
-                server_side_mm.publish(server_side.spawn(make_pong_behavior),
-                                       0, local_host));
+                server_side_mm.publish_udp(server_side.spawn(make_pong_behavior),
+                                           0, local_host));
   // client side
-  CAF_EXP_THROW(pong, client_side_mm.remote_actor(local_host, port));
+  CAF_EXP_THROW(pong, client_side_mm.remote_actor_udp(local_host, port));
   client_side.spawn(make_ping_behavior, pong);
 }
 
-CAF_TEST(custom_message_type_tcp) {
+CAF_TEST(custom_message_type_udp) {
   // server side
-  CAF_EXP_THROW(port, server_side_mm.publish(server_side.spawn(make_sort_behavior),
-                                             0, local_host));
+  CAF_EXP_THROW(port,
+                server_side_mm.publish_udp(server_side.spawn(make_sort_behavior),
+                                           0, local_host));
   // client side
-  CAF_EXP_THROW(sorter, client_side_mm.remote_actor(local_host, port));
+  CAF_EXP_THROW(sorter, client_side_mm.remote_actor_udp(local_host, port));
   client_side.spawn(make_sort_requester_behavior, sorter);
 }
 
-CAF_TEST(remote_link_tcp) {
+CAF_TEST(remote_link_udp) {
   // server side
-  CAF_EXP_THROW(port, server_side_mm.publish(server_side.spawn(fragile_mirror),
-                                             0, local_host));
+  CAF_EXP_THROW(port,
+                server_side_mm.publish_udp(server_side.spawn(fragile_mirror),
+                                           0, local_host));
   // client side
-  CAF_EXP_THROW(mirror, client_side_mm.remote_actor(local_host, port));
+  CAF_EXP_THROW(mirror, client_side_mm.remote_actor_udp(local_host, port));
   auto linker = client_side.spawn(linking_actor, mirror);
   scoped_actor self{client_side};
   self->wait_for(linker);
   CAF_MESSAGE("linker exited");
   self->wait_for(mirror);
   CAF_MESSAGE("mirror exited");
+}
+
+CAF_TEST(multiple_endpoints_udp) {
+  config cfg;
+  // setup server
+  CAF_MESSAGE("creating server");
+  actor_system server_sys{cfg};
+  auto mirror = server_sys.spawn([]() -> behavior {
+    return {
+      [] (std::string str) {
+        std::reverse(begin(str), end(str));
+        return str;
+      }
+    };
+  });
+  server_sys.middleman().publish_udp(mirror, 12345);
+  auto client_fun = [](event_based_actor* self) -> behavior {
+    return {
+      [=](actor s) {
+        self->send(s, "hellow, world");
+      },
+      [=](const std::string& str) {
+        CAF_CHECK_EQUAL(str, "dlrow ,wolleh");
+        self->quit();
+        CAF_MESSAGE("done");
+      }
+    };
+  };
+  // setup client a
+  CAF_MESSAGE("creating first client");
+  config client_cfg;
+  actor_system client_sys{client_cfg};
+  auto client = client_sys.spawn(client_fun);
+  // acquire remote actor from the server
+  auto client_srv = client_sys.middleman().remote_actor_udp("localhost", 12345);
+  CAF_REQUIRE(client_srv);
+  // setup other clients
+  for (int i = 0; i < 5; ++i) {
+    config other_cfg;
+    actor_system other_sys{other_cfg};
+    CAF_MESSAGE("creating new client");
+    auto other = other_sys.spawn(client_fun);
+    // acquire remote actor from the server
+    auto other_srv = other_sys.middleman().remote_actor_udp("localhost", 12345);
+    CAF_REQUIRE(other_srv);
+    // establish communication and exit
+    CAF_MESSAGE("client contacts server and exits");
+    anon_send(other, *other_srv);
+    other_sys.await_all_actors_done();
+  }
+  // establish communication and exit
+  CAF_MESSAGE("first client contacts server and exits");
+  anon_send(client, *client_srv);
+  client_sys.await_all_actors_done();
+  anon_send_exit(mirror, exit_reason::user_shutdown);
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()


### PR DESCRIPTION
Although this allows compilation of the asio multiplexer with UDP it does not enable to use UDP with the multiplexer. The related stubs will throw runtime errors when called. Addresses the fist suggestion in #638