### PR TITLE
Call remove_from_loop in manager::detach

### DIFF
--- a/libcaf_io/caf/io/datagram_servant.hpp
+++ b/libcaf_io/caf/io/datagram_servant.hpp
@@ -72,8 +72,6 @@ public:
 
   virtual void remove_endpoint(datagram_handle hdl) = 0;
 
-  void io_failure(execution_unit* ctx, network::operation op) override;
-
   bool consume(execution_unit*, datagram_handle hdl,
                network::receive_buffer& buf) override;
 

--- a/libcaf_io/caf/io/doorman.hpp
+++ b/libcaf_io/caf/io/doorman.hpp
@@ -43,8 +43,6 @@ public:
 
   ~doorman() override;
 
-  void io_failure(execution_unit* ctx, network::operation op) override;
-
   using doorman_base::new_connection;
 
   bool new_connection(execution_unit* ctx, connection_handle x);

--- a/libcaf_io/caf/io/network/default_multiplexer.hpp
+++ b/libcaf_io/caf/io/network/default_multiplexer.hpp
@@ -167,6 +167,12 @@ public:
   /// Get the next id to create a new datagram handle
   int64_t next_endpoint_id();
 
+  /// Returns the number of socket handlers.
+  size_t num_socket_handlers() const noexcept;
+
+  /// Run all pending events generated from calls to `add` or `del`.
+  void handle_internal_events();
+
 private:
   /// Calls `epoll`, `kqueue`, or `poll` with or without blocking.
   bool poll_once_impl(bool block);

--- a/libcaf_io/caf/io/network/manager.hpp
+++ b/libcaf_io/caf/io/network/manager.hpp
@@ -63,8 +63,8 @@ public:
   /// Adds the I/O device to the event loop of the middleman.
   virtual void add_to_loop() = 0;
 
-  /// Called by the underlying I/O device to report failures.
-  virtual void io_failure(execution_unit* ctx, operation op) = 0;
+  /// Detaches this manager from its parent in case of an error.
+  void io_failure(execution_unit* ctx, operation op);
 
   /// Get the address of the underlying I/O device.
   virtual std::string addr() const = 0;

--- a/libcaf_io/caf/io/scribe.hpp
+++ b/libcaf_io/caf/io/scribe.hpp
@@ -57,8 +57,6 @@ public:
   /// content of the buffer via the network.
   virtual void flush() = 0;
 
-  void io_failure(execution_unit* ctx, network::operation op) override;
-
   bool consume(execution_unit*, const void*, size_t) override;
 
   void data_transferred(execution_unit*, size_t, size_t) override;

--- a/libcaf_io/src/datagram_servant.cpp
+++ b/libcaf_io/src/datagram_servant.cpp
@@ -73,13 +73,6 @@ void datagram_servant::datagram_sent(execution_unit* ctx, datagram_handle hdl,
   invoke_mailbox_element_impl(ctx, tmp);
 }
 
-void datagram_servant::io_failure(execution_unit* ctx, network::operation op) {
-  CAF_LOG_TRACE(CAF_ARG(hdl()) << CAF_ARG(op));
-  // keep compiler happy when compiling w/o logging
-  static_cast<void>(op);
-  detach(ctx, true);
-}
-
 } // namespace io
 } // namespace caf
 

--- a/libcaf_io/src/doorman.cpp
+++ b/libcaf_io/src/doorman.cpp
@@ -37,13 +37,6 @@ message doorman::detach_message() {
   return make_message(acceptor_closed_msg{hdl()});
 }
 
-void doorman::io_failure(execution_unit* ctx, network::operation op) {
-  CAF_LOG_TRACE(CAF_ARG(hdl().id()) << CAF_ARG(op));
-  // keep compiler happy when compiling w/o logging
-  static_cast<void>(op);
-  detach(ctx, true);
-}
-
 bool doorman::new_connection(execution_unit* ctx, connection_handle x) {
   msg().handle = x;
   return invoke_mailbox_element(ctx);

--- a/libcaf_io/src/scribe.cpp
+++ b/libcaf_io/src/scribe.cpp
@@ -77,12 +77,5 @@ void scribe::data_transferred(execution_unit* ctx, size_t written,
   //parent()->consume(std::move(ptr));
 }
 
-void scribe::io_failure(execution_unit* ctx, network::operation op) {
-  CAF_LOG_TRACE(CAF_ARG(hdl()) << CAF_ARG(op));
-  // keep compiler happy when compiling w/o logging
-  static_cast<void>(op);
-  detach(ctx, true);
-}
-
 } // namespace io
 } // namespace caf

