### PR TITLE
Fix --config-file option

### DIFF
--- a/libcaf_core/src/actor_system_config.cpp
+++ b/libcaf_core/src/actor_system_config.cpp
@@ -373,7 +373,7 @@ void actor_system_config::extract_config_file_path(string_list& args) {
   });
   if (i == last)
     return;
-  auto arg_begin = i->begin() + sizeof(needle);
+  auto arg_begin = i->begin() + strlen(needle);
   auto arg_end = i->end();
   if (arg_begin == arg_end) {
     // Missing value.


### PR DESCRIPTION
This should fix #840. This is not a critical path and I went with `strlen` over `sizeof(needle) - 1`. There is still no warning or message if an empty string is passed (e.g. `--caf#config-file=\"\"`) or if the file does not exist. There are a few `TODO`s in the code for this ... 