### PR TITLE
Fix build on Clang 10

### DIFF
--- a/libcaf_test/caf/test/dsl.hpp
+++ b/libcaf_test/caf/test/dsl.hpp
@@ -339,7 +339,7 @@ public:
   }
 
   expect_clause& to(const caf::scoped_actor& whom) {
-    dest_ = whom.ptr();
+    dest_ = caf::actor_cast<caf::abstract_actor*>(whom);
     return *this;
   }
 
@@ -415,7 +415,7 @@ public:
   }
 
   expect_clause& to(const caf::scoped_actor& whom) {
-    dest_ = whom.ptr();
+    dest_ = caf::actor_cast<caf::abstract_actor*>(whom);
     return *this;
   }
 
@@ -452,11 +452,6 @@ public:
   template <class Handle>
   inject_clause& to(const Handle& whom) {
     dest_ = caf::actor_cast<caf::strong_actor_ptr>(whom);
-    return *this;
-  }
-
-  inject_clause& to(const caf::scoped_actor& whom) {
-    dest_ = caf::actor_cast<caf::strong_actor_ptr>(whom.ptr());
     return *this;
   }
 
@@ -531,11 +526,6 @@ public:
   allow_clause& to(const Handle& whom) {
     if (sched_.prioritize(whom))
       dest_ = &sched_.next_job<caf::abstract_actor>();
-    return *this;
-  }
-
-  allow_clause& to(const caf::scoped_actor& whom) {
-    dest_ = whom.ptr();
     return *this;
   }
 


### PR DESCRIPTION
This patch should fix the testing DSL on Clang 10. #1079 didn't take care of all conversions from `scoped_actor` to `strong_actor_ptr`. I've run into a couple more errors today.

Relates #1077.