### PR TITLE
Clean up string algorithms header and fix caf::split

### DIFF
--- a/libcaf_core/caf/string_algorithms.hpp
+++ b/libcaf_core/caf/string_algorithms.hpp
@@ -64,7 +64,7 @@ std::string join(InputIterator first, InputIterator last, string_view glue) {
 }
 
 template <class Container>
-std::string join(const Container& c, const std::string& glue) {
+std::string join(const Container& c, string_view glue) {
   return join(c.begin(), c.end(), glue);
 }
 

--- a/libcaf_core/caf/string_algorithms.hpp
+++ b/libcaf_core/caf/string_algorithms.hpp
@@ -68,18 +68,6 @@ std::string join(const Container& c, string_view glue) {
   return join(c.begin(), c.end(), glue);
 }
 
-// end of recursion
-inline void splice(std::string&, string_view) {
-  // nop
-}
-
-template <class T, class... Ts>
-void splice(std::string& str, string_view glue, T&& arg, Ts&&... xs) {
-  str.insert(str.end(), glue.begin(), glue.end());
-  str += std::forward<T>(arg);
-  splice(str, glue, std::forward<Ts>(xs)...);
-}
-
 /// Replaces all occurrences of `what` by `with` in `str`.
 void replace_all(std::string& str, string_view what, string_view with);
 
@@ -89,18 +77,4 @@ bool starts_with(string_view str, string_view prefix);
 /// Returns whether `str` ends with `suffix`.
 bool ends_with(string_view str, string_view suffix);
 
-template <class T>
-typename std::enable_if<
-  std::is_arithmetic<T>::value,
-  std::string
->::type
-convert_to_str(T value) {
-  return std::to_string(value);
-}
-
-inline std::string convert_to_str(std::string value) {
-  return value;
-}
-
 } // namespace caf
-

--- a/libcaf_core/src/string_algorithms.cpp
+++ b/libcaf_core/src/string_algorithms.cpp
@@ -27,15 +27,15 @@ void split_impl(F consume, string_view str, string_view delims, bool keep_all) {
   size_t pos = 0;
   size_t prev = 0;
   while ((pos = str.find_first_of(delims, prev)) != std::string::npos) {
-    if (pos > prev) {
-      auto substr = str.substr(prev, pos - prev);
-      if (!substr.empty() || keep_all)
-        consume(substr);
-    }
+    auto substr = str.substr(prev, pos - prev);
+    if (keep_all || !substr.empty())
+      consume(substr);
     prev = pos + 1;
   }
   if (prev < str.size())
-    consume(str.substr(prev, std::string::npos));
+    consume(str.substr(prev));
+  else if (keep_all)
+    consume(string_view{});
 }
 
 } // namespace <anonymous>

