### PR TITLE
Fix tables, lists, and nested commands in manual

### DIFF
--- a/doc/tex/Actors.tex
+++ b/doc/tex/Actors.tex
@@ -302,15 +302,15 @@ Blocking actors simply implement their behavior in the function body. The actor
 is done once it returns from that function.
 
 Event-based actors can either return a \lstinline^behavior^
-\see{message-handler} that is used to initialize the actor or explicitly set
-the initial behavior by calling \lstinline^self->become(...)^. Due to the
+\see{message-handler} that is used to initialize the actor or explicitly set the
+initial behavior by calling \lstinline^self->become(...)^. Due to the
 asynchronous, event-based nature of this kind of actor, the function usually
 returns immediately after setting a behavior (message handler) for the
-\emph{next} incoming message. Hence, variables on the stack will be out of
-scope once a message arrives. Managing state in function-based actors can be
-done either via rebinding state with \lstinline^become^, using heap-located
-data referenced via \lstinline^std::shared_ptr^ or by using the ``stateful
-actor'' abstraction~\see{stateful-actor}.
+\emph{next} incoming message. Hence, variables on the stack will be out of scope
+once a message arrives. Managing state in function-based actors can be done
+either via rebinding state with \lstinline^become^, using heap-located data
+referenced via \lstinline^std::shared_ptr^ or by using the \textit{stateful
+actor} abstraction~\see{stateful-actor}.
 
 The following three functions implement the prototypes shown in~\sref{spawn}
 and illustrate one blocking actor and two event-based actors (statically and
@@ -396,8 +396,8 @@ A behavior that combines the behaviors \lstinline^X^, \lstinline^Y^, and
 inheriting from the three classes directly. The class
 \lstinline^composed_behavior^ ensures that the behaviors are concatenated
 correctly. In case one message handler is defined in multiple base types, the
-\emph{first} type in declaration order ``wins''. For example, if \lstinline^X^
-and \lstinline^Y^ both implement the interface
+\emph{first} type in declaration order wins. For example, if \lstinline^X^ and
+\lstinline^Y^ both implement the interface
 \lstinline^replies_to<int,int>::with<int>^, only the handler implemented in
 \lstinline^X^ is active.
 

--- a/doc/tex/ConfiguringActorApplications.tex
+++ b/doc/tex/ConfiguringActorApplications.tex
@@ -121,12 +121,12 @@ for CLI parsing and allows users to abbreviate commonly used option names. The
 third and final argument to \lstinline^add^ is a help text.
 
 The custom \lstinline^config^ class allows end users to set the port for the
-application to 42 with either \lstinline^--port=42^ (long name) or \lstinline^-p
-42^ (short name). The long option name is prefixed by the category when using a
-different category than ``global''. For example, adding the port option to the
-category \lstinline^foo^ means end users have to type \lstinline^--foo.port=42^
-when using the long name. Short names are unaffected by the category, but have
-to be unique.
+application to 42 with either \lstinline^-p 42^ (short name) or
+\lstinline^--port=42^ (long name). The long option name is prefixed by the
+category when using a different category than ``global''. For example, adding
+the port option to the category \lstinline^foo^ means end users have to type
+\lstinline^--foo.port=42^ when using the long name. Short names are unaffected
+by the category, but have to be unique.
 
 Boolean options do not require arguments. The member variable
 \lstinline^server_mode^ is set to \lstinline^true^ if the command line contains

--- a/doc/tex/ConfiguringActorApplications.tex
+++ b/doc/tex/ConfiguringActorApplications.tex
@@ -104,16 +104,16 @@ object \emph{before} initializing an actor system with it.
 \subsection{Command Line Options and INI Configuration Files}
 \label{system-config-options}
 
-CAF organizes program options in categories and parses CLI arguments as well
-as INI files. CLI arguments override values in the INI file which override
+CAF organizes program options in categories and parses CLI arguments as well as
+INI files. CLI arguments override values in the INI file which override
 hard-coded defaults. Users can add any number of custom program options by
 implementing a subtype of \lstinline^actor_system_config^. The example below
-adds three options to the ``global'' category.
+adds three options to the \lstinline^global^ category.
 
 \cppexample[222-234]{remoting/distributed_calculator}
 
-We create a new ``global'' category in  \lstinline^custom_options_}^. Each
-following call to \lstinline^add^ then appends individual options to the
+We create a new \lstinline^global^ category in  \lstinline^custom_options_}^.
+Each following call to \lstinline^add^ then appends individual options to the
 category. The first argument to \lstinline^add^ is the associated variable. The
 second argument is the name for the parameter, optionally suffixed with a
 comma-separated single-character short name. The short name is only considered
@@ -121,12 +121,12 @@ for CLI parsing and allows users to abbreviate commonly used option names. The
 third and final argument to \lstinline^add^ is a help text.
 
 The custom \lstinline^config^ class allows end users to set the port for the
-application to 42 with either \lstinline^--port=42^ (long name) or
-\lstinline^-p 42^ (short name). The long option name is prefixed by the
-category when using a different category than ``global''. For example, adding
-the port option to the category ``foo'' means end users have to type
-\lstinline^--foo.port=42^ when using the long name. Short names are unaffected
-by the category, but have to be unique.
+application to 42 with either \lstinline^--port=42^ (long name) or \lstinline^-p
+42^ (short name). The long option name is prefixed by the category when using a
+different category than ``global''. For example, adding the port option to the
+category \lstinline^foo^ means end users have to type \lstinline^--foo.port=42^
+when using the long name. Short names are unaffected by the category, but have
+to be unique.
 
 Boolean options do not require arguments. The member variable
 \lstinline^server_mode^ is set to \lstinline^true^ if the command line contains
