### PR TITLE
Consolidate take_front code in DRR queues

### DIFF
--- a/libcaf_core/caf/intrusive/task_queue.hpp
+++ b/libcaf_core/caf/intrusive/task_queue.hpp
@@ -155,6 +155,28 @@ public:
     dec_total_task_size(policy_.task_size(x));
   }
 
+  /// @private
+  unique_pointer next(task_size_type& deficit) noexcept {
+    unique_pointer result;
+    if (!empty()) {
+      auto ptr = promote(head_.next);
+      auto ts = policy_.task_size(*ptr);
+      CAF_ASSERT(ts > 0);
+      if (ts <= deficit) {
+        deficit -= ts;
+        total_task_size_ -= ts;
+        head_.next = ptr->next;
+        if (total_task_size_ == 0) {
+          CAF_ASSERT(head_.next == &(tail_));
+          deficit = 0;
+          tail_.next = &(head_);
+        }
+        result.reset(ptr);
+      }
+    }
+    return result;
+  }
+
   // -- iterator access --------------------------------------------------------
 
   /// Returns an iterator to the dummy before the first element.

--- a/libcaf_core/test/drr_cached_queue.cpp
+++ b/libcaf_core/test/drr_cached_queue.cpp
@@ -145,6 +145,28 @@ CAF_TEST(skipping) {
   CAF_CHECK_EQUAL(seq, "246");
 }
 
+CAF_TEST(take_front) {
+  std::string seq;
+  fill(queue, 1, 2, 3, 4, 5, 6);
+  auto f = [&](inode& x) {
+    seq += to_string(x);
+    return task_result::resume;
+  };
+  CAF_CHECK_EQUAL(queue.deficit(), 0);
+  while (!queue.empty()) {
+    auto ptr = queue.take_front();
+    f(*ptr);
+  }
+  CAF_CHECK_EQUAL(seq, "123456");
+  fill(queue, 5, 4, 3, 2, 1);
+  while (!queue.empty()) {
+    auto ptr = queue.take_front();
+    f(*ptr);
+  }
+  CAF_CHECK_EQUAL(seq, "12345654321");
+  CAF_CHECK_EQUAL(queue.deficit(), 0);
+}
+
 CAF_TEST(alternating_consumer) {
   using fun_type = std::function<task_result (inode&)>;
   fun_type f;


### PR DESCRIPTION
`drr_queue::take_front` and `drr_cached_queue::take_front` were
essentially the same function. Moreover, `drr_cached_queue::new_round`
duplicated the algorithm a third time (entangled with the actual logic
for a new credit round). The new `task_queue::next` funciton now
implements this algorithm once.

Moreover, `take_front` is only used directly from
`blocking_actor::dequeue`. This function bypasses the deficit counter on
the caller side. To clean up the awkward use of the queue, the new
`take_front` of the cached DRR queue bypasses the deficit counter
internally.

Restructuring the code seems to fix the original issue as well. After
debugging this extensively, it appears that GCC emitted code that didn't
properly track reads and writes to the head node. Reading `begin().ptr`
twice (via printf) causes the value to change between reads - even
though the printf statements where on consecutive lines.

Relates #723.