### PR TITLE
Fix insecure RPATH of the caf-python binary

### DIFF
--- a/libcaf_python/CMakeLists.txt
+++ b/libcaf_python/CMakeLists.txt
@@ -53,7 +53,7 @@ if(NOT CAF_NO_PYTHON)
                         ${PTHREAD_LIBRARIES}
                         ${LIBEDIT_LIBRARIES}
                         ${PYTHON_LIBRARIES})
-  install(PROGRAMS ${EXECUTABLE_OUTPUT_PATH}/caf-python DESTINATION bin)
+  install(TARGETS caf-python DESTINATION bin)
 else()
   add_custom_target(caf-python SOURCES ${CAF_PYTHON_SRCS} ${CAF_PYTHON_HDRS})
 endif()


### PR DESCRIPTION
Cmakes install type PROGRAMS is misleading it is not supposed to be
used with binaries.

From the cmake documentation:
> This form [install(PROGRAMS)] is intended to install programs that are
> not targets, such as shell scripts. Use the TARGETS form to install
> targets built within the project.

One of the problems with "PROGRAMS" is, that it does not strip the RPATH
from binaries when installing. This is a problem because the is is
used to look up shared libraries. If it's destination is user
controllable it could be used for privilege escalation.