### PR TITLE
Fix build with C++17 enabled

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,11 @@ config = [
             extraSteps: ['coverageReport'],
         ]],
         ['Linux', [
+            builds: ['debug'],
+            tools: ['gcc8'],
+            extraFlags: ['EXTRA_FLAGS=-std=c++17']
+        ]],
+        ['Linux', [
             builds: ['release'],
             tools: ['gcc8'],
         ]],

--- a/libcaf_core/caf/detail/type_traits.hpp
+++ b/libcaf_core/caf/detail/type_traits.hpp
@@ -471,6 +471,23 @@ struct callable_trait<R (C::*)(Ts...)> : callable_trait<R (Ts...)> {};
 template <class R, class... Ts>
 struct callable_trait<R (*)(Ts...)> : callable_trait<R (Ts...)> {};
 
+#if __cplusplus >= 201703L
+
+// member const function pointer
+template <class C, typename R, class... Ts>
+struct callable_trait<R (C::*)(Ts...) const noexcept>
+  : callable_trait<R(Ts...)> {};
+
+// member function pointer
+template <class C, typename R, class... Ts>
+struct callable_trait<R (C::*)(Ts...) noexcept> : callable_trait<R(Ts...)> {};
+
+// good ol' function pointer
+template <class R, class... Ts>
+struct callable_trait<R (*)(Ts...) noexcept> : callable_trait<R(Ts...)> {};
+
+#endif
+
 template <class T>
 struct has_apply_operator {
   template <class U>

--- a/libcaf_opencl/examples/proper_matrix.cpp
+++ b/libcaf_opencl/examples/proper_matrix.cpp
@@ -27,9 +27,13 @@
 
 #include "caf/opencl/all.hpp"
 
-using namespace std;
 using namespace caf;
 using namespace caf::opencl;
+
+using std::cout;
+using std::endl;
+using std::string;
+using std::vector;
 
 using caf::detail::limited_vector;
 
@@ -111,11 +115,12 @@ private:
 
 template<size_t Size>
 string to_string(const square_matrix<Size>& m) {
-  ostringstream oss;
+  std::ostringstream oss;
   oss.fill(' ');
   for (size_t row = 0; row < Size; ++row) {
     for (size_t column = 0; column < Size; ++column)
-      oss << fixed << setprecision(2) << setw(9) << m(column, row);
+      oss << std::fixed << std::setprecision(2) << std::setw(9)
+          << m(column, row);
     oss << '\n';
   }
   return oss.str();
@@ -181,11 +186,10 @@ void multiplier(event_based_actor* self) {
 
   // send both matrices to the actor and
   // wait for results in form of a matrix_type
-  self->request(worker, chrono::seconds(5), move(m1), move(m2)).then(
-    [](const matrix_type& result) {
+  self->request(worker, std::chrono::seconds(5), std::move(m1), std::move(m2))
+    .then([](const matrix_type& result) {
       cout << "result:" << endl << to_string(result);
-    }
-  );
+    });
 }
 
 int main() {

--- a/libcaf_opencl/examples/scan.cpp
+++ b/libcaf_opencl/examples/scan.cpp
@@ -26,9 +26,14 @@
 #include "caf/all.hpp"
 #include "caf/opencl/all.hpp"
 
-using namespace std;
 using namespace caf;
 using namespace caf::opencl;
+
+using std::cerr;
+using std::cout;
+using std::endl;
+using std::string;
+using std::vector;
 
 using caf::detail::limited_vector;
 
@@ -166,8 +171,8 @@ kernel void phase_3(global uint* restrict data,
 
 } // namespace
 
-template <class T, class E = caf::detail::enable_if_t<is_integral<T>::value>>
-T round_up(T numToRound, T multiple)  {
+template <class T, class = caf::detail::enable_if_t<std::is_integral<T>::value>>
+T round_up(T numToRound, T multiple) {
   return ((numToRound + multiple - 1) / multiple) * multiple;
 }
 
@@ -180,9 +185,9 @@ int main() {
        << "' values." << endl;
   // ---- create data ----
   uvec values(problem_size);
-  random_device rd;
-  mt19937 gen(rd());
-  uniform_int_distribution<uval> val_gen(0, 1023);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<uval> val_gen(0, 1023);
   std::generate(begin(values), end(values), [&]() { return val_gen(gen); });
   // ---- find device ----
   auto& mngr = system.opencl_manager();
@@ -205,7 +210,7 @@ int main() {
   }
   {
     // ---- general ----
-    auto dev = move(*opt);
+    auto dev = std::move(*opt);
     auto prog = mngr.create_program(kernel_source, "", dev);
     scoped_actor self{system};
     // ---- config parameters ----
@@ -243,7 +248,8 @@ int main() {
         return msg.apply([&](uref& data, uref& incs) {
           auto size = incs.size();
           range = nd_conf(size);
-          return make_message(move(data), move(incs), static_cast<uval>(size));
+          return make_message(std::move(data), std::move(incs),
+                              static_cast<uval>(size));
         });
       },
       in_out<uval,mref,mref>{},
@@ -256,7 +262,8 @@ int main() {
         return msg.apply([&](uref& data, uref& incs) {
           auto size = incs.size();
           range = nd_conf(size);
-          return make_message(move(data), move(incs), static_cast<uval>(size));
+          return make_message(std::move(data), std::move(incs),
+                              static_cast<uval>(size));
         });
       },
       in_out<uval,mref,val>{},
@@ -273,8 +280,8 @@ int main() {
         cout << " index | values |  scan  " << endl
              << "-------+--------+--------" << endl;
         for (size_t i = 0; i < problem_size; ++i)
-          cout << setw(6) << i << " | " << setw(6) << values[i] << " | "
-               << setw(6) << results[i] << endl;
+          cout << std::setw(6) << i << " | " << std::setw(6) << values[i]
+               << " | " << std::setw(6) << results[i] << std::endl;
       }
     );
   }

--- a/libcaf_opencl/test/opencl.cpp
+++ b/libcaf_opencl/test/opencl.cpp
@@ -12,9 +12,13 @@
 
 #include "caf/opencl/all.hpp"
 
-using namespace std;
 using namespace caf;
 using namespace caf::opencl;
+
+using std::cout;
+using std::endl;
+using std::string;
+using std::vector;
 
 using caf::detail::tl_at;
 using caf::detail::tl_head;
@@ -292,7 +296,7 @@ void check_vector_results(const string& description,
     cout << "Size: " << expected.size() << " vs. " << result.size() << endl;
     cout << "Differ at: " << endl;
     bool same = true;
-    for (size_t i = 0; i < min(expected.size(), result.size()); ++i) {
+    for (size_t i = 0; i < std::min(expected.size(), result.size()); ++i) {
       if (expected[i] != result[i]) {
         cout << "[" << i << "] " << expected[i] << " != " << result[i] << endl;
         same = false;
@@ -405,7 +409,7 @@ void test_opencl(actor_system& sys) {
               "semicolon is missing).");
   try {
     /* auto expected_error = */ mngr.create_program(kernel_source_error);
-  } catch (const exception& exc) {
+  } catch (const std::exception& exc) {
     CAF_MESSAGE("got: " << exc.what());
   }
 #endif // CAF_NO_EXCEPTIONS
@@ -423,7 +427,7 @@ void test_opencl(actor_system& sys) {
   );
 
   // test for manuel return size selection (max workgroup size 1d)
-  auto max_wg_size = min(dev->max_work_item_sizes()[0], size_t{512});
+  auto max_wg_size = std::min(dev->max_work_item_sizes()[0], size_t{512});
   auto reduce_buffer_size = static_cast<size_t>(max_wg_size) * 8;
   auto reduce_local_size  = static_cast<size_t>(max_wg_size);
   auto reduce_work_groups = reduce_buffer_size / reduce_local_size;
@@ -731,7 +735,7 @@ void test_in_val_out_val(actor_system& sys) {
   }, others >> wrong_msg);
 
   // test for manuel return size selection (max workgroup size 1d)
-  auto max_wg_size = min(dev->max_work_item_sizes()[0], size_t{512});
+  auto max_wg_size = std::min(dev->max_work_item_sizes()[0], size_t{512});
   auto reduce_buffer_size = static_cast<size_t>(max_wg_size) * 8;
   auto reduce_local_size  = static_cast<size_t>(max_wg_size);
   auto reduce_work_groups = reduce_buffer_size / reduce_local_size;
@@ -801,7 +805,7 @@ void test_in_val_out_mref(actor_system& sys) {
                        " (kernel passed directly)", res1, result);
   }, others >> wrong_msg);
   // test for manuel return size selection (max workgroup size 1d)
-  auto max_wg_size = min(dev->max_work_item_sizes()[0], size_t{512});
+  auto max_wg_size = std::min(dev->max_work_item_sizes()[0], size_t{512});
   auto reduce_buffer_size = static_cast<size_t>(max_wg_size) * 8;
   auto reduce_local_size  = static_cast<size_t>(max_wg_size);
   auto reduce_work_groups = reduce_buffer_size / reduce_local_size;
@@ -858,7 +862,7 @@ void test_in_mref_out_val(actor_system& sys) {
                          " (kernel passed directly)", res1, result);
   }, others >> wrong_msg);
   // test for manuel return size selection (max workgroup size 1d)
-  auto max_wg_size = min(dev->max_work_item_sizes()[0], size_t{512});
+  auto max_wg_size = std::min(dev->max_work_item_sizes()[0], size_t{512});
   auto reduce_buffer_size = static_cast<size_t>(max_wg_size) * 8;
   auto reduce_local_size  = static_cast<size_t>(max_wg_size);
   auto reduce_work_groups = reduce_buffer_size / reduce_local_size;
@@ -917,7 +921,7 @@ void test_in_mref_out_mref(actor_system& sys) {
                        " (kernel passed directly)", res1, result);
   }, others >> wrong_msg);
   // test for manuel return size selection (max workgroup size 1d)
-  auto max_wg_size = min(dev->max_work_item_sizes()[0], size_t{512});
+  auto max_wg_size = std::min(dev->max_work_item_sizes()[0], size_t{512});
   auto reduce_buffer_size = static_cast<size_t>(max_wg_size) * 8;
   auto reduce_local_size  = static_cast<size_t>(max_wg_size);
   auto reduce_work_groups = reduce_buffer_size / reduce_local_size;


### PR DESCRIPTION
With C++17, `noexcept` became part of the type system. This means we need more specializations for `callable_trait` when detecting never versions of the standard. Closes #1078.