### PR TITLE
Denoise gcc build on linux

### DIFF
--- a/libcaf_core/caf/detail/init_fun_factory.hpp
+++ b/libcaf_core/caf/detail/init_fun_factory.hpp
@@ -76,6 +76,7 @@ public:
     if (hook_ != nullptr)
       hook_(self);
     auto dptr = static_cast<Base*>(self);
+    CAF_IGNORE_UNUSED(dptr);
     if constexpr (ReturnsBehavior) {
       auto unbox = [](auto x) -> behavior { return std::move(x.unbox()); };
       if constexpr (args_empty) {

--- a/libcaf_core/caf/detail/init_fun_factory.hpp
+++ b/libcaf_core/caf/detail/init_fun_factory.hpp
@@ -75,8 +75,7 @@ public:
   behavior operator()(local_actor* self) final {
     if (hook_ != nullptr)
       hook_(self);
-    auto dptr = static_cast<Base*>(self);
-    CAF_IGNORE_UNUSED(dptr);
+    [[maybe_unused]] auto dptr = static_cast<Base*>(self);
     if constexpr (ReturnsBehavior) {
       auto unbox = [](auto x) -> behavior { return std::move(x.unbox()); };
       if constexpr (args_empty) {

--- a/libcaf_core/caf/outbound_path.hpp
+++ b/libcaf_core/caf/outbound_path.hpp
@@ -108,7 +108,8 @@ public:
       return;
     CAF_ASSERT(open_credit >= 0);
     CAF_ASSERT(desired_batch_size > 0);
-    CAF_ASSERT(cache.size() <= std::numeric_limits<int32_t>::max());
+    CAF_ASSERT(cache.size()
+               <= static_cast<size_t>(std::numeric_limits<int32_t>::max()));
     auto first = cache.begin();
     auto last
       = first + std::min(open_credit, static_cast<int32_t>(cache.size()));

--- a/libcaf_core/caf/settings.hpp
+++ b/libcaf_core/caf/settings.hpp
@@ -70,7 +70,7 @@ T get_or(const settings& xs, string_view name, T default_value) {
   auto result = get_if<T>(&xs, name);
   if (result)
     return std::move(*result);
-  return std::move(default_value);
+  return default_value;
 }
 
 CAF_CORE_EXPORT std::string


### PR DESCRIPTION
There are some warnings that pop up multiple times during gcc builds on Linux. Hence the build output is cluttered with unnecessary prints.
This PR should fix some of those warnings so the linux build contains less noise.