### PR TITLE
Fix data buffered in OpenSSL not being flushed

### DIFF
--- a/libcaf_openssl/caf/openssl/session.hpp
+++ b/libcaf_openssl/caf/openssl/session.hpp
@@ -59,6 +59,7 @@ public:
   bool try_connect(native_socket fd);
   bool try_accept(native_socket fd);
   const char* openssl_passphrase();
+  int pending_read_fd();
 
 private:
   rw_state do_some(int (*f)(SSL*, void*, int), size_t& result, void* buf,
@@ -74,6 +75,8 @@ private:
   std::string openssl_passphrase_;
   bool connecting_;
   bool accepting_;
+  bool had_pending_;
+  std::pair<native_socket, native_socket> pipe_fds_;
 };
 
 /// @relates session


### PR DESCRIPTION
Reading through the two commits should be straight-forward and provide better detail, but generally: one commit adds a test case that shows the undesired behavior (the restricted_ping_pong test case should hang/timeout) and the other is a proposed fix for the underlying problem of data not getting properly flushed from internal OpenSSL buffers.