### PR TITLE
CMake: Add sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,28 @@ else()
   set(CAF_BUILD_STATIC_RUNTIME no)
 endif()
 
+option(CAF_ENABLE_SANITIZERS "Set to ON to enable the sanitizers")
+
+if ( CAF_ENABLE_SANITIZERS )
+  if ( NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" )
+    message(FATAL_ERROR "CAF_ENABLE_SANITIZERS requires the build type to be set to Debug")
+  endif ()
+
+  if ( NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND
+       NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" )
+
+    message(FATAL_ERROR "CAF_ENABLE_SANITIZERS requires the compiler to be set to Clang")
+  endif ()
+
+  set(sanitizer_flags
+    "-fno-omit-frame-pointer -fsanitize=address,undefined"
+  )
+
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${sanitizer_flags}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${sanitizer_flags}")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${sanitizer_flags}")
+endif ()
+
 # add helper target that simplifies re-running configure
 if(NOT caf_is_subproject)
   add_custom_target(configure COMMAND ${CMAKE_CURRENT_BINARY_DIR}/config.status)


### PR DESCRIPTION
This PR adds a new option named `CAF_ENABLE_SANITIZERS` that turns on the ub and address sanitizers when the build type is set to `Debug` and the selected compiler is Clang.

Related: https://github.com/zeek/broker/pull/77

When the sanitizers are enabled, a number of tests will fail due to either leaks or undefined behaviours.

```
Test project /home/alessandro/Projects/Public/actor-framework/build
        Start   1: actor_clock
  1/128 Test   #1: actor_clock ................................***Failed    0.23 sec
        Start   2: actor_factory
  2/128 Test   #2: actor_factory ..............................***Failed    0.30 sec
        Start   3: actor_lifetime
  3/128 Test   #3: actor_lifetime .............................***Failed    0.22 sec
        Start   4: actor_pool
  4/128 Test   #4: actor_pool .................................***Failed    0.24 sec
        Start   5: actor_profiler
  5/128 Test   #5: actor_profiler .............................   Passed    0.07 sec
        Start   6: actor_registry
  6/128 Test   #6: actor_registry .............................***Failed    0.20 sec
        Start   7: actor_system_config
  7/128 Test   #7: actor_system_config ........................   Passed    0.08 sec
        Start   8: actor_termination
  8/128 Test   #8: actor_termination ..........................***Failed    0.22 sec
        Start   9: aout
  9/128 Test   #9: aout .......................................***Failed    0.23 sec
        Start  10: atom
 10/128 Test  #10: atom .......................................***Failed    0.25 sec
        Start  11: behavior
 11/128 Test  #11: behavior ...................................***Failed    0.21 sec
        Start  12: blocking_actor
 12/128 Test  #12: blocking_actor .............................***Failed    0.37 sec
        Start  13: broadcast_downstream_manager
 13/128 Test  #13: broadcast_downstream_manager ...............***Failed    0.26 sec
        Start  14: byte
 14/128 Test  #14: byte .......................................   Passed    0.08 sec
        Start  15: composable_behavior
 15/128 Test  #15: composable_behavior ........................***Failed    0.22 sec
        Start  16: composition
 16/128 Test  #16: composition ................................***Failed    0.21 sec
        Start  17: config_option
 17/128 Test  #17: config_option ..............................   Passed    0.09 sec
        Start  18: config_option_set
 18/128 Test  #18: config_option_set ..........................   Passed    0.08 sec
        Start  19: config_value
 19/128 Test  #19: config_value ...............................   Passed    0.08 sec
        Start  20: config_value_adaptor
 20/128 Test  #20: config_value_adaptor .......................   Passed    0.07 sec
        Start  21: constructor_attach
 21/128 Test  #21: constructor_attach .........................***Failed    0.21 sec
        Start  22: continuous_streaming
 22/128 Test  #22: continuous_streaming .......................***Failed    0.24 sec
        Start  23: cow_tuple
 23/128 Test  #23: cow_tuple ..................................***Failed    0.21 sec
        Start  24: custom_exception_handler
 24/128 Test  #24: custom_exception_handler ...................***Failed    0.21 sec
        Start  25: decorator.sequencer
 25/128 Test  #25: decorator.sequencer ........................***Failed    0.33 sec
        Start  26: decorator.splitter
 26/128 Test  #26: decorator.splitter .........................***Failed    0.24 sec
        Start  27: deep_to_string
 27/128 Test  #27: deep_to_string .............................   Passed    0.07 sec
        Start  28: detached_actors
 28/128 Test  #28: detached_actors ............................***Failed    0.28 sec
        Start  29: detail.bounds_checker
 29/128 Test  #29: detail.bounds_checker ......................   Passed    0.07 sec
        Start  30: detail.ini_consumer
 30/128 Test  #30: detail.ini_consumer ........................   Passed    0.07 sec
        Start  31: detail.limited_vector
 31/128 Test  #31: detail.limited_vector ......................   Passed    0.07 sec
        Start  32: detail.parse
 32/128 Test  #32: detail.parse ...............................   Passed    0.07 sec
        Start  33: detail.parser.read_atom
 33/128 Test  #33: detail.parser.read_atom ....................   Passed    0.07 sec
        Start  34: detail.parser.read_bool
 34/128 Test  #34: detail.parser.read_bool ....................   Passed    0.07 sec
        Start  35: detail.parser.read_floating_point
 35/128 Test  #35: detail.parser.read_floating_point ..........   Passed    0.07 sec
        Start  36: detail.parser.read_ini
 36/128 Test  #36: detail.parser.read_ini .....................   Passed    0.07 sec
        Start  37: detail.parser.read_number
 37/128 Test  #37: detail.parser.read_number ..................   Passed    0.09 sec
        Start  38: detail.parser.read_number_or_timespan
 38/128 Test  #38: detail.parser.read_number_or_timespan ......   Passed    0.07 sec
        Start  39: detail.parser.read_signed_integer
 39/128 Test  #39: detail.parser.read_signed_integer ..........   Passed    0.07 sec
        Start  40: detail.parser.read_string
 40/128 Test  #40: detail.parser.read_string ..................   Passed    0.07 sec
        Start  41: detail.parser.read_timespan
 41/128 Test  #41: detail.parser.read_timespan ................   Passed    0.07 sec
        Start  42: detail.parser.read_unsigned_integer
 42/128 Test  #42: detail.parser.read_unsigned_integer ........   Passed    0.07 sec
        Start  43: detail.ringbuffer
 43/128 Test  #43: detail.ringbuffer ..........................   Passed    0.08 sec
        Start  44: detail.ripemd_160
 44/128 Test  #44: detail.ripemd_160 ..........................   Passed    0.07 sec
        Start  45: detail.serialized_size
 45/128 Test  #45: detail.serialized_size .....................***Failed    0.20 sec
        Start  46: detail.tick_emitter
 46/128 Test  #46: detail.tick_emitter ........................   Passed    0.07 sec
        Start  47: detail.unique_function
 47/128 Test  #47: detail.unique_function .....................   Passed    0.08 sec
        Start  48: detail.unordered_flat_map
 48/128 Test  #48: detail.unordered_flat_map ..................   Passed    0.07 sec
        Start  49: dictionary
 49/128 Test  #49: dictionary .................................   Passed    0.07 sec
        Start  50: dynamic_spawn
 50/128 Test  #50: dynamic_spawn ..............................***Failed    0.42 sec
        Start  51: expected
 51/128 Test  #51: expected ...................................   Passed    0.08 sec
        Start  52: extract
 52/128 Test  #52: extract ....................................   Passed    0.07 sec
        Start  53: function_view
 53/128 Test  #53: function_view ..............................***Failed    0.25 sec
        Start  54: fused_downstream_manager
 54/128 Test  #54: fused_downstream_manager ...................***Failed    0.22 sec
        Start  55: handles
 55/128 Test  #55: handles ....................................***Failed    0.28 sec
        Start  56: inbound_path
 56/128 Test  #56: inbound_path ...............................   Passed    0.08 sec
        Start  57: inspector
 57/128 Test  #57: inspector ..................................***Failed    0.21 sec
        Start  58: intrusive.drr_cached_queue
 58/128 Test  #58: intrusive.drr_cached_queue .................   Passed    0.08 sec
        Start  59: intrusive.drr_queue
 59/128 Test  #59: intrusive.drr_queue ........................   Passed    0.08 sec
        Start  60: intrusive.fifo_inbox
 60/128 Test  #60: intrusive.fifo_inbox .......................   Passed    0.08 sec
        Start  61: intrusive.lifo_inbox
 61/128 Test  #61: intrusive.lifo_inbox .......................   Passed    0.08 sec
        Start  62: intrusive.task_queue
 62/128 Test  #62: intrusive.task_queue .......................   Passed    0.08 sec
        Start  63: intrusive.wdrr_dynamic_multiplexed_queue
 63/128 Test  #63: intrusive.wdrr_dynamic_multiplexed_queue ...   Passed    0.07 sec
        Start  64: intrusive.wdrr_fixed_multiplexed_queue
 64/128 Test  #64: intrusive.wdrr_fixed_multiplexed_queue .....   Passed    0.07 sec
        Start  65: intrusive_ptr
 65/128 Test  #65: intrusive_ptr ..............................   Passed    0.07 sec
        Start  66: ipv4_address
 66/128 Test  #66: ipv4_address ...............................   Passed    0.08 sec
        Start  67: ipv4_endpoint
 67/128 Test  #67: ipv4_endpoint ..............................***Failed    0.25 sec
        Start  68: ipv4_subnet
 68/128 Test  #68: ipv4_subnet ................................   Passed    0.08 sec
        Start  69: ipv6_address
 69/128 Test  #69: ipv6_address ...............................   Passed    0.07 sec
        Start  70: ipv6_endpoint
 70/128 Test  #70: ipv6_endpoint ..............................***Failed    0.24 sec
        Start  71: ipv6_subnet
 71/128 Test  #71: ipv6_subnet ................................   Passed    0.07 sec
        Start  72: local_group
 72/128 Test  #72: local_group ................................***Failed    0.21 sec
        Start  73: local_migration
 73/128 Test  #73: local_migration ............................   Passed    0.07 sec
        Start  74: logger
 74/128 Test  #74: logger .....................................***Failed    0.20 sec
        Start  75: mailbox_element
 75/128 Test  #75: mailbox_element ............................   Passed    0.08 sec
        Start  76: make_config_value_field
 76/128 Test  #76: make_config_value_field ....................   Passed    0.08 sec
        Start  77: match
 77/128 Test  #77: match ......................................   Passed    0.07 sec
        Start  78: message_operations
 78/128 Test  #78: message_operations .........................   Passed    0.08 sec
        Start  79: message_id
 79/128 Test  #79: message_id .................................   Passed    0.07 sec
        Start  80: message_lifetime
 80/128 Test  #80: message_lifetime ...........................***Failed    0.24 sec
        Start  81: metaprogramming
 81/128 Test  #81: metaprogramming ............................   Passed    0.07 sec
        Start  82: mixin.requester
 82/128 Test  #82: mixin.requester ............................***Failed    0.26 sec
        Start  83: mixin.sender
 83/128 Test  #83: mixin.sender ...............................***Failed    0.21 sec
        Start  84: mock_streaming_classes
 84/128 Test  #84: mock_streaming_classes .....................   Passed    0.07 sec
        Start  85: native_streaming_classes
 85/128 Test  #85: native_streaming_classes ...................***Failed    0.22 sec
        Start  86: optional
 86/128 Test  #86: optional ...................................   Passed    0.07 sec
        Start  87: or_else
 87/128 Test  #87: or_else ....................................***Failed    0.25 sec
        Start  88: pipeline_streaming
 88/128 Test  #88: pipeline_streaming .........................***Failed    0.25 sec
        Start  89: policy.categorized
 89/128 Test  #89: policy.categorized .........................***Failed    0.20 sec
        Start  90: request_timeout
 90/128 Test  #90: request_timeout ............................***Failed    0.22 sec
        Start  91: result
 91/128 Test  #91: result .....................................   Passed    0.08 sec
        Start  92: rtti_pair
 92/128 Test  #92: rtti_pair ..................................   Passed    0.07 sec
        Start  93: runtime_settings_map
 93/128 Test  #93: runtime_settings_map .......................   Passed    0.07 sec
        Start  94: selective_streaming
 94/128 Test  #94: selective_streaming ........................***Failed    0.21 sec
        Start  95: serial_reply
 95/128 Test  #95: serial_reply ...............................***Failed    0.21 sec
        Start  96: serialization
 96/128 Test  #96: serialization ..............................***Failed    0.90 sec
        Start  97: serializer_impl
 97/128 Test  #97: serializer_impl ............................***Failed    0.22 sec
        Start  98: settings
 98/128 Test  #98: settings ...................................   Passed    0.08 sec
        Start  99: simple_timeout
 99/128 Test  #99: simple_timeout .............................***Failed    0.21 sec
        Start 100: span
100/128 Test #100: span .......................................   Passed    0.07 sec
        Start 101: stateful_actor
101/128 Test #101: stateful_actor .............................***Failed    0.26 sec
        Start 102: streambuf
102/128 Test #102: streambuf ..................................   Passed    0.07 sec
        Start 103: string_algorithms
103/128 Test #103: string_algorithms ..........................   Passed    0.07 sec
        Start 104: string_view
104/128 Test #104: string_view ................................   Passed    0.07 sec
        Start 105: sum_type
105/128 Test #105: sum_type ...................................   Passed    0.07 sec
        Start 106: sum_type_token
106/128 Test #106: sum_type_token .............................   Passed    0.07 sec
        Start 107: thread_hook
107/128 Test #107: thread_hook ................................***Failed    0.23 sec
        Start 108: to_string
108/128 Test #108: to_string ..................................   Passed    0.07 sec
        Start 109: type_erased_tuple
109/128 Test #109: type_erased_tuple ..........................   Passed    0.07 sec
        Start 110: typed_response_promise
110/128 Test #110: typed_response_promise .....................***Failed    0.26 sec
        Start 111: typed_spawn
111/128 Test #111: typed_spawn ................................***Failed    0.32 sec
        Start 112: unit
112/128 Test #112: unit .......................................***Failed    0.21 sec
        Start 113: uri
113/128 Test #113: uri ........................................   Passed    0.09 sec
        Start 114: variant
114/128 Test #114: variant ....................................***Failed    0.22 sec
        Start 115: io.basp.message_queue
115/128 Test #115: io.basp.message_queue ......................***Failed    0.21 sec
        Start 116: io.basp_broker
116/128 Test #116: io.basp_broker .............................***Failed    0.34 sec
        Start 117: io.broker
117/128 Test #117: io.broker ..................................***Failed    0.23 sec
        Start 118: io_http_broker
118/128 Test #118: io_http_broker .............................***Failed    0.22 sec
        Start 119: io.network.default_multiplexer
119/128 Test #119: io.network.default_multiplexer .............***Failed    0.21 sec
        Start 120: io.network.ip_endpoint
120/128 Test #120: io.network.ip_endpoint .....................***Failed    0.22 sec
        Start 121: io_receive_buffer
121/128 Test #121: io_receive_buffer ..........................   Passed    0.07 sec
        Start 122: io.remote_actor
122/128 Test #122: io.remote_actor ............................***Failed    0.24 sec
        Start 123: io_dynamic_remote_group
123/128 Test #123: io_dynamic_remote_group ....................***Failed    0.22 sec
        Start 124: io.remote_spawn
124/128 Test #124: io.remote_spawn ............................***Failed    0.23 sec
        Start 125: io.unpublish
125/128 Test #125: io.unpublish ...............................***Failed    0.21 sec
        Start 126: io_basp_worker
126/128 Test #126: io_basp_worker .............................***Failed    0.21 sec
        Start 127: openssl.authentication
127/128 Test #127: openssl.authentication .....................***Failed    0.24 sec
        Start 128: openssl_dynamic_remote_actor
128/128 Test #128: openssl_dynamic_remote_actor ...............   Passed    0.07 sec

52% tests passed, 61 tests failed out of 128

Total Test time (real) =  21.24 sec

The following tests FAILED:
	  1 - actor_clock (Failed)
	  2 - actor_factory (Failed)
	  3 - actor_lifetime (Failed)
	  4 - actor_pool (Failed)
	  6 - actor_registry (Failed)
	  8 - actor_termination (Failed)
	  9 - aout (Failed)
	 10 - atom (Failed)
	 11 - behavior (Failed)
	 12 - blocking_actor (Failed)
	 13 - broadcast_downstream_manager (Failed)
	 15 - composable_behavior (Failed)
	 16 - composition (Failed)
	 21 - constructor_attach (Failed)
	 22 - continuous_streaming (Failed)
	 23 - cow_tuple (Failed)
	 24 - custom_exception_handler (Failed)
	 25 - decorator.sequencer (Failed)
	 26 - decorator.splitter (Failed)
	 28 - detached_actors (Failed)
	 45 - detail.serialized_size (Failed)
	 50 - dynamic_spawn (Failed)
	 53 - function_view (Failed)
	 54 - fused_downstream_manager (Failed)
	 55 - handles (Failed)
	 57 - inspector (Failed)
	 67 - ipv4_endpoint (Failed)
	 70 - ipv6_endpoint (Failed)
	 72 - local_group (Failed)
	 74 - logger (Failed)
	 80 - message_lifetime (Failed)
	 82 - mixin.requester (Failed)
	 83 - mixin.sender (Failed)
	 85 - native_streaming_classes (Failed)
	 87 - or_else (Failed)
	 88 - pipeline_streaming (Failed)
	 89 - policy.categorized (Failed)
	 90 - request_timeout (Failed)
	 94 - selective_streaming (Failed)
	 95 - serial_reply (Failed)
	 96 - serialization (Failed)
	 97 - serializer_impl (Failed)
	 99 - simple_timeout (Failed)
	101 - stateful_actor (Failed)
	107 - thread_hook (Failed)
	110 - typed_response_promise (Failed)
	111 - typed_spawn (Failed)
	112 - unit (Failed)
	114 - variant (Failed)
	115 - io.basp.message_queue (Failed)
	116 - io.basp_broker (Failed)
	117 - io.broker (Failed)
	118 - io_http_broker (Failed)
	119 - io.network.default_multiplexer (Failed)
	120 - io.network.ip_endpoint (Failed)
	122 - io.remote_actor (Failed)
	123 - io_dynamic_remote_group (Failed)
	124 - io.remote_spawn (Failed)
	125 - io.unpublish (Failed)
	126 - io_basp_worker (Failed)
	127 - openssl.authentication (Failed)
Errors while running CTest
```

The full output (with the output of the sanitizers) can be seen by running `ctest -V`