### PR TITLE
Various fixes, mostly related to typed_actor_view

### DIFF
--- a/libcaf_core/caf/composed_behavior.hpp
+++ b/libcaf_core/caf/composed_behavior.hpp
@@ -38,8 +38,7 @@ public:
 
   using broker_base = typename handle_type::broker_base;
 
-  using self_pointer =
-    typename detail::tl_apply<signatures, typed_actor_pointer>::type;
+  using self_pointer = typename handle_type::pointer_view;
 
   composed_behavior() : self(nullptr) {
     // nop

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -71,6 +71,7 @@ template <class...> class delegated;
 template <class...> class result;
 template <class...> class typed_actor;
 template <class...> class typed_actor_pointer;
+template <class...> class typed_actor_view;
 template <class...> class typed_event_based_actor;
 template <class...> class typed_response_promise;
 template <class...> class variant;

--- a/libcaf_core/caf/typed_actor.hpp
+++ b/libcaf_core/caf/typed_actor.hpp
@@ -93,6 +93,10 @@ public:
   /// Identifies pointers to instances of this kind of actor.
   using pointer = typed_event_based_actor<Sigs...>*;
 
+  /// Allows a view to an actor implementing this messaging interface without
+  /// knowledge of the actual type..
+  using pointer_view = typed_actor_pointer<Sigs...>;
+
   /// Identifies the base class for this kind of actor.
   using base = typed_event_based_actor<Sigs...>;
 

--- a/libcaf_core/caf/typed_actor_pointer.hpp
+++ b/libcaf_core/caf/typed_actor_pointer.hpp
@@ -29,15 +29,19 @@ public:
   /// Stores the template parameter pack.
   using signatures = detail::type_list<Sigs...>;
 
+  typed_actor_pointer() : view_(nullptr) {
+    // nop
+  }
+
   template <class Supertype>
-  typed_actor_pointer(Supertype* selfptr) : view_(selfptr) {
+  explicit typed_actor_pointer(Supertype* selfptr) : view_(selfptr) {
     using namespace caf::detail;
     static_assert(
       tl_subset_of<type_list<Sigs...>, typename Supertype::signatures>::value,
       "cannot create a pointer view to an unrelated actor type");
   }
 
-  typed_actor_pointer(std::nullptr_t) : view_(nullptr) {
+  explicit typed_actor_pointer(std::nullptr_t) : view_(nullptr) {
     // nop
   }
 

--- a/libcaf_core/caf/typed_actor_view.hpp
+++ b/libcaf_core/caf/typed_actor_view.hpp
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "caf/actor_traits.hpp"
 #include "caf/mixin/requester.hpp"
 #include "caf/mixin/sender.hpp"
 #include "caf/scheduled_actor.hpp"
@@ -101,6 +102,14 @@ public:
     self_->demonitor(x);
   }
 
+  message_id new_request_id(message_priority mp) {
+    return self_->new_request_id(mp);
+  }
+
+  void request_response_timeout(const duration& d, message_id mid) {
+    return self_->request_response_timeout(d, mid);
+  }
+
   response_promise make_response_promise() {
     return self_->make_response_promise();
   }
@@ -112,6 +121,20 @@ public:
               >::type>
   R response(Ts&&... xs) {
     return self_->response(std::forward<Ts>(xs)...);
+  }
+
+  template <class... Ts>
+  void eq_impl(Ts&&... xs) {
+    self_->eq_impl(std::forward<Ts>(xs)...);
+  }
+
+  void add_awaited_response_handler(message_id response_id, behavior bhvr) {
+    return self_->add_awaited_response_handler(response_id, std::move(bhvr));
+  }
+
+  void add_multiplexed_response_handler(message_id response_id, behavior bhvr) {
+    return self_->add_multiplexed_response_handler(response_id,
+                                                   std::move(bhvr));
   }
 
   /// Returns a pointer to the sender of the current message.
@@ -142,6 +165,19 @@ public:
 
 private:
   scheduled_actor* self_;
+};
+
+template <class... Sigs>
+struct actor_traits<typed_actor_view<Sigs...>> {
+  static constexpr bool is_dynamically_typed = false;
+
+  static constexpr bool is_statically_typed = true;
+
+  static constexpr bool is_blocking = false;
+
+  static constexpr bool is_non_blocking = true;
+
+  static constexpr bool is_incomplete = false;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/typed_actor_view.hpp
+++ b/libcaf_core/caf/typed_actor_view.hpp
@@ -22,6 +22,7 @@
 #include "caf/mixin/requester.hpp"
 #include "caf/mixin/sender.hpp"
 #include "caf/scheduled_actor.hpp"
+#include "caf/timespan.hpp"
 #include "caf/typed_actor_view_base.hpp"
 
 namespace caf {
@@ -106,7 +107,7 @@ public:
     return self_->new_request_id(mp);
   }
 
-  void request_response_timeout(const duration& d, message_id mid) {
+  void request_response_timeout(timespan d, message_id mid) {
     return self_->request_response_timeout(d, mid);
   }
 

--- a/libcaf_io/caf/io/middleman.hpp
+++ b/libcaf_io/caf/io/middleman.hpp
@@ -161,6 +161,8 @@ public:
                timespan timeout = timespan{std::chrono::minutes{1}}) {
     if (!nid || name.empty())
       return sec::invalid_argument;
+    if (nid == system().node())
+      return system().spawn<Handle>(std::move(name), std::move(args));
     auto res = remote_spawn_impl(nid, name, args,
                                  system().message_types<Handle>(), timeout);
     if (!res)


### PR DESCRIPTION
- Add many missing member functions to `typed_actor_view` that are required for request/response messaging.
- Add convenience typedef to `typed_actor` to make working with views easier.
- Short-circuit spawns on the local node in `remote_spawn`.