### PR TITLE
Add non-overriding receive timouts to actor clock

### DIFF
--- a/libcaf_core/caf/actor_clock.hpp
+++ b/libcaf_core/caf/actor_clock.hpp
@@ -56,7 +56,11 @@ public:
   /// Schedules a `timeout_msg` for `self` at time point `t`, overriding any
   /// previous receive timeout.
   virtual void set_ordinary_timeout(time_point t, abstract_actor* self,
-                                   atom_value type, uint64_t id) = 0;
+                                    atom_value type, uint64_t id) = 0;
+
+  /// Schedules a `timeout_msg` for `self` at time point `t`.
+  virtual void add_ordinary_timeout(time_point t, abstract_actor* self,
+                                    atom_value type, uint64_t id) = 0;
 
   /// Schedules a `sec::request_timeout` for `self` at time point `t`.
   virtual void set_request_timeout(time_point t, abstract_actor* self,

--- a/libcaf_core/caf/actor_clock.hpp
+++ b/libcaf_core/caf/actor_clock.hpp
@@ -59,8 +59,8 @@ public:
                                     atom_value type, uint64_t id) = 0;
 
   /// Schedules a `timeout_msg` for `self` at time point `t`.
-  virtual void add_ordinary_timeout(time_point t, abstract_actor* self,
-                                    atom_value type, uint64_t id) = 0;
+  virtual void set_multi_timeout(time_point t, abstract_actor* self,
+                                 atom_value type, uint64_t id) = 0;
 
   /// Schedules a `sec::request_timeout` for `self` at time point `t`.
   virtual void set_request_timeout(time_point t, abstract_actor* self,

--- a/libcaf_core/caf/detail/simple_actor_clock.hpp
+++ b/libcaf_core/caf/detail/simple_actor_clock.hpp
@@ -91,7 +91,10 @@ public:
   };
 
   void set_ordinary_timeout(time_point t, abstract_actor* self,
-                           atom_value type, uint64_t id) override;
+                            atom_value type, uint64_t id) override;
+
+  void add_ordinary_timeout(time_point t, abstract_actor* self,
+                            atom_value type, uint64_t id) override;
 
   void set_request_timeout(time_point t, abstract_actor* self,
                            message_id id) override;

--- a/libcaf_core/caf/detail/simple_actor_clock.hpp
+++ b/libcaf_core/caf/detail/simple_actor_clock.hpp
@@ -42,6 +42,12 @@ public:
     uint64_t id;
   };
 
+  struct multi_timeout {
+    strong_actor_ptr self;
+    atom_value type;
+    uint64_t id;
+  };
+
   /// Request for a `sec::request_timeout` error.
   struct request_timeout {
     strong_actor_ptr self;
@@ -61,7 +67,7 @@ public:
     message content;
   };
 
-  using value_type = variant<ordinary_timeout, request_timeout,
+  using value_type = variant<ordinary_timeout, multi_timeout, request_timeout,
                              actor_msg, group_msg>;
 
   using map_type = std::multimap<time_point, value_type>;
@@ -69,6 +75,11 @@ public:
   using secondary_map = std::multimap<abstract_actor*, map_type::iterator>;
 
   struct ordinary_predicate {
+    atom_value type;
+    bool operator()(const secondary_map::value_type& x) const noexcept;
+  };
+
+  struct multi_predicate {
     atom_value type;
     bool operator()(const secondary_map::value_type& x) const noexcept;
   };
@@ -83,6 +94,8 @@ public:
 
     void operator()(ordinary_timeout& x);
 
+    void operator()(multi_timeout& x);
+
     void operator()(request_timeout& x);
 
     void operator()(actor_msg& x);
@@ -93,8 +106,8 @@ public:
   void set_ordinary_timeout(time_point t, abstract_actor* self,
                             atom_value type, uint64_t id) override;
 
