### PR TITLE
Demote internal messages from INFO to DEBUG

### DIFF
--- a/libcaf_core/src/actor_registry.cpp
+++ b/libcaf_core/src/actor_registry.cpp
@@ -73,7 +73,7 @@ void actor_registry::put_impl(actor_id key, strong_actor_ptr val) {
       return;
   }
   // attach functor without lock
-  CAF_LOG_INFO("added actor:" << CAF_ARG(key));
+  CAF_LOG_DEBUG("added actor:" << CAF_ARG(key));
   actor_registry* reg = this;
   val->get()->attach_functor([key, reg]() {
     reg->erase(key);

--- a/libcaf_io/caf/io/basp/instance.hpp
+++ b/libcaf_io/caf/io/basp/instance.hpp
@@ -330,19 +330,19 @@ public:
         }
         // close self connection after handshake is done
         if (hdr.source_node == this_node_) {
-          CAF_LOG_INFO("close connection to self immediately");
+          CAF_LOG_DEBUG("close connection to self immediately");
           callee_.finalize_handshake(hdr.source_node, aid, sigs);
           return false;
         }
         // close this connection if we already have a direct connection
         if (tbl_.lookup_direct(hdr.source_node)) {
-          CAF_LOG_INFO("close connection since we already have a "
-                       "direct connection: " << CAF_ARG(hdr.source_node));
+          CAF_LOG_DEBUG("close connection since we already have a "
+                        "direct connection: " << CAF_ARG(hdr.source_node));
           callee_.finalize_handshake(hdr.source_node, aid, sigs);
           return false;
         }
         // add direct route to this node and remove any indirect entry
-        CAF_LOG_INFO("new direct connection:" << CAF_ARG(hdr.source_node));
+        CAF_LOG_DEBUG("new direct connection:" << CAF_ARG(hdr.source_node));
         tbl_.add_direct(hdl, hdr.source_node);
         auto was_indirect = tbl_.erase_indirect(hdr.source_node);
         // write handshake as client in response
@@ -381,12 +381,12 @@ public:
         }
         if (tcp_based) {
           if (tbl_.lookup_direct(hdr.source_node)) {
-            CAF_LOG_INFO("received second client handshake:"
+            CAF_LOG_DEBUG("received second client handshake:"
                          << CAF_ARG(hdr.source_node));
             break;
           }
           // add direct route to this node and remove any indirect entry
-          CAF_LOG_INFO("new direct connection:" << CAF_ARG(hdr.source_node));
+          CAF_LOG_DEBUG("new direct connection:" << CAF_ARG(hdr.source_node));
           tbl_.add_direct(hdl, hdr.source_node);
           auto was_indirect = tbl_.erase_indirect(hdr.source_node);
           callee_.learned_new_node_directly(hdr.source_node, was_indirect);
@@ -395,7 +395,7 @@ public:
                           && !tbl_.lookup_direct(hdr.source_node));
           if (new_node) {
             // add direct route to this node and remove any indirect entry
-            CAF_LOG_INFO("new direct connection:" << CAF_ARG(hdr.source_node));
+            CAF_LOG_DEBUG("new direct connection:" << CAF_ARG(hdr.source_node));
             tbl_.add_direct(hdl, hdr.source_node);
           }
           uint16_t seq = (ep && ep->requires_ordering) ? ep->seq_outgoing++ : 0;

--- a/libcaf_io/src/basp_broker.cpp
+++ b/libcaf_io/src/basp_broker.cpp
@@ -106,8 +106,8 @@ strong_actor_ptr basp_broker_state::make_proxy(node_id nid, actor_id aid) {
   if (!path) {
     // this happens if and only if we don't have a path to `nid`
     // and current_context_->hdl has been blacklisted
-    CAF_LOG_INFO("cannot create a proxy instance for an actor "
-                 "running on a node we don't have a route to");
+    CAF_LOG_DEBUG("cannot create a proxy instance for an actor "
+                  "running on a node we don't have a route to");
     return nullptr;
   }
   // create proxy and add functor that will be called if we
@@ -127,9 +127,9 @@ strong_actor_ptr basp_broker_state::make_proxy(node_id nid, actor_id aid) {
         bptr->state.proxies().erase(nid, res->id(), rsn);
     });
   });
