### PR TITLE
Add config file option from manual and help text

### DIFF
--- a/libcaf_core/caf/actor_system_config.hpp
+++ b/libcaf_core/caf/actor_system_config.hpp
@@ -342,7 +342,7 @@ private:
 
   actor_system_config& set_impl(string_view name, config_value value);
 
-  void extract_config_file_path(string_list& args);
+  error extract_config_file_path(string_list& args);
 
   /// Adjusts the content of the configuration, e.g., for ensuring backwards
   /// compatibility with older options.

--- a/libcaf_core/caf/sec.hpp
+++ b/libcaf_core/caf/sec.hpp
@@ -114,6 +114,8 @@ enum class sec : uint8_t {
   bad_function_call = 40,
   /// Feature is disabled in the actor system config.
   feature_disabled,
+  /// Failed to open file.
+  cannot_open_file,
 };
 
 /// @relates sec

--- a/libcaf_core/src/sec.cpp
+++ b/libcaf_core/src/sec.cpp
@@ -67,6 +67,7 @@ const char* sec_strings[] = {
   "unhandled_stream_error",
   "bad_function_call",
   "feature_disabled",
+  "cannot_open_file",
 };
 
 } // namespace <anonymous>

--- a/libcaf_core/src/sec.cpp
+++ b/libcaf_core/src/sec.cpp
@@ -64,6 +64,7 @@ const char* sec_strings[] = {
   "no_downstream_stages_defined",
   "stream_init_failed",
   "invalid_stream_state",
+  "unhandled_stream_error",
   "bad_function_call",
   "feature_disabled",
 };


### PR DESCRIPTION
Addresses #839. The global option listed in the [latest manual](https://actor-framework.readthedocs.io/en/latest/ConfiguringActorApplications.html#command-line-options-and-ini-configuration-files) was not checked before. `--help` lists the option now. 