### PR TITLE
netinet/ip.h needs sys/types.h on FreeBSD gcc architectures

### DIFF
--- a/libcaf_io/src/io/network/default_multiplexer.cpp
+++ b/libcaf_io/src/io/network/default_multiplexer.cpp
@@ -63,11 +63,11 @@
 #  include <cerrno>
 #  include <fcntl.h>
 #  include <netdb.h>
+#  include <sys/types.h>
 #  include <netinet/in.h>
 #  include <netinet/ip.h>
 #  include <netinet/tcp.h>
 #  include <sys/socket.h>
-#  include <sys/types.h>
 #  include <unistd.h>
 #  ifdef CAF_POLL_MULTIPLEXER
 #    include <poll.h>

--- a/libcaf_io/src/io/network/ip_endpoint.cpp
+++ b/libcaf_io/src/io/network/ip_endpoint.cpp
@@ -30,6 +30,7 @@
 #  include <ws2tcpip.h>
 #  include <ws2ipdef.h>
 #else
+#  include <sys/types.h>
 #  include <arpa/inet.h>
 #  include <cerrno>
 #  include <netinet/in.h>

--- a/libcaf_io/src/io/network/native_socket.cpp
+++ b/libcaf_io/src/io/network/native_socket.cpp
@@ -47,6 +47,7 @@
 #  include <arpa/inet.h>
 #  include <cerrno>
 #  include <fcntl.h>
+#  include <sys/types.h>
 #  include <netinet/in.h>
 #  include <netinet/ip.h>
 #  include <netinet/tcp.h>


### PR DESCRIPTION
Changes from https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=242908