### PR TITLE
Replace throw with CAF_RAISE_ERROR

### DIFF
--- a/libcaf_core/caf/deserializer.hpp
+++ b/libcaf_core/caf/deserializer.hpp
@@ -67,7 +67,7 @@ typename std::enable_if<
 operator&(deserializer& source, T& x) {
   auto e = source.apply(x);
   if (e)
-    throw std::runtime_error(to_string(e));
+    CAF_RAISE_ERROR(to_string(e));
 }
 
 template <class T>

--- a/libcaf_core/caf/serializer.hpp
+++ b/libcaf_core/caf/serializer.hpp
@@ -67,7 +67,7 @@ operator&(serializer& sink, const T& x) {
   // implementations are required to never modify `x` while saving
   auto e = sink.apply(const_cast<T&>(x));
   if (e)
-    throw std::runtime_error(to_string(e));
+    CAF_RAISE_ERROR(to_string(e));
 }
 
 template <class T>

--- a/libcaf_opencl/caf/opencl/actor_facade.hpp
+++ b/libcaf_opencl/caf/opencl/actor_facade.hpp
@@ -89,16 +89,14 @@ public:
                       Ts&&... xs) {
     if (range.dimensions().empty()) {
       auto str = "OpenCL kernel needs at least 1 global dimension.";
-      CAF_LOG_ERROR(str);
-      throw std::runtime_error(str);
+      CAF_RAISE_ERROR(str);
     }
     auto check_vec = [&](const dim_vec& vec, const char* name) {
       if (! vec.empty() && vec.size() != range.dimensions().size()) {
         std::ostringstream oss;
         oss << name << " vector is not empty, but "
             << "its size differs from global dimensions vector's size";
-        CAF_LOG_ERROR(CAF_ARG(oss.str()));
-        throw std::runtime_error(oss.str());
+        CAF_RAISE_ERROR(oss.str());
       }
     };
     check_vec(range.offsets(), "offsets");

--- a/libcaf_opencl/caf/opencl/command.hpp
+++ b/libcaf_opencl/caf/opencl/command.hpp
@@ -197,7 +197,7 @@ private:
                                    events.data(), &events.back());
     if (err != CL_SUCCESS) {
       this->deref(); // failed to enqueue command
-      throw std::runtime_error("clEnqueueReadBuffer: " + opencl_error(err));
+      CAF_RAISE_ERROR("clEnqueueReadBuffer: " + opencl_error(err));
     }
     pos += 1;
   }

--- a/libcaf_opencl/src/manager.cpp
+++ b/libcaf_opencl/src/manager.cpp
@@ -53,7 +53,7 @@ void manager::init(actor_system_config&) {
   std::vector<cl_platform_id> platform_ids(num_platforms);
   v2callcl(CAF_CLF(clGetPlatformIDs), num_platforms, platform_ids.data());
   if (platform_ids.empty())
-    throw std::runtime_error("no OpenCL platform found");
+    CAF_RAISE_ERROR("no OpenCL platform found");
   // initialize platforms (device discovery)
   unsigned current_device_id = 0;
   for (auto& pl_id : platform_ids) {
@@ -100,7 +100,7 @@ program_ptr manager::create_program_from_file(const char* path,
     ostringstream oss;
     oss << "No file at '" << path << "' found.";
     CAF_LOG_ERROR(CAF_ARG(oss.str()));
-    throw runtime_error(oss.str());
+    CAF_RAISE_ERROR(oss.str());
   }
   return create_program(kernel_source.c_str(), options, device_id);
 }
@@ -113,7 +113,7 @@ program_ptr manager::create_program(const char* kernel_source,
     ostringstream oss;
     oss << "No device with id '" << device_id << "' found.";
     CAF_LOG_ERROR(CAF_ARG(oss.str()));
-    throw runtime_error(oss.str());
+    CAF_RAISE_ERROR(oss.str());
   }
   return create_program(kernel_source, options, *dev);
 }
@@ -134,7 +134,7 @@ program_ptr manager::create_program_from_file(const char* path,
     ostringstream oss;
     oss << "No file at '" << path << "' found.";
     CAF_LOG_ERROR(CAF_ARG(oss.str()));
-    throw runtime_error(oss.str());
+    CAF_RAISE_ERROR(oss.str());
   }
   return create_program(kernel_source.c_str(), options, dev);
 }
@@ -176,7 +176,7 @@ program_ptr manager::create_program(const char* kernel_source,
 #endif
       oss << endl << ss.str();
     }
-    throw runtime_error(oss.str());
+    CAF_RAISE_ERROR(oss.str());
   }
   cl_uint number_of_kernels = 0;
   clCreateKernelsInProgram(pptr.get(), 0u, nullptr, &number_of_kernels);
@@ -188,7 +188,7 @@ program_ptr manager::create_program(const char* kernel_source,
     if (err != CL_SUCCESS) {
       ostringstream oss;
       oss << "clCreateKernelsInProgram: " << opencl_error(err);
-      throw runtime_error(oss.str());
+      CAF_RAISE_ERROR(oss.str());
     }
     for (cl_uint i = 0; i < number_of_kernels; ++i) {
       size_t len;
@@ -200,7 +200,7 @@ program_ptr manager::create_program(const char* kernel_source,
         ostringstream oss;
         oss << "clGetKernelInfo (CL_KERNEL_FUNCTION_NAME): "
             << opencl_error(err);
-        throw runtime_error(oss.str());
+        CAF_RAISE_ERROR(oss.str());
       }
       detail::raw_kernel_ptr kernel;
       kernel.reset(move(kernels[i]));

--- a/libcaf_opencl/src/opencl_err.cpp
+++ b/libcaf_opencl/src/opencl_err.cpp
@@ -27,7 +27,7 @@ void throwcl(const char* fname, cl_int err) {
     std::string errstr = fname;
     errstr += ": ";
     errstr += opencl_error(err);
-    throw std::runtime_error(std::move(errstr));
+    CAF_RAISE_ERROR(std::move(errstr));
   }
 }
 

--- a/libcaf_opencl/src/platform.cpp
+++ b/libcaf_opencl/src/platform.cpp
@@ -66,7 +66,7 @@ platform_ptr platform::create(cl_platform_id platform_id,
   if (device_information.empty()) {
     string errstr = "no devices for the platform found";
     CAF_LOG_ERROR(CAF_ARG(errstr));
-    throw runtime_error(move(errstr));
+    CAF_RAISE_ERROR(move(errstr));
   }
   auto name = platform_info(platform_id, CL_PLATFORM_NAME);
   auto vendor = platform_info(platform_id, CL_PLATFORM_VENDOR);


### PR DESCRIPTION
Think we talked about this a while ago. Two files besides the config still include `throw`s, a unit test (`libcaf_core/test/custom_exception_handler.cpp`) and an example (`examples/qtsupport/chatwidget.hpp`).