### PR TITLE
Fix get_mac_addresses() potential buffer over-read

### DIFF
--- a/libcaf_core/src/get_mac_addresses.cpp
+++ b/libcaf_core/src/get_mac_addresses.cpp
@@ -48,6 +48,9 @@ std::vector<iface_info> get_mac_addresses() {
     }
     auto ifm = reinterpret_cast<if_msghdr*>(buf.data());
     auto sdl = reinterpret_cast<sockaddr_dl*>(ifm + 1);
+    constexpr auto mac_addr_len = 6;
+    if (sdl->sdl_alen != mac_addr_len)
+      continue;
     auto ptr = reinterpret_cast<unsigned char*>(LLADDR(sdl));
     auto uctoi = [](unsigned char c) -> unsigned {
       return static_cast<unsigned char>(c);
@@ -57,7 +60,7 @@ std::vector<iface_info> get_mac_addresses() {
     oss.fill('0');
     oss.width(2);
     oss << uctoi(*ptr++);
-    for (auto j = 0; j < 5; ++j) {
+    for (auto j = 0; j < mac_addr_len - 1; ++j) {
       oss << ":";
       oss.width(2);
       oss << uctoi(*ptr++);


### PR DESCRIPTION
The macOS/BSD implementation of get_mac_addresses() can check the
link-layer address length early on to filter out interfaces that don't
have a MAC address.  e.g. loopback interfaces don't have one.

A concern is that the sdl_data array of sockaddr_dl contains both the
data for the interface name and link-layer address, but
get_mac_addresses() is always assuming enough space was allocated in the
array to read 6 bytes of the MAC address even when some interfaces
report an address length of 0.  e.g. long interface names without a MAC
address could be a problem.