### PR TITLE
Allow different log levels for file and console 

### DIFF
--- a/examples/caf-application.ini
+++ b/examples/caf-application.ini
@@ -63,11 +63,15 @@ enable-udp=false
 file-name="actor_log_[PID]_[TIMESTAMP]_[NODE].log"
 ; format for rendering individual log file entries
 file-format="%r %c %p %a %t %C %M %F:%L %m%n"
+; configures the minimum severity of messages that are written to the log file
+; (quiet|error|warning|info|debug|trace)
+file-verbosity='trace'
 ; mode for console log output generation (none|colored|uncolored)
 console='none'
 ; format for printing individual log entries to the console
 console-format="%m"
+; configures the minimum severity of messages that are written to the console
+; (quiet|error|warning|info|debug|trace)
+console-verbosity='trace'
 ; excludes listed components from logging
 component-filter=""
-; configures the severity level for logs (quiet|error|warning|info|debug|trace)
-verbosity='trace'

--- a/libcaf_core/caf/defaults.hpp
+++ b/libcaf_core/caf/defaults.hpp
@@ -61,12 +61,13 @@ extern const timespan relaxed_sleep_duration;
 
 namespace logger {
 
-extern const atom_value console;
-extern const atom_value verbosity;
 extern const char* component_filter;
+extern const atom_value console;
 extern const char* console_format;
+extern const atom_value console_verbosity;
 extern const char* file_format;
 extern const char* file_name;
+extern const atom_value file_verbosity;
 
 } // namespace logger
 

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -284,6 +284,8 @@ public:
 
 private:
   void handle_event(event& x);
+  void handle_file_event(event& x);
+  void handle_console_event(event& x);
 
   void log_first_line();
 
@@ -308,7 +310,9 @@ private:
   }
 
   actor_system& system_;
-  int level_;
+  int max_level_;
+  int console_level_;
+  int file_level_;
   int flags_;
   detail::shared_spinlock aids_lock_;
   std::unordered_map<std::thread::id, actor_id> aids_;
@@ -553,4 +557,3 @@ inline caf::actor_id caf_set_aid_dummy() { return 0; }
                "TERMINATE ; ID =" << thisptr->id()                             \
                  << "; REASON =" << deep_to_string(rsn).c_str()                \
                  << "; NODE =" << thisptr->node())
-

--- a/libcaf_core/src/actor_system_config.cpp
+++ b/libcaf_core/src/actor_system_config.cpp
@@ -85,7 +85,6 @@ actor_system_config::actor_system_config()
   logger_file_format = "%r %c %p %a %t %C %M %F:%L %m%n";
   logger_console = atom("none");
   logger_console_format = "%m";
-  logger_verbosity = atom("trace");
   logger_inline_output = false;
   namespace mm = defaults::middleman;
   middleman_network_backend = mm::network_backend;
@@ -143,14 +142,19 @@ actor_system_config::actor_system_config()
        "sets the filesystem path of the log file")
   .add(logger_file_format, "file-format",
        "sets the line format for individual log file entires")
+  .add<atom_value>("file-verbosity",
+       "sets the file output verbosity (quiet|error|warning|info|debug|trace)")
   .add(logger_console, "console",
        "sets the type of output to std::clog (none|colored|uncolored)")
   .add(logger_console_format, "console-format",
        "sets the line format for printing individual log entires")
+  .add<atom_value>("console-verbosity",
+       "sets the console output verbosity"
+       "(quiet|error|warning|info|debug|trace)")
   .add(logger_component_filter, "component-filter",
        "exclude all listed components from logging")
   .add(logger_verbosity, "verbosity",
-       "sets the verbosity (quiet|error|warning|info|debug|trace)")
+       "set file and console verbosity (deprecated)")
   .add(logger_inline_output, "inline-output",
        "sets whether a separate thread is used for I/O");
   opt_group{custom_options_, "middleman"}

--- a/libcaf_core/src/defaults.cpp
+++ b/libcaf_core/src/defaults.cpp
@@ -48,7 +48,7 @@ const timespan desired_batch_complexity = us(50);
 const timespan max_batch_delay = ms(5);
 const timespan credit_round_interval = ms(10);
 
-} // namespace streaming
+} // namespace stream
 
 namespace scheduler {
 
@@ -74,12 +74,13 @@ const timespan relaxed_sleep_duration = ms(10);
 
 namespace logger {
 
-const atom_value console = atom("none");
-const atom_value verbosity = atom("trace");
 const char* component_filter = "";
+const atom_value console = atom("none");
 const char* console_format = "%m";
+const atom_value console_verbosity = atom("trace");
 const char* file_format = "%r %c %p %a %t %C %M %F:%L %m%n";
 const char* file_name = "actor_log_[PID]_[TIMESTAMP]_[NODE].log";
+const atom_value file_verbosity = atom("trace");
 
 } // namespace logger
 


### PR DESCRIPTION
The concrete log levels can be set with the config options `logger.file-verbosity` and `logger.console-verbosity`. `logger.verbosity` remains to be supported for backwards compatibility. The new defaults are `info` for console and `debug` for file logging.