### PR TITLE
Add operator< for variant

### DIFF
--- a/libcaf_core/test/variant.cpp
+++ b/libcaf_core/test/variant.cpp
@@ -149,3 +149,23 @@ CAF_TEST(n_ary_visit) {
   CAF_CHECK_EQUAL(visit(f, a, b, c, d), "(42, 'foo', \"bar\", 123)");
 }
 
+CAF_TEST(less_than) {
+  using variant_type = variant<char, int>;
+  auto a = variant_type{'x'};
+  auto b = variant_type{'y'};
+  CAF_CHECK(a < b);
+  CAF_CHECK(!(a > b));
+  CAF_CHECK(a <= b);
+  CAF_CHECK(!(a >= b));
+  b = 42;
+  CAF_CHECK(a < b);
+  CAF_CHECK(!(a > b));
+  CAF_CHECK(a <= b);
+  CAF_CHECK(!(a >= b));
+  a = 42;
+  CAF_CHECK(!(a < b));
+  CAF_CHECK(!(a > b));
+  CAF_CHECK(a <= b);
+  CAF_CHECK(a >= b);
+  b = 'x';
+}


### PR DESCRIPTION
This PR adds support for the missing [relational operators that `std::variant` defines](http://en.cppreference.com/w/cpp/utility/variant/operator_cmp).

I have not touched the existing implementation of `operator==` yet, which has non-standard extensions when LHS and RHS are not instances of `caf::variant`. We may want to consider implementing all relational operators according to the standard.