### PR TITLE
Add URI class, close #708

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -122,6 +122,9 @@ set(LIBCAF_CORE_SRCS
   src/type_erased_value.cpp
   src/uniform_type_info_map.cpp
   src/unprofiled.cpp
+  src/uri.cpp
+  src/uri_builder.cpp
+  src/uri_impl.cpp
   src/work_sharing.cpp
   src/work_stealing.cpp
 )

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -68,6 +68,7 @@ set(LIBCAF_CORE_SRCS
   src/ipv4_address.cpp
   src/ipv4_subnet.cpp
   src/ipv6_address.cpp
+  src/ipv6_subnet.cpp
   src/local_actor.cpp
   src/logger.cpp
   src/mailbox_element.cpp

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -67,6 +67,7 @@ set(LIBCAF_CORE_SRCS
   src/invoke_result_visitor.cpp
   src/ipv4_address.cpp
   src/ipv4_subnet.cpp
+  src/ipv6_address.cpp
   src/local_actor.cpp
   src/logger.cpp
   src/mailbox_element.cpp

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -66,6 +66,7 @@ set(LIBCAF_CORE_SRCS
   src/ini_consumer.cpp
   src/invoke_result_visitor.cpp
   src/ipv4_address.cpp
+  src/ipv4_subnet.cpp
   src/local_actor.cpp
   src/logger.cpp
   src/mailbox_element.cpp

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -65,6 +65,7 @@ set(LIBCAF_CORE_SRCS
   src/inbound_path.cpp
   src/ini_consumer.cpp
   src/invoke_result_visitor.cpp
+  src/ipv4_address.cpp
   src/local_actor.cpp
   src/logger.cpp
   src/mailbox_element.cpp

--- a/libcaf_core/caf/byte_address.hpp
+++ b/libcaf_core/caf/byte_address.hpp
@@ -43,6 +43,13 @@ public:
     return dref().bytes()[index];
   }
 
+  // -- properties -------------------------------------------------------------
+
+  /// Returns the number of bytes of the address.
+  size_t size() const noexcept {
+    return dref().bytes().size();
+  }
+
   // -- comparison -------------------------------------------------------------
 
   /// Returns a negative number if `*this < other`, zero if `*this == other`

--- a/libcaf_core/caf/byte_address.hpp
+++ b/libcaf_core/caf/byte_address.hpp
@@ -1,0 +1,131 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+
+#include "caf/config.hpp"
+#include "caf/detail/comparable.hpp"
+
+namespace caf {
+
+/// Base type for addresses based on a byte representation such as IP or
+/// Ethernet addresses.
+template <class Derived>
+class byte_address : detail::comparable<Derived> {
+public:
+  // -- element access ---------------------------------------------------------
+
+  /// Returns the byte at given index.
+  uint8_t& operator[](size_t index) noexcept {
+    return dref().bytes()[index];
+  }
+
+  /// Returns the byte at given index.
+  const uint8_t& operator[](size_t index) const noexcept {
+    return dref().bytes()[index];
+  }
+
+  // -- comparison -------------------------------------------------------------
+
+  /// Returns a negative number if `*this < other`, zero if `*this == other`
+  /// and a positive number if `*this > other`.
+  int compare(const Derived& other) const noexcept {
+    auto& buf = dref().bytes();
+    return memcmp(buf.data(), other.bytes().data(), Derived::num_bytes);
+  }
+
+  // -- mutators ---------------------------------------------------------------
+
+  /// Masks out lower bytes of the address. For example, calling `mask(1)` on
+  /// the IPv4 address `192.168.1.1` would produce `192.0.0.0`.
+  /// @pre `bytes_to_keep < num_bytes`
+  void mask(int bytes_to_keep) noexcept {
+    auto& buf = dref().bytes();
+    memset(buf.data() + bytes_to_keep, 0, Derived::num_bytes - bytes_to_keep);
+  }
+
+  /// Returns a copy of this address with that masks out lower bytes. For
+  /// example, calling `masked(1)` on the IPv4 address `192.168.1.1` would
+  /// return `192.0.0.0`.
+  /// @pre `bytes_to_keep < num_bytes`
+  Derived masked(int bytes_to_keep) const noexcept {
+    Derived result{dref()};
+    result.mask(bytes_to_keep);
+    return result;
+  }
+
+  // -- bitwise member operators -----------------------------------------------
+
+  /// Bitwise ANDs `*this` and `other`.
+  Derived& operator&=(const Derived& other) {
+    auto& buf = dref().bytes();
+    for (size_t index = 0; index < Derived::num_bytes; ++index)
+      buf[index] &= other[index];
+    return dref();
+  }
+
+  /// Bitwise ORs `*this` and `other`.
+  Derived& operator|=(const Derived& other) {
+    auto& buf = dref().bytes();
+    for (size_t index = 0; index < Derived::num_bytes; ++index)
+      buf[index] |= other[index];
+    return dref();
+  }
+
+  /// Bitwise XORs `*this` and `other`.
+  Derived& operator^=(const Derived& other) {
+    auto& buf = dref().bytes();
+    for (size_t index = 0; index < Derived::num_bytes; ++index)
+      buf[index] ^= other[index];
+    return dref();
+  }
+
+  // -- bitwise free operators -------------------------------------------------
+
+  friend Derived operator&(const Derived& x, const Derived& y) {
+    Derived result{x};
+    result &= y;
+    return result;
+  }
+
+  friend Derived operator|(const Derived& x, const Derived& y) {
+    Derived result{x};
+    result |= y;
+    return result;
+  }
+
+  friend Derived operator^(const Derived& x, const Derived& y) {
+    Derived result{x};
+    result ^= y;
+    return result;
+  }
+
+private:
+  Derived& dref() noexcept {
+    return *static_cast<Derived*>(this);
+  }
+
+  const Derived& dref() const noexcept {
+    return *static_cast<const Derived*>(this);
+  }
+};
+
+} // namespace caf

--- a/libcaf_core/caf/config.hpp
+++ b/libcaf_core/caf/config.hpp
@@ -136,7 +136,11 @@
     _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
 #  define CAF_POP_WARNINGS                                                     \
     _Pragma("GCC diagnostic pop")
-#  define CAF_ANNOTATE_FALLTHROUGH static_cast<void>(0)
+#  if __GNUC__ >= 7
+#    define CAF_ANNOTATE_FALLTHROUGH __attribute__((fallthrough))
+#  else
+#    define CAF_ANNOTATE_FALLTHROUGH static_cast<void>(0)
+#  endif
 #  define CAF_COMPILER_VERSION                                                 \
      (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
     // disable thread_local on GCC/macOS due to heap-use-after-free bug:

--- a/libcaf_core/caf/detail/parser/fsm.hpp
+++ b/libcaf_core/caf/detail/parser/fsm.hpp
@@ -61,6 +61,15 @@
       goto s_fin;                                                              \
     e_##name :
 
+/// Defines a state in the FSM that doesn't check for end-of-input. Unstable
+/// states are supposed to contain epsilon transitions only.
+#define unstable_state(name)                                                       \
+  CAF_FSM_EVAL_MISMATCH_EC                                                     \
+  }                                                                            \
+  {                                                                            \
+    static constexpr auto mismatch_ec = caf::pec::trailing_character;          \
+    s_##name :                                                                 \
+    e_##name :
 
 /// Ends the definition of an FSM.
 #define fin()                                                                  \
@@ -237,6 +246,12 @@
   CAF_PP_OVERLOAD(CAF_FSM_EPSILON_IMPL, __VA_ARGS__)(__VA_ARGS__)
 
 #endif // CAF_MSVC
+
+// Makes a transition into another state if the `statement` is true.
+#define transition_if(statement, ...)                                          \
+  if (statement) {                                                             \
+    transition(__VA_ARGS__)                                                    \
+  }
 
 // Makes an epsiolon transition into another state if the `statement` is true.
 #define epsilon_if(statement, ...)                                             \

--- a/libcaf_core/caf/detail/parser/fsm.hpp
+++ b/libcaf_core/caf/detail/parser/fsm.hpp
@@ -273,13 +273,13 @@
 
 #endif // CAF_MSVC
 
-// Makes a transition into another state if the `statement` is true.
+/// Makes a transition into another state if the `statement` is true.
 #define transition_if(statement, ...)                                          \
   if (statement) {                                                             \
     transition(__VA_ARGS__)                                                    \
   }
 
-// Makes an epsiolon transition into another state if the `statement` is true.
+/// Makes an epsiolon transition into another state if the `statement` is true.
 #define epsilon_if(statement, ...)                                             \
   if (statement) {                                                             \
     epsilon(__VA_ARGS__)                                                       \

--- a/libcaf_core/caf/detail/parser/fsm_undef.hpp
+++ b/libcaf_core/caf/detail/parser/fsm_undef.hpp
@@ -26,6 +26,8 @@
 
 #undef term_state
 
+#undef unstable_state
+
 #undef fin
 
 #undef CAF_TRANSITION_IMPL1
@@ -73,6 +75,8 @@
 #undef fsm_transition
 
 #undef fsm_epsilon
+
+#undef transition_if
 
 #undef epsilon_if
 

--- a/libcaf_core/caf/detail/parser/read_ipv4_address.hpp
+++ b/libcaf_core/caf/detail/parser/read_ipv4_address.hpp
@@ -1,0 +1,92 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+#include "caf/config.hpp"
+#include "caf/detail/parser/chars.hpp"
+#include "caf/detail/parser/add_ascii.hpp"
+#include "caf/detail/parser/is_char.hpp"
+#include "caf/detail/parser/is_digit.hpp"
+#include "caf/detail/parser/state.hpp"
+#include "caf/detail/parser/sub_ascii.hpp"
+#include "caf/detail/scope_guard.hpp"
+#include "caf/pec.hpp"
+
+CAF_PUSH_UNUSED_LABEL_WARNING
+
+#include "caf/detail/parser/fsm.hpp"
+
+namespace caf {
+namespace detail {
+namespace parser {
+
+template <class Iterator, class Sentinel, class Consumer>
+void read_ipv4_octet(state<Iterator, Sentinel>& ps, Consumer& consumer) {
+  uint8_t res = 0;
+  // Reads the a decimal place.
+  auto rd_decimal = [&](char c) {
+    return add_ascii<10>(res, c);
+  };
+  // Computes the result on success.
+  auto g = caf::detail::make_scope_guard([&] {
+    if (ps.code <= pec::trailing_character)
+      consumer.value(res);
+  });
+  start();
+  state(init) {
+    transition(read, decimal_chars, rd_decimal(ch), pec::integer_overflow)
+  }
+  term_state(read) {
+    transition(read, decimal_chars, rd_decimal(ch), pec::integer_overflow)
+  }
+  fin();
+}
+
+/// Reads a number, i.e., on success produces either an `int64_t` or a
+/// `double`.
+template <class Iterator, class Sentinel, class Consumer>
+void read_ipv4_address(state<Iterator, Sentinel>& ps, Consumer& consumer) {
+  int octets = 0;
+  start();
+  state(init) {
+    fsm_epsilon(read_ipv4_octet(ps, consumer), rd_dot, decimal_chars, ++octets)
+  }
+  state(rd_dot) {
+    transition(rd_oct, '.')
+  }
+  state(rd_oct) {
+    fsm_epsilon_if(octets < 3, read_ipv4_octet(ps, consumer), rd_dot,
+                   decimal_chars, ++octets)
+    fsm_epsilon_if(octets == 3, read_ipv4_octet(ps, consumer), done)
+  }
+  term_state(done) {
+    // nop
+  }
+  fin();
+}
+
+} // namespace parser
+} // namespace detail
+} // namespace caf
+
+#include "caf/detail/parser/fsm_undef.hpp"
+
+CAF_POP_WARNINGS

--- a/libcaf_core/caf/detail/parser/read_ipv6_address.hpp
+++ b/libcaf_core/caf/detail/parser/read_ipv6_address.hpp
@@ -21,6 +21,7 @@
 #include <cstdint>
 
 #include "caf/config.hpp"
+#include "caf/detail/network_order.hpp"
 #include "caf/detail/parser/add_ascii.hpp"
 #include "caf/detail/parser/chars.hpp"
 #include "caf/detail/parser/is_char.hpp"

--- a/libcaf_core/caf/detail/parser/read_ipv6_address.hpp
+++ b/libcaf_core/caf/detail/parser/read_ipv6_address.hpp
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 
 #include "caf/config.hpp"

--- a/libcaf_core/caf/detail/parser/read_ipv6_address.hpp
+++ b/libcaf_core/caf/detail/parser/read_ipv6_address.hpp
@@ -1,0 +1,300 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+#include "caf/config.hpp"
+#include "caf/detail/parser/add_ascii.hpp"
+#include "caf/detail/parser/chars.hpp"
+#include "caf/detail/parser/is_char.hpp"
+#include "caf/detail/parser/is_digit.hpp"
+#include "caf/detail/parser/state.hpp"
+#include "caf/detail/parser/sub_ascii.hpp"
+#include "caf/detail/scope_guard.hpp"
+#include "caf/ipv4_address.hpp"
+#include "caf/ipv6_address.hpp"
+#include "caf/pec.hpp"
+
+CAF_PUSH_UNUSED_LABEL_WARNING
+
+#include "caf/detail/parser/fsm.hpp"
+
+namespace caf {
+namespace detail {
+namespace parser {
+
+//  IPv6address =                            6( h16 ":" ) ls32
+//              /                       "::" 5( h16 ":" ) ls32
+//              / [               h16 ] "::" 4( h16 ":" ) ls32
+//              / [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
+//              / [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
+//              / [ *3( h16 ":" ) h16 ] "::"    h16 ":"   ls32
+//              / [ *4( h16 ":" ) h16 ] "::"              ls32
+//              / [ *5( h16 ":" ) h16 ] "::"              h16
+//              / [ *6( h16 ":" ) h16 ] "::"
+//
+//  ls32        = ( h16 ":" h16 ) / IPv4address
+//
+//  h16         = 1*4HEXDIG
+
+/// Reads 16 (hex) bits of an IPv6 address.
+template <class Iterator, class Sentinel, class Consumer>
+void read_ipv6_h16(state<Iterator, Sentinel>& ps, Consumer& consumer) {
+  uint16_t res = 0;
+  size_t digits = 0;
+  // Reads the a hexadecimal place.
+  auto rd_hex = [&](char c) {
+    ++digits;
+    return add_ascii<16>(res, c);
+  };
+  // Computes the result on success.
+  auto g = caf::detail::make_scope_guard([&] {
+    if (ps.code <= pec::trailing_character)
+      consumer.value(res);
+  });
+  start();
+  state(init) {
+    transition(read, hexadecimal_chars, rd_hex(ch), pec::integer_overflow)
+  }
+  term_state(read) {
+    transition_if(digits < 4,
+                  read, hexadecimal_chars, rd_hex(ch), pec::integer_overflow)
+  }
+  fin();
+}
+
+/// Reads 16 (hex) or 32 (IPv4 notation) bits of an IPv6 address.
+template <class Iterator, class Sentinel, class Consumer>
+void read_ipv6_h16_or_l32(state<Iterator, Sentinel>& ps, Consumer& consumer) {
+  enum mode_t { indeterminate, v6_bits, v4_octets };
+  mode_t mode = indeterminate;
+  uint16_t hex_res = 0;
+  uint8_t dec_res = 0;
+  int digits = 0;
+  int octet = 0;
+  // Reads a single character (dec and/or hex).
+  auto rd_hex = [&](char c) {
+    ++digits;
+    return add_ascii<16>(hex_res, c);
+  };
+  auto rd_dec = [&](char c) {
+    ++digits;
+    return add_ascii<10>(dec_res, c);
+  };
+  auto rd_both = [&](char c) {
+    CAF_ASSERT(mode == indeterminate);
+    ++digits;
+    // IPv4 octets cannot have more than 3 digits.
+    if (!in_whitelist(decimal_chars, c) || !add_ascii<10>(dec_res, c))
+      mode = v6_bits;
+    return add_ascii<16>(hex_res, c);
+  };
+  auto fin_octet = [&]() {
+    ++octet;
+    mode = v4_octets;
+    consumer.value(dec_res);
+    dec_res = 0;
+    digits = 0;
+  };
+  // Computes the result on success. Note, when reading octets, this will give
+  // the consumer the final byte. Previous bytes were signaled during parsing.
+  auto g = caf::detail::make_scope_guard([&] {
+    if (ps.code <= pec::trailing_character) {
+      if (mode != v4_octets)
+        consumer.value(hex_res);
+      else
+        fin_octet();
+    }
+  });
+  start();
+  state(init) {
+    transition(read, hexadecimal_chars, rd_both(ch), pec::integer_overflow)
+  }
+  term_state(read) {
+    transition_if(mode == indeterminate,
+                  read, hexadecimal_chars, rd_both(ch), pec::integer_overflow)
+    transition_if(mode == v6_bits,
+                  read, hexadecimal_chars, rd_hex(ch), pec::integer_overflow)
+    transition_if(mode != v6_bits && digits > 0, read_octet, '.', fin_octet())
+  }
+  state(read_octet) {
+    transition(read_octet, decimal_chars, rd_dec(ch), pec::integer_overflow)
+    transition_if(octet < 2 && digits > 0, read_octet, '.', fin_octet())
+    transition_if(octet == 2 && digits > 0, read_last_octet, '.', fin_octet())
+  }
+  term_state(read_last_octet) {
+    transition(read_last_octet, decimal_chars,
+               rd_dec(ch), pec::integer_overflow)
+  }
+  fin();
+}
+
+template <class F>
+struct read_ipv6_address_piece_consumer {
+  F callback;
+
+  inline void value(uint16_t x) {
+    union {
+      uint16_t bits;
+      std::array<uint8_t, 2> bytes;
+    } val;
+    val.bits = to_network_order(x);
+    callback(val.bytes.data(), val.bytes.size());
+  }
+
+  inline void value(uint8_t x) {
+    callback(&x, 1);
+  }
+};
+
+template <class F>
+read_ipv6_address_piece_consumer<F> make_read_ipv6_address_piece_consumer(F f) {
+  return {f};
+}
+
+/// Reads a number, i.e., on success produces either an `int64_t` or a
+/// `double`.
+template <class Iterator, class Sentinel, class Consumer>
+void read_ipv6_address(state<Iterator, Sentinel>& ps, Consumer& consumer) {
+  // IPv6 allows omitting blocks of zeros, splitting the string into a part
+  // before the zeros (prefix) and a part after the zeros (suffix). For example,
+  // ff::1 is 00FF0000000000000000000000000001
+  ipv6_address::array_type prefix;
+  ipv6_address::array_type suffix;
+  prefix.fill(0);
+  suffix.fill(0);
+  // Keeps track of all bytes consumed so far, suffix and prefix combined.
+  size_t filled_bytes = 0;
+  auto remaining_bytes = [&] {
+    return ipv6_address::num_bytes - filled_bytes;
+  };
+  // Computes the result on success.
+  auto g = caf::detail::make_scope_guard([&] {
+    if (ps.code <= pec::trailing_character) {
+      ipv6_address::array_type bytes;
+      for (size_t i = 0; i < ipv6_address::num_bytes; ++i)
+        bytes[i] = prefix[i] | suffix[i];
+      ipv6_address result{bytes};
+      consumer.value(result);
+    }
+  });
+  // We need to parse 2-byte hexadecimal numbers (x) and also keep track of
+  // the current writing position when reading the prefix.
+  auto read_prefix = [&](uint8_t* bytes, size_t count) {
+    for (size_t i = 0; i < count; ++i)
+      prefix[filled_bytes++] = bytes[i];
+  };
+  auto prefix_consumer = make_read_ipv6_address_piece_consumer(read_prefix);
+  // The suffix reader rotates bytes into place, so that we can bitwise-OR
+  // prefix and suffix for obtaining the full address.
+  auto read_suffix = [&](uint8_t* bytes, size_t count) {
+    for (size_t i = 0; i < count; ++i)
+      suffix[i] = bytes[i];
+    std::rotate(suffix.begin(), suffix.begin() + count, suffix.end());
+    filled_bytes += count;
+  };
+  auto suffix_consumer = make_read_ipv6_address_piece_consumer(read_suffix);
+  // Utility function for promoting an IPv4 formatted input.
+  auto promote_v4 = [&] {
+    if (filled_bytes == 4) {
+      ipv4_address::array_type bytes;
+      memcpy(bytes.data(), prefix.data(), bytes.size());
+      prefix = ipv6_address{ipv4_address{bytes}}.bytes();
+      return true;
+    }
+    return false;
+  };
+  start();
+  // Either transitions to reading leading "::" or reads the first h16. When
+  // reading an l32 immediately promotes to IPv4 address and stops.
+  state(init) {
+    transition(rd_sep, ':')
+    fsm_epsilon(read_ipv6_h16_or_l32(ps, prefix_consumer),
+                maybe_has_l32, hexadecimal_chars)
+  }
+  // Checks whether the first call to read_ipv6_h16_or_l32 consumed
+  // exactly 4 bytes. If so, we have an IPv4-formatted address.
+  unstable_state(maybe_has_l32) {
+    epsilon_if(promote_v4(), done)
+    epsilon(rd_prefix_sep)
+  }
+  // Got ":" at a position where it can only be parsed as "::".
+  state(rd_sep) {
+    transition(has_sep, ':')
+  }
+  // Stops parsing after reading "::" (all-zero address) or proceeds with
+  // reading the suffix.
+  term_state(has_sep) {
+    epsilon(rd_suffix)
+  }
+  // Read part of the prefix, i.e., everything before "::".
+  state(rd_prefix) {
+    fsm_epsilon_if(remaining_bytes() > 4,
+                   read_ipv6_h16(ps, prefix_consumer),
+                   rd_prefix_sep, hexadecimal_chars)
+    fsm_epsilon_if(remaining_bytes() == 4,
+                   read_ipv6_h16_or_l32(ps, prefix_consumer),
+                   maybe_done, hexadecimal_chars)
+    fsm_epsilon_if(remaining_bytes() == 2,
+                   read_ipv6_h16(ps, prefix_consumer),
+                   done, hexadecimal_chars)
+  }
+  // Checks whether we've read an l32 in our last call to read_ipv6_h16_or_l32,
+  // in which case we're done. Otherwise continues to read the last two bytes.
+  unstable_state(maybe_done) {
+    epsilon_if(remaining_bytes() == 0, done);
+    epsilon(rd_prefix_sep)
+  }
+  // Waits for ":" after reading an h16 in the prefix.
+  state(rd_prefix_sep) {
+    transition(rd_next_prefix, ':')
+  }
+  // Waits for either the second ":" or an h16/l32 after reading an ":".
+  state(rd_next_prefix) {
+    transition(has_sep, ':')
+    epsilon(rd_prefix)
+  }
+  // Reads a part of the suffix.
+  state(rd_suffix) {
+    fsm_epsilon_if(remaining_bytes() >= 4,
+                   read_ipv6_h16_or_l32(ps, suffix_consumer),
+                   rd_next_suffix, hexadecimal_chars)
+    fsm_epsilon_if(remaining_bytes() == 2,
+                   read_ipv6_h16(ps, suffix_consumer),
+                   rd_next_suffix, hexadecimal_chars)
+  }
+  // Reads the ":" separator between h16.
+  term_state(rd_next_suffix) {
+    transition(rd_suffix, ':')
+  }
+  // Accepts only the end-of-input, since we've read a full IP address.
+  term_state(done) {
+    // nop
+  }
+  fin();
+}
+
+} // namespace parser
+} // namespace detail
+} // namespace caf
+
+#include "caf/detail/parser/fsm_undef.hpp"
+
+CAF_POP_WARNINGS

--- a/libcaf_core/caf/detail/parser/read_uri.hpp
+++ b/libcaf_core/caf/detail/parser/read_uri.hpp
@@ -98,7 +98,7 @@ void read_uri_query(state<Iterator, Sentinel>& ps, Consumer&& consumer) {
   });
   // FSM declaration.
   start();
-  // query may be empty
+  // Query may be empty.
   term_state(init) {
     read_next_char(read_key, key)
   }

--- a/libcaf_core/caf/detail/parser/read_uri.hpp
+++ b/libcaf_core/caf/detail/parser/read_uri.hpp
@@ -1,0 +1,231 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include "caf/config.hpp"
+#include "caf/detail/parser/add_ascii.hpp"
+#include "caf/detail/parser/chars.hpp"
+#include "caf/detail/parser/read_ipv6_address.hpp"
+#include "caf/detail/parser/state.hpp"
+#include "caf/detail/scope_guard.hpp"
+#include "caf/pec.hpp"
+#include "caf/uri.hpp"
+
+CAF_PUSH_UNUSED_LABEL_WARNING
+
+#include "caf/detail/parser/fsm.hpp"
+
+namespace caf {
+namespace detail {
+namespace parser {
+
+//   foo://example.com:8042/over/there?name=ferret#nose
+//   \_/   \______________/\_________/ \_________/ \__/
+//    |           |            |            |        |
+// scheme     authority       path        query   fragment
+//    |   _____________________|__
+//   / \ /                        \.
+//   urn:example:animal:ferret:nose
+
+// Unlike our other parsers, the URI parsers only check for validity and
+// generate ranges for the subcomponents. URIs can't have linebreaks, so we can
+// safely keep track of the position by looking at the column.
+
+template <class Iterator, class Sentinel>
+void read_uri_percent_encoded(state<Iterator, Sentinel>& ps, std::string& str) {
+  uint8_t char_code = 0;
+  auto g = make_scope_guard([&] {
+    if (ps.code <= pec::trailing_character)
+      str += static_cast<char>(char_code);
+  });
+  start();
+  state(init) {
+    transition(read_nibble, hexadecimal_chars, add_ascii<16>(char_code, ch))
+  }
+  state(read_nibble) {
+    transition(done, hexadecimal_chars, add_ascii<16>(char_code, ch))
+  }
+  term_state(done) {
+    // nop
+  }
+  fin();
+}
+
+template <class Iterator, class Sentinel, class Consumer>
+void read_uri_query(state<Iterator, Sentinel>& ps, Consumer&& consumer) {
+  // Local variables.
+  uri::query_map result;
+  std::string key;
+  std::string value;
+  // Utility functions.
+  auto take_str = [&](std::string& str) {
+    using std::swap;
+    std::string res;
+    swap(str, res);
+    return std::move(res);
+  };
+  auto push = [&] {
+    result.emplace(take_str(key), take_str(value));
+  };
+  // Call consumer on exit.
+  auto g = make_scope_guard([&] {
+    if (ps.code <= pec::trailing_character)
+      consumer.query(std::move(result));
+  });
+  // FSM declaration.
+  start();
+  // query may be empty
+  term_state(init) {
+    transition(read_key, alphabetic_chars, key += ch)
+  }
+  state(read_key) {
+    transition(read_key, alphanumeric_chars, key += ch)
+    transition(read_value, '=')
+  }
+  term_state(read_value, push()) {
+    transition(read_value, alphanumeric_chars, value += ch)
+    transition(read_key, '&', push())
+  }
+  fin();
+}
+
+template <class Iterator, class Sentinel, class Consumer>
+void read_uri(state<Iterator, Sentinel>& ps, Consumer&& consumer) {
+  // Local variables.
+  std::string str;
+  uint16_t port = 0;
+  // Replaces `str` with a default constructed string to make sure we're never
+  // operating on a moved-from string object.
+  auto take_str = [&] {
+    using std::swap;
+    std::string res;
+    swap(str, res);
+    return std::move(res);
+  };
+  // Allowed character sets.
+  auto path_char = [](char c) {
+    return in_whitelist(alphanumeric_chars, c) || c == '/';
+  };
+  auto authority_char = [](char c) {
+    return in_whitelist(alphanumeric_chars, c) || c == '.';
+  };
+  // Utility setters for avoiding code duplication.
+  auto set_path = [&] {
+    consumer.path(take_str());
+  };
+  auto set_host = [&] {
+    consumer.host(take_str());
+  };
+  auto set_userinfo = [&] {
+    consumer.userinfo(take_str());
+  };
+  // Consumer for reading IPv6 addresses.
+  struct {
+    Consumer& f;
+    void value(ipv6_address addr) {
+      f.host(addr);
+    }
+  } ip_consumer{consumer};
+  // FSM declaration.
+  start();
+  state(init) {
+    epsilon(read_scheme)
+  }
+  state(read_scheme) {
+    fsm_transition(read_uri_percent_encoded(ps, str), read_scheme, '%')
+    transition(read_scheme, alphabetic_chars, str += ch)
+    transition(have_scheme, ':', consumer.scheme(take_str()))
+  }
+  state(have_scheme) {
+    transition(disambiguate_path, '/')
+    transition(read_path, alphanumeric_chars, str += ch)
+    fsm_transition(read_uri_percent_encoded(ps, str), read_path, '%')
+  }
+  // This state is terminal, because "file:/" is a valid URI.
+  term_state(disambiguate_path, consumer.path("/")) {
+    transition(start_authority, '/')
+    epsilon(read_path, any_char, str += '/')
+  }
+  state(start_authority) {
+    transition(read_authority, authority_char, str += ch)
+    fsm_transition(read_ipv6_address(ps, ip_consumer), end_of_ipv6_host, '[')
+  }
+  state(end_of_ipv6_host) {
+    transition(end_of_host, ']')
+  }
+  term_state(end_of_host) {
+    transition(start_port, ':', set_host())
+    epsilon(end_of_authority, "/?#", set_host())
+  }
+  term_state(read_authority, set_host()) {
+    transition(read_authority, authority_char, str += ch)
+    transition(start_host, '@', set_userinfo())
+    transition(start_port, ':', set_host())
+    epsilon(end_of_authority, "/?#", set_host())
+  }
+  state(start_host) {
+    transition(read_host, authority_char, str += ch)
+    fsm_transition(read_ipv6_address(ps, ip_consumer), end_of_ipv6_host, '[')
+  }
+  term_state(read_host, set_host()) {
+    transition(read_host, authority_char, str += ch)
+    transition(start_port, ':', set_host())
+    epsilon(end_of_authority, "/?#", set_host())
+  }
+  state(start_port) {
+    transition(read_port, decimal_chars, add_ascii<10>(port, ch))
+  }
+  term_state(read_port, consumer.port(port)) {
+    transition(read_port, decimal_chars, add_ascii<10>(port, ch),
+               pec::integer_overflow)
+    epsilon(end_of_authority, "/?#", set_host())
+  }
+  term_state(end_of_authority) {
+    transition(read_path, '/')
+    transition(start_query, '?')
+    transition(read_fragment, '#')
+  }
+  term_state(read_path, set_path()) {
+    transition(read_path, path_char, str += ch)
+    transition(start_query, '?', set_path())
+    transition(read_fragment, '#', set_path())
+  }
+  term_state(start_query) {
+    fsm_epsilon(read_uri_query(ps, consumer), end_of_query)
+  }
+  unstable_state(end_of_query) {
+    transition(read_fragment, '#')
+    epsilon(done)
+  }
+  term_state(read_fragment, consumer.fragment(take_str())) {
+    transition(read_fragment, alphanumeric_chars, str += ch)
+  }
+  term_state(done) {
+    // nop
+  }
+  fin();
+}
+
+} // namespace parser
+} // namespace detail
+} // namespace caf
+
+#include "caf/detail/parser/fsm_undef.hpp"
+
+CAF_POP_WARNINGS

--- a/libcaf_core/caf/detail/parser/read_uri.hpp
+++ b/libcaf_core/caf/detail/parser/read_uri.hpp
@@ -202,7 +202,7 @@ void read_uri(state<Iterator, Sentinel>& ps, Consumer&& consumer) {
   term_state(read_port, consumer.port(port)) {
     transition(read_port, decimal_chars, add_ascii<10>(port, ch),
                pec::integer_overflow)
-    epsilon(end_of_authority, "/?#")
+    epsilon(end_of_authority, "/?#", consumer.port(port))
   }
   term_state(end_of_authority) {
     transition(read_path, '/')

--- a/libcaf_core/caf/detail/parser/state.hpp
+++ b/libcaf_core/caf/detail/parser/state.hpp
@@ -51,13 +51,12 @@ struct state {
   /// otherwise the next character.
   char next() noexcept {
     ++i;
+    ++column;
     if (i != e) {
       auto c = *i;
       if (c == '\n') {
         ++line;
         column = 1;
-      } else {
-        ++column;
       }
       return c;
     }

--- a/libcaf_core/caf/detail/stringification_inspector.hpp
+++ b/libcaf_core/caf/detail/stringification_inspector.hpp
@@ -81,13 +81,16 @@ public:
   }
 
   inline void consume(const char* cstr) {
-    string_view tmp{cstr, strlen(cstr)};
-    consume(tmp);
+    if (cstr == nullptr) {
+      result_ += "null";
+    } else {
+      string_view tmp{cstr, strlen(cstr)};
+      consume(tmp);
+    }
   }
 
   inline void consume(char* cstr) {
-    string_view tmp{cstr, strlen(cstr)};
-    consume(tmp);
+    consume(const_cast<const char*>(cstr));
   }
 
   template <class T>

--- a/libcaf_core/caf/detail/stringification_inspector.hpp
+++ b/libcaf_core/caf/detail/stringification_inspector.hpp
@@ -247,6 +247,7 @@ public:
     && !std::is_pointer<T>::value
     && !is_inspectable<stringification_inspector, T>::value
     && !std::is_arithmetic<T>::value
+    && !std::is_convertible<T, string_view>::value
     && !has_to_string<T>::value>
   consume(T&) {
     result_ += "<unprintable>";

--- a/libcaf_core/caf/detail/stringification_inspector.hpp
+++ b/libcaf_core/caf/detail/stringification_inspector.hpp
@@ -25,8 +25,9 @@
 #include <vector>
 
 #include "caf/atom.hpp"
-#include "caf/none.hpp"
 #include "caf/error.hpp"
+#include "caf/none.hpp"
+#include "caf/string_view.hpp"
 
 #include "caf/meta/type_name.hpp"
 #include "caf/meta/omittable.hpp"
@@ -73,18 +74,20 @@ public:
 
   void consume(atom_value& x);
 
-  void consume(const char* cstr);
+  void consume(string_view str);
 
   inline void consume(bool& x) {
     result_ += x ? "true" : "false";
   }
 
-  inline void consume(char* cstr) {
-    consume(const_cast<const char*>(cstr));
+  inline void consume(const char* cstr) {
+    string_view tmp{cstr, strlen(cstr)};
+    consume(tmp);
   }
 
-  inline void consume(std::string& str) {
-    consume(str.c_str());
+  inline void consume(char* cstr) {
+    string_view tmp{cstr, strlen(cstr)};
+    consume(tmp);
   }
 
   template <class T>
@@ -132,6 +135,7 @@ public:
   template <class T>
   enable_if_t<is_iterable<T>::value
               && !is_inspectable<stringification_inspector, T>::value
+              && !std::is_convertible<T, string_view>::value
               && !has_to_string<T>::value>
   consume(T& xs) {
     result_ += '[';

--- a/libcaf_core/caf/detail/uri_impl.hpp
+++ b/libcaf_core/caf/detail/uri_impl.hpp
@@ -1,0 +1,84 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include "caf/fwd.hpp"
+#include "caf/uri.hpp"
+#include "caf/ref_counted.hpp"
+#include "caf/string_view.hpp"
+
+namespace caf {
+namespace detail {
+
+class uri_impl {
+public:
+  // -- constructors, destructors, and assignment operators --------------------
+
+  uri_impl();
+
+  uri_impl(const uri_impl&) = delete;
+
+  uri_impl& operator=(const uri_impl&) = delete;
+
+  // -- member variables -------------------------------------------------------
+
+  static uri_impl default_instance;
+
+  /// Null-terminated buffer for holding the string-representation of the URI.
+  std::string str;
+
+  /// Scheme component.
+  std::string scheme;
+
+  /// Assembled authority component.
+  uri::authority_type authority;
+
+  /// Path component.
+  std::string path;
+
+  /// Query component as key-value pairs.
+  uri::query_map query;
+
+  /// The fragment component.
+  std::string fragment;
+
+  // -- modifiers --------------------------------------------------------------
+
+  /// Assembles the human-readable string representation for this URI.
+  void assemble_str();
+
+  // -- friend functions -------------------------------------------------------
+
+  friend void intrusive_ptr_add_ref(const uri_impl* p);
+
+  friend void intrusive_ptr_release(const uri_impl* p);
+
+private:
+  // -- member variables -------------------------------------------------------
+
+  mutable std::atomic<size_t> rc_;
+};
+
+} // namespace detail
+} // namespace caf

--- a/libcaf_core/caf/detail/uri_impl.hpp
+++ b/libcaf_core/caf/detail/uri_impl.hpp
@@ -68,6 +68,10 @@ public:
   /// Assembles the human-readable string representation for this URI.
   void assemble_str();
 
+  // Escapes all reserved characters according to RFC 3986 in `x` and
+  // adds the encoded string to `str`.
+  void add_encoded(string_view x, bool is_path = false);
+
   // -- friend functions -------------------------------------------------------
 
   friend void intrusive_ptr_add_ref(const uri_impl* p);

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -104,7 +104,9 @@ class group;
 class group_module;
 class inbound_path;
 class ipv4_address;
+class ipv4_subnet;
 class ipv6_address;
+class ipv6_subnet;
 class local_actor;
 class mailbox_element;
 class message;
@@ -161,6 +163,8 @@ enum class atom_value : uint64_t;
 // -- aliases ------------------------------------------------------------------
 
 using actor_id = uint64_t;
+using ip_address = ipv6_address;
+using ip_subnet = ipv6_subnet;
 using stream_slot = uint16_t;
 
 // -- functions ----------------------------------------------------------------

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -128,6 +128,8 @@ class string_view;
 class type_erased_tuple;
 class type_erased_value;
 class uniform_type_info_map;
+class uri;
+class uri_builder;
 
 // -- structs ------------------------------------------------------------------
 
@@ -239,10 +241,15 @@ template <class> class type_erased_value_impl;
 template <class> class stream_distribution_tree;
 
 class disposer;
-class message_data;
-class group_manager;
-class private_thread;
 class dynamic_message_data;
+class group_manager;
+class message_data;
+class private_thread;
+class uri_impl;
+
+void intrusive_ptr_add_ref(const uri_impl* p);
+
+void intrusive_ptr_release(const uri_impl* p);
 
 } // namespace detail
 

--- a/libcaf_core/caf/ip_address.hpp
+++ b/libcaf_core/caf/ip_address.hpp
@@ -1,0 +1,27 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include "caf/fwd.hpp"
+
+namespace caf {
+
+using ip_address = ipv6_address;
+
+} // namespace caf

--- a/libcaf_core/caf/ip_address.hpp
+++ b/libcaf_core/caf/ip_address.hpp
@@ -18,10 +18,11 @@
 
 #pragma once
 
-#include "caf/fwd.hpp"
+#include "caf/ipv6_address.hpp"
 
 namespace caf {
 
+/// An IP address. The address family is IPv6 unless `embeds_v4` returns true.
 using ip_address = ipv6_address;
 
 } // namespace caf

--- a/libcaf_core/caf/ip_subnet.hpp
+++ b/libcaf_core/caf/ip_subnet.hpp
@@ -1,0 +1,29 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include "caf/ipv6_subnet.hpp"
+
+namespace caf {
+
+/// An IP subnetwork. The address family is IPv6 unless `embeds_v4` returns
+/// true.
+using ip_subnet = ipv6_subnet;
+
+} // namespace caf

--- a/libcaf_core/caf/ipv4_address.hpp
+++ b/libcaf_core/caf/ipv4_address.hpp
@@ -28,8 +28,7 @@
 
 namespace caf {
 
-class ipv4_address : public byte_address<ipv4_address>,
-                     detail::comparable<ipv4_address, ipv6_address> {
+class ipv4_address : public byte_address<ipv4_address> {
 public:
   // -- constants --------------------------------------------------------------
 
@@ -47,14 +46,6 @@ public:
 
   ipv4_address(array_type bytes);
 
-  // -- comparison -------------------------------------------------------------
-
-  using super::compare;
-
-  /// Returns a negative number if `*this < other`, zero if `*this == other`
-  /// and a positive number if `*this > other`.
-  int compare(const ipv6_address& other) const noexcept;
-
   // -- properties -------------------------------------------------------------
 
   /// Returns whether this is a loopback address.
@@ -66,6 +57,12 @@ public:
   /// Returns the bits of the IP address in a single integer.
   inline uint32_t bits() const noexcept {
     return bits_;
+  }
+
+  /// Sets all bits of the IP address in a single 32-bit write.
+  /// @private
+  inline void bits(uint32_t value) noexcept {
+    bits_ = value;
   }
 
   /// Returns the bytes of the IP address as array.

--- a/libcaf_core/caf/ipv4_address.hpp
+++ b/libcaf_core/caf/ipv4_address.hpp
@@ -44,7 +44,7 @@ public:
 
   ipv4_address();
 
-  ipv4_address(array_type bytes);
+  explicit ipv4_address(array_type bytes);
 
   // -- properties -------------------------------------------------------------
 

--- a/libcaf_core/caf/ipv4_address.hpp
+++ b/libcaf_core/caf/ipv4_address.hpp
@@ -85,10 +85,6 @@ public:
     return bytes_;
   }
 
-  constexpr size_t size() const noexcept {
-    return bytes_.size();
-  }
-
   // -- inspection -------------------------------------------------------------
 
   template <class Inspector>

--- a/libcaf_core/caf/ipv4_address.hpp
+++ b/libcaf_core/caf/ipv4_address.hpp
@@ -92,6 +92,13 @@ public:
     return bytes_.size();
   }
 
+  // -- inspection -------------------------------------------------------------
+
+  template <class Inspector>
+  friend typename Inspector::result_type inspect(Inspector& f, ipv4_address& x) {
+    return f(x.bits_);
+  }
+
 private:
   // -- member variables -------------------------------------------------------
 

--- a/libcaf_core/caf/ipv4_address.hpp
+++ b/libcaf_core/caf/ipv4_address.hpp
@@ -1,0 +1,119 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+#include "caf/byte_address.hpp"
+#include "caf/detail/comparable.hpp"
+#include "caf/fwd.hpp"
+
+namespace caf {
+
+class ipv4_address : public byte_address<ipv4_address>,
+                     detail::comparable<ipv4_address, ipv6_address> {
+public:
+  // -- constants --------------------------------------------------------------
+
+  static constexpr size_t num_bytes = 4;
+
+  // -- member types -----------------------------------------------------------
+
+  using super = byte_address<ipv4_address>;
+
+  using array_type = std::array<uint8_t, num_bytes>;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  ipv4_address();
+
+  ipv4_address(array_type bytes);
+
+  // -- comparison -------------------------------------------------------------
+
+  using super::compare;
+
+  /// Returns a negative number if `*this < other`, zero if `*this == other`
+  /// and a positive number if `*this > other`.
+  int compare(const ipv6_address& other) const noexcept;
+
+  // -- properties -------------------------------------------------------------
+
+  /// Returns whether this is a loopback address.
+  bool is_loopback() const noexcept;
+
+  /// Returns whether this is a multicast address.
+  bool is_multicast() const noexcept;
+
+  /// Returns the bits of the IP address in a single integer.
+  inline uint32_t bits() const noexcept {
+    return bits_;
+  }
+
+  /// Returns the bytes of the IP address as array.
+  inline array_type& bytes() noexcept {
+    return bytes_;
+  }
+
+  /// Returns the bytes of the IP address as array.
+  inline const array_type& bytes() const noexcept {
+    return bytes_;
+  }
+
+  /// Alias for `bytes()`.
+  inline array_type& data() noexcept {
+    return bytes_;
+  }
+
+  /// Alias for `bytes()`.
+  inline const array_type& data() const noexcept {
+    return bytes_;
+  }
+
+  constexpr size_t size() const noexcept {
+    return bytes_.size();
+  }
+
+private:
+  // -- member variables -------------------------------------------------------
+
+  union {
+    uint32_t bits_;
+    array_type bytes_;
+  };
+
+  // -- sanity checks ----------------------------------------------------------
+
+  static_assert(sizeof(array_type) == sizeof(uint32_t),
+                "array<char, 4> has a different size than uint32");
+};
+
+// -- related free functions ---------------------------------------------------
+
+/// Returns a human-readable string representation of the address.
+/// @relates ipv4_address
+std::string to_string(const ipv4_address& x);
+
+/// Tries to parse the content of `str` into `dest`.
+/// @relates ipv4_address
+error parse(string_view str, ipv4_address& dest);
+
+} // namespace caf

--- a/libcaf_core/caf/ipv4_subnet.hpp
+++ b/libcaf_core/caf/ipv4_subnet.hpp
@@ -40,7 +40,7 @@ public:
     return address_;
   }
 
-  /// Returns the prefix length of the netmask.
+  /// Returns the prefix length of the netmask in bits.
   inline uint8_t prefix_length() const noexcept {
     return prefix_length_;
   }

--- a/libcaf_core/caf/ipv4_subnet.hpp
+++ b/libcaf_core/caf/ipv4_subnet.hpp
@@ -1,0 +1,65 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+#include "caf/detail/comparable.hpp"
+#include "caf/ipv4_address.hpp"
+
+namespace caf {
+
+class ipv4_subnet : detail::comparable<ipv4_subnet> {
+public:
+  // -- constructors, destructors, and assignment operators --------------------
+
+  ipv4_subnet();
+
+  ipv4_subnet(ipv4_address network_address, uint8_t prefix_length);
+
+  // -- properties -------------------------------------------------------------
+
+  /// Returns the network address for this subnet.
+  inline ipv4_address network_address() const noexcept {
+    return address_;
+  }
+
+  /// Returns the prefix length of the netmask.
+  inline uint8_t prefix_length() const noexcept {
+    return prefix_length_;
+  }
+
+  /// Returns whether `addr` belongs to this subnet.
+  bool contains(ipv4_address addr) const noexcept;
+
+  /// Returns whether this subnet includes `other`.
+  bool contains(ipv4_subnet other) const noexcept;
+
+  // -- comparison -------------------------------------------------------------
+
+  int compare(const ipv4_subnet& other) const noexcept;
+
+private:
+  // -- member variables -------------------------------------------------------
+
+  ipv4_address address_;
+  uint8_t prefix_length_;
+};
+
+} // namespace caf

--- a/libcaf_core/caf/ipv6_address.hpp
+++ b/libcaf_core/caf/ipv6_address.hpp
@@ -42,6 +42,8 @@ public:
 
   using array_type = std::array<uint8_t, num_bytes>;
 
+  using u16_array_type = std::array<uint16_t, 8>;
+
   using uint16_ilist = std::initializer_list<uint16_t>;
 
   // -- constructors, destructors, and assignment operators --------------------
@@ -121,7 +123,7 @@ private:
   union {
     std::array<uint64_t, 2> half_segments_;
     std::array<uint32_t, 4> quad_segments_;
-    std::array<uint16_t, 8> oct_segments_;
+    u16_array_type oct_segments_;
     array_type bytes_;
   };
 };

--- a/libcaf_core/caf/ipv6_address.hpp
+++ b/libcaf_core/caf/ipv6_address.hpp
@@ -20,6 +20,7 @@
 
 #include <array>
 #include <cstdint>
+#include <initializer_list>
 #include <string>
 
 #include "caf/byte_address.hpp"
@@ -41,12 +42,22 @@ public:
 
   using array_type = std::array<uint8_t, num_bytes>;
 
+  using uint16_ilist = std::initializer_list<uint16_t>;
+
   // -- constructors, destructors, and assignment operators --------------------
 
+  /// Constructs an all-zero address.
   ipv6_address();
 
+  /// Constructs an address from given prefix and suffix.
+  /// @pre `prefix.size() + suffix.size() <= 8`
+  /// @warning assumes network byte order for prefix and suffix
+  ipv6_address(uint16_ilist prefix, uint16_ilist suffix);
+
+  /// Embeds an IPv4 address into an IPv6 address.
   explicit ipv6_address(ipv4_address addr);
 
+  /// Constructs an IPv6 address from given bytes.
   explicit ipv6_address(array_type bytes);
 
   // -- comparison -------------------------------------------------------------

--- a/libcaf_core/caf/ipv6_address.hpp
+++ b/libcaf_core/caf/ipv6_address.hpp
@@ -47,7 +47,7 @@ public:
 
   explicit ipv6_address(ipv4_address addr);
 
-  ipv6_address(array_type bytes);
+  explicit ipv6_address(array_type bytes);
 
   // -- comparison -------------------------------------------------------------
 

--- a/libcaf_core/caf/ipv6_address.hpp
+++ b/libcaf_core/caf/ipv6_address.hpp
@@ -100,11 +100,6 @@ public:
     return bytes_;
   }
 
-  /// Returns the number of bytes of an IPv6 address.
-  inline size_t size() const noexcept {
-    return bytes_.size();
-  }
-
   /// Returns whether this address contains only zeros, i.e., equals `::`.
   inline bool zero() const noexcept {
     return half_segments_[0] == 0 && half_segments_[1] == 0;

--- a/libcaf_core/caf/ipv6_address.hpp
+++ b/libcaf_core/caf/ipv6_address.hpp
@@ -1,0 +1,125 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+#include "caf/byte_address.hpp"
+#include "caf/detail/comparable.hpp"
+#include "caf/fwd.hpp"
+
+namespace caf {
+
+class ipv6_address : public byte_address<ipv6_address>,
+                     detail::comparable<ipv6_address, ipv4_address> {
+public:
+  // -- constants --------------------------------------------------------------
+
+  static constexpr size_t num_bytes = 16;
+
+  // -- member types -----------------------------------------------------------
+
+  using super = byte_address<ipv6_address>;
+
+  using array_type = std::array<uint8_t, num_bytes>;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  ipv6_address();
+
+  explicit ipv6_address(ipv4_address addr);
+
+  ipv6_address(array_type bytes);
+
+  // -- comparison -------------------------------------------------------------
+
+  using super::compare;
+
+  /// Returns a negative number if `*this < other`, zero if `*this == other`
+  /// and a positive number if `*this > other`.
+  int compare(ipv4_address other) const noexcept;
+
+  // -- properties -------------------------------------------------------------
+
+  /// Returns whether this address embeds an IPv4 address.
+  bool embeds_v4() const noexcept;
+
+  /// Returns an embedded IPv4 address.
+  /// @pre `embeds_v4()`
+  ipv4_address embedded_v4() const noexcept;
+
+  /// Returns whether this is a loopback address.
+  bool is_loopback() const noexcept;
+
+  /// Returns the bytes of the IP address as array.
+  inline array_type& bytes() noexcept {
+    return bytes_;
+  }
+
+  /// Returns the bytes of the IP address as array.
+  inline const array_type& bytes() const noexcept {
+    return bytes_;
+  }
+
+  /// Alias for `bytes()`.
+  inline array_type& data() noexcept {
+    return bytes_;
+  }
+
+  /// Alias for `bytes()`.
+  inline const array_type& data() const noexcept {
+    return bytes_;
+  }
+
+  /// Returns the number of bytes of an IPv6 address.
+  inline size_t size() const noexcept {
+    return bytes_.size();
+  }
+
+  /// Returns whether this address contains only zeros, i.e., equals `::`.
+  inline bool zero() const noexcept {
+    return half_segments_[0] == 0 && half_segments_[1] == 0;
+  }
+
+  // -- inspection -------------------------------------------------------------
+
+  template <class Inspector>
+  friend typename Inspector::result_type inspect(Inspector& f,
+                                                 ipv6_address& x) {
+    return f(x.bytes_);
+  }
+
+  friend std::string to_string(ipv6_address x);
+
+private:
+  // -- member variables -------------------------------------------------------
+
+  union {
+    std::array<uint64_t, 2> half_segments_;
+    std::array<uint32_t, 4> quad_segments_;
+    std::array<uint16_t, 8> oct_segments_;
+    array_type bytes_;
+  };
+};
+
+error parse(string_view str, ipv6_address& dest);
+
+} // namespace caf

--- a/libcaf_core/caf/ipv6_subnet.hpp
+++ b/libcaf_core/caf/ipv6_subnet.hpp
@@ -1,0 +1,92 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+#include "caf/detail/comparable.hpp"
+#include "caf/fwd.hpp"
+#include "caf/ipv4_address.hpp"
+#include "caf/ipv4_subnet.hpp"
+#include "caf/ipv6_address.hpp"
+
+namespace caf {
+
+class ipv6_subnet : detail::comparable<ipv6_subnet> {
+public:
+  // -- constants --------------------------------------------------------------
+
+  /// Stores the offset of an embedded IPv4 subnet in bits.
+  static constexpr uint8_t v4_offset =
+    static_cast<uint8_t>(ipv6_address::num_bytes - ipv4_address::num_bytes) * 8;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  ipv6_subnet();
+
+  explicit ipv6_subnet(ipv4_subnet subnet);
+
+  ipv6_subnet(ipv4_address network_address, uint8_t prefix_length);
+
+  ipv6_subnet(ipv6_address network_address, uint8_t prefix_length);
+
+  // -- properties -------------------------------------------------------------
+
+  /// Returns whether this subnet embeds an IPv4 subnet.
+  bool embeds_v4() const noexcept;
+
+  /// Returns an embedded IPv4 subnet.
+  /// @pre `embeds_v4()`
+  ipv4_subnet embedded_v4() const noexcept;
+
+  /// Returns the network address for this subnet.
+  inline ipv6_address network_address() const noexcept {
+    return address_;
+  }
+
+  /// Returns the prefix length of the netmask.
+  inline uint8_t prefix_length() const noexcept {
+    return prefix_length_;
+  }
+
+  /// Returns whether `addr` belongs to this subnet.
+  bool contains(ipv6_address addr) const noexcept;
+
+  /// Returns whether this subnet includes `other`.
+  bool contains(ipv6_subnet other) const noexcept;
+
+  /// Returns whether `addr` belongs to this subnet.
+  bool contains(ipv4_address addr) const noexcept;
+
+  /// Returns whether this subnet includes `other`.
+  bool contains(ipv4_subnet other) const noexcept;
+
+  // -- comparison -------------------------------------------------------------
+
+  int compare(const ipv6_subnet& other) const noexcept;
+
+private:
+  // -- member variables -------------------------------------------------------
+
+  ipv6_address address_;
+  uint8_t prefix_length_;
+};
+
+} // namespace caf
+

--- a/libcaf_core/caf/string_view.hpp
+++ b/libcaf_core/caf/string_view.hpp
@@ -52,11 +52,11 @@ struct is_string_like {
         decltype(x->size())
       >::value
     >::type* = nullptr,
-    // check if `x->compare(*x)` is well-formed and returns an integer
+    // check if `x->find('?', 0)` is well-formed and returns an integer
     // (distinguishes vectors from strings)
     typename std::enable_if<
       std::is_integral<
-        decltype(x->compare(*x))
+        decltype(x->find('?', 0))
       >::value
     >::type* = nullptr);
 

--- a/libcaf_core/caf/uri.hpp
+++ b/libcaf_core/caf/uri.hpp
@@ -111,11 +111,22 @@ public:
 
   int compare(string_view x) const noexcept;
 
+  // -- friend functions -------------------------------------------------------
+
+  friend error inspect(caf::serializer& dst, uri& x);
+
+  friend error inspect(caf::deserializer& src, uri& x);
+
 private:
   impl_ptr impl_;
 };
 
 // -- related free functions ---------------------------------------------------
+
+template <class Inspector>
+typename Inspector::result_type inspect(Inspector& f, uri::authority_type& x) {
+  return f(x.userinfo, x.host, x.port);
+}
 
 /// @relates uri
 std::string to_string(const uri& x);

--- a/libcaf_core/caf/uri.hpp
+++ b/libcaf_core/caf/uri.hpp
@@ -1,0 +1,125 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "caf/detail/comparable.hpp"
+#include "caf/detail/unordered_flat_map.hpp"
+#include "caf/fwd.hpp"
+#include "caf/intrusive_ptr.hpp"
+#include "caf/ip_address.hpp"
+#include "caf/string_view.hpp"
+#include "caf/variant.hpp"
+
+namespace caf {
+
+/// A URI according to RFC 3986.
+class uri : detail::comparable<uri>, detail::comparable<uri, string_view> {
+public:
+  // -- member types -----------------------------------------------------------
+
+  /// Pointer to implementation.
+  using impl_ptr = intrusive_ptr<const detail::uri_impl>;
+
+  /// Host subcomponent of the authority component. Either an IP address or
+  /// an hostname as string.
+  using host_type = variant<std::string, ip_address>;
+
+  /// Bundles the authority component of the URI, i.e., userinfo, host, and
+  /// port.
+  struct authority_type {
+    std::string userinfo;
+    host_type host;
+    uint16_t port;
+
+    inline authority_type() : port(0) {
+      // nop
+    }
+  };
+
+  /// Separates the query component into key-value pairs.
+  using path_list = std::vector<string_view>;
+
+  /// Separates the query component into key-value pairs.
+  using query_map = detail::unordered_flat_map<std::string, std::string>;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  uri();
+
+  uri(uri&&) = default;
+
+  uri(const uri&) = default;
+
+  uri& operator=(uri&&) = default;
+
+  uri& operator=(const uri&) = default;
+
+  explicit uri(impl_ptr ptr);
+
+  // -- properties -------------------------------------------------------------
+
+  /// Returns whether all components of this URI are empty.
+  bool empty() const noexcept;
+
+  /// Returns the full URI as provided by the user.
+  string_view str() const noexcept;
+
+  /// Returns the scheme component.
+  string_view scheme() const noexcept;
+
+  /// Returns the authority component.
+  const authority_type& authority() const noexcept;
+
+  /// Returns the path component as provided by the user.
+  string_view path() const noexcept;
+
+  /// Returns the query component as key-value map.
+  const query_map& query() const noexcept;
+
+  /// Returns the fragment component.
+  string_view fragment() const noexcept;
+
+  // -- comparison -------------------------------------------------------------
+
+  int compare(const uri& other) const noexcept;
+
+  int compare(string_view x) const noexcept;
+
+private:
+  impl_ptr impl_;
+};
+
+// -- related free functions ---------------------------------------------------
+
+/// @relates uri
+std::string to_string(const uri::host_type& x);
+
+/// @relates uri
+std::string to_string(const uri::authority_type& x);
+
+/// @relates uri
+std::string to_string(const uri& x);
+
+/// @relates uri
+error parse(string_view str, uri& dest);
+
+} // namespace caf

--- a/libcaf_core/caf/uri.hpp
+++ b/libcaf_core/caf/uri.hpp
@@ -53,6 +53,13 @@ public:
     inline authority_type() : port(0) {
       // nop
     }
+
+    /// Returns whether `host` is empty, i.e., the host is not an IP address
+    /// and the string is empty.
+    bool empty() const noexcept {
+      auto str = get_if<std::string>(&host);
+      return str != nullptr && str->empty();
+    }
   };
 
   /// Separates the query component into key-value pairs.
@@ -109,12 +116,6 @@ private:
 };
 
 // -- related free functions ---------------------------------------------------
-
-/// @relates uri
-std::string to_string(const uri::host_type& x);
-
-/// @relates uri
-std::string to_string(const uri::authority_type& x);
 
 /// @relates uri
 std::string to_string(const uri& x);

--- a/libcaf_core/caf/uri_builder.hpp
+++ b/libcaf_core/caf/uri_builder.hpp
@@ -1,0 +1,72 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "caf/fwd.hpp"
+#include "caf/uri.hpp"
+
+namespace caf {
+
+class uri_builder {
+public:
+  // -- member types -----------------------------------------------------------
+
+  /// Pointer to implementation.
+  using impl_ptr = intrusive_ptr<detail::uri_impl>;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  uri_builder();
+
+  uri_builder(uri_builder&&) = default;
+
+  uri_builder& operator=(uri_builder&&) = default;
+
+  // -- setter -----------------------------------------------------------------
+
+  uri_builder& scheme(std::string str);
+
+  uri_builder& userinfo(std::string str);
+
+  uri_builder& host(std::string str);
+
+  uri_builder& host(ip_address addr);
+
+  uri_builder& port(uint16_t value);
+
+  uri_builder& path(std::string str);
+
+  uri_builder& query(uri::query_map map);
+
+  uri_builder& fragment(std::string str);
+
+  // -- factory functions ------------------------------------------------------
+
+  uri make();
+
+private:
+  // -- member variables -------------------------------------------------------
+
+  impl_ptr impl_;
+};
+
+} // namespace caf

--- a/libcaf_core/src/ipv4_address.cpp
+++ b/libcaf_core/src/ipv4_address.cpp
@@ -1,0 +1,95 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/ipv4_address.hpp"
+
+#include "caf/detail/network_order.hpp"
+#include "caf/detail/parser/read_ipv4_address.hpp"
+#include "caf/error.hpp"
+#include "caf/pec.hpp"
+#include "caf/string_view.hpp"
+
+namespace caf {
+
+namespace {
+
+inline uint32_t net_order(uint32_t value) {
+  return detail::to_network_order(value);
+}
+
+struct ipv4_address_consumer {
+  size_t pos;
+  ipv4_address& dest;
+
+  ipv4_address_consumer(ipv4_address& ref) : pos(0), dest(ref) {
+    // nop
+  }
+
+  void value(uint8_t octet) {
+    dest[pos++] = octet;
+  }
+};
+
+} // namespace <anonymous>
+
+// -- constructors, destructors, and assignment operators ----------------------
+
+ipv4_address::ipv4_address() {
+  bits_ = 0u;
+}
+
+ipv4_address::ipv4_address(array_type bytes) {
+  memcpy(bytes_.data(), bytes.data(), bytes.size());
+}
+
+// -- properties ---------------------------------------------------------------
+
+bool ipv4_address::is_loopback() const noexcept {
+  // All addresses in 127.0.0.0/8 are considered loopback addresses.
+  return (bits_ & net_order(0xFF000000)) == net_order(0x7F000000);
+}
+
+bool ipv4_address::is_multicast() const noexcept {
+  // All addresses in 224.0.0.0/8 are considered loopback addresses.
+  return (bits_ & net_order(0xFF000000)) == net_order(0xE0000000);
+}
+
+// -- related free functions ---------------------------------------------------
+
+std::string to_string(const ipv4_address& x) {
+  using std::to_string;
+  std::string result;
+  result += to_string(x[0]);
+  for (size_t i = 1; i < x.data().size(); ++i) {
+    result += '.';
+    result += to_string(x[i]);
+  }
+  return result;
+}
+
+error parse(string_view str, ipv4_address& dest) {
+  using namespace detail;
+  parser::state<string_view::iterator> res{str.begin(), str.end()};
+  ipv4_address_consumer f{dest};
+  parser::read_ipv4_address(res, f);
+  if (res.code == pec::success)
+    return none;
+  return make_error(res.code, res.line, res.column);
+}
+
+} // namespace caf

--- a/libcaf_core/src/ipv4_subnet.cpp
+++ b/libcaf_core/src/ipv4_subnet.cpp
@@ -1,0 +1,58 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/ipv4_subnet.hpp"
+
+namespace caf {
+
+// -- constructors, destructors, and assignment operators --------------------
+
+ipv4_subnet::ipv4_subnet() {
+  // nop
+}
+
+ipv4_subnet::ipv4_subnet(ipv4_address network_address, uint8_t prefix_length)
+    : address_(network_address),
+      prefix_length_(prefix_length) {
+  // nop
+}
+
+// -- properties ---------------------------------------------------------------
+
+bool ipv4_subnet::contains(ipv4_address addr) const noexcept {
+  return address_ == addr.network_address(prefix_length_);
+}
+
+bool ipv4_subnet::contains(ipv4_subnet other) const noexcept {
+  // We can only contain a subnet if it's prefix is greater or equal.
+  if (prefix_length_ > other.prefix_length_)
+    return false;
+  return prefix_length_ == other.prefix_length_
+         ? address_ == other.address_
+         : address_ == other.address_.network_address(prefix_length_);
+}
+
+// -- comparison ---------------------------------------------------------------
+
+int ipv4_subnet::compare(const ipv4_subnet& other) const noexcept {
+  auto sub_res = address_.compare(other.address_);
+  return sub_res != 0 ? sub_res
+                      : static_cast<int>(prefix_length_) - other.prefix_length_;
+}
+
+} // namespace caf

--- a/libcaf_core/src/ipv6_address.cpp
+++ b/libcaf_core/src/ipv6_address.cpp
@@ -86,6 +86,26 @@ ipv6_address::ipv6_address() {
   half_segments_[1] = 0;
 }
 
+ipv6_address::ipv6_address(uint16_ilist prefix, uint16_ilist suffix) {
+  CAF_ASSERT((prefix.size() + suffix.size()) <= 8);
+  auto addr_fill = [&](uint16_ilist chunks) {
+    union {
+      uint16_t i;
+      std::array<uint8_t, 2> a;
+    } tmp;
+    size_t p = 0;
+    for (auto chunk : chunks) {
+      tmp.i = detail::to_network_order(chunk);
+      bytes_[p++] = tmp.a[0];
+      bytes_[p++] = tmp.a[1];
+    }
+  };
+  bytes_.fill(0);
+  addr_fill(suffix);
+  std::rotate(bytes_.begin(), bytes_.begin() + suffix.size() * 2, bytes_.end());
+  addr_fill(prefix);
+}
+
 ipv6_address::ipv6_address(ipv4_address addr) {
   std::copy(v4_prefix.begin(), v4_prefix.end(), quad_segments_.begin());
   quad_segments_.back() = addr.bits();

--- a/libcaf_core/src/ipv6_address.cpp
+++ b/libcaf_core/src/ipv6_address.cpp
@@ -1,0 +1,203 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/ipv6_address.hpp"
+
+#include "caf/detail/append_hex.hpp"
+#include "caf/detail/network_order.hpp"
+#include "caf/detail/parser/read_ipv6_address.hpp"
+#include "caf/error.hpp"
+#include "caf/ipv4_address.hpp"
+#include "caf/pec.hpp"
+#include "caf/string_view.hpp"
+
+namespace caf {
+
+namespace {
+
+struct ipv6_address_consumer {
+  ipv6_address& dest;
+
+  ipv6_address_consumer(ipv6_address& ref) : dest(ref) {
+    // nop
+  }
+
+  void value(ipv6_address val) {
+    dest = val;
+  }
+};
+
+// It's good practice when printing IPv6 addresses to:
+// - remove leading zeros in all segments
+// - use lowercase hexadecimal characters
+// @param pointer to an uint16_t segment converted to uint8_t*
+void append_v6_hex(std::string& result, const uint8_t* xs) {
+  auto tbl = "0123456789abcdef";
+  size_t j = 0;
+  std::array<char, (sizeof(uint16_t) * 2) + 1> buf;
+  buf.fill(0);
+  for (size_t i = 0; i < sizeof(uint16_t); ++i) {
+    auto c = xs[i];
+    buf[j++] = tbl[c >> 4];
+    buf[j++] = tbl[c & 0x0F];
+  }
+  auto pred = [](char c) {
+    return c != '0';
+  };
+  auto first_non_zero = std::find_if(buf.begin(), buf.end(), pred);
+  CAF_ASSERT(first_non_zero != buf.end());
+  if (*first_non_zero != '\0')
+    result += &(*first_non_zero);
+  else
+    result += '0';
+}
+
+inline uint32_t net_order_32(uint32_t value) {
+  return detail::to_network_order(value);
+}
+
+inline uint64_t net_order_64(uint64_t value) {
+  return detail::to_network_order(value);
+}
+
+std::array<uint32_t, 3> v4_prefix{{0, 0, net_order_32(0x0000FFFFu)}};
+
+} // namespace <anonymous>
+
+// -- constructors, destructors, and assignment operators ----------------------
+
+ipv6_address::ipv6_address() {
+  half_segments_[0] = 0;
+  half_segments_[1] = 0;
+}
+
+ipv6_address::ipv6_address(ipv4_address addr) {
+  std::copy(v4_prefix.begin(), v4_prefix.end(), quad_segments_.begin());
+  quad_segments_.back() = addr.bits();
+}
+
+ipv6_address::ipv6_address(array_type bytes) {
+  memcpy(bytes_.data(), bytes.data(), bytes.size());
+}
+
+int ipv6_address::compare(ipv4_address other) const noexcept {
+  ipv6_address tmp{other};
+  return compare(tmp);
+}
+
+// -- properties ---------------------------------------------------------------
+
+bool ipv6_address::embeds_v4() const noexcept {
+  using std::begin;
+  using std::end;
+  return std::equal(begin(v4_prefix), end(v4_prefix), quad_segments_.begin());
+}
+
+ipv4_address ipv6_address::embedded_v4() const noexcept {
+  ipv4_address result;
+  result.bits(quad_segments_.back());
+  return result;
+}
+
+bool ipv6_address::is_loopback() const noexcept {
+  // IPv6 defines "::1" as the loopback address, when embedding a v4 we
+  // dispatch accordingly.
+  return embeds_v4()
+         ? embedded_v4().is_loopback()
+         : half_segments_[0] == 0 && half_segments_[1] == net_order_64(1u);
+}
+
+// -- related free functions ---------------------------------------------------
+
+namespace {
+
+using u16_iterator = const uint16_t*;
+
+using u16_range = std::pair<u16_iterator, u16_iterator>;
+
+u16_range longest_streak(u16_iterator first, u16_iterator last) {
+  auto zero = [](uint16_t x, uint16_t y) {
+    return x == 0 && y == 0;
+  };
+  auto not_zero = [](uint16_t x) {
+    return x != 0;
+  };
+  u16_range result;
+  result.first = std::adjacent_find(first, last, zero);
+  if (result.first == last)
+    return {last, last};
+  result.second = std::find_if(result.first + 2, last, not_zero);
+  if (result.second == last)
+    return result;
+  auto next_streak = longest_streak(result.second, last);
+  auto distance = [](u16_range x) {
+    return std::distance(x.first, x.second);
+  };
+  return distance(result) >= distance(next_streak) ? result : next_streak;
+}
+
+} // namespace <anonymous>
+
+std::string to_string(ipv6_address x) {
+  // Shortcut for embedded v4 addresses.
+  if (x.embeds_v4())
+    return to_string(x.embedded_v4());
+  // Shortcut for all-zero addresses.
+  if (x.zero())
+    return "::";
+  // Output buffer.
+  std::string result;
+  // Utility for appending chunks to the result.
+  auto add_chunk = [&](uint16_t x) {
+    append_v6_hex(result, reinterpret_cast<uint8_t*>(&x));
+  };
+  auto add_chunks = [&](u16_iterator i, u16_iterator e) {
+    if (i != e) {
+      add_chunk(*i++);
+      for (; i != e; ++i) {
+        result += ':';
+        add_chunk(*i);
+      }
+    }
+  };
+  // Scan for the longest streak of 0 16-bit chunks for :: shorthand.
+  auto first = x.oct_segments_.begin();
+  auto last = x.oct_segments_.end();
+  auto streak = longest_streak(first, last);
+  // Put it all together.
+  if (streak.first == last) {
+    add_chunks(first, last);
+  } else {
+    add_chunks(first, streak.first);
+    result += "::";
+    add_chunks(streak.second, last);
+  }
+  return result;
+}
+
+error parse(string_view str, ipv6_address& dest) {
+  using namespace detail;
+  parser::state<string_view::iterator> res{str.begin(), str.end()};
+  ipv6_address_consumer f{dest};
+  parser::read_ipv6_address(res, f);
+  if (res.code == pec::success)
+    return none;
+  return make_error(res.code, res.line, res.column);
+}
+
+} // namespace caf

--- a/libcaf_core/src/ipv6_subnet.cpp
+++ b/libcaf_core/src/ipv6_subnet.cpp
@@ -1,0 +1,88 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/ipv6_subnet.hpp"
+
+namespace caf {
+
+// -- constructors, destructors, and assignment operators --------------------
+
+ipv6_subnet::ipv6_subnet() {
+  // nop
+}
+
+ipv6_subnet::ipv6_subnet(ipv4_subnet subnet)
+    : address_(ipv6_address{subnet.network_address()}),
+      prefix_length_(v4_offset + subnet.prefix_length()){
+  // nop
+}
+
+ipv6_subnet::ipv6_subnet(ipv4_address network_address, uint8_t prefix_length)
+    : address_(network_address),
+      prefix_length_(prefix_length + v4_offset) {
+  // nop
+}
+
+ipv6_subnet::ipv6_subnet(ipv6_address network_address, uint8_t prefix_length)
+    : address_(network_address),
+      prefix_length_(prefix_length) {
+  // nop
+}
+
+// -- properties ---------------------------------------------------------------
+
+bool ipv6_subnet::embeds_v4() const noexcept {
+  return prefix_length_ >= v4_offset && address_.embeds_v4();
+}
+
+ipv4_subnet ipv6_subnet::embedded_v4() const noexcept {
+  return {address_.embedded_v4(),
+          static_cast<uint8_t>(prefix_length_ - v4_offset)};
+}
+
+bool ipv6_subnet::contains(ipv6_address addr) const noexcept {
+  return address_ == addr.network_address(prefix_length_);
+}
+
+bool ipv6_subnet::contains(ipv6_subnet other) const noexcept {
+  // We can only contain a subnet if it's prefix is greater or equal.
+  if (prefix_length_ > other.prefix_length_)
+    return false;
+  return prefix_length_ == other.prefix_length_
+         ? address_ == other.address_
+         : address_ == other.address_.network_address(prefix_length_);
+}
+
+bool ipv6_subnet::contains(ipv4_address addr) const noexcept {
+  return embeds_v4() ? embedded_v4().contains(addr) : false;
+}
+
+bool ipv6_subnet::contains(ipv4_subnet other) const noexcept {
+  return embeds_v4() ? embedded_v4().contains(other) : false;
+}
+
+// -- comparison ---------------------------------------------------------------
+
+int ipv6_subnet::compare(const ipv6_subnet& other) const noexcept {
+  auto sub_res = address_.compare(other.address_);
+  return sub_res != 0 ? sub_res
+                      : static_cast<int>(prefix_length_) - other.prefix_length_;
+}
+
+} // namespace caf
+

--- a/libcaf_core/src/string_view.cpp
+++ b/libcaf_core/src/string_view.cpp
@@ -103,18 +103,14 @@ string_view string_view::substr(size_type pos, size_type n) const noexcept {
 int string_view::compare(string_view str) const noexcept {
   auto s0 = size();
   auto s1 = str.size();
-  if (s0 == s1) {
-    return strncmp(data(), str.data(), std::min(size(), str.size()));
-  } else if (s0 < s1) {
-    auto res = strncmp(data(), str.data(), std::min(size(), str.size()));
-    if (res == 0)
-      return -1;
-  } else {
-    auto res = strncmp(data(), str.data(), std::min(size(), str.size()));
-    if (res == 0)
-      return 1;
-  }
-  return 0;
+  auto fallback = [](int x, int y) {
+    return x == 0 ? y : x;
+  };
+  if (s0 == s1)
+    return strncmp(data(), str.data(), s0);
+  else if (s0 < s1)
+    return fallback(strncmp(data(), str.data(), s0), -1);
+  return fallback(strncmp(data(), str.data(), s1), 1);
 }
 
 int string_view::compare(size_type pos1, size_type n1,

--- a/libcaf_core/src/string_view.cpp
+++ b/libcaf_core/src/string_view.cpp
@@ -101,7 +101,20 @@ string_view string_view::substr(size_type pos, size_type n) const noexcept {
 }
 
 int string_view::compare(string_view str) const noexcept {
-  return strncmp(data(), str.data(), std::min(size(), str.size()));
+  auto s0 = size();
+  auto s1 = str.size();
+  if (s0 == s1) {
+    return strncmp(data(), str.data(), std::min(size(), str.size()));
+  } else if (s0 < s1) {
+    auto res = strncmp(data(), str.data(), std::min(size(), str.size()));
+    if (res == 0)
+      return -1;
+  } else {
+    auto res = strncmp(data(), str.data(), std::min(size(), str.size()));
+    if (res == 0)
+      return 1;
+  }
+  return 0;
 }
 
 int string_view::compare(size_type pos1, size_type n1,

--- a/libcaf_core/src/stringification_inspector.cpp
+++ b/libcaf_core/src/stringification_inspector.cpp
@@ -39,20 +39,20 @@ void stringification_inspector::consume(atom_value& x) {
   result_ += '\'';
 }
 
-void stringification_inspector::consume(const char* cstr) {
-  if (cstr == nullptr || *cstr == '\0') {
+void stringification_inspector::consume(string_view str) {
+  if (str.empty()) {
     result_ += R"("")";
     return;
   }
-  if (*cstr == '"') {
-    // assume an already escaped string
-    result_ += cstr;
+  if (str[0] == '"') {
+    // Assume an already escaped string.
+    result_.insert(result_.end(), str.begin(), str.end());
     return;
   }
+  // Escape string.
   result_ += '"';
-  char c;
-  for(;;) {
-    switch (c = *cstr++) {
+  for (char c : str) {
+    switch (c) {
       default:
         result_ += c;
         break;
@@ -62,11 +62,8 @@ void stringification_inspector::consume(const char* cstr) {
       case '"':
         result_ += R"(\")";
         break;
-      case '\0':
-        goto end_of_string;
     }
   }
-  end_of_string:
   result_ += '"';
 }
 

--- a/libcaf_core/src/uri.cpp
+++ b/libcaf_core/src/uri.cpp
@@ -74,33 +74,6 @@ int uri::compare(string_view x) const noexcept {
 
 // -- related free functions ---------------------------------------------------
 
-std::string to_string(const uri::host_type& x) {
-  auto str = get_if<std::string>(&x);
-  if (str)
-    return *str;
-  auto addr = get<ip_address>(x);
-  if (addr.embeds_v4())
-    return to_string(addr.embedded_v4());
-  std::string result = to_string(addr);
-  result.insert(result.begin(), '[');
-  result += ']';
-  return result;
-}
-
-std::string to_string(const uri::authority_type& x) {
-  std::string result;
-  if (!x.userinfo.empty()) {
-    result += x.userinfo;
-    result += '@';
-  }
-  result += to_string(x.host);
-  if (x.port != 0) {
-    result += ':';
-    result += std::to_string(x.port);
-  }
-  return result;
-}
-
 std::string to_string(const uri& x) {
   auto x_str = x.str();
   std::string result{x_str.begin(), x_str.end()};

--- a/libcaf_core/src/uri.cpp
+++ b/libcaf_core/src/uri.cpp
@@ -1,0 +1,122 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/uri.hpp"
+
+#include "caf/detail/parser/read_uri.hpp"
+#include "caf/detail/uri_impl.hpp"
+#include "caf/error.hpp"
+#include "caf/make_counted.hpp"
+#include "caf/uri_builder.hpp"
+
+namespace caf {
+
+uri::uri() : impl_(&detail::uri_impl::default_instance) {
+  // nop
+}
+
+uri::uri(impl_ptr ptr) : impl_(std::move(ptr)) {
+  CAF_ASSERT(impl_ != nullptr);
+}
+
+bool uri::empty() const noexcept {
+  return str().empty();
+}
+
+string_view uri::str() const noexcept {
+  return impl_->str;
+}
+
+string_view uri::scheme() const noexcept {
+  return impl_->scheme;
+}
+
+const uri::authority_type& uri::authority() const noexcept {
+  return impl_->authority;
+}
+
+string_view uri::path() const noexcept {
+  return impl_->path;
+}
+
+const uri::query_map& uri::query() const noexcept {
+  return impl_->query;
+}
+
+string_view uri::fragment() const noexcept {
+  return impl_->fragment;
+}
+
+// -- comparison ---------------------------------------------------------------
+
+int uri::compare(const uri& other) const noexcept {
+  return str().compare(other.str());
+}
+
+int uri::compare(string_view x) const noexcept {
+  return string_view{str()}.compare(x);
+}
+
+// -- related free functions ---------------------------------------------------
+
+std::string to_string(const uri::host_type& x) {
+  auto str = get_if<std::string>(&x);
+  if (str)
+    return *str;
+  auto addr = get<ip_address>(x);
+  if (addr.embeds_v4())
+    return to_string(addr.embedded_v4());
+  std::string result = to_string(addr);
+  result.insert(result.begin(), '[');
+  result += ']';
+  return result;
+}
+
+std::string to_string(const uri::authority_type& x) {
+  std::string result;
+  if (!x.userinfo.empty()) {
+    result += x.userinfo;
+    result += '@';
+  }
+  result += to_string(x.host);
+  if (x.port != 0) {
+    result += ':';
+    result += std::to_string(x.port);
+  }
+  return result;
+}
+
+std::string to_string(const uri& x) {
+  auto x_str = x.str();
+  std::string result{x_str.begin(), x_str.end()};
+  return result;
+}
+
+error parse(string_view str, uri& dest) {
+  using namespace detail::parser;
+  uri_builder builder;
+  state<string_view::iterator> res{str.begin(), str.end()};
+  read_uri(res, builder);
+  if (res.code == pec::success) {
+    dest = builder.make();
+    return none;
+  }
+  return make_error(res.code, res.line, res.column);
+}
+
+} // namespace caf

--- a/libcaf_core/src/uri.cpp
+++ b/libcaf_core/src/uri.cpp
@@ -18,10 +18,12 @@
 
 #include "caf/uri.hpp"
 
+#include "caf/deserializer.hpp"
 #include "caf/detail/parser/read_uri.hpp"
 #include "caf/detail/uri_impl.hpp"
 #include "caf/error.hpp"
 #include "caf/make_counted.hpp"
+#include "caf/serializer.hpp"
 #include "caf/uri_builder.hpp"
 
 namespace caf {
@@ -70,6 +72,20 @@ int uri::compare(const uri& other) const noexcept {
 
 int uri::compare(string_view x) const noexcept {
   return string_view{str()}.compare(x);
+}
+
+// -- friend functions ---------------------------------------------------------
+
+error inspect(caf::serializer& dst, uri& x) {
+  return inspect(dst, const_cast<detail::uri_impl&>(*x.impl_));
+}
+
+error inspect(caf::deserializer& src, uri& x) {
+  auto impl = make_counted<detail::uri_impl>();
+  auto err = inspect(src, *impl);
+  if (err == none)
+    x = uri{std::move(impl)};
+  return err;
 }
 
 // -- related free functions ---------------------------------------------------

--- a/libcaf_core/src/uri_builder.cpp
+++ b/libcaf_core/src/uri_builder.cpp
@@ -1,0 +1,75 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/uri_builder.hpp"
+
+#include "caf/detail/uri_impl.hpp"
+#include "caf/make_counted.hpp"
+
+namespace caf {
+
+uri_builder::uri_builder() : impl_(make_counted<detail::uri_impl>()) {
+  // nop
+}
+
+uri_builder& uri_builder::scheme(std::string str) {
+  impl_->scheme = std::move(str);
+  return *this;
+}
+
+uri_builder& uri_builder::userinfo(std::string str) {
+  impl_->authority.userinfo = std::move(str);
+  return *this;
+}
+
+uri_builder& uri_builder::host(std::string str) {
+  impl_->authority.host = std::move(str);
+  return *this;
+}
+
+uri_builder& uri_builder::host(ip_address addr) {
+  impl_->authority.host = addr;
+  return *this;
+}
+
+uri_builder& uri_builder::port(uint16_t value) {
+  impl_->authority.port = value;
+  return *this;
+}
+
+uri_builder& uri_builder::path(std::string str) {
+  impl_->path = std::move(str);
+  return *this;
+}
+
+uri_builder& uri_builder::query(uri::query_map map) {
+  impl_->query = std::move(map);
+  return *this;
+}
+
+uri_builder& uri_builder::fragment(std::string str) {
+  impl_->fragment = std::move(str);
+  return *this;
+}
+
+uri uri_builder::make() {
+  impl_->assemble_str();
+  return uri{std::move(impl_)};
+}
+
+} // namespace caf

--- a/libcaf_core/src/uri_impl.cpp
+++ b/libcaf_core/src/uri_impl.cpp
@@ -1,0 +1,88 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/detail/uri_impl.hpp"
+
+#include "caf/detail/parser/read_uri.hpp"
+#include "caf/error.hpp"
+#include "caf/ip_address.hpp"
+#include "caf/string_algorithms.hpp"
+
+namespace caf {
+namespace detail {
+
+// -- constructors, destructors, and assignment operators ----------------------
+
+uri_impl::uri_impl() : rc_(1) {
+  // nop
+}
+
+// -- member variables ---------------------------------------------------------
+
+uri_impl uri_impl::default_instance;
+
+// -- modifiers ----------------------------------------------------------------
+
+void uri_impl::assemble_str() {
+  // TODO: all substrings need percent-escaping
+  str = scheme;
+  str += ':';
+  auto authority_str = to_string(authority);
+  if (!authority_str.empty()) {
+    str += "//";
+    str += authority_str;
+    if (!path.empty()) {
+      str += '/';
+      str += path;
+    }
+  } else if (!path.empty()) {
+    str += path;
+  }
+  if (!query.empty()) {
+    str += '?';
+    auto i = query.begin();
+    str += i->first;
+    str += '=';
+    str += i->second;
+    ++i;
+    for (; i != query.end(); ++i) {
+      str += '&';
+      str += i->first;
+      str += '=';
+      str += i->second;
+    }
+  }
+  if (!fragment.empty()) {
+    str += '#';
+    str += fragment;
+  }
+}
+
+// -- friend functions ---------------------------------------------------------
+
+void intrusive_ptr_add_ref(const uri_impl* p) {
+  p->rc_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void intrusive_ptr_release(const uri_impl* p) {
+  if (p->rc_ == 1 || p->rc_.fetch_sub(1, std::memory_order_acq_rel) == 1)
+    delete p;
+}
+
+} // namespace detail
+} // namespace caf

--- a/libcaf_core/src/uri_impl.cpp
+++ b/libcaf_core/src/uri_impl.cpp
@@ -63,7 +63,7 @@ void uri_impl::assemble_str() {
       str += std::to_string(authority.port);
     }
     if (!path.empty()) {
-      addr += '/';
+      str += '/';
       add_encoded(path, true);
     }
   }
@@ -76,8 +76,7 @@ void uri_impl::assemble_str() {
       add_encoded(kvp.second);
     };
     add_kvp(*i);
-    ++i;
-    for (; i != query.end(); ++i) {
+    for (++i; i != query.end(); ++i) {
       str += '&';
       add_kvp(*i);
     }

--- a/libcaf_core/src/uri_impl.cpp
+++ b/libcaf_core/src/uri_impl.cpp
@@ -96,6 +96,7 @@ void uri_impl::add_encoded(string_view x, bool is_path) {
           str += ch;
           break;
         }
+        // fall through
       case ' ':
       case ':':
       case '?':

--- a/libcaf_core/test/ipv4_address.cpp
+++ b/libcaf_core/test/ipv4_address.cpp
@@ -43,7 +43,8 @@ CAF_TEST(constructing) {
   ipv4_address localhost({127, 0, 0, 1});
   CAF_CHECK_EQUAL(localhost.bits(), to_network_order(0x7F000001u));
   CAF_CHECK_EQUAL(localhost.data(), array_type({127, 0, 0, 1}));
-  CAF_CHECK_EQUAL(ipv4_address().data(), array_type({0, 0, 0, 0}));
+  ipv4_address zero;
+  CAF_CHECK_EQUAL(zero.data(), array_type({0, 0, 0, 0}));
 }
 
 CAF_TEST(to and from string) {

--- a/libcaf_core/test/ipv4_address.cpp
+++ b/libcaf_core/test/ipv4_address.cpp
@@ -64,11 +64,17 @@ CAF_TEST(properties) {
   CAF_CHECK_EQUAL(addr(224, 0, 0, 254).is_multicast(), true);
   CAF_CHECK_EQUAL(addr(224, 0, 1, 1).is_multicast(), true);
   CAF_CHECK_EQUAL(addr(225, 0, 0, 1).is_multicast(), false);
-  CAF_CHECK_EQUAL(addr(1, 2, 3, 4).masked(0), addr(0, 0, 0, 0));
-  CAF_CHECK_EQUAL(addr(1, 2, 3, 4).masked(1), addr(1, 0, 0, 0));
-  CAF_CHECK_EQUAL(addr(1, 2, 3, 4).masked(2), addr(1, 2, 0, 0));
-  CAF_CHECK_EQUAL(addr(1, 2, 3, 4).masked(3), addr(1, 2, 3, 0));
-  CAF_CHECK_EQUAL(addr(1, 2, 3, 4).masked(4), addr(1, 2, 3, 4));
+}
+
+CAF_TEST(network addresses) {
+  auto all1 = addr(255, 255, 255, 255);
+  CAF_CHECK_EQUAL(all1.network_address(0), addr(0x00, 0x00, 0x00, 0x00));
+  CAF_CHECK_EQUAL(all1.network_address(7), addr(0xFE, 0x00, 0x00, 0x00));
+  CAF_CHECK_EQUAL(all1.network_address(8), addr(0xFF, 0x00, 0x00, 0x00));
+  CAF_CHECK_EQUAL(all1.network_address(9), addr(0xFF, 0x80, 0x00, 0x00));
+  CAF_CHECK_EQUAL(all1.network_address(31), addr(0xFF, 0xFF, 0xFF, 0xFE));
+  CAF_CHECK_EQUAL(all1.network_address(32), addr(0xFF, 0xFF, 0xFF, 0xFF));
+  CAF_CHECK_EQUAL(all1.network_address(33), addr(0xFF, 0xFF, 0xFF, 0xFF));
 }
 
 CAF_TEST(operators) {

--- a/libcaf_core/test/ipv4_address.cpp
+++ b/libcaf_core/test/ipv4_address.cpp
@@ -1,0 +1,79 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/config.hpp"
+
+#define CAF_SUITE ipv4_address
+#include "caf/test/dsl.hpp"
+
+#include "caf/ipv4_address.hpp"
+
+#include "caf/detail/network_order.hpp"
+
+using caf::detail::to_network_order;
+
+using namespace caf;
+
+namespace {
+
+using array_type = ipv4_address::array_type;
+
+ipv4_address addr(uint8_t oct1, uint8_t oct2, uint8_t oct3, uint8_t oct4) {
+  return ipv4_address({oct1, oct2, oct3, oct4});
+}
+
+} // namespace <anonymous>
+
+CAF_TEST(constructing) {
+  ipv4_address localhost({127, 0, 0, 1});
+  CAF_CHECK_EQUAL(localhost.bits(), to_network_order(0x7F000001u));
+  CAF_CHECK_EQUAL(localhost.data(), array_type({127, 0, 0, 1}));
+  CAF_CHECK_EQUAL(ipv4_address().data(), array_type({0, 0, 0, 0}));
+}
+
+CAF_TEST(to and from string) {
+  ipv4_address x;
+  auto err = parse("255.255.255.255", x);
+  CAF_CHECK_EQUAL(err, pec::success);
+  CAF_CHECK_EQUAL(x.bits(), 0xFFFFFFFF);
+  CAF_CHECK_EQUAL(to_string(x), "255.255.255.255");
+  CAF_CHECK_EQUAL(x, addr(255, 255, 255, 255));
+}
+
+CAF_TEST(properties) {
+  CAF_CHECK_EQUAL(addr(127, 0, 0, 1).is_loopback(), true);
+  CAF_CHECK_EQUAL(addr(127, 0, 0, 254).is_loopback(), true);
+  CAF_CHECK_EQUAL(addr(127, 0, 1, 1).is_loopback(), true);
+  CAF_CHECK_EQUAL(addr(128, 0, 0, 1).is_loopback(), false);
+  CAF_CHECK_EQUAL(addr(224, 0, 0, 1).is_multicast(), true);
+  CAF_CHECK_EQUAL(addr(224, 0, 0, 254).is_multicast(), true);
+  CAF_CHECK_EQUAL(addr(224, 0, 1, 1).is_multicast(), true);
+  CAF_CHECK_EQUAL(addr(225, 0, 0, 1).is_multicast(), false);
+  CAF_CHECK_EQUAL(addr(1, 2, 3, 4).masked(0), addr(0, 0, 0, 0));
+  CAF_CHECK_EQUAL(addr(1, 2, 3, 4).masked(1), addr(1, 0, 0, 0));
+  CAF_CHECK_EQUAL(addr(1, 2, 3, 4).masked(2), addr(1, 2, 0, 0));
+  CAF_CHECK_EQUAL(addr(1, 2, 3, 4).masked(3), addr(1, 2, 3, 0));
+  CAF_CHECK_EQUAL(addr(1, 2, 3, 4).masked(4), addr(1, 2, 3, 4));
+}
+
+CAF_TEST(operators) {
+  CAF_CHECK_EQUAL(addr(16, 0, 0, 8) & addr(255, 2, 4, 6), addr(16, 0, 0, 0));
+  CAF_CHECK_EQUAL(addr(16, 0, 0, 8) | addr(255, 2, 4, 6), addr(255, 2, 4, 14));
+  CAF_CHECK_EQUAL(addr(16, 0, 0, 8) ^ addr(255, 2, 4, 6), addr(239, 2, 4, 14));
+}
+

--- a/libcaf_core/test/ipv4_subnet.cpp
+++ b/libcaf_core/test/ipv4_subnet.cpp
@@ -1,0 +1,63 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/config.hpp"
+
+#define CAF_SUITE ipv4_subnet
+#include "caf/test/dsl.hpp"
+
+#include "caf/ipv4_subnet.hpp"
+
+using namespace caf;
+
+namespace {
+
+ipv4_address addr(uint8_t oct1, uint8_t oct2, uint8_t oct3, uint8_t oct4) {
+  return ipv4_address({oct1, oct2, oct3, oct4});
+}
+
+ipv4_subnet operator/(ipv4_address addr, uint8_t prefix) {
+  return {addr, prefix};
+}
+
+} // namespace <anonymous>
+
+CAF_TEST(constructing) {
+  ipv4_subnet zero{addr(0, 0, 0, 0), 32};
+  CAF_CHECK_EQUAL(zero.network_address(), addr(0, 0, 0, 0));
+  CAF_CHECK_EQUAL(zero.prefix_length(), 32u);
+  ipv4_subnet local{addr(127, 0, 0, 0), 8};
+  CAF_CHECK_EQUAL(local.network_address(), addr(127, 0, 0, 0));
+  CAF_CHECK_EQUAL(local.prefix_length(), 8u);
+}
+
+CAF_TEST(constains) {
+  ipv4_subnet local{addr(127, 0, 0, 0), 8};
+  CAF_CHECK(local.contains(addr(127, 0, 0, 1)));
+  CAF_CHECK(local.contains(addr(127, 1, 2, 3)));
+  CAF_CHECK(local.contains(addr(127, 128, 0, 0) / 9));
+  CAF_CHECK(local.contains(addr(127, 0, 0, 0) / 8));
+  CAF_CHECK(!local.contains(addr(127, 0, 0, 0) / 7));
+}
+
+CAF_TEST(ordering) {
+  CAF_CHECK_EQUAL(addr(192, 168, 168, 0) / 24, addr(192, 168, 168, 0) / 24);
+  CAF_CHECK_NOT_EQUAL(addr(192, 168, 168, 0) / 25, addr(192, 168, 168, 0) / 24);
+  CAF_CHECK_LESS(addr(192, 168, 167, 0) / 24, addr(192, 168, 168, 0) / 24);
+  CAF_CHECK_LESS(addr(192, 168, 168, 0) / 24, addr(192, 168, 168, 0) / 25);
+}

--- a/libcaf_core/test/ipv6_address.cpp
+++ b/libcaf_core/test/ipv6_address.cpp
@@ -32,36 +32,9 @@ namespace {
 
 using array_type = ipv6_address::array_type;
 
-void addr_fill(ipv6_address::array_type& arr,
-               std::initializer_list<uint16_t> chunks) {
-  union {
-    uint16_t i;
-    std::array<uint8_t, 2> a;
-  } tmp;
-  size_t p = 0;
-  for (auto chunk : chunks) {
-    tmp.i = detail::to_network_order(chunk);
-    arr[p++] = tmp.a[0];
-    arr[p++] = tmp.a[1];
-  }
-}
-
 ipv6_address addr(std::initializer_list<uint16_t> prefix,
-                  std::initializer_list<uint16_t> suffix) {
-  CAF_ASSERT((prefix.size() + suffix.size()) <= 8);
-  ipv6_address::array_type bytes;
-  bytes.fill(0);
-  addr_fill(bytes, suffix);
-  std::rotate(bytes.begin(), bytes.begin() + suffix.size() * 2, bytes.end());
-  addr_fill(bytes, prefix);
-  return ipv6_address{bytes};
-}
-
-ipv6_address addr(std::initializer_list<uint16_t> segments) {
-  ipv6_address::array_type bytes;
-  bytes.fill(0);
-  addr_fill(bytes, segments);
-  return ipv6_address{bytes};
+                  std::initializer_list<uint16_t> suffix = {}) {
+  return ipv6_address{prefix, suffix};
 }
 
 } // namespace <anonymous>

--- a/libcaf_core/test/ipv6_address.cpp
+++ b/libcaf_core/test/ipv6_address.cpp
@@ -1,0 +1,121 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include <initializer_list>
+
+#include "caf/config.hpp"
+
+#define CAF_SUITE ipv6_address
+#include "caf/test/dsl.hpp"
+
+#include "caf/ipv4_address.hpp"
+#include "caf/ipv6_address.hpp"
+
+using namespace caf;
+
+namespace {
+
+using array_type = ipv6_address::array_type;
+
+void addr_fill(ipv6_address::array_type& arr,
+               std::initializer_list<uint16_t> chunks) {
+  union {
+    uint16_t i;
+    std::array<uint8_t, 2> a;
+  } tmp;
+  size_t p = 0;
+  for (auto chunk : chunks) {
+    tmp.i = detail::to_network_order(chunk);
+    arr[p++] = tmp.a[0];
+    arr[p++] = tmp.a[1];
+  }
+}
+
+ipv6_address addr(std::initializer_list<uint16_t> prefix,
+                  std::initializer_list<uint16_t> suffix) {
+  CAF_ASSERT((prefix.size() + suffix.size()) <= 8);
+  ipv6_address::array_type bytes;
+  bytes.fill(0);
+  addr_fill(bytes, suffix);
+  std::rotate(bytes.begin(), bytes.begin() + suffix.size() * 2, bytes.end());
+  addr_fill(bytes, prefix);
+  return ipv6_address{bytes};
+}
+
+ipv6_address addr(std::initializer_list<uint16_t> segments) {
+  ipv6_address::array_type bytes;
+  bytes.fill(0);
+  addr_fill(bytes, segments);
+  return ipv6_address{bytes};
+}
+
+} // namespace <anonymous>
+
+CAF_TEST(constructing) {
+  ipv6_address localhost({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
+  CAF_CHECK_EQUAL(localhost.data(),
+                  array_type({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}));
+  CAF_CHECK_EQUAL(localhost, addr({}, {0x01}));
+}
+
+CAF_TEST(comparison) {
+  CAF_CHECK_EQUAL(addr({1, 2, 3}), addr({1, 2, 3}));
+  CAF_CHECK_NOT_EQUAL(addr({3, 2, 1}), addr({1, 2, 3}));
+  CAF_CHECK_EQUAL(addr({}, {0xFFFF, 0x7F00, 0x0001}),
+                  ipv4_address({127, 0, 0, 1}));
+}
+
+CAF_TEST(from string) {
+  auto from_string = [](string_view str) {
+    ipv6_address result;
+    auto err = parse(str, result);
+    if (err)
+      CAF_FAIL("error while parsing " << str << ": " << to_string(err));
+    return result;
+  };
+  CAF_CHECK_EQUAL(from_string("::1"), addr({}, {0x01}));
+  CAF_CHECK_EQUAL(from_string("::11"), addr({}, {0x11}));
+  CAF_CHECK_EQUAL(from_string("::112"), addr({}, {0x0112}));
+  CAF_CHECK_EQUAL(from_string("::1122"), addr({}, {0x1122}));
+  CAF_CHECK_EQUAL(from_string("::1:2"), addr({}, {0x01, 0x02}));
+  CAF_CHECK_EQUAL(from_string("::1:2"), addr({}, {0x01, 0x02}));
+  CAF_CHECK_EQUAL(from_string("1::1"), addr({0x01}, {0x01}));
+  CAF_CHECK_EQUAL(from_string("1::"), addr({0x01}, {}));
+  CAF_CHECK_EQUAL(from_string("0.1.0.1"), addr({}, {0xFFFF, 0x01, 0x01}));
+  CAF_CHECK_EQUAL(from_string("::ffff:127.0.0.1"),
+                  addr({}, {0xFFFF, 0x7F00, 0x0001}));
+  CAF_CHECK_EQUAL(from_string("1:2:3:4:5:6:7:8"), addr({1,2,3,4,5,6,7,8}));
+  CAF_CHECK_EQUAL(from_string("1:2:3:4::5:6:7:8"), addr({1,2,3,4,5,6,7,8}));
+  CAF_CHECK_EQUAL(from_string("1:2:3:4:5:6:0.7.0.8"), addr({1,2,3,4,5,6,7,8}));
+  auto invalid = [](string_view str) {
+    ipv6_address result;
+    auto err = parse(str, result);
+    return err != none;
+  };
+  CAF_CHECK(invalid("1:2:3:4:5:6:7:8:9"));
+  CAF_CHECK(invalid("1:2:3:4::5:6:7:8:9"));
+  CAF_CHECK(invalid("1:2:3::4:5:6::7:8:9"));
+}
+
+CAF_TEST(to string) {
+  CAF_CHECK_EQUAL(to_string(addr({}, {0x01})), "::1");
+  CAF_CHECK_EQUAL(to_string(addr({0x01}, {0x01})), "1::1");
+  CAF_CHECK_EQUAL(to_string(addr({0x01})), "1::");
+  CAF_CHECK_EQUAL(to_string(addr({}, {0xFFFF, 0x01, 0x01})), "0.1.0.1");
+}
+

--- a/libcaf_core/test/ipv6_subnet.cpp
+++ b/libcaf_core/test/ipv6_subnet.cpp
@@ -1,0 +1,54 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/config.hpp"
+
+#define CAF_SUITE ipv6_subnet
+#include "caf/test/dsl.hpp"
+
+#include "caf/ipv6_subnet.hpp"
+
+using namespace caf;
+
+namespace {
+
+ipv6_subnet operator/(ipv6_address addr, uint8_t prefix) {
+  return {addr, prefix};
+}
+
+} // namespace <anonymous>
+
+CAF_TEST(constructing) {
+  auto zero = ipv6_address() / 128;
+  CAF_CHECK_EQUAL(zero.network_address(), ipv6_address());
+  CAF_CHECK_EQUAL(zero.prefix_length(), 128u);
+}
+
+CAF_TEST(constains) {
+  auto local = ipv6_address{{0xbebe, 0xbebe}, {}} / 32;
+  CAF_CHECK(local.contains(ipv6_address({0xbebe, 0xbebe, 0xbebe}, {})));
+  CAF_CHECK(!local.contains(ipv6_address({0xbebe, 0xbebf}, {})));
+}
+
+CAF_TEST(embedding) {
+  ipv4_subnet v4_local{ipv4_address({127, 0, 0, 1}), 8};
+  ipv6_subnet local{v4_local};
+  CAF_CHECK(local.embeds_v4());
+  CAF_CHECK_EQUAL(local.prefix_length(), 104u);
+}
+

--- a/libcaf_core/test/string_view.cpp
+++ b/libcaf_core/test/string_view.cpp
@@ -99,7 +99,9 @@ CAF_TEST(compare) {
   CAF_CHECK(x.compare(0, 3, "abc") == 0);
   CAF_CHECK(x.compare(1, 2, y, 0, 2) == 0);
   CAF_CHECK(x.compare(2, 1, z, 0, 1) == 0);
-  CAF_CHECK(x.compare(2, 1, z, 0, 2) == 0);
+  CAF_CHECK(x.compare(2, 1, z, 0, 1) == 0);
+  // make sure substrings aren't equal
+  CAF_CHECK(string_view("a/") != string_view("a/b"));
 }
 
 CAF_TEST(copy) {

--- a/libcaf_core/test/uri.cpp
+++ b/libcaf_core/test/uri.cpp
@@ -1,0 +1,335 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/config.hpp"
+
+#define CAF_SUITE uri
+#include "caf/test/dsl.hpp"
+
+#include "caf/ipv4_address.hpp"
+#include "caf/uri.hpp"
+#include "caf/uri_builder.hpp"
+
+using namespace caf;
+
+namespace {
+
+struct authority_separator_t {} authority_separator;
+
+struct path_separator_t {} path_separator;
+
+struct uri_str_builder {
+  std::string res;
+
+  uri_str_builder() : res("http:") {
+    // nop
+  }
+
+  uri_str_builder& add() {
+    return *this;
+  }
+
+  template <class T, class... Ts>
+  uri_str_builder& add(const T& x, const Ts&... xs) {
+    res += x;
+    return add(xs...);
+  }
+
+  template <class... Ts>
+  uri_str_builder& add(const authority_separator_t&, const Ts&... xs) {
+    if (res.back() == ':')
+      return add("//", xs...);
+    return add(xs...);
+  }
+
+  template <class... Ts>
+  uri_str_builder& add(const path_separator_t&, const Ts&... xs) {
+    if (res.back() != ':')
+      return add("/", xs...);
+    return add(xs...);
+  }
+
+  uri_str_builder& userinfo(std::string str) {
+    return add(authority_separator, str, '@');
+  }
+
+  uri_str_builder& host(std::string str) {
+    return add(authority_separator, str);
+  }
+
+  uri_str_builder& host(ip_address addr) {
+    return add(authority_separator, '[', to_string(addr),  ']');
+  }
+
+  uri_str_builder& port(uint16_t value) {
+    return add(':', std::to_string(value));
+  }
+
+  uri_str_builder& path(std::string str) {
+    return add(path_separator, str);
+  }
+
+  uri_str_builder& query(uri::query_map map) {
+    if (map.empty())
+      return *this;
+    res += '?';
+    auto i = map.begin();
+    res += i->first;
+    res += '=';
+    res += i->second;
+    for (; i != map.end(); ++i) {
+      res += '&';
+      res += i->first;
+      res += '=';
+      res += i->second;
+    }
+    return *this;
+  }
+
+  uri_str_builder& fragment(std::string str) {
+    return add('#', str);
+  }
+
+  std::string operator*() {
+    using std::swap;
+    std::string str = "http:";
+    swap(str, res);
+    return str;
+  }
+};
+
+struct fixture {
+  uri_builder http;
+  uri_str_builder http_str;
+
+  fixture() {
+    http.scheme("http");
+  }
+};
+
+struct me_t {} me;
+
+template <class T>
+T& operator<<(T& builder, me_t) {
+  return builder.userinfo("me");
+}
+
+struct node_t {} node;
+
+template <class T>
+T& operator<<(T& builder, node_t) {
+  return builder.host("node");
+}
+
+struct port80_t {} port80;
+
+template <class T>
+T& operator<<(T& builder, port80_t) {
+  return builder.port(80);
+}
+
+struct file_t {} file;
+
+template <class T>
+T& operator<<(T& builder, file_t) {
+  return builder.path("file");
+}
+
+struct frag_t {} frag;
+
+template <class T>
+T& operator<<(T& builder, frag_t) {
+  return builder.fragment("42");
+}
+
+struct kvp_t {} kvp;
+
+template <class T>
+T& operator<<(T& builder, kvp_t) {
+  return builder.query(uri::query_map{{"a", "1"}, {"b", "2"}});
+}
+
+uri operator*(uri_builder& builder) {
+  auto result = builder.make();
+  builder = uri_builder();
+  auto scheme = result.scheme();
+  builder.scheme(std::string{scheme.begin(), scheme.end()});
+  return result;
+}
+
+uri operator "" _u(const char* cstr, size_t cstr_len) {
+  uri result;
+  string_view str{cstr, cstr_len};
+  auto err = parse(str, result);
+  if (err)
+    CAF_FAIL("error while parsing " << str << ": " << to_string(err));
+  return result;
+}
+
+bool operator "" _i(const char* cstr, size_t cstr_len) {
+  uri result;
+  string_view str{cstr, cstr_len};
+  auto err = parse(str, result);
+  return err != none;
+}
+
+} // namespace <anonymous>
+
+CAF_TEST_FIXTURE_SCOPE(uri_tests, fixture)
+
+CAF_TEST(constructing) {
+  uri x;
+  CAF_CHECK_EQUAL(x.empty(), true);
+  CAF_CHECK_EQUAL(x.str(), "");
+}
+
+#define BUILD(components)                                                      \
+  CAF_CHECK_EQUAL(*(http << components), *(http_str << components))
+
+CAF_TEST(builder construction) {
+  BUILD(file);
+  BUILD(file << kvp);
+  BUILD(file << frag);
+  BUILD(file << kvp << frag);
+  BUILD(node);
+  BUILD(node << frag);
+  BUILD(node << kvp);
+  BUILD(node << kvp << frag);
+  BUILD(node << port80);
+  BUILD(node << port80 << frag);
+  BUILD(node << port80 << kvp);
+  BUILD(node << port80 << kvp << frag);
+  BUILD(me << node);
+  BUILD(me << node << kvp);
+  BUILD(me << node << frag);
+  BUILD(me << node << kvp << frag);
+  BUILD(me << node << port80);
+  BUILD(me << node << port80 << frag);
+  BUILD(me << node << port80 << kvp);
+  BUILD(me << node << port80 << kvp << frag);
+  BUILD(node << file);
+  BUILD(node << file << frag);
+  BUILD(node << file << kvp);
+  BUILD(node << file << kvp << frag);
+  BUILD(node << port80 << file);
+  BUILD(node << port80 << file << frag);
+  BUILD(node << port80 << file << kvp);
+  BUILD(node << port80 << file << kvp << frag);
+  BUILD(me << node << file);
+  BUILD(me << node << file << frag);
+  BUILD(me << node << file << kvp);
+  BUILD(me << node << file << kvp << frag);
+  BUILD(me << node << port80 << file);
+  BUILD(me << node << port80 << file << frag);
+  BUILD(me << node << port80 << file << kvp);
+  BUILD(me << node << port80 << file << kvp << frag);
+}
+
+#define ROUNDTRIP(str) CAF_CHECK_EQUAL(str##_u, str)
+
+CAF_TEST(from string) {
+  ROUNDTRIP("http:file");
+  ROUNDTRIP("http:file?a=1&b=2");
+  ROUNDTRIP("http:file#42");
+  ROUNDTRIP("http:file?a=1&b=2#42");
+  ROUNDTRIP("http://node");
+  ROUNDTRIP("http://node?a=1&b=2");
+  ROUNDTRIP("http://node#42");
+  ROUNDTRIP("http://node?a=1&b=2#42");
+  ROUNDTRIP("http://node:80");
+  ROUNDTRIP("http://node:80?a=1&b=2");
+  ROUNDTRIP("http://node:80#42");
+  ROUNDTRIP("http://node:80?a=1&b=2#42");
+  ROUNDTRIP("http://me@node");
+  ROUNDTRIP("http://me@node?a=1&b=2");
+  ROUNDTRIP("http://me@node#42");
+  ROUNDTRIP("http://me@node?a=1&b=2#42");
+  ROUNDTRIP("http://me@node:80");
+  ROUNDTRIP("http://me@node:80?a=1&b=2");
+  ROUNDTRIP("http://me@node:80#42");
+  ROUNDTRIP("http://me@node:80?a=1&b=2#42");
+  ROUNDTRIP("http://node/file");
+  ROUNDTRIP("http://node/file?a=1&b=2");
+  ROUNDTRIP("http://node/file#42");
+  ROUNDTRIP("http://node/file?a=1&b=2#42");
+  ROUNDTRIP("http://node:80/file");
+  ROUNDTRIP("http://node:80/file?a=1&b=2");
+  ROUNDTRIP("http://node:80/file#42");
+  ROUNDTRIP("http://node:80/file?a=1&b=2#42");
+  ROUNDTRIP("http://me@node/file");
+  ROUNDTRIP("http://me@node/file?a=1&b=2");
+  ROUNDTRIP("http://me@node/file#42");
+  ROUNDTRIP("http://me@node/file?a=1&b=2#42");
+  ROUNDTRIP("http://me@node:80/file");
+  ROUNDTRIP("http://me@node:80/file?a=1&b=2");
+  ROUNDTRIP("http://me@node:80/file#42");
+  ROUNDTRIP("http://me@node:80/file?a=1&b=2#42");
+  ROUNDTRIP("http://[::1]");
+  ROUNDTRIP("http://[::1]?a=1&b=2");
+  ROUNDTRIP("http://[::1]#42");
+  ROUNDTRIP("http://[::1]?a=1&b=2#42");
+  ROUNDTRIP("http://[::1]:80");
+  ROUNDTRIP("http://[::1]:80?a=1&b=2");
+  ROUNDTRIP("http://[::1]:80#42");
+  ROUNDTRIP("http://[::1]:80?a=1&b=2#42");
+  ROUNDTRIP("http://me@[::1]");
+  ROUNDTRIP("http://me@[::1]?a=1&b=2");
+  ROUNDTRIP("http://me@[::1]#42");
+  ROUNDTRIP("http://me@[::1]?a=1&b=2#42");
+  ROUNDTRIP("http://me@[::1]:80");
+  ROUNDTRIP("http://me@[::1]:80?a=1&b=2");
+  ROUNDTRIP("http://me@[::1]:80#42");
+  ROUNDTRIP("http://me@[::1]:80?a=1&b=2#42");
+  ROUNDTRIP("http://[::1]/file");
+  ROUNDTRIP("http://[::1]/file?a=1&b=2");
+  ROUNDTRIP("http://[::1]/file#42");
+  ROUNDTRIP("http://[::1]/file?a=1&b=2#42");
+  ROUNDTRIP("http://[::1]:80/file");
+  ROUNDTRIP("http://[::1]:80/file?a=1&b=2");
+  ROUNDTRIP("http://[::1]:80/file#42");
+  ROUNDTRIP("http://[::1]:80/file?a=1&b=2#42");
+  ROUNDTRIP("http://me@[::1]/file");
+  ROUNDTRIP("http://me@[::1]/file?a=1&b=2");
+  ROUNDTRIP("http://me@[::1]/file#42");
+  ROUNDTRIP("http://me@[::1]/file?a=1&b=2#42");
+  ROUNDTRIP("http://me@[::1]:80/file");
+  ROUNDTRIP("http://me@[::1]:80/file?a=1&b=2");
+  ROUNDTRIP("http://me@[::1]:80/file#42");
+  ROUNDTRIP("http://me@[::1]:80/file?a=1&b=2#42");
+}
+
+CAF_TEST(empty components) {
+  CAF_CHECK_EQUAL("foo:/"_u, "foo:/");
+  CAF_CHECK_EQUAL("foo:/#"_u, "foo:/");
+  CAF_CHECK_EQUAL("foo:/?"_u, "foo:/");
+  CAF_CHECK_EQUAL("foo:/?#"_u, "foo:/");
+  CAF_CHECK_EQUAL("foo:bar#"_u, "foo:bar");
+  CAF_CHECK_EQUAL("foo:bar?"_u, "foo:bar");
+  CAF_CHECK_EQUAL("foo:bar?#"_u, "foo:bar");
+  CAF_CHECK_EQUAL("foo://bar#"_u, "foo://bar");
+  CAF_CHECK_EQUAL("foo://bar?"_u, "foo://bar");
+  CAF_CHECK_EQUAL("foo://bar?#"_u, "foo://bar");
+}
+
+CAF_TEST(invalid uris) {
+  CAF_CHECK("http"_i);
+  CAF_CHECK("http://"_i);
+  CAF_CHECK("http://foo:66000"_i);
+}
+
+CAF_TEST_FIXTURE_SCOPE_END()

--- a/libcaf_core/test/uri.cpp
+++ b/libcaf_core/test/uri.cpp
@@ -87,16 +87,17 @@ struct uri_str_builder {
   uri_str_builder& query(uri::query_map map) {
     if (map.empty())
       return *this;
+    auto print_kvp = [&](const uri::query_map::value_type& kvp) {
+      res += kvp.first;
+      res += '=';
+      res += kvp.second;
+    };
     res += '?';
     auto i = map.begin();
-    res += i->first;
-    res += '=';
-    res += i->second;
-    for (; i != map.end(); ++i) {
+    print_kvp(*i);
+    for (++i; i != map.end(); ++i) {
       res += '&';
-      res += i->first;
-      res += '=';
-      res += i->second;
+      print_kvp(*i);
     }
     return *this;
   }
@@ -279,7 +280,7 @@ CAF_TEST(builder construction) {
                    .path("file 1")
                    .fragment("[42]")
                    .make();
-  CAF_CHECK_EQUAL(escaped, "hi%20there://it%27s@me%21/file%201#%5B42%5D");
+  CAF_CHECK_EQUAL(escaped, "hi%20there://it%27s@me%2F/file%201#%5B42%5D");
 }
 
 #define ROUNDTRIP(str) CAF_CHECK_EQUAL(str##_u, str)

--- a/libcaf_core/test/uri.cpp
+++ b/libcaf_core/test/uri.cpp
@@ -202,6 +202,7 @@ CAF_TEST(constructing) {
   CAF_CHECK_EQUAL(*(http << components), *(http_str << components))
 
 CAF_TEST(builder construction) {
+  // all combinations of components
   BUILD(file);
   BUILD(file << kvp);
   BUILD(file << frag);
@@ -238,11 +239,21 @@ CAF_TEST(builder construction) {
   BUILD(me << node << port80 << file << frag);
   BUILD(me << node << port80 << file << kvp);
   BUILD(me << node << port80 << file << kvp << frag);
+  // percent encoding
+  auto escaped = uri_builder{}
+                   .scheme("hi there")
+                   .userinfo("it's")
+                   .host("me/")
+                   .path("file 1")
+                   .fragment("[42]")
+                   .make();
+  CAF_CHECK_EQUAL(escaped, "hi%20there://it%27s@me%21/file%201#%5B42%5D");
 }
 
 #define ROUNDTRIP(str) CAF_CHECK_EQUAL(str##_u, str)
 
 CAF_TEST(from string) {
+  // all combinations of components
   ROUNDTRIP("http:file");
   ROUNDTRIP("http:file?a=1&b=2");
   ROUNDTRIP("http:file#42");
@@ -279,6 +290,7 @@ CAF_TEST(from string) {
   ROUNDTRIP("http://me@node:80/file?a=1&b=2");
   ROUNDTRIP("http://me@node:80/file#42");
   ROUNDTRIP("http://me@node:80/file?a=1&b=2#42");
+  // all combinations of with IPv6 host
   ROUNDTRIP("http://[::1]");
   ROUNDTRIP("http://[::1]?a=1&b=2");
   ROUNDTRIP("http://[::1]#42");
@@ -311,6 +323,8 @@ CAF_TEST(from string) {
   ROUNDTRIP("http://me@[::1]:80/file?a=1&b=2");
   ROUNDTRIP("http://me@[::1]:80/file#42");
   ROUNDTRIP("http://me@[::1]:80/file?a=1&b=2#42");
+  // percent encoding
+  ROUNDTRIP("hi%20there://it%27s@me%21/file%201#%5B42%5D");
 }
 
 CAF_TEST(empty components) {

--- a/libcaf_test/caf/test/unit_test.hpp
+++ b/libcaf_test/caf/test/unit_test.hpp
@@ -328,7 +328,7 @@ public:
   }
 
   inline void log(level lvl, const std::nullptr_t&) {
-    log(lvl, "<null>");
+    log(lvl, "null");
   }
 
   /// Output stream for logging purposes.


### PR DESCRIPTION
An URI is modeled as immutable value type that is optimized for message passing, i.e., it is cheap to copy.

- [x] Add classes for representing IP, because an URI can contain an IP address as host
- [x] Implement URI class with an opaque PIMPL (and builder class)
- [x] Implement RFC 3986 conformant URI parser
- [x] Make URI serializable

@josephnoir I got only one TODO left (serialization), so you can go ahead and review all finished parts.