### PR TITLE
Improve reordering latency

### DIFF
--- a/libcaf_core/caf/actor_system_config.hpp
+++ b/libcaf_core/caf/actor_system_config.hpp
@@ -301,6 +301,7 @@ public:
   bool middleman_enable_tcp;
   bool middleman_enable_udp;
   size_t middleman_cached_udp_buffers;
+  size_t middleman_max_pending_msgs;
 
   // -- config parameters of the OpenCL module ---------------------------------
 

--- a/libcaf_core/src/actor_system_config.cpp
+++ b/libcaf_core/src/actor_system_config.cpp
@@ -139,6 +139,7 @@ actor_system_config::actor_system_config()
   middleman_enable_tcp = true;
   middleman_enable_udp = false;
   middleman_cached_udp_buffers = 10;
+  middleman_max_pending_msgs = 10;
   // fill our options vector for creating INI and CLI parsers
   opt_group{options_, "scheduler"}
   .add(scheduler_policy, "policy",
@@ -208,6 +209,9 @@ actor_system_config::actor_system_config()
        "enable communication via UDP (off by default)")
   .add(middleman_cached_udp_buffers, "cached-udp-buffers",
        "sets the max number of UDP send buffers that will be cached for reuse "
+       "(default: 10)")
+  .add(middleman_max_pending_msgs, "max-pending-messages",
+       "sets the max number of UDP pending messages due to ordering "
        "(default: 10)");
   opt_group(options_, "opencl")
   .add(opencl_device_ids, "device-ids",

--- a/libcaf_io/caf/io/basp/endpoint_context.hpp
+++ b/libcaf_io/caf/io/basp/endpoint_context.hpp
@@ -36,9 +36,8 @@ namespace basp {
 
 // stores meta information for active endpoints
 struct endpoint_context {
-  using pending_map = std::unordered_map<uint16_t,
-                                         std::pair<basp::header,
-                                                   std::vector<char>>>;
+  using pending_map = std::map<sequence_type, std::pair<basp::header,
+                                                        std::vector<char>>>;
   // denotes what message we expect from the remote node next
   basp::connection_state cstate;
   // our currently processed BASP header
@@ -55,9 +54,12 @@ struct endpoint_context {
   // protocols that do not implement ordering are ordered by CAF
   bool requires_ordering;
   // sequence numbers and a buffer to establish order
-  uint16_t seq_incoming;
-  uint16_t seq_outgoing;
+  sequence_type seq_incoming;
+  sequence_type seq_outgoing;
+  // pending messages due to ordering
   pending_map pending;
+  // track if a timeout to deliver pending messages is set
+  bool did_set_timeout;
 };
 
 } // namespace basp

--- a/libcaf_io/caf/io/basp/instance.hpp
+++ b/libcaf_io/caf/io/basp/instance.hpp
@@ -112,16 +112,18 @@ public:
 
     /// Adds a message with a future sequence number to the pending messages
     /// of a given endpoint context.
-    virtual void add_pending(sequence_type seq, endpoint_context& ep,
-                             header hdr, std::vector<char> payload) = 0;
+    virtual void add_pending(execution_unit* ctx, endpoint_context& ep,
+                             sequence_type seq, header hdr,
+                             std::vector<char> payload) = 0;
 
-    /// Delivers a pending incoming messages for an endpoint with
-    /// application layer ordering.
-    virtual bool deliver_pending(execution_unit* ctx,
-                                 endpoint_context& ep) = 0;
+    /// Delivers a pending incoming messages for an endpoint `ep` with
+    /// application layer ordering. Delivery of the next available packet can
+    /// be forced to simply skip undeliverd messages via the `force` flag.
+    virtual bool deliver_pending(execution_unit* ctx, endpoint_context& ep,
+                                 bool force) = 0;
 
     /// Drop pending messages with sequence number `seq`.
-    virtual void drop_pending(sequence_type seq, endpoint_context& ep) = 0;
+    virtual void drop_pending(endpoint_context& ep, sequence_type seq) = 0;
 
     /// Returns a reference to the current sent buffer, dispatching the call
     /// based on the type contained in `hdl`.

--- a/libcaf_io/caf/io/basp_broker.hpp
+++ b/libcaf_io/caf/io/basp_broker.hpp
@@ -97,15 +97,16 @@ struct basp_broker_state : proxy_registry::backend, basp::instance::callee {
   uint16_t next_sequence_number(datagram_handle hdl) override;
 
   // inherited from basp::instance::callee
-  void add_pending(uint16_t seq, basp::endpoint_context& ep, basp::header hdr,
+  void add_pending(execution_unit* ctx, basp::endpoint_context& ep,
+                   uint16_t seq, basp::header hdr,
                    std::vector<char> payload) override;
 
   // inherited from basp::instance::callee
-  bool deliver_pending(execution_unit* ctx,
-                       basp::endpoint_context& ep) override;
+  bool deliver_pending(execution_unit* ctx, basp::endpoint_context& ep,
+                       bool force) override;
 
   // inherited from basp::instance::callee
-  void drop_pending(uint16_t seq, basp::endpoint_context& ep) override;
+  void drop_pending(basp::endpoint_context& ep, uint16_t seq) override;
 
   // inherited from basp::instance::callee
   buffer_type& get_buffer(endpoint_handle hdl) override;
@@ -173,6 +174,12 @@ struct basp_broker_state : proxy_registry::backend, basp::instance::callee {
   // reusable send buffers for UDP communication
   const size_t max_buffers;
   std::stack<buffer_type> cached_buffers;
+
+  // maximum queue size for pending messages of endpoints with ordering
+  const size_t max_pending_messages;
+
+  // timeout for delivery of pending messages of endpoints with ordering
+  const std::chrono::milliseconds pending_to = std::chrono::milliseconds(100);
 
   // returns the node identifier of the underlying BASP instance
   const node_id& this_node() const {


### PR DESCRIPTION
Improve the latency in case UDP has to reorder packets. In addition to a timeout, the queue with pending messages has a length (currently 10). Pending messages will be when it runs full. We'll still need a timeout in case we received the end of a message stream and our queue will never run full, but a message is lost.

I don't see a problem with dropping messages in this case as there is no reliability guarantee at the moment. The queue length ... is a good question, 10 will reorder things that arrive a bit twisted but messages with a longer delay will be dropped. If you have a steady stream of messages the queue would need to be rather long to wait for messages that have a significant delay. I'm not sure how to determine a good queue size atm. In any case, the length is configurable via the actor system config.