### PR TITLE
 Fix potential deadlock in the thread-safe clock

### DIFF
--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -19,13 +19,14 @@
 #pragma once
 
 #include <array>
-#include <mutex>
 #include <atomic>
-#include <string>
-#include <memory>
+#include <condition_variable>
 #include <cstddef>
 #include <functional>
-#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <typeinfo>
 
 #include "caf/abstract_actor.hpp"
 #include "caf/actor_cast.hpp"
@@ -163,6 +164,9 @@ public:
     };
 
     virtual ~module();
+
+    /// Returns the human-redable name of the module.
+    const char* name() const noexcept;
 
     /// Starts any background threads needed by the module.
     virtual void start() = 0;

--- a/libcaf_core/caf/detail/thread_safe_actor_clock.hpp
+++ b/libcaf_core/caf/detail/thread_safe_actor_clock.hpp
@@ -58,8 +58,8 @@ public:
   void cancel_dispatch_loop();
 
 private:
-  std::mutex mx_;
-  std::condition_variable cv_;
+  std::recursive_mutex mx_;
+  std::condition_variable_any cv_;
   std::atomic<bool> done_;
 };
 

--- a/libcaf_core/src/actor_system.cpp
+++ b/libcaf_core/src/actor_system.cpp
@@ -203,6 +203,21 @@ actor_system::module::~module() {
   // nop
 }
 
+const char* actor_system::module::name() const noexcept {
+  switch (id()) {
+    case scheduler:
+      return "Scheduler";
+    case middleman:
+      return "Middleman";
+    case opencl_manager:
+      return "OpenCL Manager";
+    case openssl_manager:
+      return "OpenSSL Manager";
+    default:
+      return "???";
+  }
+}
+
 actor_system::actor_system(actor_system_config& cfg)
     : ids_(0),
       types_(*this),
@@ -310,9 +325,13 @@ actor_system::~actor_system() {
     // group module is the first one, relies on MM
     groups_.stop();
     // stop modules in reverse order
-    for (auto i = modules_.rbegin(); i != modules_.rend(); ++i)
-      if (*i)
-        (*i)->stop();
+    for (auto i = modules_.rbegin(); i != modules_.rend(); ++i) {
+      auto& ptr = *i;
+      if (ptr != nullptr) {
+        CAF_LOG_DEBUG("stop module" << ptr->name());
+        ptr->stop();
+      }
+    }
     await_detached_threads();
     registry_.stop();
   }

--- a/libcaf_core/src/thread_safe_actor_clock.cpp
+++ b/libcaf_core/src/thread_safe_actor_clock.cpp
@@ -23,7 +23,7 @@ namespace detail {
 
 namespace {
 
-using guard_type = std::unique_lock<std::mutex>;
+using guard_type = std::unique_lock<std::recursive_mutex>;
 
 } // namespace <anonymous>
 
@@ -110,6 +110,9 @@ void thread_safe_actor_clock::run_dispatch_loop() {
   guard_type guard{mx_};
   while (done_ == false) {
     // Wait for non-empty schedule.
+    // Note: The thread calling run_dispatch_loop() is guaranteed not to lock
+    //       the mutex recursively. Otherwise, cv_.wait() or cv_.wait_until()
+    //       would be unsafe, because wait operations call unlock() only once.
     if (schedule_.empty()) {
       cv_.wait(guard);
     } else {


### PR DESCRIPTION
This quickfix switches to a recursive mutex to avoid a deadlock caused by repeated calls to the cancel functions from different actors but within the same thread (caused by actors becoming unreachable).