### PR TITLE
Fix build with MSVC 2017

### DIFF
--- a/libcaf_core/caf/mixin/sender.hpp
+++ b/libcaf_core/caf/mixin/sender.hpp
@@ -80,7 +80,7 @@ public:
                        typename res_t::type
                      >::valid,
                   "this actor does not accept the response message");
-    if (dest != nullptr)
+    if (dest)
       dest->eq_impl(make_message_id(P), dptr()->ctrl(),
                     dptr()->context(), std::forward<Ts>(xs)...);
   }
@@ -94,7 +94,7 @@ public:
                   "statically typed actors can only send() to other "
                   "statically typed actors; use anon_send() or request() when "
                   "communicating with dynamically typed actors");
-    if (dest != nullptr)
+    if (dest)
       dest->get()->eq_impl(make_message_id(P), dptr()->ctrl(),
                            dptr()->context(), std::forward<Ts>(xs)...);
   }

--- a/libcaf_core/caf/send.hpp
+++ b/libcaf_core/caf/send.hpp
@@ -102,7 +102,7 @@ void anon_send(const Dest& dest, Ts&&... xs) {
   using token = detail::type_list<detail::strip_and_convert_t<Ts>...>;
   static_assert(response_type_unbox<signatures_of_t<Dest>, token>::valid,
                 "receiver does not accept given message");
-  if (dest != nullptr)
+  if (dest)
     dest->eq_impl(make_message_id(P), nullptr, nullptr,
                   std::forward<Ts>(xs)...);
 }
