### PR TITLE
Add/improve to_string and ostream overloads

### DIFF
--- a/libcaf_core/caf/atom.hpp
+++ b/libcaf_core/caf/atom.hpp
@@ -18,8 +18,9 @@
 
 #pragma once
 
-#include <string>
 #include <functional>
+#include <iosfwd>
+#include <string>
 #include <type_traits>
 
 #include "caf/detail/atom_val.hpp"
@@ -35,7 +36,10 @@ enum class atom_value : uint64_t {
 };
 
 /// @relates atom_value
-std::string to_string(const atom_value& what);
+std::string to_string(atom_value x);
+
+/// @relates atom_value
+std::ostream& operator<<(std::ostream& out, atom_value x);
 
 /// @relates atom_value
 atom_value to_lowercase(atom_value x);

--- a/libcaf_core/caf/dictionary.hpp
+++ b/libcaf_core/caf/dictionary.hpp
@@ -21,8 +21,10 @@
 #include <algorithm>
 #include <iterator>
 #include <map>
+#include <ostream>
 #include <string>
 
+#include "caf/deep_to_string.hpp"
 #include "caf/string_view.hpp"
 
 namespace caf {
@@ -328,6 +330,14 @@ private:
   map_type xs_;
 };
 
+// -- free functions -----------------------------------------------------------
+
+// @relates dictionary
+template <class T>
+std::string to_string(const dictionary<T>& xs) {
+  return deep_to_string(xs.container());
+}
+
 // -- operators ----------------------------------------------------------------
 
 // @relates dictionary
@@ -364,6 +374,12 @@ bool operator>(const dictionary<T>& xs, const dictionary<T>& ys) {
 template <class T>
 bool operator>=(const dictionary<T>& xs, const dictionary<T>& ys) {
   return xs.container() >= ys.container();
+}
+
+// @relates dictionary
+template <class T>
+std::ostream& operator<<(std::ostream& out, const dictionary<T>& xs) {
+  return out << to_string(xs);
 }
 
 } // namespace caf

--- a/libcaf_core/caf/node_id.hpp
+++ b/libcaf_core/caf/node_id.hpp
@@ -223,6 +223,12 @@ private:
   intrusive_ptr<data> data_;
 };
 
+/// Returns whether `x` contains an URI.
+/// @relates node_id
+inline bool wraps_uri(const node_id& x) noexcept {
+  return x && x->implementation_id() == node_id::uri_data::class_id;
+}
+
 /// @relates node_id
 inline bool operator==(const node_id& x, const node_id& y) noexcept {
   return x.compare(y) == 0;

--- a/libcaf_core/src/actor_control_block.cpp
+++ b/libcaf_core/src/actor_control_block.cpp
@@ -114,11 +114,17 @@ namespace {
 
 void append_to_string_impl(std::string& x, const actor_control_block* y) {
   if (y != nullptr) {
-    x += std::to_string(y->aid);
-    x += '@';
-    append_to_string(x, y->nid);
+    if (wraps_uri(y->nid)) {
+      append_to_string(x, y->nid);
+      x += "/id/";
+      x += std::to_string(y->aid);
+    } else {
+      x += std::to_string(y->aid);
+      x += '@';
+      append_to_string(x, y->nid);
+    }
   } else {
-    x += "0@invalid-node";
+    x += "null:pointer";
   }
 }
 

--- a/libcaf_core/src/atom.cpp
+++ b/libcaf_core/src/atom.cpp
@@ -20,6 +20,7 @@
 
 #include <array>
 #include <cstring>
+#include <ostream>
 
 #include "caf/string_view.hpp"
 
@@ -65,10 +66,17 @@ atom_value atom_from_string(string_view x) {
   return static_cast<atom_value>(detail::atom_val(buf.data()));
 }
 
-std::string to_string(const atom_value& x) {
+std::string to_string(atom_value x) {
   atom_value_buf str;
   auto len = decode(str, x);
   return std::string(str.begin(), str.begin() + len);
+}
+
+std::ostream& operator<<(std::ostream& out, atom_value x) {
+  atom_value_buf str;
+  auto len = decode(str, x);
+  out.write(str.data(), len);
+  return out;
 }
 
 int compare(atom_value x, atom_value y) {


### PR DESCRIPTION
- Improve `to_string` output for actors if the local node ID wraps an URI
- Add `to_string` and `std::ostream` support for `dictionary`
- Add `std::ostream` support for `atom_value`