### PR TITLE
Add missing cast

### DIFF
--- a/libcaf_test/caf/test/dsl.hpp
+++ b/libcaf_test/caf/test/dsl.hpp
@@ -451,7 +451,7 @@ public:
   }
 
   inject_clause& to(const caf::scoped_actor& whom) {
-    dest_ = whom.ptr();
+    dest_ = caf::actor_cast<caf::strong_actor_ptr>(whom.ptr());
     return *this;
   }
 


### PR DESCRIPTION
As the issue stated, 0.17.4 has the same problem. Do we want as well and would this be the way to do it?