### PR TITLE
Fix build for mingw (mxe)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,7 @@ if(MINGW)
   add_definitions(-D_WIN32_WINNT=0x0600)
   add_definitions(-DWIN32)
   include(GenerateExportHeader)
-  set(LD_FLAGS "ws2_32 -liphlpapi")
+  set(LD_FLAGS "ws2_32 -liphlpapi -lpsapi")
   # build static to avoid runtime dependencies to GCC libraries
   set(EXTRA_FLAGS "${EXTRA_FLAGS} -static")
 elseif(CYGWIN)

--- a/examples/broker/protobuf_broker.cpp
+++ b/examples/broker/protobuf_broker.cpp
@@ -4,10 +4,14 @@
 #include <memory>
 #include <iostream>
 
-#include <arpa/inet.h>
-
 #include "caf/all.hpp"
 #include "caf/io/all.hpp"
+
+#ifdef CAF_WINDOWS
+#include <winsock2.h>
+#else
+#include <arpa/inet.h>
+#endif
 
 CAF_PUSH_WARNINGS
 #include "pingpong.pb.h"

--- a/examples/broker/simple_broker.cpp
+++ b/examples/broker/simple_broker.cpp
@@ -13,7 +13,7 @@
 
 #ifdef WIN32
 # define _WIN32_WINNT 0x0600
-# include <Winsock2.h>
+# include <winsock2.h>
 #else
 # include <arpa/inet.h> // htonl
 #endif

--- a/libcaf_core/caf/scheduler/profiled_coordinator.hpp
+++ b/libcaf_core/caf/scheduler/profiled_coordinator.hpp
@@ -25,8 +25,8 @@
 #if defined(CAF_MACOS) || defined(CAF_IOS)
 #include <mach/mach.h>
 #elif defined(CAF_WINDOWS)
-#include <Windows.h>
-#include <Psapi.h>
+#include <windows.h>
+#include <psapi.h>
 #else
 #include <sys/resource.h>
 #endif

--- a/libcaf_core/src/get_process_id.cpp
+++ b/libcaf_core/src/get_process_id.cpp
@@ -22,7 +22,7 @@
 #include "caf/config.hpp"
 
  #ifdef CAF_WINDOWS
-#  include <Windows.h>
+#  include <windows.h>
 #else
 #  include <sys/types.h>
 #  include <unistd.h>

--- a/libcaf_io/src/ip_endpoint.cpp
+++ b/libcaf_io/src/ip_endpoint.cpp
@@ -24,9 +24,9 @@
 
 #ifdef CAF_WINDOWS
 # include <winsock2.h>
+# include <windows.h>
 # include <ws2tcpip.h>
 # include <ws2ipdef.h>
-# include <windows.h>
 #else
 # include <unistd.h>
 # include <cerrno>
@@ -209,12 +209,12 @@ std::string host(const ip_endpoint& ep) {
   switch(ep.caddress()->sa_family) {
     case AF_INET:
       inet_ntop(AF_INET,
-                &reinterpret_cast<const sockaddr_in*>(ep.caddress())->sin_addr,
+                &const_cast<sockaddr_in*>(reinterpret_cast<const sockaddr_in*>(ep.caddress()))->sin_addr,
                 addr, static_cast<socklen_t>(*ep.clength()));
       break;
     case AF_INET6:
       inet_ntop(AF_INET6,
-                &reinterpret_cast<const sockaddr_in6*>(ep.caddress())->sin6_addr,
+                &const_cast<sockaddr_in6*>(reinterpret_cast<const sockaddr_in6*>(ep.caddress()))->sin6_addr,
                 addr, static_cast<socklen_t>(*ep.clength()));
       break;
     default:

--- a/libcaf_openssl/CMakeLists.txt
+++ b/libcaf_openssl/CMakeLists.txt
@@ -15,6 +15,9 @@ set (LIBCAF_OPENSSL_SRCS
 
 add_custom_target(libcaf_openssl)
 
+if (MINGW)
+  set(OPENSSL_LIBRARIES ${OPENSSL_LIBRARIES} -lz)
+endif()
 # build shared library if not compiling static only
 if (NOT CAF_BUILD_STATIC_ONLY)
   add_library(libcaf_openssl_shared SHARED


### PR DESCRIPTION
This fixes building CAF in [MXE](https://github.com/mxe/mxe) for the Windows target. The cURL example doesn't build yet (cURL linkage and signals issues), the Qt example doesn't link but the tests are fine and 100% passed using Wine. Please test on MSVC before merge, I don't have it and can't check if everything is good.

The command to configure using MXE (64 bit, assuming you've created and switched to a new build directory inside CAF):
```
/path/to/mxe/usr/bin/x86_64-w64-mingw32.static.posix-cmake -DCMAKE_BUILD_TYPE=Release -DOPENSSL_CORRECT_VERSION_NUMBER=1 -DCAF_BUILD_STATIC_ONLY=yes -DCAF_NO_CURL_EXAMPLES=yes -DCAF_NO_QT_EXAMPLES=yes ..
```
Building a debug version takes ages for me, YMMV. The OpenSSL hack is required and reported by CMake itself.