### PR TITLE
Fix "unused" warnings when using OpenSSL 1.1

### DIFF
--- a/libcaf_openssl/src/session.cpp
+++ b/libcaf_openssl/src/session.cpp
@@ -243,7 +243,7 @@ SSL_CTX* session::create_ssl_context() {
   } else {
     // No authentication.
     SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, nullptr);
-#ifdef CAF_SSL_HAS_ECDH_AUTO
+#if defined(CAF_SSL_HAS_ECDH_AUTO) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
     SSL_CTX_set_ecdh_auto(ctx, 1);
 #else
     auto ecdh = EC_KEY_new_by_curve_name(NID_secp384r1);


### PR DESCRIPTION
Per the OpenSSL CHANGES file:

* OpenSSL 1.1 no longer requires setting locking callbacks and
  previous functions are replaced with no-op compatibility macros.

* SSL_CTX_set_ecdh_auto() is removed (replaced with no-op macro) and
  ECDH support is always enabled by default.