### PR TITLE
Fix segfault on changing to empty behavior

### DIFF
--- a/libcaf_core/src/scheduled_actor.cpp
+++ b/libcaf_core/src/scheduled_actor.cpp
@@ -768,7 +768,8 @@ void scheduled_actor::do_become(behavior bhvr, bool discard_old) {
   if (discard_old && !bhvr_stack_.empty())
     bhvr_stack_.pop_back();
   // request_timeout simply resets the timeout when it's invalid
-  bhvr_stack_.push_back(std::move(bhvr));
+  if (bhvr)
+    bhvr_stack_.push_back(std::move(bhvr));
   set_receive_timeout();
 }
 

--- a/libcaf_core/test/behavior.cpp
+++ b/libcaf_core/test/behavior.cpp
@@ -24,8 +24,12 @@
 
 #include <functional>
 
+#include "caf/send.hpp"
 #include "caf/behavior.hpp"
+#include "caf/actor_system.hpp"
 #include "caf/message_handler.hpp"
+#include "caf/event_based_actor.hpp"
+#include "caf/actor_system_config.hpp"
 #include "caf/make_type_erased_tuple_view.hpp"
 
 using namespace caf;
@@ -92,6 +96,17 @@ CAF_TEST(multiple_lambda_construct) {
   CAF_CHECK_EQUAL(to_string(f(m1)), "*(2)");
   CAF_CHECK_EQUAL(to_string(f(m2)), "*(2)");
   CAF_CHECK_EQUAL(f(m3), none);
+}
+
+CAF_TEST(become_empty_behavior) {
+  actor_system_config cfg{};
+  actor_system sys{cfg};
+  auto make_bhvr = [](event_based_actor* self) -> behavior {
+    return {
+      [=](int) { self->become(behavior{}); }
+    };
+  };
+  anon_send(sys.spawn(make_bhvr), int{5});
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()


### PR DESCRIPTION
With this commit, empty behaviors are not added to the behavior stack.
Closes #750