### PR TITLE
Replace Sleep(0) with yield() call on Windows

### DIFF
--- a/libcaf_core/caf/policy/work_stealing.hpp
+++ b/libcaf_core/caf/policy/work_stealing.hpp
@@ -152,8 +152,18 @@ public:
           if (job)
             return job;
         }
-        if (strategies[k].sleep_duration.count() > 0)
+        if (strategies[k].sleep_duration.count() > 0) {
+#ifdef CAF_MSVC
+          // Windows cannot sleep less than 1000 us, so timeout is conveted to 0
+          // inside sleep_for(), but Sleep(0) is dangerous so replace it with yield()
+          if (strategies[k].sleep_duration.count() < 1000)
+            std::this_thread::yield();
+          else
+            std::this_thread::sleep_for(strategies[k].sleep_duration);
+#else
           std::this_thread::sleep_for(strategies[k].sleep_duration);
+#endif
+        }
       }
     }
     // we assume pretty much nothing is going on so we can relax polling

--- a/libcaf_core/caf/policy/work_stealing.hpp
+++ b/libcaf_core/caf/policy/work_stealing.hpp
@@ -155,7 +155,8 @@ public:
         if (strategies[k].sleep_duration.count() > 0) {
 #ifdef CAF_MSVC
           // Windows cannot sleep less than 1000 us, so timeout is conveted to 0
-          // inside sleep_for(), but Sleep(0) is dangerous so replace it with yield()
+          // inside sleep_for(), but Sleep(0) is dangerous so replace it with
+          // yield()
           if (strategies[k].sleep_duration.count() < 1000)
             std::this_thread::yield();
           else
@@ -212,4 +213,3 @@ public:
 
 } // namespace policy
 } // namespace caf
-


### PR DESCRIPTION
We have a problem in following code inside std::this_thread::sleep_for. Default sleep duration for moderate work stealing policy is 50us, but Windows cannot sleep less than 1ms. So inside internals of MSVC STL duration = 50us is converted to 0ms and Sleep(0) is called. According to the blog post of Joe Duffy [Priority-induced starvation: Why Sleep(1) is better than Sleep(0) and the Windows balance set manager](http://joeduffyblog.com/2006/08/22/priorityinduced-starvation-why-sleep1-is-better-than-sleep0-and-the-windows-balance-set-manager/) and information from his book Concurrent Programming on Windows "Sleep
method will conditionally remove the calling thread from the current proces­sor and possibly remove it from the scheduler's runnable queue. If the value of the duration argument is 0, then Windows will only remove the current thread from the processor if there is another thread ready to run with an
equal or higher priority. If there are runnable threads at a lower priority, the calling thread will continue running instead of yielding to the other threads." In this case moderate work stealing could cause another busy-loop cycling. So recomedation is to replace Sleep(0) call with Swi tchToThread(), which could be called using high-level STL call std::this_thread::yield(). Appying this patch made our application at least twice faster.