### PR TITLE
profiled_coordinator.hpp: fix syntax error

### DIFF
--- a/libcaf_core/caf/scheduler/profiled_coordinator.hpp
+++ b/libcaf_core/caf/scheduler/profiled_coordinator.hpp
@@ -116,7 +116,7 @@ public:
 #ifdef RUSAGE_THREAD
       ::getrusage(RUSAGE_THREAD, &ru);
 #else
-      ::getrusage(RUSAGE_SELF, &ru)
+      ::getrusage(RUSAGE_SELF, &ru);
 #endif
       m.usr = to_usec(ru.ru_utime);
       m.sys = to_usec(ru.ru_stime);


### PR DESCRIPTION
Fix af299e7ef8650be6b05152e91ca7a2a6fac3eb14 by adding missing ;

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>