### PR TITLE
Add static library definition to FindCAF lookup

### DIFF
--- a/cmake/FindCAF.cmake
+++ b/cmake/FindCAF.cmake
@@ -84,6 +84,7 @@ foreach (comp ${CAF_FIND_COMPONENTS})
       find_library(CAF_LIBRARY_${UPPERCOMP}
                    NAMES
                      "caf_${comp}"
+		     "caf_${comp}_static"
                    HINTS
                      ${library_hints}
                      /usr/lib

--- a/cmake/FindCAF.cmake
+++ b/cmake/FindCAF.cmake
@@ -83,8 +83,8 @@ foreach (comp ${CAF_FIND_COMPONENTS})
       endif ()
       find_library(CAF_LIBRARY_${UPPERCOMP}
                    NAMES
-                     "caf_${comp}"
-		     "caf_${comp}_static"
+                    "caf_${comp}"  
+		      "caf_${comp}_static"
                    HINTS
                      ${library_hints}
                      /usr/lib


### PR DESCRIPTION
As far as CAF on windows has only static version, without this fix CAF cant be used in windows projects with CMake build system.