### PR TITLE
Use Jenkins Cmake plugin on Windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,32 +93,15 @@ def buildSteps(buildType, cmakeArgs) {
       echo "Windows build on $NODE_NAME"
       withEnv(['PATH=C:\\Windows\\System32;C:\\Program Files\\CMake\\bin;C:\\Program Files\\Git\\cmd;C:\\Program Files\\Git\\bin']) {
           // Configure and build.
-          def ret = bat(returnStatus: true,
-                    script: """cmake -E make_directory build
-                               cd build
-                               cmake -D CMAKE_BUILD_TYPE=$buildType -G "Visual Studio 15 2017" $cmakeArgs $msOpts ..
-                               IF /I "%ERRORLEVEL%" NEQ "0" (
-                                 EXIT 1
-                               )
-                               EXIT 0""")
-          if (ret) {
-            echo "[!!!] Configure failed!"
-            currentBuild.result = 'FAILURE'
-            return
-          }
-          // bat "echo \"Step: Build for '${tags}'\""
-          ret = bat(returnStatus: true,
-                    script: """cd build
-                               cmake --build .
-                               IF /I "%ERRORLEVEL%" NEQ "0" (
-                                 EXIT 1
-                               )
-                               EXIT 0""")
-          if (ret) {
-            echo "[!!!] Build failed!"
-            currentBuild.result = 'FAILURE'
-            return
-          }
+          cmakeBuild([
+            buildDir: 'build',
+            buildType: "$buildType",
+            cmakeArgs: "$msOpts $cmakeArgs",
+            generator: 'Visual Studio 15 2017',
+            installation: 'cmake in search path',
+            sourceDir: '.',
+            steps: [[withCmake: true]],
+          ])
           // Test.
           ctest([
             arguments: '--output-on-failure',


### PR DESCRIPTION
Picking up on your comment in #716, here is a PR to use the Jenkins Cmake plugin on Windows. The [build](https://jenkins.inet.haw-hamburg.de/blue/organizations/jenkins/CAF%2Factor-framework/detail/topic%2Fjenkins-cmake-windows/5/pipeline/66/) currently fails but it doesn't look like the error is related to Jenkins.