### PR TITLE
Enable compact list notation in config files

### DIFF
--- a/libcaf_core/caf/detail/parser/chars.hpp
+++ b/libcaf_core/caf/detail/parser/chars.hpp
@@ -38,7 +38,11 @@ constexpr bool in_whitelist(char whitelist, char ch) {
 }
 
 inline bool in_whitelist(const char* whitelist, char ch) {
-  return strchr(whitelist, ch) != nullptr;
+  // Note: using strchr breaks if `ch == '\0'`.
+  for (char c = *whitelist++; c != '\0'; c = *whitelist++)
+    if (c == ch)
+      return true;
+  return false;
 }
 
 inline bool in_whitelist(bool (*filter)(char), char ch) {

--- a/libcaf_core/caf/detail/parser/fsm.hpp
+++ b/libcaf_core/caf/detail/parser/fsm.hpp
@@ -273,15 +273,27 @@
 
 #endif // CAF_MSVC
 
-/// Makes a transition into another state if the `statement` is true.
+/// Enables a transition into another state if the `statement` is true.
 #define transition_if(statement, ...)                                          \
   if (statement) {                                                             \
     transition(__VA_ARGS__)                                                    \
   }
 
-/// Makes an epsiolon transition into another state if the `statement` is true.
+/// Enables a transition if the constexpr `statement` is true.
+#define transition_static_if(statement, ...)                                   \
+  if constexpr (statement) {                                                   \
+    transition(__VA_ARGS__)                                                    \
+  }
+
+/// Enables an epsiolon transition if the `statement` is true.
 #define epsilon_if(statement, ...)                                             \
   if (statement) {                                                             \
+    epsilon(__VA_ARGS__)                                                       \
+  }
+
+/// Enables an epsiolon transition if the constexpr `statement` is true.
+#define epsilon_static_if(statement, ...)                                      \
+  if constexpr (statement) {                                                   \
     epsilon(__VA_ARGS__)                                                       \
   }
 
@@ -292,9 +304,23 @@
     fsm_transition(__VA_ARGS__)                                                \
   }
 
+/// Makes an transition transition into another FSM if `statement` is true,
+/// resuming at state `target`.
+#define fsm_transition_static_if(statement, ...)                               \
+  if constexpr (statement) {                                                   \
+    fsm_transition(__VA_ARGS__)                                                \
+  }
+
 /// Makes an epsilon transition into another FSM if `statement` is true,
 /// resuming at state `target`.
 #define fsm_epsilon_if(statement, ...)                                         \
   if (statement) {                                                             \
+    fsm_epsilon(__VA_ARGS__)                                                   \
+  }
+
+/// Makes an epsilon transition into another FSM if `statement` is true,
+/// resuming at state `target`.
+#define fsm_epsilon_static_if(statement, ...)                                  \
+  if constexpr (statement) {                                                   \
     fsm_epsilon(__VA_ARGS__)                                                   \
   }

