### PR TITLE
Fix potential memory leak

### DIFF
--- a/libcaf_core/caf/actor_system_config.hpp
+++ b/libcaf_core/caf/actor_system_config.hpp
@@ -231,7 +231,8 @@ public:
   /// Adds a hook type to the scheduler.
   template <class Hook, class... Ts>
   actor_system_config& add_thread_hook(Ts&&... ts) {
-    thread_hooks_.emplace_back(new Hook(std::forward<Ts>(ts)...));
+    std::unique_ptr<thread_hook> hook{new Hook(std::forward<Ts>(ts)...)};
+    thread_hooks_.emplace_back(std::move(hook));
     return *this;
   }
 


### PR DESCRIPTION
Addresses #836. If reallocation throws the pointer is not cleaned up correctly.