### PR TITLE
Add missing <string> include to use std::string

### DIFF
--- a/libcaf_core/caf/detail/is_primitive_config_value.hpp
+++ b/libcaf_core/caf/detail/is_primitive_config_value.hpp
@@ -20,6 +20,7 @@
 
 #include <cstdint>
 #include <map>
+#include <string>
 #include <vector>
 
 #include "caf/detail/is_one_of.hpp"


### PR DESCRIPTION
The latest source failed with error C2039 in is_primitive_config_value.hpp, so add \<string> to fix it.