### PR TITLE
Add missing <string> include to use std::string.

### DIFF
--- a/libcaf_io/caf/io/hook.hpp
+++ b/libcaf_io/caf/io/hook.hpp
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <set>
+#include <string>
 #include <memory>
 #include <vector>
 
@@ -166,4 +167,3 @@ private:
 
 } // namespace io
 } // namespace caf
-


### PR DESCRIPTION
(Note set<string> on line 85)