### PR TITLE
Fix verbosity level with disabled console output

### DIFF
--- a/libcaf_core/src/logger.cpp
+++ b/libcaf_core/src/logger.cpp
@@ -388,6 +388,7 @@ void logger::init(actor_system_config& cfg) {
   } else if (to_lowercase(con_atm) != atom("uncolored")) {
     // Disable console output if neither 'colored' nor 'uncolored' are present.
     cfg_.console_verbosity = CAF_LOG_LEVEL_QUIET;
+    cfg_.verbosity = cfg_.file_verbosity;
   }
 }
 


### PR DESCRIPTION
This bug produces a nasty deadlock in CAF if:
- the default log level is > `quiet`
- the user configures `logger.file-verbosity = 'quiet'`
- the user sets `logger.console = 'none'` (default)

Now, the logger will not spin up its thread (neither terminal nor file output), but `logger::accept` happily returns `true`. Eventually, the ring buffer for the logger is full and the application comes to a grinding halt because no one ever reads from the queue.