--- a/libcaf_core/test/string_algorithms.cpp
+++ b/libcaf_core/test/string_algorithms.cpp
@@ -1,0 +1,109 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2018 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#define CAF_SUITE string_algorithms
+
+#include "caf/string_algorithms.hpp"
+
+#include "caf/test/dsl.hpp"
+
+#include <string>
+#include <vector>
+
+using namespace caf;
+
+namespace {
+
+struct fixture {
+
+};
+
+using str_list = std::vector<std::string>;
+
+str_list split(string_view str) {
+  str_list result;
+  caf::split(result, str, ",");
+  return result;
+}
+
+str_list compressed_split(string_view str) {
+  str_list result;
+  caf::split(result, str, ",", token_compress_on);
+  return result;
+}
+
+std::string join(str_list vec) {
+  return caf::join(vec, ",");
+}
+
+template <class... Ts>
+std::string splice(string_view glue, const Ts&... xs) {
+  std::string result;
+  caf::splice(result, glue, xs...);
+  return result;
+}
+
+} // namespace <anonymous>
+
+CAF_TEST_FIXTURE_SCOPE(string_algorithms_tests, fixture)
+
+CAF_TEST(splitting) {
+  CAF_CHECK_EQUAL(split(""), str_list({""}));
+  CAF_CHECK_EQUAL(split(","), str_list({"", ""}));
+  CAF_CHECK_EQUAL(split(",,"), str_list({"", "", ""}));
+  CAF_CHECK_EQUAL(split(",,,"), str_list({"", "", "", ""}));
+  CAF_CHECK_EQUAL(split("a,b,c"), str_list({"a", "b", "c"}));
+  CAF_CHECK_EQUAL(split("a,,b,c,"), str_list({"a", "", "b", "c", ""}));
+}
+
+CAF_TEST(compressed splitting) {
+  CAF_CHECK_EQUAL(compressed_split(""), str_list({}));
+  CAF_CHECK_EQUAL(compressed_split(","), str_list({}));
+  CAF_CHECK_EQUAL(compressed_split(",,"), str_list({}));
+  CAF_CHECK_EQUAL(compressed_split(",,,"), str_list({}));
+  CAF_CHECK_EQUAL(compressed_split("a,b,c"), str_list({"a", "b", "c"}));
+  CAF_CHECK_EQUAL(compressed_split("a,,b,c,"), str_list({"a", "b", "c"}));
+}
+
+CAF_TEST(joining) {
+  CAF_CHECK_EQUAL(join({}), "");
+  CAF_CHECK_EQUAL(join({""}), "");
+  CAF_CHECK_EQUAL(join({"", ""}), ",");
+  CAF_CHECK_EQUAL(join({"", "", ""}), ",,");
+  CAF_CHECK_EQUAL(join({"a"}), "a");
+  CAF_CHECK_EQUAL(join({"a", "b"}), "a,b");
+  CAF_CHECK_EQUAL(join({"a", "b", "c"}), "a,b,c");
+}
+
+CAF_TEST(starts with) {
+  CAF_CHECK(starts_with("foobar", "f"));
+  CAF_CHECK(starts_with("foobar", "fo"));
+  CAF_CHECK(starts_with("foobar", "fooba"));
+  CAF_CHECK(starts_with("foobar", "foobar"));
+  CAF_CHECK(!starts_with("foobar", "o"));
+}
+
+CAF_TEST(ends with) {
+  CAF_CHECK(ends_with("foobar", "r"));
+  CAF_CHECK(ends_with("foobar", "ar"));
+  CAF_CHECK(ends_with("foobar", "oobar"));
+  CAF_CHECK(ends_with("foobar", "foobar"));
+  CAF_CHECK(!ends_with("foobar", "a"));
+}
+
+CAF_TEST_FIXTURE_SCOPE_END()

--- a/libcaf_core/test/string_algorithms.cpp
+++ b/libcaf_core/test/string_algorithms.cpp
@@ -29,10 +29,6 @@ using namespace caf;
 
 namespace {
 
-struct fixture {
-
-};
-
 using str_list = std::vector<std::string>;
 
 str_list split(string_view str) {
@@ -51,16 +47,7 @@ std::string join(str_list vec) {
   return caf::join(vec, ",");
 }
 
-template <class... Ts>
-std::string splice(string_view glue, const Ts&... xs) {
-  std::string result;
-  caf::splice(result, glue, xs...);
-  return result;
-}
-
 } // namespace <anonymous>
-
-CAF_TEST_FIXTURE_SCOPE(string_algorithms_tests, fixture)
 
 CAF_TEST(splitting) {
   CAF_CHECK_EQUAL(split(""), str_list({""}));
@@ -96,6 +83,8 @@ CAF_TEST(starts with) {
   CAF_CHECK(starts_with("foobar", "fooba"));
   CAF_CHECK(starts_with("foobar", "foobar"));
   CAF_CHECK(!starts_with("foobar", "o"));
+  CAF_CHECK(!starts_with("foobar", "fa"));
+  CAF_CHECK(!starts_with("foobar", "foobaro"));
 }
 
 CAF_TEST(ends with) {
@@ -104,6 +93,6 @@ CAF_TEST(ends with) {
   CAF_CHECK(ends_with("foobar", "oobar"));
   CAF_CHECK(ends_with("foobar", "foobar"));
   CAF_CHECK(!ends_with("foobar", "a"));
+  CAF_CHECK(!ends_with("foobar", "car"));
+  CAF_CHECK(!ends_with("foobar", "afoobar"));
 }
-
-CAF_TEST_FIXTURE_SCOPE_END()


### PR DESCRIPTION
Fixes a bug in `caf::split` that was spotted by @tobim, adds unit tests for the string algorithms, and removes unused functions.