### PR TITLE
Use fold expression in the data_processor if available

### DIFF
--- a/libcaf_core/caf/data_processor.hpp
+++ b/libcaf_core/caf/data_processor.hpp
@@ -477,7 +477,7 @@ public:
 
 #if defined(__cpp_fold_expressions) && defined(__cpp_if_constexpr)
 
-  template <class... Ts> inline
+  template <class... Ts>
   error operator()(Ts&&... xs) {
     error result;
     auto f = [&result, this](auto&& x) {

--- a/libcaf_core/caf/data_processor.hpp
+++ b/libcaf_core/caf/data_processor.hpp
@@ -475,6 +475,76 @@ public:
     return none;
   }
 
+  static_assert(__cpp_fold_expressions, "C++ fold-expressions required");
+#if __cpp_fold_expressions
+
+  template <class F> inline
+  error safe_callback_action(meta::save_callback_t<F> x) {
+    return Derived::reads_state ? x.fun() : none;
+  }
+
+  template <class F> inline
+  error load_callback_action(meta::load_callback_t<F> x) {
+    return Derived::writes_state ? x.fun() : none;
+  }
+
+  inline
+  error annotation_action(const meta::annotation&) {
+    return none;
+  }
+
+  template<typename T> inline
+  typename std::enable_if<is_allowed_unsafe_message_type<T>::value, error>::type
+  allowed_unsafe_message_type_action(const T&) {
+    return none;
+  }
+
+  template <class T> inline
+  typename std::enable_if<!meta::is_annotation<T>::value && !is_allowed_unsafe_message_type<T>::value, error>::type
+  action(T&& x) {
+    static_assert(Derived::reads_state || (!std::is_rvalue_reference<T&&>::value && !std::is_const<typename std::remove_reference<T>::type>::value), "a loading inspector requires mutable lvalue references");
+    return apply(deconst(x));
+  }
+
+  struct FoldLeft {
+    Derived& derived;
+    error err = none;
+
+    template<class F> inline
+    FoldLeft& operator<<(meta::save_callback_t<F> x) {
+      if (not err) err = derived.safe_callback_action(std::move(x));
+      return *this;
+    }
+    template<class F> inline
+    FoldLeft& operator<<(meta::load_callback_t<F> x) {
+      if (not err) err = derived.load_callback_action(std::move(x));
+      return *this;
+    }
+    inline
+    FoldLeft& operator<<(const meta::annotation& x) {
+      if (not err) err = derived.annotation_action(x);
+      return *this;
+    }
+    template<typename T> inline
+    typename std::enable_if<is_allowed_unsafe_message_type<T>::value, FoldLeft&>::type
+    operator<<(const T& x) {
+      if (not err) err = derived.allowed_unsafe_message_type_action(x);
+      return *this;
+    }
+    template<typename T> inline
+    typename std::enable_if<!meta::is_annotation<T>::value && !is_allowed_unsafe_message_type<T>::value, FoldLeft&>::type
+    operator<<(T&& x) {
+      if (not err) err = derived.action(std::forward<T>(x));
+      return *this;
+    }
+  };
+
+  template <class... Ts> inline
+  error operator()(Ts&&... xs) {
+    return (FoldLeft{dref()} << ... << xs).err;
+  }
+
+#else // __cpp_fold_expressions
   template <class F, class... Ts>
   error operator()(meta::save_callback_t<F> x, Ts&&... xs) {
     // TODO: use `if constexpr` when switching to C++17.
@@ -524,6 +594,7 @@ public:
       return err;
     return dref()(std::forward<Ts>(xs)...);
   }
+#endif // __cpp_fold_expressions
 
 protected:
   virtual error apply_impl(int8_t&) = 0;

--- a/libcaf_core/caf/meta/load_callback.hpp
+++ b/libcaf_core/caf/meta/load_callback.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "caf/meta/annotation.hpp"
 
 namespace caf {
@@ -35,6 +37,12 @@ struct load_callback_t : annotation {
 
   F fun;
 };
+
+template <class T>
+struct is_load_callback : std::false_type {};
+
+template <class F>
+struct is_load_callback<load_callback_t<F>> : std::true_type {};
 
 /// Returns an annotation that allows inspectors to call
 /// user-defined code after performing load operations.

--- a/libcaf_core/caf/meta/save_callback.hpp
+++ b/libcaf_core/caf/meta/save_callback.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "caf/meta/annotation.hpp"
 
 namespace caf {
@@ -35,6 +37,12 @@ struct save_callback_t : annotation {
 
   F fun;
 };
+
+template <class T>
+struct is_save_callback : std::false_type {};
+
+template <class F>
+struct is_save_callback<save_callback_t<F>> : std::true_type {};
 
 /// Returns an annotation that allows inspectors to call
 /// user-defined code after performing save operations.

--- a/libcaf_core/test/optional.cpp
+++ b/libcaf_core/test/optional.cpp
@@ -23,7 +23,6 @@
 
 #include "caf/optional.hpp"
 
-using namespace std;
 using namespace caf;
 
 namespace {

--- a/libcaf_core/test/typed_spawn.cpp
+++ b/libcaf_core/test/typed_spawn.cpp
@@ -31,7 +31,8 @@
 #define ERROR_HANDLER                                                          \
   [&](error& err) { CAF_FAIL(system.render(err)); }
 
-using namespace std;
+using std::string;
+
 using namespace caf;
 
 using passed_atom = caf::atom_constant<caf::atom("passed")>;
@@ -423,7 +424,7 @@ CAF_TEST(event_testee_series) {
     [&](const string& str) {
       result = str;
     },
-    after(chrono::minutes(1)) >> [&] {
+    after(std::chrono::minutes(1)) >> [&] {
       CAF_FAIL("event_testee does not reply");
     }
   );
@@ -435,7 +436,7 @@ CAF_TEST(string_delegator_chain) {
   auto aut = self->spawn<monitored>(string_delegator,
                                     system.spawn(string_reverter),
                                     true);
-  set<string> iface{"caf::replies_to<@str>::with<@str>"};
+  std::set<string> iface{"caf::replies_to<@str>::with<@str>"};
   CAF_CHECK_EQUAL(aut->message_types(), iface);
   self->request(aut, infinite, "Hello World!").receive(
     [](const string& answer) {


### PR DESCRIPTION
Credits to @jokalode who reported #912 and provided the initial fold expression version.

This is a followup to https://github.com/actor-framework/actor-framework/pull/913 that provides a much more efficient implementation to `data_processor::operator()` by avoiding any recursion when compiling CAF for C++ ≥17.