### PR TITLE
Set SO_KEEPALIVE on TCP connections

### DIFF
--- a/libcaf_io/caf/io/network/native_socket.hpp
+++ b/libcaf_io/caf/io/network/native_socket.hpp
@@ -91,6 +91,9 @@ std::pair<native_socket, native_socket> create_pipe();
 /// throws `network_error` on error
 expected<void> child_process_inherit(native_socket fd, bool new_value);
 
+/// Enables keepalive on `fd`. Throws `network_error` on error.
+expected<void> keepalive(native_socket fd, bool new_value);
+
 /// Sets fd to nonblocking if `set_nonblocking == true`
 /// or to blocking if `set_nonblocking == false`
 /// throws `network_error` on error

--- a/libcaf_io/src/default_multiplexer.cpp
+++ b/libcaf_io/src/default_multiplexer.cpp
@@ -672,6 +672,7 @@ void default_multiplexer::exec_later(resumable* ptr) {
 
 scribe_ptr default_multiplexer::new_scribe(native_socket fd) {
   CAF_LOG_TRACE("");
+  keepalive(fd, true);
   return make_counted<scribe_impl>(*this, fd);
 }
 

--- a/libcaf_io/src/native_socket.cpp
+++ b/libcaf_io/src/native_socket.cpp
@@ -139,6 +139,15 @@ namespace network {
     CALL_CFUN(set_res, detail::cc_not_minus1, "fcntl", fcntl(fd, F_SETFD, wf));
     return unit;
   }
+  
+  expected<void> keepalive(native_socket fd, bool new_value) {
+    CAF_LOG_TRACE(CAF_ARG(fd) << CAF_ARG(new_value));
+    int value = new_value ? 1 : 0;
+    CALL_CFUN(res, detail::cc_zero, "setsockopt",
+              setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &value,
+                         static_cast<unsigned>(sizeof(value))));
+    return unit;
+  }
 
   expected<void> nonblocking(native_socket fd, bool new_value) {
     CAF_LOG_TRACE(CAF_ARG(fd) << CAF_ARG(new_value));
@@ -220,6 +229,15 @@ namespace network {
 
   expected<void> child_process_inherit(native_socket fd, bool new_value) {
     // nop; FIXME: possible to implement via SetHandleInformation ?
+    return unit;
+  }
+  
+  expected<void> keepalive(native_socket fd, bool new_value) {
+    CAF_LOG_TRACE(CAF_ARG(fd) << CAF_ARG(new_value));
+    char = new_value ? 1 : 0;
+    CALL_CFUN(res, detail::cc_zero, "setsockopt",
+              setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &value,
+                         static_cast<int>(sizeof(value))));
     return unit;
   }
 

--- a/libcaf_io/src/native_socket.cpp
+++ b/libcaf_io/src/native_socket.cpp
@@ -139,7 +139,7 @@ namespace network {
     CALL_CFUN(set_res, detail::cc_not_minus1, "fcntl", fcntl(fd, F_SETFD, wf));
     return unit;
   }
-  
+
   expected<void> keepalive(native_socket fd, bool new_value) {
     CAF_LOG_TRACE(CAF_ARG(fd) << CAF_ARG(new_value));
     int value = new_value ? 1 : 0;
@@ -231,7 +231,7 @@ namespace network {
     // nop; FIXME: possible to implement via SetHandleInformation ?
     return unit;
   }
-  
+
   expected<void> keepalive(native_socket fd, bool new_value) {
     CAF_LOG_TRACE(CAF_ARG(fd) << CAF_ARG(new_value));
     char value = new_value ? 1 : 0;

--- a/libcaf_io/src/native_socket.cpp
+++ b/libcaf_io/src/native_socket.cpp
@@ -234,7 +234,7 @@ namespace network {
   
   expected<void> keepalive(native_socket fd, bool new_value) {
     CAF_LOG_TRACE(CAF_ARG(fd) << CAF_ARG(new_value));
-    char = new_value ? 1 : 0;
+    char value = new_value ? 1 : 0;
     CALL_CFUN(res, detail::cc_zero, "setsockopt",
               setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &value,
                          static_cast<int>(sizeof(value))));


### PR DESCRIPTION
This PR enables keep alive socket option on TCP sockets. The socket timeout depends on the system settings. On macOS this is apparently 2 hours (keepidle is in msec according to the [Internet](https://stackoverflow.com/questions/15860127/how-to-configure-tcp-keepalive-under-mac-os-x)):

```
$ sysctl -A | grep "net.inet.tcp.*keep"
net.inet.tcp.keepidle: 7200000
net.inet.tcp.keepintvl: 75000
net.inet.tcp.keepinit: 75000
net.inet.tcp.keepcnt: 8
net.inet.tcp.always_keepalive: 0
```