### PR TITLE
Fix UDP unit tests on Windows

### DIFF
--- a/libcaf_io/caf/io/network/default_multiplexer.hpp
+++ b/libcaf_io/caf/io/network/default_multiplexer.hpp
@@ -184,6 +184,9 @@ expected<void> tcp_nodelay(native_socket fd, bool new_value);
 /// Enables or disables `SIGPIPE` events from `fd`.
 expected<void> allow_sigpipe(native_socket fd, bool new_value);
 
+/// Enables or disables `SIO_UDP_CONNRESET`error on `fd`.
+expected<void> allow_udp_connreset(native_socket fd, bool new_value);
+
 /// Get the socket buffer size for `fd`.
 expected<int> send_buffer_size(native_socket fd);
 

--- a/libcaf_io/test/ip_endpoint.cpp
+++ b/libcaf_io/test/ip_endpoint.cpp
@@ -25,18 +25,25 @@
 
 #include "caf/actor_system.hpp"
 #include "caf/actor_system_config.hpp"
-
 #include "caf/binary_serializer.hpp"
 #include "caf/binary_deserializer.hpp"
 
+#include "caf/io/middleman.hpp"
 #include "caf/io/network/interfaces.hpp"
 #include "caf/io/network/ip_endpoint.hpp"
 
 using namespace caf;
 using namespace caf::io;
 
-
 namespace {
+
+class config : public actor_system_config {
+public:
+  config() {
+    // this will call WSAStartup for network initialization on Windows
+    load<io::middleman>();
+  }
+};
 
 struct fixture {
 
@@ -54,11 +61,11 @@ void deserialize(const std::vector<char>& buf, T& x, Ts&... xs) {
   bd(x, xs...);
 }
 
-fixture() : system(cfg), context(&system) {
+fixture() : cfg(), system(cfg), context(&system) {
 
 }
 
-actor_system_config cfg;
+config cfg;
 actor_system system;
 scoped_execution_unit context;
 


### PR DESCRIPTION
Addresses #645

The tests in `io_dynamic_remote_actor_udp` received an error from `recvfrom` because `SIO_UDP_CONNRESET`. In the `ip_endpoint` test, the middleman was never initialized and thus `WSAStartup` was never called.