### PR TITLE
Fix the "quiet" log level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,7 +380,6 @@ macro(to_int_value name)
   endif()
 endmacro()
 
-to_int_value(CAF_LOG_LEVEL)
 to_int_value(CAF_NO_EXCEPTIONS)
 to_int_value(CAF_NO_MEM_MANAGEMENT)
 to_int_value(CAF_ENABLE_RUNTIME_CHECKS)

--- a/libcaf_core/caf/make_actor.hpp
+++ b/libcaf_core/caf/make_actor.hpp
@@ -32,7 +32,7 @@ namespace caf {
 
 template <class T, class R = infer_handle_from_class_t<T>, class... Ts>
 R make_actor(actor_id aid, node_id nid, actor_system* sys, Ts&&... xs) {
-#if defined(CAF_LOG_LEVEL) && CAF_LOG_LEVEL >= CAF_LOG_LEVEL_DEBUG
+#if CAF_LOG_LEVEL >= CAF_LOG_LEVEL_DEBUG
   actor_storage<T>* ptr = nullptr;
   if (logger::current_logger()->accepts(CAF_LOG_LEVEL_DEBUG,
                                         CAF_LOG_FLOW_COMPONENT)) {

--- a/libcaf_core/src/actor_registry.cpp
+++ b/libcaf_core/src/actor_registry.cpp
@@ -86,7 +86,7 @@ void actor_registry::erase(actor_id key) {
 }
 
 void actor_registry::inc_running() {
-# if defined(CAF_LOG_LEVEL) && CAF_LOG_LEVEL >= CAF_LOG_LEVEL_DEBUG
+# if CAF_LOG_LEVEL >= CAF_LOG_LEVEL_DEBUG
   auto value = ++running_;
   CAF_LOG_DEBUG(CAF_ARG(value));
 # else

--- a/libcaf_core/src/logger.cpp
+++ b/libcaf_core/src/logger.cpp
@@ -233,11 +233,7 @@ logger::~logger() {
 
 logger::logger(actor_system& sys)
     : system_(sys),
-#ifdef CAF_LOG_LEVEL
       level_(CAF_LOG_LEVEL),
-#else
-      level_(0),
-#endif
       flags_(0),
       queue_(policy{}) {
   // nop
@@ -245,7 +241,7 @@ logger::logger(actor_system& sys)
 
 void logger::init(actor_system_config& cfg) {
   CAF_IGNORE_UNUSED(cfg);
-#if defined(CAF_LOG_LEVEL)
+#if CAF_LOG_LEVEL >= 0
   namespace lg = defaults::logger;
   component_filter = get_or(cfg, "logger.component-filter",
                             lg::component_filter);
@@ -434,7 +430,7 @@ const char* logger::skip_path(const char* path) {
 }
 
 void logger::run() {
-#if defined(CAF_LOG_LEVEL)
+#if CAF_LOG_LEVEL >= 0
   log_first_line();
   // receive log entries from other threads and actors
   bool stop = false;
@@ -523,7 +519,7 @@ void logger::log_last_line() {
 }
 
 void logger::start() {
-#if defined(CAF_LOG_LEVEL)
+#if CAF_LOG_LEVEL >= 0
   parent_thread_ = std::this_thread::get_id();
   if (level_ == CAF_LOG_LEVEL_QUIET)
     return;
@@ -573,7 +569,7 @@ void logger::start() {
 }
 
 void logger::stop() {
-#if defined(CAF_LOG_LEVEL)
+#if CAF_LOG_LEVEL >= 0
   if (has(inline_output_flag)) {
     log_last_line();
     return;

--- a/libcaf_core/test/logger.cpp
+++ b/libcaf_core/test/logger.cpp
@@ -88,7 +88,7 @@ CAF_TEST(parse_default_format_strings) {
   add(logger::message_field);
   add(logger::newline_field);
   CAF_CHECK_EQUAL(logger::parse_format(file_format), lf);
-#ifdef CAF_LOG_LEVEL
+#if CAF_LOG_LEVEL >= 0
   // Not parsed when compiling without logging enabled.
   CAF_CHECK_EQUAL(sys.logger().file_format(), lf);
 #endif


### PR DESCRIPTION
The "first line" and "last line" log messages were causing a log to be generated because they only checked whether CAF_LOG_LEVEL was defined, but it's now always defined.