### PR TITLE
Don't consider uint8_t and bool as same 

### DIFF
--- a/libcaf_core/caf/detail/type_traits.hpp
+++ b/libcaf_core/caf/detail/type_traits.hpp
@@ -676,10 +676,13 @@ template <class T>
 struct is_expected<expected<T>> : std::true_type {};
 
 // Checks whether `T` and `U` are integers of the same size and signedness.
+// clang-format off
 template <class T, class U,
           bool Enable = std::is_integral<T>::value
                         && std::is_integral<U>::value
-                        && !std::is_same<T, bool>::value>
+                        && !std::is_same<T, bool>::value
+                        && !std::is_same<U, bool>::value>
+// clang-format on
 struct is_equal_int_type {
   static constexpr bool value = sizeof(T) == sizeof(U)
                                 && std::is_signed<T>::value

--- a/libcaf_core/test/variant.cpp
+++ b/libcaf_core/test/variant.cpp
@@ -143,10 +143,12 @@ CAF_TEST(constructors) {
   variant<string, atom_value> b{atom("foo")};
   variant<float, int, string> c{string{"bar"}};
   variant<int, string, double> d{123};
+  variant<bool, uint8_t> e{uint8_t{252}};
   CAF_CHECK_EQUAL(a, 42);
   CAF_CHECK_EQUAL(b, atom("foo"));
   CAF_CHECK_EQUAL(d, 123);
   CAF_CHECK_NOT_EQUAL(d, std::string{"123"});
+  CAF_CHECK_EQUAL(e, uint8_t{252});
 }
 
 CAF_TEST(n_ary_visit) {


### PR DESCRIPTION
This extra check is necessary for instantiations of `caf::variant`s containing `bool` and `uint8_t` members in that order. If one tries to construct the variant with `uint8_t`, the `type_id` calculation will place the constructor argument at the `T` argument and the type list entry at `U`. Therefore this additional condition is needed.