-  void add_ordinary_timeout(time_point t, abstract_actor* self,
-                            atom_value type, uint64_t id) override;
+  void set_multi_timeout(time_point t, abstract_actor* self,
+                         atom_value type, uint64_t id) override;
 
   void set_request_timeout(time_point t, abstract_actor* self,
                            message_id id) override;

--- a/libcaf_core/src/simple_actor_clock.cpp
+++ b/libcaf_core/src/simple_actor_clock.cpp
@@ -62,7 +62,7 @@ void simple_actor_clock::visitor::operator()(group_msg& x) {
 }
 
 void simple_actor_clock::set_ordinary_timeout(time_point t, abstract_actor* self,
-                                             atom_value type, uint64_t id) {
+                                              atom_value type, uint64_t id) {
   ordinary_predicate pred{type};
   auto i = lookup(self, pred);
   auto sptr = actor_cast<strong_actor_ptr>(self);
@@ -74,6 +74,14 @@ void simple_actor_clock::set_ordinary_timeout(time_point t, abstract_actor* self
     auto j = schedule_.emplace(t, std::move(tmp));
     actor_lookup_.emplace(self, j);
   }
+}
+
+void simple_actor_clock::add_ordinary_timeout(time_point t, abstract_actor* self,
+                                              atom_value type, uint64_t id) {
+  auto sptr = actor_cast<strong_actor_ptr>(self);
+  ordinary_timeout tmp{std::move(sptr), type, id};
+  auto j = schedule_.emplace(t, std::move(tmp));
+  actor_lookup_.emplace(self, j);
 }
 
 void simple_actor_clock::set_request_timeout(time_point t, abstract_actor* self,

--- a/libcaf_core/src/simple_actor_clock.cpp
+++ b/libcaf_core/src/simple_actor_clock.cpp
@@ -31,6 +31,12 @@ operator()(const secondary_map::value_type& x) const noexcept {
   return ptr != nullptr ? ptr->type == type : false;
 }
 
+bool simple_actor_clock::multi_predicate::
+operator()(const secondary_map::value_type& x) const noexcept {
+  auto ptr = get_if<multi_timeout>(&x.second->second);
+  return ptr != nullptr ? ptr->type == type : false;
+}
+
 bool simple_actor_clock::request_predicate::
 operator()(const secondary_map::value_type& x) const noexcept {
   auto ptr = get_if<request_timeout>(&x.second->second);
@@ -42,6 +48,14 @@ void simple_actor_clock::visitor::operator()(ordinary_timeout& x) {
   x.self->get()->eq_impl(make_message_id(), x.self, nullptr,
                          timeout_msg{x.type, x.id});
   ordinary_predicate pred{x.type};
+  thisptr->drop_lookup(x.self->get(), pred);
+}
+
+void simple_actor_clock::visitor::operator()(multi_timeout& x) {
+  CAF_ASSERT(x.self != nullptr);
+  x.self->get()->eq_impl(make_message_id(), x.self, nullptr,
+                         timeout_msg{x.type, x.id});
+  multi_predicate pred{x.type};
   thisptr->drop_lookup(x.self->get(), pred);
 }
 
@@ -76,10 +90,10 @@ void simple_actor_clock::set_ordinary_timeout(time_point t, abstract_actor* self
   }
 }
 
-void simple_actor_clock::add_ordinary_timeout(time_point t, abstract_actor* self,
-                                              atom_value type, uint64_t id) {
+void simple_actor_clock::set_multi_timeout(time_point t, abstract_actor* self,
+                                           atom_value type, uint64_t id) {
   auto sptr = actor_cast<strong_actor_ptr>(self);
-  ordinary_timeout tmp{std::move(sptr), type, id};
+  multi_timeout tmp{std::move(sptr), type, id};
   auto j = schedule_.emplace(t, std::move(tmp));
   actor_lookup_.emplace(self, j);
 }


### PR DESCRIPTION
This PR adds a  new function to the actor clock that allows adding a new receive timeout without overriding existing receive timeouts.

A use case is the new broker implementation that needs this feature for retransmit timeouts (among others) where multiple messages might need retransmission.