@@ -111,7 +111,7 @@ void anon_send(const Dest& dest, Ts&&... xs) {
 template <message_priority P = message_priority::normal, class... Ts>
 void anon_send(const strong_actor_ptr& dest, Ts&&... xs) {
   static_assert(sizeof...(Ts) > 0, "no message to send");
-  if (dest != nullptr)
+  if (dest)
     dest->get()->eq_impl(make_message_id(P), nullptr, nullptr,
                          std::forward<Ts>(xs)...);
 }


### PR DESCRIPTION
Build Output:

> 9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\mixin\sender.hpp(83): error C2666: "caf::operator !=": 6 Überladungen haben ähnliche Konvertierungen
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\expected.hpp(423): note: kann "bool caf::operator !=(const caf::expected<void> &,const caf::expected<void> &)" sein
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\duration.hpp(145): note: oder "bool caf::operator !=(const caf::duration &,const caf::duration &)"
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\actor_addr.hpp(159): note: oder "bool caf::operator !=(std::nullptr_t,const caf::actor_addr &)"
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\actor_addr.hpp(155): note: oder "bool caf::operator !=(const caf::actor_addr &,std::nullptr_t)"
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\actor.hpp(224): note: oder "bool caf::operator !=(caf::abstract_actor *,const caf::actor &)"
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\actor.hpp(221): note: oder "bool caf::operator !=(const caf::actor &,caf::abstract_actor *)"
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\actor_control_block.hpp(179): note: oder "bool caf::operator !=(const caf::abstract_actor *,const caf::strong_actor_ptr &)"
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\actor_control_block.hpp(174): note: oder "bool caf::operator !=(const caf::strong_actor_ptr &,const caf::abstract_actor *)"
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\node_id.hpp(188): note: oder "bool caf::operator !=(const caf::node_id &,const caf::node_id &)"
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\node_id.hpp(180): note: oder "bool caf::operator !=(caf::none_t,const caf::node_id &)"
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\node_id.hpp(175): note: oder "bool caf::operator !=(const caf::node_id &,caf::none_t)"
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\error.hpp(239): note: oder "bool caf::operator !=(caf::none_t,const caf::error &)"
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\error.hpp(234): note: oder "bool caf::operator !=(const caf::error &,caf::none_t)"
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(88): note: oder "bool caf::detail::comparable<caf::none_t,Subclass>::operator !=(const Subclass &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::none_t
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(88): note: oder "bool caf::detail::comparable<caf::error,Subclass>::operator !=(const Subclass &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::error
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(88): note: oder "bool caf::detail::comparable<caf::unit_t,Subclass>::operator !=(const Subclass &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::unit_t
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\message_data.hpp(145): note: oder "bool caf::detail::operator !=(const caf::detail::message_data::cow_ptr &,std::nullptr_t)" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\message_data.hpp(149): note: oder "bool caf::detail::operator !=(std::nullptr_t,const caf::detail::message_data::cow_ptr &)" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(88): note: oder "bool caf::detail::comparable<caf::message_id,Subclass>::operator !=(const Subclass &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::message_id
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(88): note: oder "bool caf::detail::comparable<caf::weak_intrusive_ptr<caf::actor_control_block>,Subclass>::operator !=(const Subclass &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::weak_intrusive_ptr<caf::actor_control_block>
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(41): note: oder "bool caf::detail::comparable<caf::weak_intrusive_ptr<caf::actor_control_block>,const T *>::operator !=(const Subclass &,const caf::actor_control_block *const &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            T=caf::actor_control_block,
9>            Subclass=caf::weak_intrusive_ptr<caf::actor_control_block>
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(45): note: oder "bool caf::detail::comparable<caf::weak_intrusive_ptr<caf::actor_control_block>,const T *>::operator !=(const caf::actor_control_block *const &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            T=caf::actor_control_block,
9>            Subclass=caf::weak_intrusive_ptr<caf::actor_control_block>
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(41): note: oder "bool caf::detail::comparable<caf::weak_intrusive_ptr<caf::actor_control_block>,std::nullptr_t>::operator !=(const Subclass &,const T &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::weak_intrusive_ptr<caf::actor_control_block>,
9>            T=std::nullptr_t
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(45): note: oder "bool caf::detail::comparable<caf::weak_intrusive_ptr<caf::actor_control_block>,std::nullptr_t>::operator !=(const T &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            T=std::nullptr_t,
9>            Subclass=caf::weak_intrusive_ptr<caf::actor_control_block>
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(88): note: oder "bool caf::detail::comparable<caf::actor,Subclass>::operator !=(const Subclass &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::actor
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(41): note: oder "bool caf::detail::comparable<caf::actor,caf::actor_addr>::operator !=(const Subclass &,const T &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::actor,
9>            T=caf::actor_addr
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(45): note: oder "bool caf::detail::comparable<caf::actor,caf::actor_addr>::operator !=(const T &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            T=caf::actor_addr,
9>            Subclass=caf::actor
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(41): note: oder "bool caf::detail::comparable<caf::actor,caf::strong_actor_ptr>::operator !=(const Subclass &,const T &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::actor,
9>            T=caf::strong_actor_ptr
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(45): note: oder "bool caf::detail::comparable<caf::actor,caf::strong_actor_ptr>::operator !=(const T &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            T=caf::strong_actor_ptr,
9>            Subclass=caf::actor
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(88): note: oder "bool caf::detail::comparable<caf::actor_addr,Subclass>::operator !=(const Subclass &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::actor_addr
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(41): note: oder "bool caf::detail::comparable<caf::actor_addr,caf::weak_actor_ptr>::operator !=(const Subclass &,const T &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::actor_addr,
9>            T=caf::weak_actor_ptr
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(45): note: oder "bool caf::detail::comparable<caf::actor_addr,caf::weak_actor_ptr>::operator !=(const T &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            T=caf::weak_actor_ptr,
9>            Subclass=caf::actor_addr
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(41): note: oder "bool caf::detail::comparable<caf::actor_addr,caf::strong_actor_ptr>::operator !=(const Subclass &,const T &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::actor_addr,
9>            T=caf::strong_actor_ptr
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(45): note: oder "bool caf::detail::comparable<caf::actor_addr,caf::strong_actor_ptr>::operator !=(const T &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            T=caf::strong_actor_ptr,
9>            Subclass=caf::actor_addr
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(41): note: oder "bool caf::detail::comparable<caf::actor_addr,caf::abstract_actor *>::operator !=(const Subclass &,const T &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::actor_addr,
9>            T=caf::abstract_actor *
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(45): note: oder "bool caf::detail::comparable<caf::actor_addr,caf::abstract_actor *>::operator !=(const T &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            T=caf::abstract_actor *,
9>            Subclass=caf::actor_addr
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(41): note: oder "bool caf::detail::comparable<caf::actor_addr,caf::actor_control_block *>::operator !=(const Subclass &,const T &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::actor_addr,
9>            T=caf::actor_control_block *
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(45): note: oder "bool caf::detail::comparable<caf::actor_addr,caf::actor_control_block *>::operator !=(const T &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            T=caf::actor_control_block *,
9>            Subclass=caf::actor_addr
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(88): note: oder "bool caf::detail::comparable<caf::stream_slots,Subclass>::operator !=(const Subclass &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::stream_slots
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(88): note: oder "bool caf::detail::comparable<caf::group,Subclass>::operator !=(const Subclass &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::group
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(41): note: oder "bool caf::detail::comparable<caf::group,caf::invalid_group_t>::operator !=(const Subclass &,const T &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=caf::group,
9>            T=caf::invalid_group_t
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(45): note: oder "bool caf::detail::comparable<caf::group,caf::invalid_group_t>::operator !=(const T &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            T=caf::invalid_group_t,
9>            Subclass=caf::group
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(88): note: oder "bool caf::detail::comparable<`anonymous-namespace'::caf_handle,Subclass>::operator !=(const Subclass &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=`anonymous-namespace'::caf_handle
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(41): note: oder "bool caf::detail::comparable<`anonymous-namespace'::caf_handle,std::nullptr_t>::operator !=(const Subclass &,const T &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            Subclass=`anonymous-namespace'::caf_handle,
9>            T=std::nullptr_t
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\detail\comparable.hpp(45): note: oder "bool caf::detail::comparable<`anonymous-namespace'::caf_handle,std::nullptr_t>::operator !=(const T &,const Subclass &) noexcept" [bei der Verwendung der argumentbezogenen Suche gefunden]
9>        with
9>        [
9>            T=std::nullptr_t,
9>            Subclass=`anonymous-namespace'::caf_handle
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\mixin\sender.hpp(83): note: bei Anpassung der Argumentliste "(const caf::actor, nullptr)"
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\test\actor_clock.cpp(96): note: Siehe Verweis auf die Instanziierung der gerade kompilierten Funktions-Vorlage "void caf::mixin::sender<B,D>::send<caf::message_priority::normal,caf::actor,const caf::atom_constant<64816>&>(const Dest &,const caf::atom_constant<64816> &)".
9>        with
9>        [
9>            B=caf::mixin::requester<caf::local_actor,caf::blocking_actor>,
9>            D=caf::blocking_actor,
9>            Dest=caf::actor
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\test\actor_clock.cpp(96): note: Siehe Verweis auf die Instanziierung der gerade kompilierten Funktions-Vorlage "void caf::mixin::sender<B,D>::send<caf::message_priority::normal,caf::actor,const caf::atom_constant<64816>&>(const Dest &,const caf::atom_constant<64816> &)".
9>        with
9>        [
9>            B=caf::mixin::requester<caf::local_actor,caf::blocking_actor>,
9>            D=caf::blocking_actor,
9>            Dest=caf::actor
9>        ]
9>c:\users\marian\gitrepos\actor-framework\libcaf_core\caf\mixin\sender.hpp(83): error C2088: "!=": Ungültig für class