### PR TITLE
Fix missing return

### DIFF
--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -246,7 +246,7 @@ public:
     CAF_ASSERT(current_element_);
     auto& stages = current_element_->stages;
     if (!stages.empty())
-      stages.back();
+      return stages.back();
     return nullptr;
   }
 


### PR DESCRIPTION
Hi, I'm getting warnings in Visual Studio for this line, and it looks like it's just missing a `return`.  I haven't tested the change, but it seems pretty straightforward.  I'm surprised it's not causing any bugs, though, maybe this function is not used?