### PR TITLE
Add typed view types for messages

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -185,6 +185,7 @@ set(CAF_CORE_TEST_SOURCES
   test/config_option_set.cpp
   test/config_value.cpp
   test/config_value_adaptor.cpp
+  test/const_typed_message_view.cpp
   test/constructor_attach.cpp
   test/continuous_streaming.cpp
   test/cow_tuple.cpp
@@ -272,6 +273,7 @@ set(CAF_CORE_TEST_SOURCES
   test/tracing_data.cpp
   test/type_erased_tuple.cpp
   test/type_id_list.cpp
+  test/typed_message_view.cpp
   test/typed_response_promise.cpp
   test/typed_spawn.cpp
   test/unit.cpp

--- a/libcaf_core/caf/const_typed_message_view.hpp
+++ b/libcaf_core/caf/const_typed_message_view.hpp
@@ -1,0 +1,57 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2019 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include "caf/detail/type_list.hpp"
+#include "caf/message.hpp"
+
+namespace caf {
+
+template <class... Ts>
+class const_typed_message_view {
+public:
+  explicit const_typed_message_view(const message& msg) noexcept
+    : ptr_(msg.cvals().get()) {
+    // nop
+  }
+
+  const_typed_message_view() = delete;
+
+  const_typed_message_view(const const_typed_message_view&) noexcept = default;
+
+  const_typed_message_view& operator=(const const_typed_message_view&) noexcept
+    = default;
+
+  const detail::message_data* operator->() const noexcept {
+    return ptr_;
+  }
+
+private:
+  const detail::message_data* ptr_;
+};
+
+template <size_t Position, class... Ts>
+const auto& get(const const_typed_message_view<Ts...>& x) {
+  static_assert(Position < sizeof...(Ts));
+  using types = detail::type_list<Ts...>;
+  using type = detail::tl_at_t<types, Position>;
+  return *reinterpret_cast<const type*>(x->get(Position));
+}
+
+} // namespace caf

--- a/libcaf_core/caf/typed_message_view.hpp
+++ b/libcaf_core/caf/typed_message_view.hpp
@@ -1,0 +1,56 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2019 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include "caf/detail/type_list.hpp"
+#include "caf/message.hpp"
+
+namespace caf {
+
+template <class... Ts>
+class typed_message_view {
+public:
+  explicit typed_message_view(message& msg) noexcept
+    : ptr_(msg.vals().unshared_ptr()) {
+    // nop
+  }
+
+  typed_message_view() = delete;
+
+  typed_message_view(const typed_message_view&) noexcept = default;
+
+  typed_message_view& operator=(const typed_message_view&) noexcept = default;
+
+  detail::message_data* operator->() noexcept {
+    return ptr_;
+  }
+
+private:
+  detail::message_data* ptr_;
+};
+
+template <size_t Position, class... Ts>
+auto& get(typed_message_view<Ts...>& x) {
+  static_assert(Position < sizeof...(Ts));
+  using types = detail::type_list<Ts...>;
+  using type = detail::tl_at_t<types, Position>;
+  return *reinterpret_cast<type*>(x->get_mutable(Position));
+}
+
+} // namespace caf

--- a/libcaf_core/test/const_typed_message_view.cpp
+++ b/libcaf_core/test/const_typed_message_view.cpp
@@ -1,0 +1,47 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2019 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#define CAF_SUITE const_typed_message_view
+
+#include "caf/const_typed_message_view.hpp"
+
+#include "caf/test/dsl.hpp"
+
+#include "caf/make_message.hpp"
+#include "caf/message.hpp"
+
+using namespace caf;
+
+CAF_TEST(const message views never detach their content) {
+  auto msg1 = make_message(1, 2, 3, "four");
+  auto msg2 = msg1;
+  CAF_REQUIRE(msg1.cvals().get() == msg2.cvals().get());
+  CAF_REQUIRE(msg1.match_elements<int, int, int, std::string>());
+  const_typed_message_view<int, int, int, std::string> view{msg1};
+  CAF_REQUIRE(msg1.cvals().get() == msg2.cvals().get());
+}
+
+CAF_TEST(const message views allow access via get) {
+  auto msg = make_message(1, 2, 3, "four");
+  CAF_REQUIRE(msg.match_elements<int, int, int, std::string>());
+  const_typed_message_view<int, int, int, std::string> view{msg};
+  CAF_CHECK_EQUAL(get<0>(view), 1);
+  CAF_CHECK_EQUAL(get<1>(view), 2);
+  CAF_CHECK_EQUAL(get<2>(view), 3);
+  CAF_CHECK_EQUAL(get<3>(view), "four");
+}

--- a/libcaf_core/test/typed_message_view.cpp
+++ b/libcaf_core/test/typed_message_view.cpp
@@ -1,0 +1,57 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2019 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#define CAF_SUITE typed_message_view
+
+#include "caf/typed_message_view.hpp"
+
+#include "caf/test/dsl.hpp"
+
+#include "caf/make_message.hpp"
+#include "caf/message.hpp"
+
+using namespace caf;
+
+CAF_TEST(message views detach their content) {
+  auto msg1 = make_message(1, 2, 3, "four");
+  auto msg2 = msg1;
+  CAF_REQUIRE(msg1.cvals().get() == msg2.cvals().get());
+  CAF_REQUIRE(msg1.match_elements<int, int, int, std::string>());
+  typed_message_view<int, int, int, std::string> view{msg1};
+  CAF_REQUIRE(msg1.cvals().get() != msg2.cvals().get());
+}
+
+CAF_TEST(message views allow access via get) {
+  auto msg = make_message(1, 2, 3, "four");
+  CAF_REQUIRE(msg.match_elements<int, int, int, std::string>());
+  typed_message_view<int, int, int, std::string> view{msg};
+  CAF_CHECK_EQUAL(get<0>(view), 1);
+  CAF_CHECK_EQUAL(get<1>(view), 2);
+  CAF_CHECK_EQUAL(get<2>(view), 3);
+  CAF_CHECK_EQUAL(get<3>(view), "four");
+}
+
+CAF_TEST(message views allow mutating elements) {
+  auto msg1 = make_message(1, 2, 3, "four");
+  auto msg2 = msg1;
+  CAF_REQUIRE(msg1.match_elements<int, int, int, std::string>());
+  typed_message_view<int, int, int, std::string> view{msg1};
+  get<0>(view) = 10;
+  CAF_CHECK_EQUAL(msg1.get_as<int>(0), 10);
+  CAF_CHECK_EQUAL(msg2.get_as<int>(0), 1);
+}


### PR DESCRIPTION
The typed message view types are a missing puzzle piece for reimplementing the matching based on `type_id_list`.