### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ brew install caf --HEAD
 A [Conan](https://conan.io/) recipe for CAF along with pre-built libraries
 for most platforms are available at [bincrafters/caf](https://bintray.com/bincrafters/public-conan/caf%3Abincrafters).
 
+### VCPKG
+
+You can build and install CAF using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager with a single command:
+
+```sh
+vcpkg install caf
+```
+
+The caf port in vcpkg is kept up to date by Microsoft team members and community contributors.
 
 ## Get the Sources
 


### PR DESCRIPTION
CAF is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build caf , ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for caf and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.