### PR TITLE
Fix excessive buffering in stream stages

### DIFF
--- a/libcaf_core/caf/inbound_path.hpp
+++ b/libcaf_core/caf/inbound_path.hpp
@@ -144,10 +144,10 @@ public:
   /// @param self Points to the parent actor, i.e., sender of the message.
   /// @param queued_items Accumulated size of all batches that are currently
   ///                     waiting in the mailbox.
+  /// @param now Current timestamp.
   /// @param cycle Time between credit rounds.
   /// @param desired_batch_complexity Desired processing time per batch.
   void emit_ack_batch(local_actor* self, int32_t queued_items,
-                      int32_t max_downstream_capacity,
                       actor_clock::time_point now, timespan cycle,
                       timespan desired_batch_complexity);
 

--- a/libcaf_core/src/scheduled_actor.cpp
+++ b/libcaf_core/src/scheduled_actor.cpp
@@ -1156,8 +1156,7 @@ scheduled_actor::advance_streams(actor_clock::time_point now) {
     for (auto& kvp : qs) {
       auto inptr = kvp.second.policy().handler.get();
       auto bs = static_cast<int32_t>(kvp.second.total_task_size());
-      inptr->emit_ack_batch(this, bs, inptr->mgr->out().max_capacity(),
-                            now, cycle, bc);
+      inptr->emit_ack_batch(this, bs, now, cycle, bc);
     }
   }
   return stream_ticks_.next_timeout(now, {max_batch_delay_ticks_,

--- a/libcaf_core/src/stream_manager.cpp
+++ b/libcaf_core/src/stream_manager.cpp
@@ -161,8 +161,7 @@ void stream_manager::advance() {
       // Ignore inbound paths of other managers.
       if (inptr->mgr.get() == this) {
         auto bs = static_cast<int32_t>(kvp.second.total_task_size());
-        inptr->emit_ack_batch(self_, bs, out().max_capacity(), now, interval,
-                              bc);
+        inptr->emit_ack_batch(self_, bs, now, interval, bc);
       }
     }
   }

--- a/libcaf_core/test/native_streaming_classes.cpp
+++ b/libcaf_core/test/native_streaming_classes.cpp
@@ -342,7 +342,7 @@ public:
         for (auto& kvp : qs) {
           auto inptr = kvp.second.policy().handler.get();
           auto bs = static_cast<int32_t>(kvp.second.total_task_size());
-          inptr->emit_ack_batch(this, bs, 30, now(), cycle,
+          inptr->emit_ack_batch(this, bs, now(), cycle,
                                 desired_batch_complexity);
         }
       }


### PR DESCRIPTION
By not considering how many items are currently buffered at a stage, CAF happily hands out infinite credit to upstream stages. By restricting the maximum capacity we communicate upstream by the number of currently cached elements, we achieve the correct behavior.