### PR TITLE
Send client handshake immediately

### DIFF
--- a/libcaf_io/src/io/basp/instance.cpp
+++ b/libcaf_io/src/io/basp/instance.cpp
@@ -344,10 +344,8 @@ connection_state instance::handle(execution_unit* ctx, connection_handle hdl,
         CAF_LOG_ERROR("no route to host after server handshake");
         return no_route_to_receiving_node;
       }
-      write_client_handshake(ctx, callee_.get_buffer(path->hdl));
       callee_.learned_new_node_directly(source_node, was_indirect);
       callee_.finalize_handshake(source_node, aid, sigs);
-      flush(*path);
       break;
     }
     case message_type::client_handshake: {

--- a/libcaf_io/src/io/basp_broker.cpp
+++ b/libcaf_io/src/io/basp_broker.cpp
@@ -283,6 +283,9 @@ behavior basp_broker::make_behavior() {
       ctx.callback = rp;
       // await server handshake
       configure_read(hdl, receive_policy::exactly(basp::header_size));
+      // send client handshake
+      instance.write_client_handshake(context(), get_buffer(hdl));
+      flush(hdl);
     },
     [=](delete_atom, const node_id& nid, actor_id aid) {
       CAF_LOG_TRACE(CAF_ARG(nid) << ", " << CAF_ARG(aid));


### PR DESCRIPTION
Sending the client handshake without waiting for the server handshake triggers connection errors early when trying to connect two CAF nodes where one is using SSL and the other does not.

Closes #1061.