### PR TITLE
Make node_id opaque and add an URI-based alternative

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -54,6 +54,7 @@ set(LIBCAF_CORE_SRCS
   src/event_based_actor.cpp
   src/execution_unit.cpp
   src/exit_reason.cpp
+  src/fnv_hash.cpp
   src/forwarding_actor_proxy.cpp
   src/get_mac_addresses.cpp
   src/get_process_id.cpp

--- a/libcaf_core/caf/actor_control_block.hpp
+++ b/libcaf_core/caf/actor_control_block.hpp
@@ -20,16 +20,16 @@
 
 #include <atomic>
 
-#include "caf/fwd.hpp"
+#include "caf/config.hpp"
 #include "caf/error.hpp"
-#include "caf/node_id.hpp"
+#include "caf/fwd.hpp"
 #include "caf/intrusive_ptr.hpp"
-#include "caf/weak_intrusive_ptr.hpp"
-
-#include "caf/meta/type_name.hpp"
-#include "caf/meta/save_callback.hpp"
 #include "caf/meta/load_callback.hpp"
 #include "caf/meta/omittable_if_none.hpp"
+#include "caf/meta/save_callback.hpp"
+#include "caf/meta/type_name.hpp"
+#include "caf/node_id.hpp"
+#include "caf/weak_intrusive_ptr.hpp"
 
 namespace caf {
 

--- a/libcaf_core/caf/atom.hpp
+++ b/libcaf_core/caf/atom.hpp
@@ -40,7 +40,11 @@ std::string to_string(const atom_value& what);
 /// @relates atom_value
 atom_value to_lowercase(atom_value x);
 
+/// @relates atom_value
 atom_value atom_from_string(string_view x);
+
+/// @relates atom_value
+int compare(atom_value x, atom_value y);
 
 /// Creates an atom from given string literal.
 template <size_t Size>
@@ -219,4 +223,3 @@ struct hash<caf::atom_value> {
 };
 
 } // namespace std
-

--- a/libcaf_core/caf/detail/fnv_hash.hpp
+++ b/libcaf_core/caf/detail/fnv_hash.hpp
@@ -1,0 +1,71 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2019 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+#include "caf/detail/type_traits.hpp"
+
+namespace caf {
+namespace detail {
+
+/// Non-cryptographic hash function named after Glenn Fowler, Landon Curt Noll,
+/// and Kiem-Phong Vo.
+///
+/// See:
+/// - https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+/// - http://www.isthe.com/chongo/tech/comp/fnv/index.html
+size_t fnv_hash(const unsigned char* first, const unsigned char* last);
+
+size_t fnv_hash_append(size_t intermediate, const unsigned char* first,
+                       const unsigned char* last);
+
+template <class T>
+enable_if_t<has_data_member<T>::value, size_t> fnv_hash(const T& x) {
+  auto ptr = x.data();
+  auto first = reinterpret_cast<const uint8_t*>(ptr);
+  auto last = first + (sizeof(decay_t<decltype(*ptr)>) * x.size());
+  return fnv_hash(first, last);
+}
+
+template <class T>
+enable_if_t<has_data_member<T>::value, size_t>
+fnv_hash_append(size_t intermediate, const T& x) {
+  auto ptr = x.data();
+  auto first = reinterpret_cast<const uint8_t*>(ptr);
+  auto last = first + (sizeof(decay_t<decltype(*ptr)>) * x.size());
+  return fnv_hash_append(intermediate, first, last);
+}
+
+template <class T>
+enable_if_t<std::is_integral<T>::value, size_t> fnv_hash(const T& x) {
+  auto first = reinterpret_cast<const uint8_t*>(&x);
+  return fnv_hash(first, first + sizeof(T));
+}
+
+template <class T>
+enable_if_t<std::is_integral<T>::value, size_t> fnv_hash_append(size_t interim,
+                                                                const T& x) {
+  auto first = reinterpret_cast<const uint8_t*>(&x);
+  return fnv_hash_append(interim, first, first + sizeof(T));
+}
+
+} // namespace detail
+} // namespace caf

--- a/libcaf_core/caf/node_id.hpp
+++ b/libcaf_core/caf/node_id.hpp
@@ -29,6 +29,7 @@
 #include "caf/intrusive_ptr.hpp"
 #include "caf/none.hpp"
 #include "caf/ref_counted.hpp"
+#include "caf/uri.hpp"
 
 namespace caf {
 
@@ -125,6 +126,47 @@ public:
     host_id_type host_;
   };
 
+  // A technology-agnostic node identifier using an URI.
+  class uri_data final : public data {
+  public:
+    // -- constants ------------------------------------------------------------
+
+    /// Identifies this data implementation type.
+    static constexpr atom_value class_id = atom("uri");
+
+    // -- constructors, destructors, and assignment operators ------------------
+
+    explicit uri_data(uri value);
+
+    // -- properties -----------------------------------------------------------
+
+    const uri& value() const noexcept {
+      return value_;
+    }
+
+    // -- interface implementation ---------------------------------------------
+
+    bool valid() const noexcept override;
+
+    size_t hash_code() const noexcept override;
+
+    atom_value implementation_id() const noexcept override;
+
+    int compare(const data& other) const noexcept override;
+
+    void print(std::string& dst) const override;
+
+    error serialize(serializer& sink) const override;
+
+    error deserialize(deserializer& source) override;
+
+  private:
+    // -- member variables -----------------------------------------------------
+
+    uri value_;
+  };
+
+
   // -- constructors, destructors, and assignment operators --------------------
 
   constexpr node_id() noexcept {
@@ -206,6 +248,10 @@ void append_to_string(std::string& str, const node_id& x);
 /// Converts `x` into a human-readable string representation.
 /// @relates node_id
 std::string to_string(const node_id& x);
+
+/// Creates a node ID from the URI `from`.
+/// @relates node_id
+node_id make_node_id(uri from);
 
 /// Creates a node ID from `process_id` and `host_id`.
 /// @param process_id System-wide unique process identifier.

--- a/libcaf_core/caf/node_id.hpp
+++ b/libcaf_core/caf/node_id.hpp
@@ -41,8 +41,6 @@ public:
   // A reference counted, implementation-specific implementation of a node ID.
   class data : public ref_counted {
   public:
-    // static intrusive_ptr<data> create_singleton();
-
     ~data() override;
 
     virtual bool valid() const noexcept = 0;
@@ -280,9 +278,6 @@ error inspect(serializer& sink, const node_id& x);
 
 /// @relates node_id
 error inspect(deserializer& source, node_id& x);
-
-/// @relates node_id
-std::string to_string(const node_id& x);
 
 /// Appends `x` in human-readable string representation to `str`.
 /// @relates node_id

--- a/libcaf_core/caf/node_id.hpp
+++ b/libcaf_core/caf/node_id.hpp
@@ -34,8 +34,7 @@
 namespace caf {
 
 /// A node ID is an opaque value for representing CAF instances in the network.
-class node_id : detail::comparable<node_id>,
-                detail::comparable<node_id, none_t> {
+class node_id {
 public:
   // -- member types -----------------------------------------------------------
 
@@ -195,11 +194,6 @@ public:
   /// @returns -1 if `*this < other`, 0 if `*this == other`, and 1 otherwise.
   int compare(const node_id& other) const noexcept;
 
-  /// Compares this instance as if comparing to a default-constructed
-  /// `node_id`.
-  /// @returns `compare(node_id{})`.
-  int compare(const none_t&) const;
-
   /// Exchanges the value of this object with `other`.
   void swap(node_id& other);
 
@@ -230,6 +224,56 @@ public:
 private:
   intrusive_ptr<data> data_;
 };
+
+/// @relates node_id
+inline bool operator==(const node_id& x, const node_id& y) noexcept {
+  return x.compare(y) == 0;
+}
+
+/// @relates node_id
+inline bool operator!=(const node_id& x, const node_id& y) noexcept {
+  return x.compare(y) != 0;
+}
+
+/// @relates node_id
+inline bool operator<(const node_id& x, const node_id& y) noexcept {
+  return x.compare(y) < 0;
+}
+
+/// @relates node_id
+inline bool operator<=(const node_id& x, const node_id& y) noexcept {
+  return x.compare(y) <= 0;
+}
+
+/// @relates node_id
+inline bool operator>(const node_id& x, const node_id& y) noexcept {
+  return x.compare(y) > 0;
+}
+
+/// @relates node_id
+inline bool operator>=(const node_id& x, const node_id& y) noexcept {
+  return x.compare(y) >= 0;
+}
+
+/// @relates node_id
+inline bool operator==(const node_id& x, const none_t&) noexcept {
+  return !x;
+}
+
+/// @relates node_id
+inline bool operator==(const none_t&, const node_id& x) noexcept {
+  return !x;
+}
+
+/// @relates node_id
+inline bool operator!=(const node_id& x, const none_t&) noexcept {
+  return static_cast<bool>(x);
+}
+
+/// @relates node_id
+inline bool operator!=(const none_t&, const node_id& x) noexcept {
+  return static_cast<bool>(x);
+}
 
 /// @relates node_id
 error inspect(serializer& sink, const node_id& x);

--- a/libcaf_core/caf/node_id.hpp
+++ b/libcaf_core/caf/node_id.hpp
@@ -166,7 +166,6 @@ public:
     uri value_;
   };
 
-
   // -- constructors, destructors, and assignment operators --------------------
 
   constexpr node_id() noexcept {

--- a/libcaf_core/caf/uri.hpp
+++ b/libcaf_core/caf/uri.hpp
@@ -105,6 +105,9 @@ public:
   /// Returns the fragment component.
   string_view fragment() const noexcept;
 
+  /// Returns a hash code over all components.
+  size_t hash_code() const noexcept;
+
   // -- comparison -------------------------------------------------------------
 
   int compare(const uri& other) const noexcept;
@@ -135,3 +138,14 @@ std::string to_string(const uri& x);
 error parse(string_view str, uri& dest);
 
 } // namespace caf
+
+namespace std {
+
+template <>
+struct hash<caf::uri> {
+  size_t operator()(const caf::uri& x) const noexcept {
+    return x.hash_code();
+  }
+};
+
+} // namespace std

--- a/libcaf_core/src/atom.cpp
+++ b/libcaf_core/src/atom.cpp
@@ -71,4 +71,8 @@ std::string to_string(const atom_value& x) {
   return std::string(str.begin(), str.begin() + len);
 }
 
+int compare(atom_value x, atom_value y) {
+  return memcmp(&x, &y, sizeof(atom_value));
+}
+
 } // namespace caf

--- a/libcaf_core/src/fnv_hash.cpp
+++ b/libcaf_core/src/fnv_hash.cpp
@@ -1,0 +1,62 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2019 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/detail/fnv_hash.hpp"
+
+namespace caf {
+namespace detail {
+
+namespace {
+
+template <size_t IntegerSize>
+struct hash_conf_helper;
+
+template <>
+struct hash_conf_helper<4> {
+  static constexpr size_t basis = 2166136261u;
+
+  static constexpr size_t prime = 16777619u;
+};
+
+template <>
+struct hash_conf_helper<8> {
+  static constexpr size_t basis = 14695981039346656037u;
+
+  static constexpr size_t prime = 1099511628211u;
+};
+
+struct hash_conf : hash_conf_helper<sizeof(size_t)> {};
+
+} // namespace
+
+size_t fnv_hash(const unsigned char* first, const unsigned char* last) {
+  return fnv_hash_append(hash_conf::basis, first, last);
+}
+
+size_t fnv_hash_append(size_t intermediate, const unsigned char* first,
+                       const unsigned char* last) {
+  auto result = intermediate;
+  for (; first != last; ++first) {
+    result *= hash_conf::prime;
+    result ^= *first;
+  }
+  return result;
+}
+
+} // namespace detail
+} // namespace caf

--- a/libcaf_core/src/node_id.cpp
+++ b/libcaf_core/src/node_id.cpp
@@ -55,7 +55,7 @@ namespace {
 
 std::atomic<uint8_t> system_id;
 
-} // <anonymous>
+} // namespace
 
 node_id node_id::default_data::local(const actor_system_config&) {
   CAF_LOG_TRACE("");

--- a/libcaf_core/src/node_id.cpp
+++ b/libcaf_core/src/node_id.cpp
@@ -16,121 +16,39 @@
  * http://www.boost.org/LICENSE_1_0.txt.                                      *
  ******************************************************************************/
 
+#include "caf/node_id.hpp"
+
 #include <cstdio>
 #include <cstring>
-#include <sstream>
 #include <iterator>
+#include <sstream>
 
 #include "caf/config.hpp"
-#include "caf/node_id.hpp"
-#include "caf/serializer.hpp"
 #include "caf/deserializer.hpp"
-#include "caf/make_counted.hpp"
-#include "caf/string_algorithms.hpp"
-#include "caf/primitive_variant.hpp"
-
-#include "caf/logger.hpp"
-#include "caf/detail/ripemd_160.hpp"
-#include "caf/detail/get_root_uuid.hpp"
-#include "caf/detail/get_process_id.hpp"
 #include "caf/detail/get_mac_addresses.hpp"
+#include "caf/detail/get_process_id.hpp"
+#include "caf/detail/get_root_uuid.hpp"
+#include "caf/detail/parser/ascii_to_int.hpp"
+#include "caf/detail/ripemd_160.hpp"
+#include "caf/logger.hpp"
+#include "caf/make_counted.hpp"
+#include "caf/sec.hpp"
+#include "caf/serializer.hpp"
+#include "caf/string_algorithms.hpp"
 
 namespace caf {
-
-namespace {
-
-uint32_t invalid_process_id = 0;
-
-node_id::host_id_type invalid_host_id;
-
-} // namespace <anonymous>
-
-node_id::~node_id() {
-  // nop
-}
-
-node_id::node_id(const none_t&) {
-  // nop
-}
-
-node_id& node_id::operator=(const none_t&) {
-  data_.reset();
-  return *this;
-}
-
-node_id::node_id(intrusive_ptr<data> dataptr) : data_(std::move(dataptr)) {
-  // nop
-}
-
-node_id::node_id(uint32_t procid, const std::string& hash)
-    : data_(make_counted<data>(procid, hash)) {
-  // nop
-}
-
-node_id::node_id(uint32_t procid, const host_id_type& hid)
-    : data_(make_counted<data>(procid, hid)) {
-  // nop
-}
-
-int node_id::compare(const none_t&) const {
-  return data_ ? 1 : 0; // invalid instances are always smaller
-}
-
-int node_id::compare(const node_id& other) const {
-  if (this == &other || data_ == other.data_)
-    return 0; // shortcut for comparing to self or identical instances
-  if (!data_ != !other.data_)
-    return data_ ? 1 : -1; // invalid instances are always smaller
-  // use mismatch instead of strncmp because the
-  // latter bails out on the first 0-byte
-  auto last = host_id().end();
-  auto ipair = std::mismatch(host_id().begin(), last, other.host_id().begin());
-  if (ipair.first == last)
-    return static_cast<int>(process_id())-static_cast<int>(other.process_id());
-  if (*ipair.first < *ipair.second)
-    return -1;
-  return 1;
-}
-
-node_id::data::data() : pid_(0) {
-  memset(host_.data(), 0, host_.size());
-}
-
-node_id::data::data(uint32_t procid, host_id_type hid)
-    : pid_(procid),
-      host_(hid) {
-  // nop
-}
-
-node_id::data::data(uint32_t procid, const std::string& hash) : pid_(procid) {
-  if (hash.size() != (host_id_size * 2)) {
-    host_ = invalid_host_id;
-    return;
-  }
-  auto hex_value = [](char c) -> uint8_t {
-    if (isalpha(c) != 0) {
-      if (c >= 'a' && c <= 'f')
-        return static_cast<uint8_t>((c - 'a') + 10);
-      if (c >= 'A' && c <= 'F')
-        return static_cast<uint8_t>((c - 'A') + 10);
-    }
-    return isdigit(c) != 0 ? static_cast<uint8_t>(c - '0') : 0;
-  };
-  auto j = hash.c_str();
-  for (size_t i = 0; i < host_id_size; ++i) {
-    // read two characters, each representing 4 bytes
-    host_[i] = static_cast<uint8_t>(hex_value(j[0]) << 4) | hex_value(j[1]);
-    j += 2;
-  }
-}
 
 node_id::data::~data() {
   // nop
 }
 
-bool node_id::data::valid() const {
-  auto is_zero = [](uint8_t x) { return x == 0; };
-  return pid_ != 0 && !std::all_of(host_.begin(), host_.end(), is_zero);
+node_id::default_data::default_data() : pid_(0) {
+  memset(host_.data(), 0, host_.size());
+}
+
+node_id::default_data::default_data(uint32_t pid, const host_id_type& host)
+  : pid_(pid), host_(host) {
+  // nop
 }
 
 namespace {
@@ -139,42 +57,144 @@ std::atomic<uint8_t> system_id;
 
 } // <anonymous>
 
-// initializes singleton
-intrusive_ptr<node_id::data> node_id::data::create_singleton() {
+node_id node_id::default_data::local(const actor_system_config&) {
   CAF_LOG_TRACE("");
   auto ifs = detail::get_mac_addresses();
   std::vector<std::string> macs;
   macs.reserve(ifs.size());
-  for (auto& i : ifs) {
+  for (auto& i : ifs)
     macs.emplace_back(std::move(i.second));
-  }
   auto hd_serial_and_mac_addr = join(macs, "") + detail::get_root_uuid();
-  node_id::host_id_type nid;
-  detail::ripemd_160(nid, hd_serial_and_mac_addr);
-  // TODO: redesign network layer, make node_id an opaque type, etc.
-  // this hack enables multiple actor systems in a single process
-  // by overriding the last byte in the node ID with the actor system "ID"
-  nid.back() = system_id.fetch_add(1);
-  // note: pointer has a ref count of 1 -> implicitly held by detail::singletons
-  intrusive_ptr<data> result;
-  result.reset(new node_id::data(detail::get_process_id(), nid), false);
-  return result;
+  host_id_type hid;
+  detail::ripemd_160(hid, hd_serial_and_mac_addr);
+  // This hack enables multiple actor systems in a single process by overriding
+  // the last byte in the node ID with the actor system "ID".
+  hid.back() = system_id.fetch_add(1);
+  return make_node_id(detail::get_process_id(), hid);
 }
 
-uint32_t node_id::process_id() const {
-  return data_ ? data_->pid_ : invalid_process_id;
+bool node_id::default_data::valid(const host_id_type& x) noexcept {
+  auto is_zero = [](uint8_t x) { return x == 0; };
+  return !std::all_of(x.begin(), x.end(), is_zero);
 }
 
-const node_id::host_id_type& node_id::host_id() const {
-  return data_ ? data_->host_ : invalid_host_id;
+bool node_id::default_data::valid() const noexcept {
+  return pid_ != 0 && valid(host_);
+}
+
+size_t node_id::default_data::hash_code() const noexcept {
+  // XOR the first few bytes from the node ID and the process ID.
+  auto x = static_cast<size_t>(pid_);
+  auto y = *reinterpret_cast<const size_t*>(host_.data());
+  return x ^ y;
+}
+
+atom_value node_id::default_data::implementation_id() const noexcept {
+  return class_id;
+}
+
+int node_id::default_data::compare(const data& other) const noexcept {
+  if (this == &other)
+    return 0;
+  auto other_id = other.implementation_id();
+  if (class_id != other_id)
+    return caf::compare(class_id, other_id);
+  auto& x = static_cast<const default_data&>(other);
+  if (pid_ != x.pid_)
+    return pid_ < x.pid_ ? -1 : 1;
+  return memcmp(host_.data(), x.host_.data(), host_.size());
+}
+
+void node_id::default_data::print(std::string& dst) const {
+  if (!valid()) {
+    dst += "invalid-node";
+    return;
+  }
+  detail::append_hex(dst, host_);
+  dst += '#';
+  dst += std::to_string(pid_);
+}
+
+error node_id::default_data::serialize(serializer& sink) const {
+  return sink(pid_, host_);
+}
+
+error node_id::default_data::deserialize(deserializer& source) {
+  return source(pid_, host_);
+}
+
+node_id& node_id::operator=(const none_t&) {
+  data_.reset();
+  return *this;
+}
+
+node_id::node_id(intrusive_ptr<data> data) : data_(std::move(data)) {
+  // nop
+}
+
+node_id::~node_id() {
+  // nop
 }
 
 node_id::operator bool() const {
   return static_cast<bool>(data_);
 }
 
+int node_id::compare(const none_t&) const {
+  // Invalid instances are always smaller.
+  return data_ ? 1 : 0;
+}
+
+int node_id::compare(const node_id& other) const noexcept {
+  if (this == &other || data_ == other.data_)
+    return 0;
+  if (data_ == nullptr)
+    return other.data_ == nullptr ? 0 : -1;
+  return other.data_ == nullptr ? 1 : data_->compare(*other.data_);
+}
+
 void node_id::swap(node_id& x) {
   data_.swap(x.data_);
+}
+
+error node_id::serialize(serializer& sink) const {
+  if (data_ && data_->valid()) {
+    if (auto err = sink(data_->implementation_id()))
+      return err;
+    return data_->serialize(sink);
+  }
+  return sink(atom(""));
+}
+
+error node_id::deserialize(deserializer& source) {
+  atom_value impl;
+  if (auto err = source(impl))
+    return err;
+  if (impl == atom("")) {
+    data_.reset();
+    return none;
+  }
+  if (impl == atom("default")) {
+    if (data_ == nullptr || data_->implementation_id() != atom("default"))
+      data_.reset(new default_data);
+    return data_->deserialize(source);
+  }
+  return sec::unknown_type;
+}
+
+error inspect(serializer& sink, const node_id& x) {
+  return x.serialize(sink);
+}
+
+error inspect(deserializer& source, node_id& x) {
+  return x.deserialize(source);
+}
+
+void append_to_string(std::string& str, const node_id& x) {
+  if (x != none)
+    x->print(str);
+  else
+    str += "invalid-node";
 }
 
 std::string to_string(const node_id& x) {
@@ -183,15 +203,28 @@ std::string to_string(const node_id& x) {
   return result;
 }
 
-void append_to_string(std::string& x, const node_id& y) {
-  if (!y) {
-    x += "invalid-node";
-    return;
+node_id make_node_id(uint32_t process_id,
+                     const node_id::default_data::host_id_type& host_id) {
+  auto ptr = make_counted<node_id::default_data>(process_id, host_id);
+  return node_id{std::move(ptr)};
+}
+
+optional<node_id> make_node_id(uint32_t process_id,
+                               const std::string& host_hash) {
+  using node_data = node_id::default_data;
+  if (host_hash.size() != node_data::host_id_size * 2)
+    return none;
+  detail::parser::ascii_to_int<16, uint8_t> xvalue;
+  node_data::host_id_type host_id;
+  for (size_t i = 0; i < node_data::host_id_size; i += 2) {
+    // Read two characters, each representing 4 bytes.
+    if (!isxdigit(host_hash[i]) || !isxdigit(host_hash[i + 1]))
+      return none;
+    host_id[i / 2] = (xvalue(host_hash[i]) << 4) | xvalue(host_hash[i + 1]);
   }
-  detail::append_hex(x, reinterpret_cast<const uint8_t*>(y.host_id().data()),
-                     y.host_id().size());
-  x += '#';
-  x += std::to_string(y.process_id());
+  if (!node_data::valid(host_id))
+    return none;
+  return make_node_id(process_id, host_id);
 }
 
 } // namespace caf

--- a/libcaf_core/src/node_id.cpp
+++ b/libcaf_core/src/node_id.cpp
@@ -182,11 +182,6 @@ node_id::operator bool() const {
   return static_cast<bool>(data_);
 }
 
-int node_id::compare(const none_t&) const {
-  // Invalid instances are always smaller.
-  return data_ ? 1 : 0;
-}
-
 int node_id::compare(const node_id& other) const noexcept {
   if (this == &other || data_ == other.data_)
     return 0;

--- a/libcaf_core/src/uri.cpp
+++ b/libcaf_core/src/uri.cpp
@@ -19,6 +19,7 @@
 #include "caf/uri.hpp"
 
 #include "caf/deserializer.hpp"
+#include "caf/detail/fnv_hash.hpp"
 #include "caf/detail/parser/read_uri.hpp"
 #include "caf/detail/uri_impl.hpp"
 #include "caf/error.hpp"
@@ -62,6 +63,10 @@ const uri::query_map& uri::query() const noexcept {
 
 string_view uri::fragment() const noexcept {
   return impl_->fragment;
+}
+
+size_t uri::hash_code() const noexcept {
+  return detail::fnv_hash(str());
 }
 
 // -- comparison ---------------------------------------------------------------

--- a/libcaf_io/src/basp_broker.cpp
+++ b/libcaf_io/src/basp_broker.cpp
@@ -541,7 +541,7 @@ void basp_broker::set_context(connection_handle hdl) {
                      invalid_actor_id};
     i = ctx
           .emplace(hdl, basp::endpoint_context{basp::await_header, hdr, hdl,
-                                               none, 0, 0, none})
+                                               node_id{}, 0, 0, none})
           .first;
   }
   this_context = &i->second;

--- a/libcaf_io/src/middleman.cpp
+++ b/libcaf_io/src/middleman.cpp
@@ -384,8 +384,8 @@ void middleman::init(actor_system_config& cfg) {
      .add_message_type<connection_handle>("@connection_handle")
      .add_message_type<connection_passivated_msg>("@connection_passivated_msg")
      .add_message_type<acceptor_passivated_msg>("@acceptor_passivated_msg");
-  // compute and set ID for this network node
-  node_id this_node{node_id::data::create_singleton()};
+  // Compute and set ID for this network node.
+  auto this_node = node_id::default_data::local(cfg);
   system().node_.swap(this_node);
   // give config access to slave mode implementation
   cfg.slave_mode_fun = &middleman::exec_slave_mode;

--- a/libcaf_io/src/routing_table.cpp
+++ b/libcaf_io/src/routing_table.cpp
@@ -62,7 +62,7 @@ node_id routing_table::lookup_direct(const connection_handle& hdl) const {
   auto i = direct_by_hdl_.find(hdl);
   if (i != direct_by_hdl_.end())
     return i->second;
-  return none;
+  return {};
 }
 
 optional<connection_handle>
@@ -71,24 +71,24 @@ routing_table::lookup_direct(const node_id& nid) const {
   auto i = direct_by_nid_.find(nid);
   if (i != direct_by_nid_.end())
     return i->second;
-  return none;
+  return {};
 }
 
 node_id routing_table::lookup_indirect(const node_id& nid) const {
   std::unique_lock<std::mutex> guard{mtx_};
   auto i = indirect_.find(nid);
   if (i == indirect_.end())
-    return none;
+    return {};
   if (!i->second.empty())
     return *i->second.begin();
-  return none;
+  return {};
 }
 
 node_id routing_table::erase_direct(const connection_handle& hdl) {
   std::unique_lock<std::mutex> guard{mtx_};
   auto i = direct_by_hdl_.find(hdl);
   if (i == direct_by_hdl_.end())
-    return none;
+    return {};
   direct_by_nid_.erase(i->second);
   node_id result = std::move(i->second);
   direct_by_hdl_.erase(i->first);

--- a/libcaf_io/test/basp.cpp
+++ b/libcaf_io/test/basp.cpp
@@ -129,12 +129,13 @@ public:
     registry_ = &sys.registry();
     registry_->put((*self_)->id(), actor_cast<strong_actor_ptr>(*self_));
     // first remote node is everything of this_node + 1, then +2, etc.
+    auto pid = static_cast<node_id::default_data&>(*this_node_).process_id();
+    auto hid = static_cast<node_id::default_data&>(*this_node_).host_id();
     for (uint32_t i = 0; i < num_remote_nodes; ++i) {
       auto& n = nodes_[i];
-      node_id::host_id_type tmp = this_node_.host_id();
-      for (auto& c : tmp)
-        c = static_cast<uint8_t>(c + i + 1);
-      n.id = node_id{this_node_.process_id() + i + 1, tmp};
+      for (auto& c : hid)
+        ++c;
+      n.id = make_node_id(++pid, hid);
       n.connection = connection_handle::from_int(i + 1);
       new (&n.dummy_actor) scoped_actor(sys);
       // register all pseudo remote actors in the registry

--- a/libcaf_io/test/worker.cpp
+++ b/libcaf_io/test/worker.cpp
@@ -82,9 +82,7 @@ struct fixture : test_coordinator_fixture<> {
   node_id last_hop;
   actor testee;
 
-  fixture()
-    : proxies_backend(sys),
-      proxies(sys, proxies_backend) {
+  fixture() : proxies_backend(sys), proxies(sys, proxies_backend) {
     auto tmp = make_node_id(123, "0011223344556677889900112233445566778899");
     last_hop = unbox(std::move(tmp));
     testee = sys.spawn<lazy_init>(testee_impl);

--- a/libcaf_io/test/worker.cpp
+++ b/libcaf_io/test/worker.cpp
@@ -84,8 +84,9 @@ struct fixture : test_coordinator_fixture<> {
 
   fixture()
     : proxies_backend(sys),
-      proxies(sys, proxies_backend),
-      last_hop(123, "0011223344556677889900112233445566778899") {
+      proxies(sys, proxies_backend) {
+    auto tmp = make_node_id(123, "0011223344556677889900112233445566778899");
+    last_hop = unbox(std::move(tmp));
     testee = sys.spawn<lazy_init>(testee_impl);
     sys.registry().put(testee.id(), testee);
   }

--- a/tools/caf-vec.cpp
+++ b/tools/caf-vec.cpp
@@ -150,7 +150,10 @@ std::istream& operator>>(std::istream& in, node_id& x) {
   string node_hex_id;
   uint32_t pid;
   if (in >> rd_line(node_hex_id, '#') >> pid) {
-    x = node_id{pid, node_hex_id};
+    if (auto nid = make_node_id(pid, node_hex_id))
+      x = std::move(*nid);
+    else
+      in.setstate(std::ios::failbit);
   }
   return in;
 }


### PR DESCRIPTION
Currently, `node_id` hardcodes a process ID and a 20 Byte host ID (hash code). However, we want to switch to URI-based node IDs in `caf_net`. This set of changes make `node_id` opaque and allows users to pick either implementation at runtime.