### PR TITLE
Fix dictionary emplace with char array

### DIFF
--- a/libcaf_core/caf/dictionary.hpp
+++ b/libcaf_core/caf/dictionary.hpp
@@ -290,6 +290,11 @@ private:
     return std::lower_bound(from, end(), key, cmp);
   }
 
+  template <size_t N>
+  static inline std::string copy(const char (&str)[N]) {
+    return std::string{str};
+  }
+
   // Copies the content of `str` into a new string.
   static inline std::string copy(string_view str) {
     return std::string{str.begin(), str.end()};

--- a/libcaf_core/test/dictionary.cpp
+++ b/libcaf_core/test/dictionary.cpp
@@ -79,6 +79,13 @@ CAF_TEST(swapping) {
   CAF_CHECK_NOT_EQUAL(xs, zs);
 }
 
+CAF_TEST(emplacing) {
+  int_dict xs;
+  CAF_CHECK_EQUAL(xs.emplace("x", 1).second, true);
+  CAF_CHECK_EQUAL(xs.emplace("y", 2).second, true);
+  CAF_CHECK_EQUAL(xs.emplace("y", 3).second, false);
+}
+
 CAF_TEST(insertion) {
   int_dict xs;
   CAF_CHECK_EQUAL(xs.insert("a", 1).second, true);


### PR DESCRIPTION
This PR disambiguates a copy overload when using a char array.