-  CAF_LOG_INFO("successfully created proxy instance, "
-               "write announce_proxy_instance:"
-               << CAF_ARG(nid) << CAF_ARG(aid));
+  CAF_LOG_DEBUG("successfully created proxy instance, "
+                "write announce_proxy_instance:"
+                << CAF_ARG(nid) << CAF_ARG(aid));
   auto& ctx = *this_context;
   // tell remote side we are monitoring this actor now
   instance.write_announce_proxy(self->context(),
@@ -159,7 +159,7 @@ void basp_broker_state::finalize_handshake(const node_id& nid, actor_id aid,
     if (nid == this_node()) {
       // connected to self
       ptr = actor_cast<strong_actor_ptr>(system().registry().get(aid));
-      CAF_LOG_INFO_IF(!ptr, "actor not found:" << CAF_ARG(aid));
+      CAF_LOG_DEBUG_IF(!ptr, "actor not found:" << CAF_ARG(aid));
     } else {
       ptr = namespace_.get_or_put(nid, aid);
       CAF_LOG_ERROR_IF(!ptr, "creating actor in finalize_handshake failed");
@@ -440,7 +440,7 @@ void basp_broker_state::set_context(connection_handle hdl) {
   CAF_LOG_TRACE(CAF_ARG(hdl));
   auto i = ctx_tcp.find(hdl);
   if (i == ctx_tcp.end()) {
-    CAF_LOG_INFO("create new BASP context:" << CAF_ARG(hdl));
+    CAF_LOG_DEBUG("create new BASP context:" << CAF_ARG(hdl));
     i = ctx_tcp.emplace(
       hdl,
       basp::endpoint_context{
@@ -460,7 +460,7 @@ void basp_broker_state::set_context(datagram_handle hdl) {
   CAF_LOG_TRACE(CAF_ARG(hdl));
   auto i = ctx_udp.find(hdl);
   if (i == ctx_udp.end()) {
-    CAF_LOG_INFO("create new BASP context:" << CAF_ARG(hdl));
+    CAF_LOG_DEBUG("create new BASP context:" << CAF_ARG(hdl));
     i = ctx_udp.emplace(
       hdl,
       basp::endpoint_context{
@@ -643,7 +643,7 @@ behavior basp_broker::make_behavior() {
   state.allow_tcp = !get_or(config(), "middleman.disable-tcp", false);
   state.allow_udp = get_or(config(), "middleman.enable-udp", false);
   if (get_or(config(), "middleman.enable-automatic-connections", false)) {
-    CAF_LOG_INFO("enable automatic connections");
+    CAF_LOG_DEBUG("enable automatic connections");
     // open a random port and store a record for our peers how to
     // connect to this broker directly in the configuration server
     if (state.allow_tcp) {
@@ -673,7 +673,7 @@ behavior basp_broker::make_behavior() {
   auto heartbeat_interval = get_or(config(), "middleman.heartbeat-interval",
                                    defaults::middleman::heartbeat_interval);
   if (heartbeat_interval > 0) {
-    CAF_LOG_INFO("enable heartbeat" << CAF_ARG(heartbeat_interval));
+    CAF_LOG_DEBUG("enable heartbeat" << CAF_ARG(heartbeat_interval));
     send(this, tick_atom::value, heartbeat_interval);
   }
   return {

--- a/libcaf_io/src/default_multiplexer.cpp
+++ b/libcaf_io/src/default_multiplexer.cpp
@@ -768,10 +768,10 @@ expected<native_socket>
 new_tcp_connection(const std::string& host, uint16_t port,
                    optional<protocol::network> preferred) {
   CAF_LOG_TRACE(CAF_ARG(host) << CAF_ARG(port) << CAF_ARG(preferred));
-  CAF_LOG_INFO("try to connect to:" << CAF_ARG(host) << CAF_ARG(port));
+  CAF_LOG_DEBUG("try to connect to:" << CAF_ARG(host) << CAF_ARG(port));
   auto res = interfaces::native_address(host, std::move(preferred));
   if (!res) {
-    CAF_LOG_INFO("no such host");
+    CAF_LOG_DEBUG("no such host");
     return make_error(sec::cannot_connect_to_node, "no such host", host, port);
   }
   auto proto = res->second;
@@ -781,7 +781,8 @@ new_tcp_connection(const std::string& host, uint16_t port,
   detail::socket_guard sguard(fd);
   if (proto == ipv6) {
     if (ip_connect<AF_INET6>(fd, res->first, port)) {
-      CAF_LOG_INFO("successfully connected to host via IPv6");
+      CAF_LOG_INFO("successfully connected to (IPv6):"
+                  << CAF_ARG(host) << CAF_ARG(port));
       return sguard.release();
     }
     sguard.close();
@@ -789,11 +790,12 @@ new_tcp_connection(const std::string& host, uint16_t port,
     return new_tcp_connection(host, port, ipv4);
   }
   if (!ip_connect<AF_INET>(fd, res->first, port)) {
-    CAF_LOG_INFO("could not connect to:" << CAF_ARG(host) << CAF_ARG(port));
+    CAF_LOG_WARNING("could not connect to:" << CAF_ARG(host) << CAF_ARG(port));
     return make_error(sec::cannot_connect_to_node,
                       "ip_connect failed", host, port);
   }
-  CAF_LOG_INFO("successfully connected to host via IPv4");
+  CAF_LOG_INFO("successfully connected to (IPv4):"
+              << CAF_ARG(host) << CAF_ARG(port));
   return sguard.release();
 }
 


### PR DESCRIPTION
This PR demotes a few internal messages from log level INFO to DEBUG. A
lot of them were redundant. Now there's one INFO message per successful
connection.