### PR TITLE
Do not use thread_local for MinGW

### DIFF
--- a/libcaf_core/caf/config.hpp
+++ b/libcaf_core/caf/config.hpp
@@ -148,6 +148,9 @@
 #  ifdef __APPLE__
 #    define CAF_NO_THREAD_LOCAL
 #  endif
+#  ifdef __MINGW32__
+#    define CAF_NO_THREAD_LOCAL
+#  endif
 #elif defined(_MSC_VER)
 #  define CAF_MSVC
 #  define CAF_LIKELY(x) x


### PR DESCRIPTION
MinGW's support for thread_local seems to be broken. When used, many unit tests stay in actor_system destructor forever. See also #951 . Without thread_local everything works fine.
This pull request fixes it by disabling thread_local for MinGW.

