### PR TITLE
Fix thread-safe multitimeout

### DIFF
--- a/libcaf_core/caf/detail/thread_safe_actor_clock.hpp
+++ b/libcaf_core/caf/detail/thread_safe_actor_clock.hpp
@@ -39,6 +39,9 @@ public:
   void set_request_timeout(time_point t, abstract_actor* self,
                            message_id id) override;
 
+  void set_multi_timeout(time_point t, abstract_actor* self,
+                         atom_value type, uint64_t id) override;
+
   void cancel_ordinary_timeout(abstract_actor* self, atom_value type) override;
 
   void cancel_request_timeout(abstract_actor* self, message_id id) override;

--- a/libcaf_core/src/thread_safe_actor_clock.cpp
+++ b/libcaf_core/src/thread_safe_actor_clock.cpp
@@ -52,6 +52,15 @@ void thread_safe_actor_clock::set_request_timeout(time_point t,
   }
 }
 
+void thread_safe_actor_clock::set_multi_timeout(time_point t, abstract_actor* self,
+                       atom_value type, uint64_t id) {
+  guard_type guard{mx_};
+  if (!done_) {
+    super::set_multi_timeout(t, self, type, id);
+    cv_.notify_all();
+  }
+}
+
 void thread_safe_actor_clock::cancel_ordinary_timeout(abstract_actor* self,
                                                       atom_value type) {
   guard_type guard{mx_};


### PR DESCRIPTION
Setting a multitimeout did not notify the condition variable of the thread-safe actor clock. As a result no timeouts were triggered.