### PR TITLE
Fix a file descriptor leak in get_mac_addresses()

### DIFF
--- a/libcaf_core/src/get_mac_addresses.cpp
+++ b/libcaf_core/src/get_mac_addresses.cpp
@@ -110,6 +110,7 @@ std::vector<iface_info> get_mac_addresses() {
   ifc.ifc_buf = buf;
   if (ioctl(sck, SIOCGIFCONF, &ifc) < 0) {
     perror("ioctl(SIOCGIFCONF)");
+    close(sck);
     return {};
   }
   std::vector<iface_info> result;
@@ -124,6 +125,7 @@ std::vector<iface_info> get_mac_addresses() {
     // get mac address
     if (ioctl(sck, SIOCGIFHWADDR, item) < 0) {
       perror("ioctl(SIOCGIFHWADDR)");
+      close(sck);
       return {};
     }
     std::ostringstream oss;
@@ -140,6 +142,7 @@ std::vector<iface_info> get_mac_addresses() {
       result.push_back({item->ifr_name, std::move(addr)});
     }
   }
+  close(sck);
   return result;
 }
 


### PR DESCRIPTION
Probably even better to re-use the socket_guard class to ensure it gets closed on all code paths, including exceptions, though unsure how exactly you would have liked to have that factored out to make it more widely usable.