### PR TITLE
Fix performance of thread-safe actor clock

### DIFF
--- a/libcaf_core/caf/detail/make_unique.hpp
+++ b/libcaf_core/caf/detail/make_unique.hpp
@@ -1,0 +1,32 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2019 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <memory>
+
+namespace caf {
+namespace detail {
+
+template <class T, class... Ts>
+std::unique_ptr<T> make_unique(Ts&&... xs) {
+  return std::unique_ptr<T>{new T(std::forward<Ts>(xs)...)};
+}
+
+} // namespace detail
+} // namespace caf

--- a/libcaf_core/caf/detail/ringbuffer.hpp
+++ b/libcaf_core/caf/detail/ringbuffer.hpp
@@ -23,6 +23,8 @@
 #include <condition_variable>
 #include <mutex>
 
+#include "caf/config.hpp"
+
 namespace caf {
 namespace detail {
 
@@ -46,6 +48,15 @@ public:
       cv_empty_.wait(guard);
   }
 
+  template <class TimePoint>
+  bool wait_nonempty(TimePoint timeout) {
+    if (!empty())
+      return true;
+    auto pred = [&] { return !empty(); };
+    guard_type guard{mtx_};
+    return cv_empty_.wait_until(guard, timeout, pred);
+  }
+
   T& front() {
     // Safe to access without lock, because we assume a single consumer.
     return buf_[rd_pos_];
@@ -58,6 +69,33 @@ public:
     // Wakeup a waiting producers if the queue became non-full.
     if (rp == next(wr_pos_))
       cv_full_.notify_all();
+  }
+
+  template <class OutputIterator>
+  OutputIterator get_all(OutputIterator i) {
+    // No lock needed, again because of single-consumer assumption.
+    auto first = rd_pos_.load();
+    auto last = wr_pos_.load();
+    size_t n;
+    CAF_ASSERT(first != last);
+    // Move buffer content to the output iterator.
+    if (first < last) {
+      n = last - first;
+      for (auto j = first; j != last; ++j)
+        *i++ = std::move(buf_[j]);
+    } else {
+      n = (Size - first) + last;
+      for (size_t j = first; j != Size; ++j)
+        *i++ = std::move(buf_[j]);
+      for (size_t j = 0; j != last; ++j)
+        *i++ = std::move(buf_[j]);
+    }
+    guard_type guard{mtx_};
+    rd_pos_ = (first + n) % Size;
+    // Wakeup a waiting producers if the queue became non-full.
+    if (first == next(last))
+      cv_full_.notify_all();
+    return i;
   }
 
   void push_back(T&& x) {

--- a/libcaf_core/caf/detail/ringbuffer.hpp
+++ b/libcaf_core/caf/detail/ringbuffer.hpp
@@ -93,7 +93,7 @@ public:
     guard_type guard{mtx_};
     rd_pos_ = (first + n) % Size;
     // Wakeup a waiting producers if the queue became non-full.
-    if (first == next(last))
+    if (first == next(wr_pos_))
       cv_full_.notify_all();
     return i;
   }

--- a/libcaf_core/caf/detail/simple_actor_clock.hpp
+++ b/libcaf_core/caf/detail/simple_actor_clock.hpp
@@ -38,8 +38,6 @@ class simple_actor_clock : public actor_clock {
 public:
   // -- member types -----------------------------------------------------------
 
-  using super = simple_actor_clock;
-
   struct event;
 
   struct delayed_event;
@@ -136,7 +134,7 @@ public:
 
   /// A delayed `sec::request_timeout` error that gets cancelled when the
   /// request arrives in time.
-  struct request_timeout final: delayed_event {
+  struct request_timeout final : delayed_event {
     static constexpr bool cancellable = true;
 
     request_timeout(time_point due, strong_actor_ptr self, message_id id)

--- a/libcaf_core/caf/detail/test_actor_clock.hpp
+++ b/libcaf_core/caf/detail/test_actor_clock.hpp
@@ -51,10 +51,6 @@ public:
   /// @returns The number of triggered timeouts.
   size_t trigger_timeouts();
 
-  /// Triggers all timeouts with timestamp <= now.
-  /// @returns The number of triggered timeouts.
-  size_t trigger_expired_timeouts();
-
   /// Advances the time by `x` and dispatches timeouts and delayed messages.
   /// @returns The number of triggered timeouts.
   size_t advance_time(duration_type x);

--- a/libcaf_core/src/simple_actor_clock.cpp
+++ b/libcaf_core/src/simple_actor_clock.cpp
@@ -94,7 +94,7 @@ void simple_actor_clock::ship(delayed_event& x) {
       break;
     }
     case multi_timeout_type: {
-      auto& dref = static_cast<ordinary_timeout&>(x);
+      auto& dref = static_cast<multi_timeout&>(x);
       auto& self = dref.self;
       self->get()->eq_impl(make_message_id(), self, nullptr,
                            timeout_msg{dref.type, dref.id});
@@ -134,7 +134,7 @@ void simple_actor_clock::handle(const ordinary_timeout_cancellation& x) {
 void simple_actor_clock::handle(const multi_timeout_cancellation& x) {
   auto pred = [&](const actor_lookup_map::value_type& kvp) {
     auto& y = *kvp.second->second;
-    if (y.subtype != ordinary_timeout_type)
+    if (y.subtype != multi_timeout_type)
       return false;
     auto& dref = static_cast<const multi_timeout&>(y);
     return x.type == dref.type && x.id == dref.id;

--- a/libcaf_core/src/simple_actor_clock.cpp
+++ b/libcaf_core/src/simple_actor_clock.cpp
@@ -25,108 +25,40 @@
 namespace caf {
 namespace detail {
 
-bool simple_actor_clock::ordinary_predicate::
-operator()(const secondary_map::value_type& x) const noexcept {
-  auto ptr = get_if<ordinary_timeout>(&x.second->second);
-  return ptr != nullptr ? ptr->type == type : false;
+simple_actor_clock::event::~event() {
+  // nop
 }
 
-bool simple_actor_clock::multi_predicate::
-operator()(const secondary_map::value_type& x) const noexcept {
-  auto ptr = get_if<multi_timeout>(&x.second->second);
-  return ptr != nullptr ? ptr->type == type : false;
-}
-
-bool simple_actor_clock::request_predicate::
-operator()(const secondary_map::value_type& x) const noexcept {
-  auto ptr = get_if<request_timeout>(&x.second->second);
-  return ptr != nullptr ? ptr->id == id : false;
-}
-
-void simple_actor_clock::visitor::operator()(ordinary_timeout& x) {
-  CAF_ASSERT(x.self != nullptr);
-  x.self->get()->eq_impl(make_message_id(), x.self, nullptr,
-                         timeout_msg{x.type, x.id});
-  ordinary_predicate pred{x.type};
-  thisptr->drop_lookup(x.self->get(), pred);
-}
-
-void simple_actor_clock::visitor::operator()(multi_timeout& x) {
-  CAF_ASSERT(x.self != nullptr);
-  x.self->get()->eq_impl(make_message_id(), x.self, nullptr,
-                         timeout_msg{x.type, x.id});
-  multi_predicate pred{x.type};
-  thisptr->drop_lookup(x.self->get(), pred);
-}
-
-void simple_actor_clock::visitor::operator()(request_timeout& x) {
-  CAF_ASSERT(x.self != nullptr);
-  x.self->get()->eq_impl(x.id, x.self, nullptr, sec::request_timeout);
-  request_predicate pred{x.id};
-  thisptr->drop_lookup(x.self->get(), pred);
-}
-
-void simple_actor_clock::visitor::operator()(actor_msg& x) {
-  x.receiver->enqueue(std::move(x.content), nullptr);
-}
-
-void simple_actor_clock::visitor::operator()(group_msg& x) {
-  x.target->eq_impl(make_message_id(), std::move(x.sender), nullptr,
-                    std::move(x.content));
-}
-
-void simple_actor_clock::set_ordinary_timeout(time_point t, abstract_actor* self,
+void simple_actor_clock::set_ordinary_timeout(time_point t,
+                                              abstract_actor* self,
                                               atom_value type, uint64_t id) {
-  ordinary_predicate pred{type};
-  auto i = lookup(self, pred);
-  auto sptr = actor_cast<strong_actor_ptr>(self);
-  ordinary_timeout tmp{std::move(sptr), type, id};
-  if (i != actor_lookup_.end()) {
-    schedule_.erase(i->second);
-    i->second = schedule_.emplace(t, std::move(tmp));
-  } else {
-    auto j = schedule_.emplace(t, std::move(tmp));
-    actor_lookup_.emplace(self, j);
-  }
+  new_schedule_entry<ordinary_timeout>(t, self->ctrl(), type, id);
 }
 
 void simple_actor_clock::set_multi_timeout(time_point t, abstract_actor* self,
                                            atom_value type, uint64_t id) {
-  auto sptr = actor_cast<strong_actor_ptr>(self);
-  multi_timeout tmp{std::move(sptr), type, id};
-  auto j = schedule_.emplace(t, std::move(tmp));
-  actor_lookup_.emplace(self, j);
+  new_schedule_entry<multi_timeout>(t, self->ctrl(), type, id);
 }
 
 void simple_actor_clock::set_request_timeout(time_point t, abstract_actor* self,
                                              message_id id) {
-  request_predicate pred{id};
-  auto i = lookup(self, pred);
-  auto sptr = actor_cast<strong_actor_ptr>(self);
-  request_timeout tmp{std::move(sptr), id};
-  if (i != actor_lookup_.end()) {
-    schedule_.erase(i->second);
-    i->second = schedule_.emplace(t, std::move(tmp));
-  } else {
-    auto j = schedule_.emplace(t, std::move(tmp));
-    actor_lookup_.emplace(self, j);
-  }
+  new_schedule_entry<request_timeout>(t, self->ctrl(), id);
 }
 
 void simple_actor_clock::cancel_ordinary_timeout(abstract_actor* self,
                                                  atom_value type) {
-  ordinary_predicate pred{type};
-  cancel(self, pred);
+  ordinary_timeout_cancellation tmp{self->id(), type};
+  handle(tmp);
 }
 
 void simple_actor_clock::cancel_request_timeout(abstract_actor* self,
                                                 message_id id) {
-  request_predicate pred{id};
-  cancel(self, pred);
+  request_timeout_cancellation tmp{self->id(), id};
+  handle(tmp);
 }
 
 void simple_actor_clock::cancel_timeouts(abstract_actor* self) {
-  auto range = actor_lookup_.equal_range(self);
+  auto range = actor_lookup_.equal_range(self->id());
   if (range.first == range.second)
     return;
   for (auto i = range.first; i != range.second; ++i)
@@ -137,19 +69,133 @@ void simple_actor_clock::cancel_timeouts(abstract_actor* self) {
 void simple_actor_clock::schedule_message(time_point t,
                                           strong_actor_ptr receiver,
                                           mailbox_element_ptr content) {
-  schedule_.emplace(t, actor_msg{std::move(receiver), std::move(content)});
+  new_schedule_entry<actor_msg>(t, std::move(receiver), std::move(content));
 }
 
 void simple_actor_clock::schedule_message(time_point t, group target,
                                           strong_actor_ptr sender,
                                           message content) {
-  schedule_.emplace(
-    t, group_msg{std::move(target), std::move(sender), std::move(content)});
+  new_schedule_entry<group_msg>(t, std::move(target), std::move(sender),
+                                std::move(content));
 }
 
 void simple_actor_clock::cancel_all() {
   actor_lookup_.clear();
   schedule_.clear();
+}
+
+void simple_actor_clock::ship(delayed_event& x) {
+  switch (x.subtype) {
+    case ordinary_timeout_type: {
+      auto& dref = static_cast<ordinary_timeout&>(x);
+      auto& self = dref.self;
+      self->get()->eq_impl(make_message_id(), self, nullptr,
+                           timeout_msg{dref.type, dref.id});
+      break;
+    }
+    case multi_timeout_type: {
+      auto& dref = static_cast<ordinary_timeout&>(x);
+      auto& self = dref.self;
+      self->get()->eq_impl(make_message_id(), self, nullptr,
+                           timeout_msg{dref.type, dref.id});
+      break;
+    }
+    case request_timeout_type: {
+      auto& dref = static_cast<request_timeout&>(x);
+      auto& self = dref.self;
+      self->get()->eq_impl(dref.id, self, nullptr, sec::request_timeout);
+      break;
+    }
+    case actor_msg_type: {
+      auto& dref = static_cast<actor_msg&>(x);
+      dref.receiver->enqueue(std::move(dref.content), nullptr);
+      break;
+    }
+    case group_msg_type: {
+      auto& dref = static_cast<group_msg&>(x);
+      dref.target->eq_impl(make_message_id(), std::move(dref.sender), nullptr,
+                           std::move(dref.content));
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+void simple_actor_clock::handle(const ordinary_timeout_cancellation& x) {
+  auto pred = [&](const actor_lookup_map::value_type& kvp) {
+    auto& y = *kvp.second->second;
+    return y.subtype == ordinary_timeout_type
+           && x.type == static_cast<const ordinary_timeout&>(y).type;
+  };
+  cancel(x.aid, pred);
+}
+
+void simple_actor_clock::handle(const multi_timeout_cancellation& x) {
+  auto pred = [&](const actor_lookup_map::value_type& kvp) {
+    auto& y = *kvp.second->second;
+    if (y.subtype != ordinary_timeout_type)
+      return false;
+    auto& dref = static_cast<const multi_timeout&>(y);
+    return x.type == dref.type && x.id == dref.id;
+  };
+  cancel(x.aid, pred);
+}
+
+void simple_actor_clock::handle(const request_timeout_cancellation& x) {
+  auto pred = [&](const actor_lookup_map::value_type& kvp) {
+    auto& y = *kvp.second->second;
+    return y.subtype == request_timeout_type
+           && x.id == static_cast<const request_timeout&>(y).id;
+  };
+  cancel(x.aid, pred);
+}
+
+void simple_actor_clock::handle(const timeouts_cancellation& x) {
+  auto range = actor_lookup_.equal_range(x.aid);
+  if (range.first == range.second)
+    return;
+  for (auto i = range.first; i != range.second; ++i)
+    schedule_.erase(i->second);
+  actor_lookup_.erase(range.first, range.second);
+}
+
+size_t simple_actor_clock::trigger_expired_timeouts() {
+  size_t result = 0;
+  auto t = now();
+  auto i = schedule_.begin();
+  auto e = schedule_.end();
+  while (i != e && i->first <= t) {
+    auto ptr = std::move(i->second);
+    auto backlink = ptr->backlink;
+    if (backlink != actor_lookup_.end())
+      actor_lookup_.erase(backlink);
+    i = schedule_.erase(i);
+    ship(*ptr);
+    ++result;
+  }
+  return result;
+}
+
+void
+simple_actor_clock::add_schedule_entry(time_point t,
+                                       std::unique_ptr<ordinary_timeout> x) {
+  auto aid = x->self->id();
+  auto type = x->type;
+  auto pred = [&](const actor_lookup_map::value_type& kvp) {
+    auto& y = *kvp.second->second;
+    return y.subtype == ordinary_timeout_type
+           && static_cast<const ordinary_timeout&>(y).type == type;
+  };
+  auto i = lookup(aid, pred);
+  if (i != actor_lookup_.end()) {
+    schedule_.erase(i->second);
+    i->second = schedule_.emplace(t, std::move(x));
+  } else {
+    auto j = schedule_.emplace(t, std::move(x));
+    i = actor_lookup_.emplace(aid, j);
+  }
+  i->second->second->backlink = i;
 }
 
 } // namespace detail


### PR DESCRIPTION
With this set of changes, the `thread_safe_actor_clock` can handle about 10x more request. Closes #845.