@@ -138,18 +138,18 @@ simplicity. However, this is not required. For example,
 values of the configuration are accessible with \lstinline^get_or^. Note that
 all global options can omit the \lstinline^"global."^ prefix.
 
-CAF adds the program options ``help'' (with short names \lstinline^-h^ and
-\lstinline^-?^) as well as ``long-help'' to the ``global'' category.
+CAF adds the program options \lstinline^help^ (with short names \lstinline^-h^
+and \lstinline^-?^) as well as \lstinline^long-help^ to the \lstinline^global^
+category.
 
 The default name for the INI file is \lstinline^caf-application.ini^. Users can
-change the file name and path by passing \lstinline^--config-file=<path>^ on
-the command line.
+change the file name and path by passing \lstinline^--config-file=<path>^ on the
+command line.
 
-INI files are organized in categories. No value is allowed outside of a
-category (no implicit ``global'' category). The parses uses the following
-syntax:
+INI files are organized in categories. No value is allowed outside of a category
+(no implicit \lstinline^global^ category). The parses uses the following syntax:
 
-\begin{tabular}{p{0.3\textwidth}p{0.65\textwidth}}
+\begin{tabular}{ll}
   \lstinline^key=true^ & is a boolean \\
   \lstinline^key=1^ & is an integer \\
   \lstinline^key=1.0^ & is an floating point number \\
@@ -253,9 +253,10 @@ with \lstinline^std::string^.
 
 Logging is disabled in CAF per default. It can be enabled by setting the
 \lstinline^--with-log-level=^ option of the \lstinline^configure^ script to one
-of ``error'', ``warning'', ``info'', ``debug'', or ``trace'' (from least output
-to most). Alternatively, setting the CMake variable \lstinline^CAF_LOG_LEVEL^
-to 0, 1, 2, 3, or 4 (from least output to most) has the same effect.
+of \lstinline^error^, \lstinline^warning^, \lstinline^info^, \lstinline^debug^,
+or \lstinline^trace^ (from least output to most). Alternatively, setting the
+CMake variable \lstinline^CAF_LOG_LEVEL^ to one of these values has the same
+effect.
 
 All logger-related configuration options listed here and in
 \sref{system-config-options} are silently ignored if logging is disabled.
@@ -266,7 +267,7 @@ All logger-related configuration options listed here and in
 The output file is generated from the template configured by
 \lstinline^logger-file-name^. This template supports the following variables.
 
-\begin{tabular}{|p{0.2\textwidth}|p{0.75\textwidth}|}
+\begin{tabular}{ll}
   \hline
   \textbf{Variable} & \textbf{Output} \\
   \hline
@@ -294,15 +295,15 @@ events via \lstinline^logger-file-format^ and
 \lstinline^logger-console-format^. Note that format modifiers are not supported
 at the moment. The recognized field identifiers are:
 
-\begin{tabular}{|p{0.1\textwidth}|p{0.85\textwidth}|}
+\begin{tabular}{ll}
   \hline
   \textbf{Character} & \textbf{Output} \\
   \hline
-  \texttt{c} & The category/component. This name is defined by the macro \lstinline^CAF_LOG_COMPONENT^. Set this macro before including any CAF header. \\
+  \texttt{c} & The category/component. \\
   \hline
   \texttt{C} & The full qualifier of the current function. For example, the qualifier of \lstinline^void ns::foo::bar()^ is printed as \lstinline^ns.foo^. \\
   \hline
-  \texttt{d} & The date in ISO 8601 format, i.e., \lstinline^"YYYY-MM-DD hh:mm:ss"^. \\
+  \texttt{d} & The date in ISO 8601 format, i.e., \lstinline^"YYYY-MM-DDThh:mm:ss"^. \\
   \hline
   \texttt{F} & The file name. \\
   \hline
@@ -320,7 +321,7 @@ at the moment. The recognized field identifiers are:
   \hline
   \texttt{t} & ID of the current thread. \\
   \hline
-  \texttt{a} & ID of the current actor (or ``actor0'' when not logging inside an actor). \\
+  \texttt{a} & ID of the current actor (or \lstinline^actor0^ when not logging inside an actor). \\
   \hline
   \texttt{\%} & A single percent sign. \\
   \hline

--- a/doc/tex/Introduction.tex
+++ b/doc/tex/Introduction.tex
@@ -27,8 +27,8 @@ and from one node to many nodes. However, the actor model has not yet been
 widely adopted in the native programming domain. With CAF, we contribute a
 library for actor programming in C++ as open-source software to ease native
 development of concurrent as well as distributed systems. In this regard, CAF
-follows the C++ philosophy ``building the highest abstraction possible without
-sacrificing performance''.
+follows the C++ philosophy \textit{building the highest abstraction possible
+without sacrificing performance}.
 
 \subsection{Terminology}
 
@@ -41,10 +41,10 @@ differences when comparing CAF to other actor frameworks.
 \subsubsection{Dynamically Typed Actor}
 
 A dynamically typed actor accepts any kind of message and dispatches on its
-content dynamically at the receiver. This is the ``traditional'' messaging
-style found in implementations like Erlang or Akka. The upside of this approach
-is (usually) faster prototyping and less code. This comes at the cost of
-requiring excessive testing.
+content dynamically at the receiver. This is the traditional messaging style
+found in implementations like Erlang or Akka. The upside of this approach is
+(usually) faster prototyping and less code. This comes at the cost of requiring
+excessive testing.
 
 \subsubsection{Statically Typed Actor}
 


### PR DESCRIPTION
Fixes #1030 and a bunch of other issues with the manual. There are still some warning when building the manual, but this patch at least fixes the big offenders.