### PR TITLE
Pull in a missing lib file on Windows

### DIFF
--- a/libcaf_core/src/get_mac_addresses.cpp
+++ b/libcaf_core/src/get_mac_addresses.cpp
@@ -167,6 +167,8 @@ std::vector<iface_info> get_mac_addresses() {
 #include <iterator>
 #include <algorithm>
 
+#pragma comment(lib, "Iphlpapi.lib")
+
 namespace {
 
 constexpr size_t working_buffer_size = 15 * 1024; // 15kb by default


### PR DESCRIPTION
Fix missing lib linking error when building with caf_core_static.lib