--- a/libcaf_io/src/stream.cpp
+++ b/libcaf_io/src/stream.cpp
@@ -196,8 +196,6 @@ void stream::handle_error_propagation() {
     reader_->io_failure(&backend(), operation::read);
   if (writer_)
     writer_->io_failure(&backend(), operation::write);
-  // backend will delete this handler anyway,
-  // no need to call backend().del() here
 }
 
 } // namespace network

--- a/libcaf_io/test/default_multiplexer.cpp
+++ b/libcaf_io/test/default_multiplexer.cpp
@@ -1,0 +1,105 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/config.hpp"
+
+#define CAF_SUITE io_default_multiplexer
+#include "caf/test/io_dsl.hpp"
+
+#include <vector>
+#include <algorithm>
+
+#include "caf/all.hpp"
+#include "caf/io/all.hpp"
+#include "caf/io/network/default_multiplexer.hpp"
+#include "caf/io/network/operation.hpp"
+
+using namespace caf;
+
+namespace {
+
+struct sub_fixture : test_coordinator_fixture<> {
+  io::network::default_multiplexer mpx;
+
+  sub_fixture() : mpx(&sys) {
+    // nop
+  }
+
+  bool exec_all() {
+    size_t count = 0;
+    while (mpx.poll_once(false)) {
+      ++count;
+    }
+    return count != 0;
+  }
+};
+
+struct fixture {
+  sub_fixture client;
+
+  sub_fixture server;
+
+  void exec_all() {
+    while (client.exec_all() || server.exec_all()) {
+      // Rince and repeat.
+    }
+  }
+};
+
+} // namespace <anonymous>
+
+CAF_TEST_FIXTURE_SCOPE(default_multiplexer_tests, fixture)
+
+CAF_TEST(doorman io_failure) {
+  CAF_MESSAGE("add doorman to server");
+  // The multiplexer adds a pipe reader on startup.
+  CAF_CHECK_EQUAL(server.mpx.num_socket_handlers(), 1u);
+  auto doorman = unbox(server.mpx.new_tcp_doorman(0, nullptr, false));
+  doorman->add_to_loop();
+  server.mpx.handle_internal_events();
+  CAF_CHECK_EQUAL(server.mpx.num_socket_handlers(), 2u);
+  CAF_MESSAGE("trigger I/O failure in doorman");
+  doorman->io_failure(&server.mpx, io::network::operation::propagate_error);
+  server.mpx.handle_internal_events();
+  CAF_CHECK_EQUAL(server.mpx.num_socket_handlers(), 1u);
+}
+
+CAF_TEST(scribe io_failure) {
+  CAF_MESSAGE("add doorman to server");
+  CAF_CHECK_EQUAL(server.mpx.num_socket_handlers(), 1u);
+  auto doorman = unbox(server.mpx.new_tcp_doorman(0, nullptr, false));
+  doorman->add_to_loop();
+  server.mpx.handle_internal_events();
+  CAF_CHECK_EQUAL(server.mpx.num_socket_handlers(), 2u);
+  CAF_MESSAGE("connect to server (add scribe to client)");
+  auto scribe = unbox(client.mpx.new_tcp_scribe("localhost", doorman->port()));
+  CAF_CHECK_EQUAL(client.mpx.num_socket_handlers(), 1u);
+  scribe->add_to_loop();
+  client.mpx.handle_internal_events();
+  CAF_CHECK_EQUAL(client.mpx.num_socket_handlers(), 2u);
+  CAF_MESSAGE("trigger I/O failure in scribe");
+  scribe->io_failure(&client.mpx, io::network::operation::propagate_error);
+  client.mpx.handle_internal_events();
+  CAF_CHECK_EQUAL(client.mpx.num_socket_handlers(), 1u);
+  CAF_MESSAGE("trigger I/O failure in doorman");
+  doorman->io_failure(&server.mpx, io::network::operation::propagate_error);
+  server.mpx.handle_internal_events();
+  CAF_CHECK_EQUAL(server.mpx.num_socket_handlers(), 1u);
+}
+
+CAF_TEST_FIXTURE_SCOPE_END()


### PR DESCRIPTION
Relates #695.

@jsiwek I've consolidated all `io_failure` implementations into a single one (all implementations were identical) and call `remove_from_loop` in `detach` (whether or not detaching from parent actually succeeds). This *should* make sure the sockets get removed on all code paths. Can you still reproduce hangs with this patch?