### PR TITLE
Fix issues with XCode CMake Generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -667,6 +667,8 @@ if(NOT CAF_NO_SUMMARY)
         "\n"
         "\nSource directory:      ${CMAKE_CURRENT_SOURCE_DIR}"
         "\nBuild directory:       ${CMAKE_CURRENT_BINARY_DIR}"
+        "\nExecutable path:       ${EXECUTABLE_OUTPUT_PATH}"
+        "\nLibrary path:          ${LIBRARY_OUTPUT_PATH}"
         "\nInstall prefix:        ${CMAKE_INSTALL_PREFIX}"
         "\nGenerator:             ${CMAKE_GENERATOR}"
         "\n"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ include(CheckCSourceRuns)          # Check whether compiler produces binaries
 include(GNUInstallDirs)            # Sets default install paths
 include(GenerateExportHeader)      # Auto-generates dllexport macros
 
+# -- project-specific includes ------------------------------------------------------------------
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(XcodeSpecifics)
+
 # -- check whether we are running as CMake subdirectory ------------------------
 
 get_directory_property(_parent PARENT_DIRECTORY)
@@ -268,20 +272,17 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
                         "./configure to choose a build directory and "
                         "initialize the build configuration.")
 endif()
-# set module path appropriately
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-# set binary output path if not defined by user
-if(NOT EXECUTABLE_OUTPUT_PATH)
-  set(EXECUTABLE_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/bin")
-endif()
-# set library output path if not defined by user, but always set
-# library output path to binary output path for Xcode projects
-if(CMAKE_GENERATOR STREQUAL "Xcode")
-  set(LIBRARY_OUTPUT_PATH "${EXECUTABLE_OUTPUT_PATH}")
-elseif(NOT LIBRARY_OUTPUT_PATH)
-  set(LIBRARY_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/lib")
-endif()
 
+if(NOT XCODE)
+  # set binary output path if not defined by user
+  if(NOT EXECUTABLE_OUTPUT_PATH)
+    set(EXECUTABLE_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/bin")
+  endif()
+  # set library output path if not defined by user
+  if(NOT LIBRARY_OUTPUT_PATH)
+    set(LIBRARY_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/lib")
+  endif()
+endif()
 
 ################################################################################
 #                                compiler setup                                #
@@ -666,8 +667,6 @@ if(NOT CAF_NO_SUMMARY)
         "\n"
         "\nSource directory:      ${CMAKE_CURRENT_SOURCE_DIR}"
         "\nBuild directory:       ${CMAKE_CURRENT_BINARY_DIR}"
-        "\nExecutable path:       ${EXECUTABLE_OUTPUT_PATH}"
-        "\nLibrary path:          ${LIBRARY_OUTPUT_PATH}"
         "\nInstall prefix:        ${CMAKE_INSTALL_PREFIX}"
         "\nGenerator:             ${CMAKE_GENERATOR}"
         "\n"

--- a/cmake/XcodeSpecifics.cmake
+++ b/cmake/XcodeSpecifics.cmake
@@ -1,0 +1,38 @@
+#  -*- mode: cmake; coding: utf-8; indent-tabs-mode: nil; -*-
+#
+# Specifics of the Xcode generator
+#
+#########################################################################
+#
+# FUNCTION: xcode_assert_target_not_empty(target)
+#
+# If `target` was defined in conjunction with an object library
+# (`TARGET_OBJECTS`), then the Xcode build system may delete the
+# generated `target` artefact during the build. This occurs, when
+# there are no regular sources in the `target`.
+#
+# Calling this function will generate a dummy source file, to make
+# sure that the SOURCES property of `target` contains at least one
+# regular source file.
+#
+# Applies only under the Xcode generator. For all other generators,
+# the function does nothing.
+#
+# If `target` is not a valid target, does nothing.
+#
+function(xcode_assert_target_not_empty target)
+  if(XCODE)
+    if(TARGET ${target})
+      set(dummy_content "namespace { [[maybe_unused]] auto dummy = 0; }\n")
+      set(dummy_location "${CMAKE_CURRENT_BINARY_DIR}/src/${target}_dummy.cpp")
+      file(GENERATE OUTPUT "${dummy_location}" CONTENT "${dummy_content}")
+      if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.1)
+        target_sources(${target} PRIVATE "${dummy_location}")
+      else()
+        set_property(TARGET ${target} APPEND PROPERTY SOURCES "${dummy_location}")
+      endif()
+    else(TARGET ${target})
+      message(WARNING "xcode_assert_target_not_empty(): Not a target: ${target}")
+    endif(TARGET ${target})
+  endif(XCODE)
+endfunction(xcode_assert_target_not_empty)

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -284,6 +284,8 @@ add_library(libcaf_core_obj OBJECT ${CAF_CORE_SOURCES} ${CAF_CORE_HEADERS})
 
 add_library(libcaf_core $<TARGET_OBJECTS:libcaf_core_obj>)
 
+xcode_assert_target_not_empty(libcaf_core)
+
 add_library(caf::core ALIAS libcaf_core)
 
 if(BUILD_SHARED_LIBS AND NOT WIN32)

--- a/libcaf_io/CMakeLists.txt
+++ b/libcaf_io/CMakeLists.txt
@@ -73,6 +73,8 @@ add_library(libcaf_io_obj OBJECT ${CAF_IO_SOURCES} ${CAF_IO_HEADERS})
 
 add_library(libcaf_io $<TARGET_OBJECTS:libcaf_io_obj>)
 
+xcode_assert_target_not_empty(libcaf_io)
+
 add_library(caf::io ALIAS libcaf_io)
 
 if(BUILD_SHARED_LIBS AND NOT WIN32)

--- a/libcaf_openssl/CMakeLists.txt
+++ b/libcaf_openssl/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(libcaf_openssl_obj OBJECT ${CAF_OPENSSL_SOURCES} ${CAF_OPENSSL_HEADE
 
 add_library(libcaf_openssl $<TARGET_OBJECTS:libcaf_openssl_obj>)
 
+xcode_assert_target_not_empty(libcaf_openssl)
+
 add_library(caf::openssl ALIAS libcaf_openssl)
 
 if(BUILD_SHARED_LIBS AND NOT WIN32)


### PR DESCRIPTION
The CMake Xcode generator does not like targets that consist solely of `TARGET_OBJECTS` from an object library.

This pull request introduces a utility function `xcode_assert_target_not_empty` to create a simple default source file when using the Xcode generator with "objects only" targets.

Also, ignores deprecated build variables `EXECUTABLE_OUTPUT_PATH` and `LIBRARY_OUTPUT_PATH` when using the Xcode generator.