### PR TITLE
Improve workaround for older libstdc++ versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,20 @@ else()
   set(CAF_USE_ASIO_INT -1)
 endif()
 
+# GCC (libstdc++) < 4.9 has a broken STL: vector::erase accepts iterator
+# instead of const_iterator.
+# TODO: remove when dropping support for GCC 4.8.
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles("
+#include <vector>
+int main(int argc, char** argv) {
+  std::vector<int> v;
+  std::vector<int>::const_iterator it = v.begin();
+  v.erase(it);
+  return 0;
+}
+" CAF_HAVE_VECTOR_ERASE_CONST_ITERATOR)
+
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_config.hpp.in"
                "${CMAKE_CURRENT_SOURCE_DIR}/libcaf_core/caf/detail/build_config.hpp"
                IMMEDIATE @ONLY)

--- a/cmake/build_config.hpp.in
+++ b/cmake/build_config.hpp.in
@@ -41,3 +41,4 @@
 #define CAF_NO_EXCEPTIONS
 #endif
 
+#cmakedefine CAF_HAVE_VECTOR_ERASE_CONST_ITERATOR

--- a/libcaf_core/caf/detail/unordered_flat_map.hpp
+++ b/libcaf_core/caf/detail/unordered_flat_map.hpp
@@ -268,18 +268,15 @@ public:
   }
 
 private:
-  // GCC < 4.9 has a broken STL: vector::erase accepts iterator instead of
-  // const_iterator.
-  // TODO: remove when dropping support for GCC 4.8.
-#if defined(CAF_GCC) && CAF_COMPILER_VERSION < 49000
+#ifdef CAF_HAVE_VECTOR_ERASE_CONST_ITERATOR
+  const_iterator gcc48_iterator_workaround(const_iterator i) {
+    return i;
+  }
+#else
   iterator gcc48_iterator_workaround(const_iterator i) {
     auto j = begin();
     std::advance(j, std::distance(cbegin(), i));
     return j;
-  }
-#else
-  const_iterator gcc48_iterator_workaround(const_iterator i) {
-    return i;
   }
 #endif
 


### PR DESCRIPTION
Checking just for GCC version is not sufficient as the problem lies
with whether libstdc++ (usable from Clang) implements the required
vector::erase(const_iterator).

The easiest way to check for a valid libstdc++ version at the moment
seems to be via a compilation check at CMake's configure-time.