### PR TITLE
Fix update message in config server

### DIFF
--- a/libcaf_core/src/actor_system.cpp
+++ b/libcaf_core/src/actor_system.cpp
@@ -86,13 +86,13 @@ behavior config_serv_impl(stateful_actor<kvstate>* self) {
         // we never put a nullptr in our map
         auto subscriber = actor_cast<actor>(subscriber_ptr);
         if (subscriber != self->current_sender())
-          self->send(subscriber, update_atom::value, key, vp.second);
+          self->send(subscriber, update_atom::value, key, vp.first);
       }
       // also iterate all subscribers for '*'
       for (auto& subscriber : self->state.data[wildcard].second)
         if (subscriber != self->current_sender())
           self->send(actor_cast<actor>(subscriber), update_atom::value,
-                     key, vp.second);
+                     key, vp.first);
     },
     // get a key/value pair
     [=](get_atom, std::string& key) -> message {


### PR DESCRIPTION
If I'm not mistaken the `msg` should be sent to the subscriber not the subscriber set. Since this has probably been there forever here is a PR for that and not just a push.