### PR TITLE
Improve stringification_inspector implementation

### DIFF
--- a/libcaf_core/caf/deep_to_string.hpp
+++ b/libcaf_core/caf/deep_to_string.hpp
@@ -18,47 +18,37 @@
 
 #pragma once
 
-#include <array>
-#include <tuple>
 #include <string>
-#include <utility>
-#include <functional>
-#include <type_traits>
+#include <tuple>
 
-#include "caf/atom.hpp"
-#include "caf/detail/apply_args.hpp"
-#include "caf/detail/type_traits.hpp"
 #include "caf/detail/stringification_inspector.hpp"
 
 namespace caf {
-
-class deep_to_string_t {
-public:
-  constexpr deep_to_string_t() {
-    // nop
-  }
-
-  template <class... Ts>
-  std::string operator()(Ts&&... xs) const {
-    std::string result;
-    detail::stringification_inspector f{result};
-    f(std::forward<Ts>(xs)...);
-    return result;
-  }
-};
 
 /// Unrolls collections such as vectors/maps, decomposes
 /// tuples/pairs/arrays, auto-escapes strings and calls
 /// `to_string` for user-defined types via argument-dependent
 /// loopkup (ADL). Any user-defined type that does not
 /// provide a `to_string` is mapped to `<unprintable>`.
-constexpr deep_to_string_t deep_to_string = deep_to_string_t{};
+template <class... Ts>
+std::string deep_to_string(const Ts&... xs) {
+  std::string result;
+  detail::stringification_inspector f{result};
+  f(xs...);
+  return result;
+}
+
+struct deep_to_string_t {
+  template <class... Ts>
+  std::string operator()(const Ts&... xs) const {
+    return deep_to_string(xs...);
+  }
+};
 
 /// Convenience function for `deep_to_string(std::forward_as_tuple(xs...))`.
 template <class... Ts>
-std::string deep_to_string_as_tuple(Ts&&... xs) {
-  return deep_to_string(std::forward_as_tuple(std::forward<Ts>(xs)...));
+std::string deep_to_string_as_tuple(const Ts&... xs) {
+  return deep_to_string(std::forward_as_tuple(xs...));
 }
 
 } // namespace caf
-

--- a/libcaf_core/caf/detail/parser/read_timespan.hpp
+++ b/libcaf_core/caf/detail/parser/read_timespan.hpp
@@ -46,11 +46,11 @@ void read_timespan(state<Iterator, Sentinel>& ps, Consumer&& consumer,
   struct interim_consumer {
     using value_type = int64_t;
 
-    void value(int64_t y) {
+    void value(value_type y) {
       x = y;
     }
 
-    int64_t x = 0;
+    value_type x = 0;
   };
   interim_consumer ic;
   timespan result;

--- a/libcaf_core/caf/detail/stringification_inspector.hpp
+++ b/libcaf_core/caf/detail/stringification_inspector.hpp
@@ -175,7 +175,6 @@ public:
 
   template <class T>
   enable_if_t<is_iterable<T>::value && !is_map_like<T>::value
-              && !is_inspectable<stringification_inspector, T>::value
               && !std::is_convertible<T, string_view>::value
               && !is_inspectable<stringification_inspector, T>::value
               && !has_to_string<T>::value>

--- a/libcaf_core/caf/detail/stringification_inspector.hpp
+++ b/libcaf_core/caf/detail/stringification_inspector.hpp
@@ -187,7 +187,7 @@ public:
               && !is_iterable<T>::value // pick begin()/end() over peek_all
               && !is_inspectable<stringification_inspector, T>::value
               && !has_to_string<T>::value>
-  consume(T& xs) {
+  consume(const T& xs) {
     result_ += '[';
     xs.peek_all(*this);
     result_ += ']';

--- a/libcaf_core/src/actor_system_config.cpp
+++ b/libcaf_core/src/actor_system_config.cpp
@@ -336,7 +336,7 @@ void print(const config_value::dictionary& xs, indentation indent) {
       cout << indent << kvp.first << " = " << to_string(kvp.second) << '\n';
     }
   }
-};
+}
 
 } // namespace <anonymous>
 

--- a/libcaf_core/src/stringification_inspector.cpp
+++ b/libcaf_core/src/stringification_inspector.cpp
@@ -173,21 +173,18 @@ void stringification_inspector::consume(const char* cstr) {
   result_ += '"';
 }
 
-void stringification_inspector::consume(float x) {
-  result_ += std::to_string(x);
+void stringification_inspector::consume(const std::vector<bool>& xs) {
+  result_ += '[';
+  for (bool x : xs) {
+    sep();
+    consume(x);
+  }
+  result_ += ']';
 }
 
-void stringification_inspector::consume(double x) {
-  result_ += std::to_string(x);
-}
-
-void stringification_inspector::consume(long double x) {
-  result_ += std::to_string(x);
-}
-
-void stringification_inspector::consume(int64_t x) {
+void stringification_inspector::consume_int(int64_t x) {
   if (x >= 0)
-    return consume(static_cast<uint64_t>(x));
+    return consume_int(static_cast<uint64_t>(x));
   result_ += '-';
   auto begin = result_.size();
   result_ += -(x % 10) + '0';
@@ -199,7 +196,7 @@ void stringification_inspector::consume(int64_t x) {
   std::reverse(result_.begin() + begin, result_.end());
 }
 
-void stringification_inspector::consume(uint64_t x) {
+void stringification_inspector::consume_int(uint64_t x) {
   auto begin = result_.size();
   result_ += (x % 10) + '0';
   x /= 10;

--- a/libcaf_core/src/stringification_inspector.cpp
+++ b/libcaf_core/src/stringification_inspector.cpp
@@ -18,7 +18,34 @@
 
 #include "caf/detail/stringification_inspector.hpp"
 
+#include <algorithm>
 #include <ctime>
+
+#include "caf/atom.hpp"
+
+namespace {
+
+void escape(std::string& result, char c) {
+  switch (c) {
+    default:
+      result += c;
+      break;
+    case '\n':
+      result += R"(\n)";
+      break;
+    case '\t':
+      result += R"(\t)";
+      break;
+    case '\\':
+      result += R"(\\)";
+      break;
+    case '"':
+      result += R"(\")";
+      break;
+  }
+}
+
+} // namespace
 
 namespace caf {
 namespace detail {
@@ -36,7 +63,7 @@ void stringification_inspector::sep() {
     }
 }
 
-void stringification_inspector::consume(atom_value& x) {
+void stringification_inspector::consume(atom_value x) {
   result_ += '\'';
   result_ += to_string(x);
   result_ += '\'';
@@ -54,42 +81,54 @@ void stringification_inspector::consume(string_view str) {
   }
   // Escape string.
   result_ += '"';
-  for (char c : str) {
-    switch (c) {
-      default:
-        result_ += c;
-        break;
-      case '\\':
-        result_ += R"(\\)";
-        break;
-      case '"':
-        result_ += R"(\")";
-        break;
-    }
-  }
+  for (char c : str)
+    escape(result_, c);
   result_ += '"';
 }
 
-void stringification_inspector::consume(timespan& x) {
-  auto count = x.count();
-  auto res = [&](const char* suffix) {
-    result_ += std::to_string(count);
-    result_ += suffix;
-  };
-  // Check whether it's nano-, micro-, or milliseconds.
-  for (auto suffix : {"ns", "us", "ms"}) {
-    if (count % 1000 != 0)
-      return res(suffix);
-    count /= 1000;
+void stringification_inspector::consume(timespan x) {
+  auto ns = x.count();
+  if (ns % 1000 > 0) {
+    consume(ns);
+    result_ += "ns";
+    return;
   }
-  // After the loop we only need to differentiate between seconds and minutes.
-  if (count % 60 != 0)
-    return res("s");
-  count /= 60;
-  return res("min");
+  auto us = ns / 1000;
+  if (us % 1000 > 0) {
+    consume(us);
+    result_ += "us";
+    return;
+  }
+  auto ms = us / 1000;
+  if (ms % 1000 > 0) {
+    consume(ms);
+    result_ += "ms";
+    return;
+  }
+  auto s = ms / 1000;
+  if (s % 60 > 0) {
+    consume(s);
+    result_ += "s";
+    return;
+  }
+  auto min = s / 60;
+  if (min % 60 > 0) {
+    consume(min);
+    result_ += "min";
+    return;
+  }
+  auto h = min / 60;
+  if (min % 24 > 0) {
+    consume(h);
+    result_ += "h";
+    return;
+  }
+  auto d = h / 24;
+  consume(d);
+  result_ += "d";
 }
 
-void stringification_inspector::consume(timestamp& x) {
+void stringification_inspector::consume(timestamp x) {
   char buf[64];
   auto y = std::chrono::time_point_cast<timestamp::clock::duration>(x);
   auto z = timestamp::clock::to_time_t(y);
@@ -102,6 +141,73 @@ void stringification_inspector::consume(timestamp& x) {
   if (frac.size() < 3)
     frac.insert(0, 3 - frac.size(), '0');
   result_ += frac;
+}
+
+void stringification_inspector::consume(bool x) {
+  result_ += x ? "true" : "false";
+}
+
+void stringification_inspector::consume(const void* ptr) {
+  result_ += "0x";
+  consume(reinterpret_cast<intptr_t>(ptr));
+}
+
+void stringification_inspector::consume(const char* cstr) {
+  if (cstr == nullptr) {
+    result_ += "<null>";
+    return;
+  }
+  if (cstr[0] == '\0') {
+    result_ += R"("")";
+    return;
+  }
+  if (cstr[0] == '"') {
+    // Assume an already escaped string.
+    result_ += cstr;
+    return;
+  }
+  // Escape string.
+  result_ += '"';
+  for (char c = *cstr++; c != '\0'; c = *cstr++)
+    escape(result_, c);
+  result_ += '"';
+}
+
+void stringification_inspector::consume(float x) {
+  result_ += std::to_string(x);
+}
+
+void stringification_inspector::consume(double x) {
+  result_ += std::to_string(x);
+}
+
+void stringification_inspector::consume(long double x) {
+  result_ += std::to_string(x);
+}
+
+void stringification_inspector::consume(int64_t x) {
+  if (x >= 0)
+    return consume(static_cast<uint64_t>(x));
+  result_ += '-';
+  auto begin = result_.size();
+  result_ += -(x % 10) + '0';
+  x /= 10;
+  while (x != 0) {
+    result_ += -(x % 10) + '0';
+    x /= 10;
+  }
+  std::reverse(result_.begin() + begin, result_.end());
+}
+
+void stringification_inspector::consume(uint64_t x) {
+  auto begin = result_.size();
+  result_ += (x % 10) + '0';
+  x /= 10;
+  while (x != 0) {
+    result_ += (x % 10) + '0';
+    x /= 10;
+  }
+  std::reverse(result_.begin() + begin, result_.end());
 }
 
 } // namespace detail

--- a/libcaf_core/test/deep_to_string.cpp
+++ b/libcaf_core/test/deep_to_string.cpp
@@ -32,16 +32,38 @@ void foobar() {
 
 } // namespace <anonymous>
 
+#define CHECK_DEEP_TO_STRING(val, str) CAF_CHECK_EQUAL(deep_to_string(val), str)
+
 CAF_TEST(timespans) {
-  CAF_CHECK_EQUAL(deep_to_string(timespan{1}), "1ns");
-  CAF_CHECK_EQUAL(deep_to_string(timespan{1000}), "1us");
-  CAF_CHECK_EQUAL(deep_to_string(timespan{1000000}), "1ms");
-  CAF_CHECK_EQUAL(deep_to_string(timespan{1000000000}), "1s");
-  CAF_CHECK_EQUAL(deep_to_string(timespan{60000000000}), "1min");
+  CHECK_DEEP_TO_STRING(timespan{1}, "1ns");
+  CHECK_DEEP_TO_STRING(timespan{1000}, "1us");
+  CHECK_DEEP_TO_STRING(timespan{1000000}, "1ms");
+  CHECK_DEEP_TO_STRING(timespan{1000000000}, "1s");
+  CHECK_DEEP_TO_STRING(timespan{60000000000}, "1min");
+}
+
+CAF_TEST(integer lists) {
+  int carray[] = {1, 2, 3, 4};
+  using array_type = std::array<int, 4>;
+  CHECK_DEEP_TO_STRING(std::list<int>({1, 2, 3, 4}), "[1, 2, 3, 4]");
+  CHECK_DEEP_TO_STRING(std::vector<int>({1, 2, 3, 4}), "[1, 2, 3, 4]");
+  CHECK_DEEP_TO_STRING(std::set<int>({1, 2, 3, 4}), "[1, 2, 3, 4]");
+  CHECK_DEEP_TO_STRING(array_type({{1, 2, 3, 4}}), "[1, 2, 3, 4]");
+  CHECK_DEEP_TO_STRING(carray, "[1, 2, 3, 4]");
+}
+
+CAF_TEST(boolean lists) {
+  bool carray[] = {false, true};
+  using array_type = std::array<bool, 2>;
+  CHECK_DEEP_TO_STRING(std::list<bool>({false, true}), "[false, true]");
+  CHECK_DEEP_TO_STRING(std::vector<bool>({false, true}), "[false, true]");
+  CHECK_DEEP_TO_STRING(std::set<bool>({false, true}), "[false, true]");
+  CHECK_DEEP_TO_STRING(array_type({{false, true}}), "[false, true]");
+  CHECK_DEEP_TO_STRING(carray, "[false, true]");
 }
 
 CAF_TEST(pointers) {
   auto i = 42;
-  CAF_CHECK_EQUAL(deep_to_string(&i), "*42");
-  CAF_CHECK_EQUAL(deep_to_string(foobar), "<fun>");
+  CHECK_DEEP_TO_STRING(&i, "*42");
+  CHECK_DEEP_TO_STRING(foobar, "<fun>");
 }

--- a/libcaf_core/test/message.cpp
+++ b/libcaf_core/test/message.cpp
@@ -272,10 +272,10 @@ CAF_TEST(tuples_to_string) {
 }
 
 CAF_TEST(arrays_to_string) {
-  CAF_CHECK_EQUAL(msg_as_string(s1{}), "((10, 20, 30))");
+  CAF_CHECK_EQUAL(msg_as_string(s1{}), "([10, 20, 30])");
   auto msg2 = make_message(s2{});
   s2 tmp;
   tmp.value[0][1] = 100;
-  CAF_CHECK_EQUAL(to_string(msg2), "(((1, 10), (2, 20), (3, 30), (4, 40)))");
-  CAF_CHECK_EQUAL(msg_as_string(s3{}), "((1, 2, 3, 4))");
+  CAF_CHECK_EQUAL(to_string(msg2), "([[1, 10], [2, 20], [3, 30], [4, 40]])");
+  CAF_CHECK_EQUAL(msg_as_string(s3{}), "([1, 2, 3, 4])");
 }

--- a/libcaf_core/test/serialization.cpp
+++ b/libcaf_core/test/serialization.cpp
@@ -554,7 +554,7 @@ SERIALIZATION_TEST(bool_vector_size_0) {
 
 SERIALIZATION_TEST(bool_vector_size_1) {
   std::vector<bool> xs{true};
-  CAF_CHECK_EQUAL(deep_to_string(xs), "[1]");
+  CAF_CHECK_EQUAL(deep_to_string(xs), "[true]");
   CAF_CHECK_EQUAL(xs, roundtrip(xs));
   CAF_CHECK_EQUAL(xs, msg_roundtrip(xs));
 }
@@ -563,11 +563,14 @@ SERIALIZATION_TEST(bool_vector_size_63) {
   std::vector<bool> xs;
   for (int i = 0; i < 63; ++i)
     xs.push_back(i % 3 == 0);
-  CAF_CHECK_EQUAL(deep_to_string(xs),
-                  "[1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, "
-                  "0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, "
-                  "1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, "
-                  "0, 1, 0, 0]");
+  CAF_CHECK_EQUAL(
+    deep_to_string(xs),
+    "[true, false, false, true, false, false, true, false, false, true, false, "
+    "false, true, false, false, true, false, false, true, false, false, true, "
+    "false, false, true, false, false, true, false, false, true, false, false, "
+    "true, false, false, true, false, false, true, false, false, true, false, "
+    "false, true, false, false, true, false, false, true, false, false, true, "
+    "false, false, true, false, false, true, false, false]");
   CAF_CHECK_EQUAL(xs, roundtrip(xs));
   CAF_CHECK_EQUAL(xs, msg_roundtrip(xs));
 }
@@ -577,10 +580,14 @@ SERIALIZATION_TEST(bool_vector_size_64) {
   for (int i = 0; i < 64; ++i)
     xs.push_back(i % 5 == 0);
   CAF_CHECK_EQUAL(deep_to_string(xs),
-                  "[1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, "
-                  "0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, "
-                  "0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, "
-                  "0, 1, 0, 0, 0]");
+                  "[true, false, false, false, false, true, false, false, "
+                  "false, false, true, false, false, false, false, true, "
+                  "false, false, false, false, true, false, false, false, "
+                  "false, true, false, false, false, false, true, false, "
+                  "false, false, false, true, false, false, false, false, "
+                  "true, false, false, false, false, true, false, false, "
+                  "false, false, true, false, false, false, false, true, "
+                  "false, false, false, false, true, false, false, false]");
   CAF_CHECK_EQUAL(xs, roundtrip(xs));
   CAF_CHECK_EQUAL(xs, msg_roundtrip(xs));
 }
@@ -589,11 +596,14 @@ SERIALIZATION_TEST(bool_vector_size_65) {
   std::vector<bool> xs;
   for (int i = 0; i < 65; ++i)
     xs.push_back(!(i % 7 == 0));
-  CAF_CHECK_EQUAL(deep_to_string(xs),
-                  "[0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, "
-                  "1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, "
-                  "1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, "
-                  "1, 1, 1, 1, 0, 1]");
+  CAF_CHECK_EQUAL(
+    deep_to_string(xs),
+    "[false, true, true, true, true, true, true, false, true, true, true, "
+    "true, true, true, false, true, true, true, true, true, true, false, true, "
+    "true, true, true, true, true, false, true, true, true, true, true, true, "
+    "false, true, true, true, true, true, true, false, true, true, true, true, "
+    "true, true, false, true, true, true, true, true, true, false, true, true, "
+    "true, true, true, true, false, true]");
   CAF_CHECK_EQUAL(xs, roundtrip(xs));
   CAF_CHECK_EQUAL(xs, msg_roundtrip(xs));
 }

--- a/libcaf_core/test/serializer_impl.cpp
+++ b/libcaf_core/test/serializer_impl.cpp
@@ -165,4 +165,4 @@ CAF_TEST(serialize and deserialize with std::vector<uint8_t>) {
   CAF_CHECK_EQUAL(data_to_serialize, deserialized_data);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END();
+CAF_TEST_FIXTURE_SCOPE_END()


### PR DESCRIPTION
- Remove unnecessary `deconst`
- Move more code to the `.cpp` file
- Properly escape tab and newline characters
- Print timespans in the highest resolution possible