### PR TITLE
Fix stringification inspector concept modeling

### DIFF
--- a/libcaf_core/caf/detail/stringification_inspector.hpp
+++ b/libcaf_core/caf/detail/stringification_inspector.hpp
@@ -52,6 +52,7 @@ public:
   using result_type = void;
 
   static constexpr bool reads_state = true;
+  static constexpr bool writes_state = false;
 
   // -- constructors, destructors, and assignment operators --------------------
 


### PR DESCRIPTION
Prior to this change, it wasn't possible write generic code that checks for `Inspector::writes_state`.