### PR TITLE
Enable states with non-default constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,15 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Our manual now uses `reStructuredText` instead of `LaTeX`. We hope this makes
   extending the manual easier and lowers the barrier to entry for new
   contributors.
+- A `stateful_actor` now forwards excess arguments to the `State` rather than to
+  the `Base`. This enables states with non-default constructors. When using
+  `stateful_actor<State>` as pointer type in function-based actors, nothing
+  changes (i.e. the new API is backwards compatible for this case). However,
+  calling `spawn<stateful_actor<State>>(xs...)` now initializes the `State` with
+  the argument pack `xs...` (plus optionally a `self` pointer as first
+  argument). Furthermore, the state class can now provide a `make_behavior`
+  member function to initialize the actor (this has no effect for function-based
+  actors).
 
 ### Removed
 

--- a/examples/message_passing/fan_out_request.cpp
+++ b/examples/message_passing/fan_out_request.cpp
@@ -16,7 +16,6 @@
 #include "caf/function_view.hpp"
 #include "caf/policy/select_all.hpp"
 #include "caf/scoped_actor.hpp"
-#include "caf/stateful_actor.hpp"
 #include "caf/typed_actor.hpp"
 #include "caf/typed_event_based_actor.hpp"
 

--- a/libcaf_core/caf/composable_behavior_based_actor.hpp
+++ b/libcaf_core/caf/composable_behavior_based_actor.hpp
@@ -33,7 +33,9 @@ public:
 
   using super = stateful_actor<State, Base>;
 
