### PR TITLE
Cap logger level to not exceed CAF_LOG_LEVEL

### DIFF
--- a/libcaf_core/src/logger.cpp
+++ b/libcaf_core/src/logger.cpp
@@ -384,8 +384,10 @@ void logger::init(actor_system_config& cfg) {
   file_verbosity = get_or(cfg, "logger.file-verbosity", file_verbosity);
   console_verbosity =
     get_or(cfg, "logger.console-verbosity", console_verbosity);
-  cfg_.file_verbosity = to_level_int(file_verbosity);
-  cfg_.console_verbosity = to_level_int(console_verbosity);
+  cfg_.file_verbosity = std::min(static_cast<unsigned>(CAF_LOG_LEVEL),
+                                 to_level_int(file_verbosity));
+  cfg_.console_verbosity = std::min(static_cast<unsigned>(CAF_LOG_LEVEL),
+                                    to_level_int(console_verbosity));
   cfg_.verbosity = std::max(cfg_.file_verbosity, cfg_.console_verbosity);
   // Parse the format string.
   file_format_ =


### PR DESCRIPTION
If the build system isn't configured at a high enough level, then a user setting a higher log level in their config shouldn't do anything. For example, if the configured level is QUIET, then a log file
should never be produced (the original logic would actually result in producing an empty log file by default).

To follow along with that example, see the logger initialize a "quiet" verbosity level from `CAF_LOG_LEVEL` here:

https://github.com/actor-framework/actor-framework/blob/14c187b81c77c7c76734adc1daf414d109ac489b/libcaf_core/src/logger.cpp#L249

This logic overwrite's the logger's level with "trace":

https://github.com/actor-framework/actor-framework/blob/14c187b81c77c7c76734adc1daf414d109ac489b/libcaf_core/src/logger.cpp#L381-L389

This condition is now false:

https://github.com/actor-framework/actor-framework/blob/14c187b81c77c7c76734adc1daf414d109ac489b/libcaf_core/src/logger.cpp#L636

A log file gets opened:

https://github.com/actor-framework/actor-framework/blob/14c187b81c77c7c76734adc1daf414d109ac489b/libcaf_core/src/logger.cpp#L666

But nothing will be written to it as technically it's log level "quiet" and logging should be pre-processed out.