### PR TITLE
Improve to_string output for caf::error

### DIFF
--- a/libcaf_core/src/actor_system_config.cpp
+++ b/libcaf_core/src/actor_system_config.cpp
@@ -431,7 +431,8 @@ timespan actor_system_config::stream_tick_duration() const noexcept {
   return timespan{ns_count};
 }
 std::string actor_system_config::render(const error& err) {
-  std::string msg;
+  if (!err)
+    return "none";
   switch (static_cast<uint64_t>(err.category())) {
     case atom_uint("system"):
       return render_sec(err.code(), err.category(), err.context());
@@ -439,8 +440,11 @@ std::string actor_system_config::render(const error& err) {
       return render_exit_reason(err.code(), err.category(), err.context());
     case atom_uint("parser"):
       return render_pec(err.code(), err.category(), err.context());
+    default:
+      return deep_to_string(meta::type_name("error"), err.code(),
+                            err.category(), meta::omittable_if_empty(),
+                            err.context());
   }
-  return "unknown-error";
 }
 
 std::string actor_system_config::render_sec(uint8_t x, atom_value,

--- a/libcaf_core/src/error.cpp
+++ b/libcaf_core/src/error.cpp
@@ -18,6 +18,7 @@
 
 #include "caf/error.hpp"
 
+#include "caf/actor_system_config.hpp"
 #include "caf/config.hpp"
 #include "caf/deep_to_string.hpp"
 #include "caf/deserializer.hpp"
@@ -166,10 +167,7 @@ error error::apply(const inspect_fun& f) {
 }
 
 std::string to_string(const error& x) {
-  if (!x)
-    return "none";
-  return deep_to_string(meta::type_name("error"), x.code(), x.category(),
-                        meta::omittable_if_empty(), x.context());
+  return actor_system_config::render(x);
 }
 
 } // namespace caf


### PR DESCRIPTION
Basically, the `to_string` output of `error` required users to have the CAF sources at hand to interpret the error codes. This change gives users nice output for all builtin error categories (but still falls back to the cryptic version for user-defined errors).