### PR TITLE
Report errors while connecting two CAF nodes

### DIFF
--- a/libcaf_core/caf/sec.hpp
+++ b/libcaf_core/caf/sec.hpp
@@ -126,6 +126,17 @@ enum class sec : uint8_t {
   socket_operation_failed = 45,
   /// A resource is temporarily unavailable or would block.
   unavailable_or_would_block,
+  /// Connection refused because of incompatible CAF versions.
+  incompatible_versions,
+  /// Connection refused because of incompatible application IDs.
+  incompatible_application_ids,
+  /// The middleman received a malformed BASP message from another node.
+  malformed_basp_message,
+  /// The middleman closed a connection because it failed to serialize or
+  /// deserialize a payload.
+  serializing_basp_payload_failed,
+  /// The middleman closed a connection to itself or an already connected node.
+  redundant_connection,
   /// Resolving a path on a remote node failed.
   remote_lookup_failed,
   /// Serialization failed because actor_system::tracing_context is null.

--- a/libcaf_io/CMakeLists.txt
+++ b/libcaf_io/CMakeLists.txt
@@ -6,12 +6,14 @@ file(GLOB_RECURSE CAF_IO_HEADERS "caf/*.hpp")
 
 enum_to_string("caf/io/basp/message_type.hpp" "message_type_to_string.cpp")
 enum_to_string("caf/io/network/operation.hpp" "operation_to_string.cpp")
+enum_to_string("caf/io/basp/connection_state.hpp" "connection_state_to_string.cpp")
 
 # -- list cpp files ------------------------------------------------------------
 
 set(CAF_IO_SOURCES
   "${CMAKE_BINARY_DIR}/message_type_to_string.cpp"
   "${CMAKE_BINARY_DIR}/operation_to_string.cpp"
+  "${CMAKE_BINARY_DIR}/connection_state_to_string.cpp"
   src/detail/socket_guard.cpp
   src/io/abstract_broker.cpp
   src/io/basp/header.cpp

--- a/libcaf_io/caf/io/basp/connection_state.hpp
+++ b/libcaf_io/caf/io/basp/connection_state.hpp
@@ -18,11 +18,15 @@
 
 #pragma once
 
+#include "caf/sec.hpp"
+#include "caf/detail/io_export.hpp"
+
 namespace caf::io::basp {
 
 /// @addtogroup BASP
 
-/// Denotes the state of a connection between to BASP nodes.
+/// Denotes the state of a connection between two BASP nodes. Overlaps with
+/// `sec` (these states get converted to an error by the BASP instance).
 enum connection_state {
   /// Indicates that a connection is established and this node is
   /// waiting for the next BASP header.
@@ -31,15 +35,54 @@ enum connection_state {
   /// and is waiting for the data.
   await_payload,
   /// Indicates that this connection no longer exists.
-  close_connection
+  close_connection,
+  /// See `sec::incompatible_versions`.
+  incompatible_versions,
+  /// See `sec::incompatible_application_ids`.
+  incompatible_application_ids,
+  /// See `sec::malformed_basp_message`.
+  malformed_basp_message,
+  /// See `sec::serializing_basp_payload_failed`.
+  serializing_basp_payload_failed,
+  /// See `sec::redundant_connection`.
+  redundant_connection,
+  /// See `sec::no_route_to_receiving_node`.
+  no_route_to_receiving_node,
 };
 
+/// Returns whether the connection state requries a shutdown of the socket
+/// connection.
 /// @relates connection_state
-inline std::string to_string(connection_state x) {
-  return x == await_header
-           ? "await_header"
-           : (x == await_payload ? "await_payload" : "close_connection");
+inline bool requires_shutdown(connection_state x) {
+  // Any enum value other than await_header (0) and await_payload (1) signal the
+  // BASP broker to shutdown the connection.
+  return static_cast<int>(x) > 1;
 }
+
+/// Converts the connection state to a system error code if it holds one of the
+/// overlapping values. Otherwise returns `sec::none`.
+/// @relates connection_state
+inline sec to_sec(connection_state x) {
+  switch (x) {
+    default:
+      return sec::none;
+    case incompatible_versions:
+      return sec::incompatible_versions;
+    case incompatible_application_ids:
+      return sec::incompatible_application_ids;
+    case malformed_basp_message:
+      return sec::malformed_basp_message;
+    case serializing_basp_payload_failed:
+      return sec::serializing_basp_payload_failed;
+    case redundant_connection:
+      return sec::redundant_connection;
+    case no_route_to_receiving_node:
+      return sec::no_route_to_receiving_node;
+  }
+}
+
+/// @relates connection_state
+CAF_IO_EXPORT std::string to_string(connection_state x);
 
 /// @}
 

--- a/libcaf_io/caf/io/basp/connection_state.hpp
+++ b/libcaf_io/caf/io/basp/connection_state.hpp
@@ -18,8 +18,8 @@
 
 #pragma once
 
-#include "caf/sec.hpp"
 #include "caf/detail/io_export.hpp"
+#include "caf/sec.hpp"
 
 namespace caf::io::basp {
 

--- a/libcaf_io/caf/io/basp/instance.hpp
+++ b/libcaf_io/caf/io/basp/instance.hpp
@@ -221,8 +221,8 @@ public:
     return system().config();
   }
 
-  bool handle(execution_unit* ctx, connection_handle hdl, header& hdr,
-              byte_buffer* payload);
+  connection_state handle(execution_unit* ctx, connection_handle hdl,
+                          header& hdr, byte_buffer* payload);
 
 private:
   void forward(execution_unit* ctx, const node_id& dest_node, const header& hdr,

--- a/libcaf_io/caf/io/basp_broker.hpp
+++ b/libcaf_io/caf/io/basp_broker.hpp
@@ -111,7 +111,7 @@ public:
   void set_context(connection_handle hdl);
 
   /// Cleans up any state for `hdl`.
-  void connection_cleanup(connection_handle hdl);
+  void connection_cleanup(connection_handle hdl, sec code);
 
   /// Sends a basp::down_message message to a remote node.
   void send_basp_down_message(const node_id& nid, actor_id aid, error err);


### PR DESCRIPTION
Connecting two CAF nodes can fail for several reasons:
- unexpected TCP disconnects
- an application ID mismatch
- a CAF version mismatch

Currently, CAF reports all of the above errors as `disconnect_during_handshake`. Masking the true error makes it impossible for users to troubleshoot CAF applications or to respond to errors programmatically. For example, an application may try to reconnect on actual TCP disconnects but there's no point in disconnecting to an incompatible node.

For original context, see https://github.com/zeek/broker/issues/80.

(Note: the branch `topic/basp-error-codes` contains the same fix but branched off from 0.17.3 to be included in CAF 0.17.4.)