### PR TITLE
OpenBSD support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,12 @@ math(EXPR CAF_VERSION_PATCH "${VERSION_INT} % 100")
 # create full version string
 set(CAF_VERSION
     "${CAF_VERSION_MAJOR}.${CAF_VERSION_MINOR}.${CAF_VERSION_PATCH}")
-
+# set the library version for our shared library targets
+if(CMAKE_HOST_SYSTEM_NAME MATCHES "OpenBSD")
+  set(CAF_LIB_VERSION "${CAF_VERSION_MAJOR}.${CAF_VERSION_MINOR}")
+else()
+  set(CAF_LIB_VERSION "${CAF_VERSION}")
+endif()
 
 ################################################################################
 #   set output paths for binaries and libraries if not provided by the user    #

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -181,7 +181,7 @@ if (NOT CAF_BUILD_STATIC_ONLY)
   set_target_properties(libcaf_core_shared
     PROPERTIES
     SOVERSION ${CAF_VERSION}
-    VERSION ${CAF_VERSION}
+    VERSION ${CAF_LIB_VERSION}
     OUTPUT_NAME caf_core
   )
   install(TARGETS libcaf_core_shared

--- a/libcaf_core/caf/config.hpp
+++ b/libcaf_core/caf/config.hpp
@@ -209,6 +209,8 @@
 #  endif
 #elif defined(__FreeBSD__)
 #  define CAF_BSD
+#elif defined(__OpenBSD__)
+#  define CAF_BSD
 #elif defined(__CYGWIN__)
 #  define CAF_CYGWIN
 #elif defined(WIN32) || defined(_WIN32)

--- a/libcaf_io/CMakeLists.txt
+++ b/libcaf_io/CMakeLists.txt
@@ -64,7 +64,7 @@ if (NOT CAF_BUILD_STATIC_ONLY)
   set_target_properties(libcaf_io_shared
                         PROPERTIES
                         SOVERSION ${CAF_VERSION}
-                        VERSION ${CAF_VERSION}
+                        VERSION ${CAF_LIB_VERSION}
                         OUTPUT_NAME caf_io)
   install(TARGETS libcaf_io_shared
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/libcaf_io/src/io/network/interfaces.cpp
+++ b/libcaf_io/src/io/network/interfaces.cpp
@@ -288,8 +288,10 @@ bool interfaces::get_endpoint(const std::string& host, uint16_t port,
   hint.ai_socktype = SOCK_DGRAM;
   if (preferred)
     hint.ai_family = *preferred == protocol::network::ipv4 ? AF_INET : AF_INET6;
+#ifndef __OpenBSD__
   if (hint.ai_family == AF_INET6)
     hint.ai_flags = AI_V4MAPPED;
+#endif
   addrinfo* tmp = nullptr;
   if (getaddrinfo(host.c_str(), port_hint, &hint, &tmp) != 0)
     return false;

--- a/libcaf_io/src/io/network/interfaces.cpp
+++ b/libcaf_io/src/io/network/interfaces.cpp
@@ -288,7 +288,7 @@ bool interfaces::get_endpoint(const std::string& host, uint16_t port,
   hint.ai_socktype = SOCK_DGRAM;
   if (preferred)
     hint.ai_family = *preferred == protocol::network::ipv4 ? AF_INET : AF_INET6;
-#ifndef __OpenBSD__
+#ifdef AI_V4MAPPED
   if (hint.ai_family == AF_INET6)
     hint.ai_flags = AI_V4MAPPED;
 #endif

--- a/libcaf_io/src/io/network/native_socket.cpp
+++ b/libcaf_io/src/io/network/native_socket.cpp
@@ -93,22 +93,17 @@ const int ec_out_of_memory = ENOMEM;
 const int ec_interrupted_syscall = EINTR;
 #endif
 
-// platform-dependent SIGPIPE setup
-#if defined(CAF_MACOS) || defined(CAF_IOS) || defined(CAF_BSD)
-// Use the socket option but no flags to recv/send on macOS/iOS/BSD.
-// (OpenBSD doesn't have SO_NOSIGPIPE)
-#ifndef __OpenBSD__
+// Platform-dependent setup for supressing SIGPIPE.
+#if defined(CAF_MACOS) || defined(CAF_IOS) || defined(__FreeBSD__)
+// Set the SO_NOSIGPIPE socket option on macOS, iOS and FreeBSD.
 const int no_sigpipe_socket_flag = SO_NOSIGPIPE;
-#else
-const int no_sigpipe_socket_flag = 0;
-#endif
 const int no_sigpipe_io_flag = 0;
 #elif defined(CAF_WINDOWS)
 // Do nothing on Windows (SIGPIPE does not exist).
 const int no_sigpipe_socket_flag = 0;
 const int no_sigpipe_io_flag = 0;
 #else
-// Use flags to recv/send on Linux/Android but no socket option.
+// Pass MSG_NOSIGNAL to recv/send on Linux/Android/OpenBSD.
 const int no_sigpipe_socket_flag = 0;
 const int no_sigpipe_io_flag = MSG_NOSIGNAL;
 #endif

--- a/libcaf_io/src/io/network/native_socket.cpp
+++ b/libcaf_io/src/io/network/native_socket.cpp
@@ -96,7 +96,12 @@ const int ec_interrupted_syscall = EINTR;
 // platform-dependent SIGPIPE setup
 #if defined(CAF_MACOS) || defined(CAF_IOS) || defined(CAF_BSD)
 // Use the socket option but no flags to recv/send on macOS/iOS/BSD.
+// (OpenBSD doesn't have SO_NOSIGPIPE)
+#ifndef __OpenBSD__
 const int no_sigpipe_socket_flag = SO_NOSIGPIPE;
+#else
+const int no_sigpipe_socket_flag = 0;
+#endif
 const int no_sigpipe_io_flag = 0;
 #elif defined(CAF_WINDOWS)
 // Do nothing on Windows (SIGPIPE does not exist).

--- a/libcaf_opencl/CMakeLists.txt
+++ b/libcaf_opencl/CMakeLists.txt
@@ -28,7 +28,7 @@ if(NOT CAF_BUILD_STATIC_ONLY)
   set_target_properties(libcaf_opencl_shared
                         PROPERTIES
                         SOVERSION "${CAF_VERSION}"
-                        VERSION "${CAF_VERSION}"
+                        VERSION "${CAF_LIB_VERSION}"
                         OUTPUT_NAME caf_opencl)
   install(TARGETS libcaf_opencl_shared LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()

--- a/libcaf_openssl/CMakeLists.txt
+++ b/libcaf_openssl/CMakeLists.txt
@@ -32,7 +32,7 @@ if (NOT CAF_BUILD_STATIC_ONLY)
   set_target_properties(libcaf_openssl_shared
                         PROPERTIES
                         SOVERSION ${CAF_VERSION}
-                        VERSION ${CAF_VERSION}
+                        VERSION ${CAF_LIB_VERSION}
                         OUTPUT_NAME caf_openssl)
   if (CYGWIN)
     install(TARGETS libcaf_openssl_shared RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Since our friends over in Zeek land [need the CAF-side fix](https://github.com/zeek/zeek/issues/649#issuecomment-548135527), I tried #950 on OpenBSD today. I noticed that many unit test fail due to the missing `AI_V4MAPPED` support. Since fixing this requires non-trivial changes, I'm fleshing out what @douglas-carmichael started

This PR builds on #950, fixes SIGPIPE handling, and makes sure unit tests don't run into `AI_V4MAPPED`-related failures.