### PR TITLE
Tweak build scaffold

### DIFF
--- a/cmake/FindCAF.cmake
+++ b/cmake/FindCAF.cmake
@@ -2,7 +2,7 @@
 #
 # Use this module as follows:
 #
-#     find_package(CAF [COMPONENTS <core|io|opencl|...>*] [REQUIRED])
+#     find_package(CAF [COMPONENTS <core|io|openssl|...>*] [REQUIRED])
 #
 # Variables used by this module (they can change the default behaviour and need
 # to be set before calling find_package):
@@ -61,6 +61,7 @@ foreach (comp ${CAF_FIND_COMPONENTS})
                 NAMES
                   caf/detail/build_config.hpp
                 HINTS
+                  ${CAF_ROOT_DIR}
                   ${header_hints}
                   /usr/include
                   /usr/local/include
@@ -71,7 +72,7 @@ foreach (comp ${CAF_FIND_COMPONENTS})
         message(WARNING "Found all.hpp for CAF core, but not build_config.hpp")
         set(CAF_${comp}_FOUND false)
       else()
-        list(APPEND CAF_INCLUDE_DIR_${UPPERCOMP} "${caf_build_header_path}")
+        list(APPEND CAF_INCLUDE_DIRS "${caf_build_header_path}")
       endif()
     endif()
     list(APPEND CAF_INCLUDE_DIRS "${CAF_INCLUDE_DIR_${UPPERCOMP}}")
@@ -145,13 +146,6 @@ if (CAF_openssl_FOUND AND NOT TARGET caf::openssl)
     set_property(TARGET caf::openssl APPEND PROPERTY
       INTERFACE_LINK_LIBRARIES "OpenSSL::SSL")
   endif ()
-endif ()
-if (CAF_opencl_FOUND AND NOT TARGET caf::opencl)
-  add_library(caf::opencl UNKNOWN IMPORTED)
-  set_target_properties(caf::opencl PROPERTIES
-    IMPORTED_LOCATION "${CAF_LIBRARY_OPENCL}"
-    INTERFACE_INCLUDE_DIRECTORIES "${CAF_INCLUDE_DIR_OPENCL}"
-    INTERFACE_LINK_LIBRARIES "caf::core")
 endif ()
 if (CAF_test_FOUND AND NOT TARGET caf::test)
   add_library(caf::test INTERFACE IMPORTED)

--- a/configure
+++ b/configure
@@ -82,7 +82,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --dev-mode                  sets --build-type=debug, --no-examples,
                                 --no-tools, --with-runtime-checks,
                                 --log-level=trace, and
-                                --sanitizers=address,undefined
+                                --with-sanitizers=address,undefined
 
   Influential Environment Variables (only on first invocation):
     CXX                         C++ compiler command


### PR DESCRIPTION
This PR fixes a bug in the `FindCAF.cmake` that lead to not finding the `build_config.hpp`, throws out an unused openCL reference and fixes a typo in `configure`.