### PR TITLE
Use CMAKE_INSTALL_* vars for install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ project(caf C CXX)
 include(CheckCSourceCompiles)
 include(CheckCSourceRuns)
 
+# Set default install paths. 
+# See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
+include(GNUInstallDirs)
+
 get_directory_property(_parent PARENT_DIRECTORY)
 if(_parent)
   set(caf_is_subproject ON)
@@ -407,7 +411,7 @@ endif()
 ################################################################################
 
 # install includes from test
-install(DIRECTORY libcaf_test/caf/ DESTINATION include/caf
+install(DIRECTORY libcaf_test/caf/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/caf
         FILES_MATCHING PATTERN "*.hpp")
 
 # process cmake_uninstall.cmake.in

--- a/cmake/FindCAF.cmake
+++ b/cmake/FindCAF.cmake
@@ -66,7 +66,7 @@ foreach (comp ${CAF_FIND_COMPONENTS})
                   /usr/local/include
                   /opt/local/include
                   /sw/include
-                  ${CMAKE_INSTALL_PREFIX}/include)
+                  ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
       if ("${caf_build_header_path}" STREQUAL "caf_build_header_path-NOTFOUND")
         message(WARNING "Found all.hpp for CAF core, but not build_config.hpp")
         set(CAF_${comp}_FOUND false)
@@ -91,8 +91,8 @@ foreach (comp ${CAF_FIND_COMPONENTS})
                      /usr/local/lib
                      /opt/local/lib
                      /sw/lib
-                     ${CMAKE_INSTALL_PREFIX}/lib
-                     ${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_BUILD_TYPE})
+                     ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
+                     ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${CMAKE_BUILD_TYPE})
       mark_as_advanced(CAF_LIBRARY_${UPPERCOMP})
       if ("${CAF_LIBRARY_${UPPERCOMP}}"
           STREQUAL "CAF_LIBRARY_${UPPERCOMP}-NOTFOUND")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,7 +10,7 @@ macro(add folder name)
                         ${CAF_EXTRA_LDFLAGS}
                         ${CAF_LIBRARIES}
                         ${PTHREAD_LIBRARIES})
-  install(FILES ${folder}/${name}.cpp DESTINATION share/caf/examples/${folder})
+  install(FILES ${folder}/${name}.cpp DESTINATION ${CMAKE_INSTALL_DATADIR}/caf/examples/${folder})
   add_dependencies(${name} all_examples)
 endmacro()
 

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -143,7 +143,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/../cmake/build_config.hpp.in"
                "${CMAKE_CURRENT_BINARY_DIR}/caf/detail/build_config.hpp"
                @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/caf/detail/build_config.hpp"
-        DESTINATION include/caf/detail
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/caf/detail
 )
 list(APPEND LIBCAF_CORE_HDRS
   "${CMAKE_CURRENT_BINARY_DIR}/caf/detail/build_config.hpp"
@@ -167,8 +167,8 @@ if (NOT CAF_BUILD_STATIC_ONLY)
     OUTPUT_NAME caf_core
   )
   install(TARGETS libcaf_core_shared
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   )
   add_dependencies(libcaf_core_shared libcaf_core)
 endif ()
@@ -183,11 +183,11 @@ if (CAF_BUILD_STATIC_ONLY OR CAF_BUILD_STATIC)
     $<INSTALL_INTERFACE:include>
   )
   set_target_properties(libcaf_core_static PROPERTIES OUTPUT_NAME caf_core_static)
-  install(TARGETS libcaf_core_static ARCHIVE DESTINATION lib)
+  install(TARGETS libcaf_core_static ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
   add_dependencies(libcaf_core_static libcaf_core)
 endif ()
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/caf"
-        DESTINATION include
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} 
         FILES_MATCHING PATTERN "*.hpp"
 )

--- a/libcaf_io/CMakeLists.txt
+++ b/libcaf_io/CMakeLists.txt
@@ -65,8 +65,8 @@ if (NOT CAF_BUILD_STATIC_ONLY)
                         VERSION ${CAF_VERSION}
                         OUTPUT_NAME caf_io)
   install(TARGETS libcaf_io_shared
-          RUNTIME DESTINATION bin
-          LIBRARY DESTINATION lib)
+          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
   add_dependencies(libcaf_io_shared libcaf_io)
 endif ()
 
@@ -79,11 +79,11 @@ if (CAF_BUILD_STATIC_ONLY OR CAF_BUILD_STATIC)
     $<INSTALL_INTERFACE:include>
   )
   set_target_properties(libcaf_io_static PROPERTIES OUTPUT_NAME caf_io_static)
