### PR TITLE
Fix compiler error caused by function hiding

### DIFF
--- a/libcaf_core/caf/fused_downstream_manager.hpp
+++ b/libcaf_core/caf/fused_downstream_manager.hpp
@@ -212,6 +212,8 @@ public:
     return i->second.ptr;
   }
 
+  using downstream_manager::close;
+
   void close() override {
     CAF_LOG_TRACE(CAF_ARG(paths_));
     for (auto ptr : ptrs_)


### PR DESCRIPTION
I ran into this compiler error with Broker. One cannot close a path on a fused downstream manager, because it overloads the signature taking no arguments (thereby hiding all other overloads).

(PR is just for documentation and CI)