-  composable_behavior_based_actor(actor_config& cfg) : super(cfg) {
+  template <class... Ts>
+  explicit composable_behavior_based_actor(actor_config& cfg, Ts&&... xs)
+    : super(cfg, std::forward<Ts>(xs)...) {
     // nop
   }
 

--- a/libcaf_core/caf/detail/type_traits.hpp
+++ b/libcaf_core/caf/detail/type_traits.hpp
@@ -437,6 +437,7 @@ public:
 
 CAF_HAS_MEMBER_TRAIT(size);
 CAF_HAS_MEMBER_TRAIT(data);
+CAF_HAS_MEMBER_TRAIT(make_behavior);
 
 /// Checks whether F is convertible to either `std::function<void (T&)>`
 /// or `std::function<void (const T&)>`.

--- a/libcaf_core/caf/infer_handle.hpp
+++ b/libcaf_core/caf/infer_handle.hpp
@@ -21,7 +21,6 @@
 #include "caf/abstract_composable_behavior.hpp"
 #include "caf/actor.hpp"
 #include "caf/actor_addr.hpp"
-#include "caf/stateful_actor.hpp"
 #include "caf/typed_behavior.hpp"
 
 namespace caf {

--- a/libcaf_core/caf/stateful_actor.hpp
+++ b/libcaf_core/caf/stateful_actor.hpp
@@ -60,12 +60,10 @@ public:
 
   template <class... Ts>
   explicit stateful_actor(actor_config& cfg, Ts&&... xs) : super(cfg) {
-    using pointer = stateful_actor*;
-    if constexpr (std::is_constructible<State, pointer, Ts&&...>::value) {
-      new (&state) State(this, std::forward<Ts>(xs)...);
-    } else {
+    if constexpr (std::is_constructible<State, Ts&&...>::value)
       new (&state) State(std::forward<Ts>(xs)...);
-    }
+    else
+      new (&state) State(this, std::forward<Ts>(xs)...);
   }
 
   ~stateful_actor() override {

--- a/libcaf_core/caf/stateful_actor.hpp
+++ b/libcaf_core/caf/stateful_actor.hpp
@@ -24,88 +24,89 @@
 #include "caf/fwd.hpp"
 #include "caf/sec.hpp"
 
-#include "caf/logger.hpp"
-
 #include "caf/detail/type_traits.hpp"
+
+namespace caf::detail {
+
+/// Conditional base type for `stateful_actor` that overrides `make_behavior` if
+/// `State::make_behavior()` exists.
+template <class State, class Base>
+class stateful_actor_base : public Base {
+public:
+  using Base::Base;
+
+  typename Base::behavior_type make_behavior() override;
+};
+
+/// Evaluates to either `stateful_actor_base<State, Base> `or `Base`, depending
+/// on whether `State::make_behavior()` exists.
+template <class State, class Base>
+using stateful_actor_base_t
+  = std::conditional_t<has_make_behavior_member<State>::value,
+                       stateful_actor_base<State, Base>, Base>;
+
+} // namespace caf::detail
 
 namespace caf {
 
-/// An event-based actor with managed state. The state is constructed
-/// before `make_behavior` will get called and destroyed after the
-/// actor called `quit`. This state management brakes cycles and
-/// allows actors to automatically release resources as soon
+/// An event-based actor with managed state. The state is constructed with the
+/// actor, but destroyed when the actor calls `quit`. This state management
+/// brakes cycles and allows actors to automatically release resources as soon
 /// as possible.
 template <class State, class Base /* = event_based_actor (see fwd.hpp) */>
-class stateful_actor : public Base {
+class stateful_actor : public detail::stateful_actor_base_t<State, Base> {
 public:
+  using super = detail::stateful_actor_base_t<State, Base>;
+
   template <class... Ts>
-  explicit stateful_actor(actor_config& cfg, Ts&&... xs)
-    : Base(cfg, std::forward<Ts>(xs)...), state(state_) {
-    cr_state(this);
+  explicit stateful_actor(actor_config& cfg, Ts&&... xs) : super(cfg) {
+    using pointer = stateful_actor*;
+    if constexpr (std::is_constructible<State, pointer, Ts&&...>::value) {
+      new (&state) State(this, std::forward<Ts>(xs)...);
+    } else {
+      new (&state) State(std::forward<Ts>(xs)...);
+    }
   }
 
   ~stateful_actor() override {
     // nop
   }
 
-  /// Destroys the state of this actor (no further overriding allowed).
-  void on_exit() final {
-    CAF_LOG_TRACE("");
-    state_.~State();
+  /// @copydoc local_actor::on_exit
+  /// @note when overriding this member function, make sure to call
+  ///       `super::on_exit()` in order to clean up the state.
+  void on_exit() override {
+    state.~State();
   }
 
-  const char* name() const final {
-    return get_name(state_);
-  }
-
-  /// A reference to the actor's state.
-  State& state;
-
-  /// @cond PRIVATE
-
-  void initialize() override {
-    Base::initialize();
-  }
-
-  /// @endcond
-
-private:
-  template <class T>
-  typename std::enable_if<std::is_constructible<State, T>::value>::type
-  cr_state(T arg) {
-    new (&state_) State(arg);
-  }
-
-  template <class T>
-  typename std::enable_if<!std::is_constructible<State, T>::value>::type
-  cr_state(T) {
-    new (&state_) State();
-  }
-
-  static const char* unbox_str(const char* str) {
-    return str;
-  }
-
-  template <class U>
-  static const char* unbox_str(const U& str) {
-    return str.c_str();
-  }
-
-  template <class U>
-  typename std::enable_if<detail::has_name<U>::value, const char*>::type
-  get_name(const U& st) const {
-    return unbox_str(st.name);
-  }
-
-  template <class U>
-  typename std::enable_if<!detail::has_name<U>::value, const char*>::type
-  get_name(const U&) const {
-    return Base::name();
+  const char* name() const override {
+    if constexpr (detail::has_name<State>::value) {
+      if constexpr (std::is_convertible<decltype(state.name),
+                                        const char*>::value)
+        return state.name;
+      else
+        return state.name.c_str();
+    } else {
+      return Base::name();
+    }
   }
 
   union {
-    State state_;
+    /// The actor's state. This member lives inside a union since its lifetime
+    /// ends when the actor terminates while the actual actor object lives until
+    /// its reference count drops to zero.
+    State state;
   };
 };
 
 } // namespace caf
+
+namespace caf::detail {
+
+template <class State, class Base>
+typename Base::behavior_type stateful_actor_base<State, Base>::make_behavior() {
+  auto dptr = static_cast<stateful_actor<State, Base>*>(this);
+  return dptr->state.make_behavior();
+}
+
+} // namespace caf::detail

--- a/libcaf_core/caf/type_nr.hpp
+++ b/libcaf_core/caf/type_nr.hpp
@@ -36,6 +36,12 @@
 
 #define CAF_MSG_TYPE_ADD_ATOM(name)                                            \
   struct name {};                                                              \
+  [[maybe_unused]] constexpr bool operator==(name, name) {                     \
+    return true;                                                               \
+  }                                                                            \
+  [[maybe_unused]] constexpr bool operator!=(name, name) {                     \
+    return false;                                                              \
+  }                                                                            \
   template <class Inspector>                                                   \
   auto inspect(Inspector& f, name&) {                                          \
     return f(meta::type_name("caf::" #name));                                  \

--- a/libcaf_core/caf/typed_actor_pointer.hpp
+++ b/libcaf_core/caf/typed_actor_pointer.hpp
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "caf/detail/type_list.hpp"
+#include "caf/detail/type_traits.hpp"
 #include "caf/typed_actor_view.hpp"
 
 namespace caf {
@@ -33,21 +34,53 @@ public:
     // nop
   }
 
-  template <class Supertype>
-  explicit typed_actor_pointer(Supertype* selfptr) : view_(selfptr) {
-    using namespace caf::detail;
-    static_assert(
-      tl_subset_of<type_list<Sigs...>, typename Supertype::signatures>::value,
-      "cannot create a pointer view to an unrelated actor type");
+  template <class Supertype,
+            class = detail::enable_if_t< //
+              detail::tl_subset_of<detail::type_list<Sigs...>,
+                                   typename Supertype::signatures>::value>>
+  typed_actor_pointer(Supertype* selfptr) : view_(selfptr) {
+    // nop
   }
 
-  explicit typed_actor_pointer(std::nullptr_t) : view_(nullptr) {
+  template <class... OtherSigs,
+            class = detail::enable_if_t< //
+              detail::tl_subset_of<detail::type_list<Sigs...>,
+                                   detail::type_list<OtherSigs...>>::value>>
+  typed_actor_pointer(typed_actor_pointer<OtherSigs...> other)
+    : view_(other.internal_ptr()) {
     // nop
   }
 
   typed_actor_pointer(const typed_actor_pointer&) = default;
 
+  explicit typed_actor_pointer(std::nullptr_t) : view_(nullptr) {
+    // nop
+  }
+
   typed_actor_pointer& operator=(const typed_actor_pointer&) = default;
+
+  template <class Supertype>
+  typed_actor_pointer& operator=(Supertype* ptr) {
+    using namespace detail;
+    static_assert(
+      tl_subset_of<type_list<Sigs...>, typename Supertype::signatures>::value,
+      "cannot assign pointer of unrelated actor type");
+    view_.reset(ptr);
+    return *this;
+  }
+
+  template <class... OtherSigs,
+            class = detail::enable_if_t< //
+              detail::tl_subset_of<detail::type_list<Sigs...>,
+                                   detail::type_list<OtherSigs...>>::value>>
+  typed_actor_pointer& operator=(typed_actor_pointer<OtherSigs...> other) {
+    using namespace detail;
+    static_assert(
+      tl_subset_of<type_list<Sigs...>, type_list<OtherSigs...>>::value,
+      "cannot assign pointer of unrelated actor type");
+    view_.reset(other.internal_ptr());
+    return *this;
+  }
 
   typed_actor_view<Sigs...>* operator->() {
     return &view_;
@@ -73,16 +106,6 @@ public:
 
   operator scheduled_actor*() const noexcept {
     return view_.internal_ptr();
-  }
-
-  template <class Supertype>
-  typed_actor_pointer& operator=(Supertype* ptr) {
-    using namespace caf::detail;
-    static_assert(
-      tl_subset_of<type_list<Sigs...>, typename Supertype::signatures>::value,
-      "cannot assign pointer of unrelated actor type");
-    view_ = ptr;
-    return *this;
   }
 
 private:

--- a/libcaf_core/caf/typed_actor_view.hpp
+++ b/libcaf_core/caf/typed_actor_view.hpp
@@ -31,30 +31,24 @@ namespace caf {
 /// Decorates a pointer to a @ref scheduled_actor with a statically typed actor
 /// interface.
 template <class... Sigs>
-class typed_actor_view : public extend<typed_actor_view_base,
-                                       typed_actor_view<Sigs...>>::template
-                                with<mixin::sender, mixin::requester> {
+class typed_actor_view
+  : public extend<typed_actor_view_base, typed_actor_view<Sigs...>>::
+      template with<mixin::sender, mixin::requester> {
 public:
   /// Stores the template parameter pack.
   using signatures = detail::type_list<Sigs...>;
 
   using pointer = scheduled_actor*;
 
-  typed_actor_view(scheduled_actor* ptr) : self_(ptr) {
+  explicit typed_actor_view(scheduled_actor* ptr) : self_(ptr) {
     // nop
-  }
-
-  typed_actor_view& operator=(scheduled_actor* ptr) {
-    self_ = ptr;
-    return *this;
   }
 
   // -- spawn functions --------------------------------------------------------
 
   /// @copydoc local_actor::spawn
   template <class T, spawn_options Os = no_spawn_options, class... Ts>
-  typename infer_handle_from_class<T>::type
-  spawn(Ts&&... xs) {
+  typename infer_handle_from_class<T>::type spawn(Ts&&... xs) {
     return self_->spawn<T, Os>(std::forward<Ts>(xs)...);
   }
 
@@ -66,8 +60,7 @@ public:
 
   /// @copydoc local_actor::spawn
   template <spawn_options Os = no_spawn_options, class F, class... Ts>
-  typename infer_handle_from_fun<F>::type
-  spawn(F fun, Ts&&... xs) {
+  typename infer_handle_from_fun<F>::type spawn(F fun, Ts&&... xs) {
     return self_->spawn<Os>(std::move(fun), std::forward<Ts>(xs)...);
   }
 
@@ -208,10 +201,8 @@ public:
   }
 
   template <class... Ts,
-            class R =
-              typename detail::make_response_promise_helper<
-                typename std::decay<Ts>::type...
-              >::type>
+            class R = typename detail::make_response_promise_helper<
+              typename std::decay<Ts>::type...>::type>
   R response(Ts&&... xs) {
     return self_->response(std::forward<Ts>(xs)...);
   }
@@ -230,6 +221,11 @@ public:
                                                    std::move(bhvr));
   }
 
+  template <class Handle, class... Ts>
+  auto delegate(const Handle& dest, Ts&&... xs) {
+    return self_->delegate(dest, std::forward<Ts>(xs)...);
+  }
+
   /// Returns a pointer to the sender of the current message.
   /// @pre `current_mailbox_element() != nullptr`
   strong_actor_ptr& current_sender() {
@@ -244,12 +240,18 @@ public:
   /// @private
   actor_control_block* ctrl() const noexcept {
     CAF_ASSERT(self_ != nullptr);
-    return actor_control_block::from(self_);;
+    return actor_control_block::from(self_);
+    ;
   }
 
   /// @private
   scheduled_actor* internal_ptr() const noexcept {
     return self_;
+  }
+
+  /// @private
+  void reset(scheduled_actor* ptr) {
+    self_ = ptr;
   }
 
   operator scheduled_actor*() const noexcept {

--- a/libcaf_core/src/actor_registry.cpp
+++ b/libcaf_core/src/actor_registry.cpp
@@ -31,7 +31,6 @@
 #include "caf/exit_reason.hpp"
 #include "caf/actor_system.hpp"
 #include "caf/scoped_actor.hpp"
-#include "caf/stateful_actor.hpp"
 #include "caf/event_based_actor.hpp"
 #include "caf/uniform_type_info_map.hpp"
 

--- a/libcaf_core/src/actor_system.cpp
+++ b/libcaf_core/src/actor_system.cpp
@@ -32,6 +32,7 @@
 #include "caf/scheduler/coordinator.hpp"
 #include "caf/scheduler/test_coordinator.hpp"
 #include "caf/send.hpp"
+#include "caf/stateful_actor.hpp"
 #include "caf/to_string.hpp"
 
 namespace caf {

--- a/libcaf_test/caf/test/dsl.hpp
+++ b/libcaf_test/caf/test/dsl.hpp
@@ -458,12 +458,13 @@ public:
   }
 
   void with(Ts... xs) {
-    if (src_ == nullptr)
-      CAF_FAIL("missing .from() in inject() statement");
     if (dest_ == nullptr)
       CAF_FAIL("missing .to() in inject() statement");
-    caf::send_as(caf::actor_cast<caf::actor>(src_),
-                 caf::actor_cast<caf::actor>(dest_), xs...);
+    if (src_ == nullptr)
+      caf::anon_send(caf::actor_cast<caf::actor>(dest_), xs...);
+    else
+      caf::send_as(caf::actor_cast<caf::actor>(src_),
+                   caf::actor_cast<caf::actor>(dest_), xs...);
     CAF_REQUIRE(sched_.prioritize(dest_));
     auto dest_ptr = &sched_.next_job<caf::abstract_actor>();
     auto ptr = dest_ptr->peek_at_next_mailbox_element();


### PR DESCRIPTION
Restricting state classes to the default constructor leads to many anti-patterns in practice. For example by falling back to an `init` function and putting members without default constructor into a `unique_ptr`, `union`, or the like.

This change makes the stateful actor API much more powerful by allowing state classes with arbitrary constructors.