-  install(TARGETS libcaf_io_static ARCHIVE DESTINATION lib)
+  install(TARGETS libcaf_io_static ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
   add_dependencies(libcaf_io_static libcaf_io)
 endif ()
 
 # install includes
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/caf
-        DESTINATION include
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         FILES_MATCHING PATTERN "*.hpp")

--- a/libcaf_opencl/CMakeLists.txt
+++ b/libcaf_opencl/CMakeLists.txt
@@ -30,7 +30,7 @@ if(NOT CAF_BUILD_STATIC_ONLY)
                         SOVERSION "${CAF_VERSION}"
                         VERSION "${CAF_VERSION}"
                         OUTPUT_NAME caf_opencl)
-  install(TARGETS libcaf_opencl_shared LIBRARY DESTINATION lib)
+  install(TARGETS libcaf_opencl_shared LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 # build static library only if --build-static or --build-static-only was set
@@ -46,10 +46,10 @@ if(CAF_BUILD_STATIC_ONLY OR CAF_BUILD_STATIC)
     $<INSTALL_INTERFACE:include>
   )
   set_target_properties(libcaf_opencl_static PROPERTIES OUTPUT_NAME caf_opencl_static)
-  install(TARGETS libcaf_opencl_static ARCHIVE DESTINATION lib)
+  install(TARGETS libcaf_opencl_static ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 # install includes
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/caf
-        DESTINATION include
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         FILES_MATCHING PATTERN "*.hpp")

--- a/libcaf_openssl/CMakeLists.txt
+++ b/libcaf_openssl/CMakeLists.txt
@@ -35,9 +35,9 @@ if (NOT CAF_BUILD_STATIC_ONLY)
                         VERSION ${CAF_VERSION}
                         OUTPUT_NAME caf_openssl)
   if (CYGWIN)
-    install(TARGETS libcaf_openssl_shared RUNTIME DESTINATION bin)
+    install(TARGETS libcaf_openssl_shared RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   elseif (NOT WIN32)
-    install(TARGETS libcaf_openssl_shared LIBRARY DESTINATION lib)
+    install(TARGETS libcaf_openssl_shared LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
   endif()
   add_dependencies(libcaf_openssl_shared libcaf_openssl)
 endif ()
@@ -51,7 +51,7 @@ if (CAF_BUILD_STATIC_ONLY OR CAF_BUILD_STATIC)
   set_target_properties(libcaf_openssl_static PROPERTIES
                         OUTPUT_NAME caf_openssl_static)
   if(NOT WIN32)
-    install(TARGETS libcaf_openssl_static ARCHIVE DESTINATION lib)
+    install(TARGETS libcaf_openssl_static ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
   endif()
   add_dependencies(libcaf_openssl_static libcaf_openssl)
 endif ()
@@ -61,6 +61,6 @@ include_directories(. ${INCLUDE_DIRS})
 
 # install includes
 if(NOT WIN32)
-  install(DIRECTORY caf/ DESTINATION include/caf FILES_MATCHING PATTERN "*.hpp")
+  install(DIRECTORY caf/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/caf FILES_MATCHING PATTERN "*.hpp")
 endif()
 

--- a/libcaf_python/CMakeLists.txt
+++ b/libcaf_python/CMakeLists.txt
@@ -53,7 +53,7 @@ if(NOT CAF_NO_PYTHON)
                         ${PTHREAD_LIBRARIES}
                         ${LIBEDIT_LIBRARIES}
                         ${PYTHON_LIBRARIES})
-  install(TARGETS caf-python DESTINATION bin)
+  install(TARGETS caf-python DESTINATION ${CMAKE_INSTALL_BINDIR})
 else()
   add_custom_target(caf-python SOURCES ${CAF_PYTHON_SRCS} ${CAF_PYTHON_HDRS})
 endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,7 +10,7 @@ macro(add name)
                         ${CAF_EXTRA_LDFLAGS}
                         ${CAF_LIBRARIES}
                         ${PTHREAD_LIBRARIES})
-  install(FILES ${name}.cpp DESTINATION share/caf/tools/${folder})
+  install(FILES ${name}.cpp DESTINATION ${CMAKE_INSTALL_DATADIR}/caf/tools/${folder})
   add_dependencies(${name} all_tools)
 endmacro()
 


### PR DESCRIPTION
Updates each `CMakeLists.txt` to use `CMAKE_INSTALL_*` from GNUInstallDirs. This makes it easier to package for package repositories while maintaining user overrides via CMake cache and defines.