--- a/libcaf_core/caf/detail/parser/read_floating_point.hpp
+++ b/libcaf_core/caf/detail/parser/read_floating_point.hpp
@@ -112,7 +112,8 @@ void read_floating_point(State& ps, Consumer&& consumer,
   start();
   unstable_state(init) {
     epsilon_if(start_value == none, regular_init)
-    epsilon(after_dec)
+    epsilon(after_dec, "eE.")
+    epsilon(after_dot, any_char)
   }
   state(regular_init) {
     transition(regular_init, " \t")

--- a/libcaf_core/caf/pec.hpp
+++ b/libcaf_core/caf/pec.hpp
@@ -72,7 +72,9 @@ enum class pec : uint8_t {
   repeated_field_name,
   /// Stopped while reading a user-defined type with one or more missing
   /// mandatory fields.
-  missing_field,
+  missing_field = 20,
+  /// Parsing a range statement ('n..m' or 'n..m..step') failed.
+  invalid_range_expression,
 };
 
 /// @relates pec

--- a/libcaf_core/test/detail/parser/read_ini.cpp
+++ b/libcaf_core/test/detail/parser/read_ini.cpp
@@ -126,8 +126,9 @@ some-other-bool=false
 some-list=[
 ; here we have some list entries
 123,
+  1..3,
   23 ; twenty-three!
-  ,
+  ,2..4..2,
   "abc",
   'def', ; some comment and a trailing comma
 ]
@@ -179,7 +180,12 @@ const auto ini0_log = make_log(
     "key: some-list",
     "[",
       "value (integer): 123",
+      "value (integer): 1",
+      "value (integer): 2",
+      "value (integer): 3",
       "value (integer): 23",
+      "value (integer): 2",
+      "value (integer): 4",
       "value (string): \"abc\"",
       "value (atom): 'def'",
     "]",

--- a/libcaf_core/test/detail/parser/read_number.cpp
+++ b/libcaf_core/test/detail/parser/read_number.cpp
@@ -341,4 +341,9 @@ CAF_TEST(ranges can use signed integers) {
   CHECK_RANGE("-2..+2..+2", -2, 0, 2);
 }
 
+CAF_TEST(the parser rejects invalid step values) {
+  CAF_CHECK_EQUAL(r("-2..+2..-2"), pec::invalid_range_expression);
+  CAF_CHECK_EQUAL(r("+2..-2..+2"), pec::invalid_range_expression);
+}
+
 CAF_TEST_FIXTURE_SCOPE_END()

--- a/libcaf_core/test/detail/parser/read_number.cpp
+++ b/libcaf_core/test/detail/parser/read_number.cpp
@@ -341,9 +341,18 @@ CAF_TEST(ranges can use signed integers) {
   CHECK_RANGE("-2..+2..+2", -2, 0, 2);
 }
 
+#define CHECK_ERR(expr, enum_value)                                            \
+  if (auto res = r(expr)) {                                                    \
+    CAF_FAIL("expected expression to produce to an error");                    \
+  } else {                                                                     \
+    auto& err = res.error();                                                   \
+    CAF_CHECK_EQUAL(err.category(), atom("parser"));                           \
+    CAF_CHECK_EQUAL(err.code(), static_cast<uint8_t>(enum_value));             \
+  }
+
 CAF_TEST(the parser rejects invalid step values) {
-  CAF_CHECK_EQUAL(r("-2..+2..-2"), pec::invalid_range_expression);
-  CAF_CHECK_EQUAL(r("+2..-2..+2"), pec::invalid_range_expression);
+  CHECK_ERR("-2..+2..-2", pec::invalid_range_expression);
+  CHECK_ERR("+2..-2..+2", pec::invalid_range_expression);
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()

--- a/libcaf_core/test/detail/parser/read_number.cpp
+++ b/libcaf_core/test/detail/parser/read_number.cpp
@@ -36,13 +36,23 @@ using namespace caf;
 
 namespace {
 
-struct numbers_parser_consumer {
+struct number_consumer {
   variant<int64_t, double> x;
-  inline void value(double y) {
+  void value(double y) {
     x = y;
   }
-  inline void value(int64_t y) {
+  void value(int64_t y) {
     x = y;
+  }
+};
+
+struct range_consumer {
+  std::vector<int64_t> xs;
+  void value(double) {
+    CAF_FAIL("range consumer called with a double");
+  }
+  void value(int64_t y) {
+    xs.emplace_back(y);
   }
 };
 
@@ -53,6 +63,10 @@ struct res_t {
     // nop
   }
 };
+
+std::string to_string(const res_t& x) {
+  return caf::visit([](auto& y) { return deep_to_string(y); }, x.val);
+}
 
 bool operator==(const res_t& x, const res_t& y) {
   if (x.val.index() != y.val.index())
@@ -70,12 +84,23 @@ bool operator==(const res_t& x, const res_t& y) {
 
 struct numbers_parser {
   res_t operator()(string_view str) {
-    numbers_parser_consumer f;
+    number_consumer f;
     string_parser_state res{str.begin(), str.end()};
     detail::parser::read_number(res, f);
     if (res.code == pec::success)
       return f.x;
     return res.code;
+  }
+};
+
+struct range_parser {
+  expected<std::vector<int64_t>> operator()(string_view str) {
+    range_consumer f;
+    string_parser_state res{str.begin(), str.end()};
+    detail::parser::read_number(res, f, std::true_type{}, std::true_type{});
+    if (res.code == pec::success)
+      return std::move(f.xs);
+    return make_error(res);
   }
 };
 
@@ -92,6 +117,7 @@ res(T x) {
 
 struct fixture {
   numbers_parser p;
+  range_parser r;
 };
 
 } // namespace
@@ -205,12 +231,18 @@ CAF_TEST(floating point numbers) {
   CHECK_NUMBER(0.0);
   CHECK_NUMBER(.0);
   CHECK_NUMBER(0.);
+  CHECK_NUMBER(1.1);
+  CHECK_NUMBER(.1);
+  CHECK_NUMBER(1.);
   CHECK_NUMBER(0.123);
   CHECK_NUMBER(.123);
   CHECK_NUMBER(123.456);
   CHECK_NUMBER(-0.0);
   CHECK_NUMBER(-.0);
   CHECK_NUMBER(-0.);
+  CHECK_NUMBER(-1.1);
+  CHECK_NUMBER(-.1);
+  CHECK_NUMBER(-1.);
   CHECK_NUMBER(-0.123);
   CHECK_NUMBER(-.123);
   CHECK_NUMBER(-123.456);
@@ -267,6 +299,46 @@ CAF_TEST(fractional mantissa with negative exponent) {
   CHECK_NUMBER(-42.001e-3);
   CHECK_NUMBER(-42001e-6);
   CHECK_NUMBER(-42.0001e-5);
+}
+
+#define CHECK_RANGE(expr, ...)                                                 \
+  CAF_CHECK_EQUAL(r(expr), std::vector<int64_t>({__VA_ARGS__}))
+
+CAF_TEST(a range from n to n is just n) {
+  CHECK_RANGE("0..0", 0);
+  CHECK_RANGE("1..1", 1);
+  CHECK_RANGE("2..2", 2);
+  CHECK_RANGE("101..101", 101);
+  CHECK_RANGE("101..101..1", 101);
+  CHECK_RANGE("101..101..2", 101);
+  CHECK_RANGE("101..101..-1", 101);
+  CHECK_RANGE("101..101..-2", 101);
+}
+
+CAF_TEST(ranges are either ascending or descending) {
+  CHECK_RANGE("0..1", 0, 1);
+  CHECK_RANGE("0..2", 0, 1, 2);
+  CHECK_RANGE("0..3", 0, 1, 2, 3);
+  CHECK_RANGE("3..0", 3, 2, 1, 0);
+  CHECK_RANGE("3..1", 3, 2, 1);
+  CHECK_RANGE("3..2", 3, 2);
+}
+
+CAF_TEST(ranges can use positive step values) {
+  CHECK_RANGE("2..6..2", 2, 4, 6);
+  CHECK_RANGE("3..8..3", 3, 6);
+}
+
+CAF_TEST(ranges can use negative step values) {
+  CHECK_RANGE("6..2..-2", 6, 4, 2);
+  CHECK_RANGE("8..3..-3", 8, 5);
+}
+
+CAF_TEST(ranges can use signed integers) {
+  CHECK_RANGE("+2..+6..+2", 2, 4, 6);
+  CHECK_RANGE("+6..+2..-2", 6, 4, 2);
+  CHECK_RANGE("+2..-2..-2", 2, 0, -2);
+  CHECK_RANGE("-2..+2..+2", -2, 0, 2);
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()


### PR DESCRIPTION
Adds support for `from..to..step` syntax (borrowed form `bash` & friends) in config files (steps are optional). Particularly useful for defining affinity groups (see https://github.com/actor-framework/actor-framework/pull/980).

Two motivating examples:
- `[1..3]` expands to `[1, 2, 3]`
- `[4..-4..-2]` expands to `[4, 2, 0,- 2, -4]`