### PR TITLE
Use type IDs for error code enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   losing connection to the monitored node.
 - In preparation of potential future API additions/changes, CAF now includes an
   RFC4122-compliant `uuid` class.
+- The new trait class `is_error_code_enum` allows users to enable conversion of
+  custom error code enums to `error` and `error_code`.
+
+### Deprecated
+
+- The `to_string` output for `error` now renders the error code enum by default.
+  This renders the member functions `actor_system::render` and
+  `actor_system_config::render` obsolete.
 
 ### Changed
 

--- a/examples/broker/protobuf_broker.cpp
+++ b/examples/broker/protobuf_broker.cpp
@@ -30,8 +30,7 @@ using kickoff_atom = atom_constant<atom("kickoff")>;
 // utility function to print an exit message with custom name
 void print_on_exit(scheduled_actor* self, const std::string& name) {
   self->attach_functor([=](const error& reason) {
-    aout(self) << name << " exited: " << self->home_system().render(reason)
-               << endl;
+    aout(self) << name << " exited: " << to_string(reason) << endl;
   });
 }
 
@@ -174,8 +173,8 @@ void run_server(actor_system& system, const config& cfg) {
   auto server_actor = system.middleman().spawn_server(server, cfg.port,
                                                       pong_actor);
   if (!server_actor)
-    cerr << "unable to spawn server: "
-         << system.render(server_actor.error()) << endl;
+    cerr << "unable to spawn server: " << to_string(server_actor.error())
+         << endl;
 }
 
 void run_client(actor_system& system, const config& cfg) {
@@ -184,8 +183,8 @@ void run_client(actor_system& system, const config& cfg) {
   auto io_actor = system.middleman().spawn_client(protobuf_io, cfg.host,
                                                   cfg.port, ping_actor);
   if (!io_actor) {
-    cout << "cannot connect to " << cfg.host << " at port " << cfg.port
-         << ": " << system.render(io_actor.error()) << endl;
+    cout << "cannot connect to " << cfg.host << " at port " << cfg.port << ": "
+         << to_string(io_actor.error()) << endl;
     return;
   }
   send_as(*io_actor, ping_actor, kickoff_atom::value, *io_actor);

--- a/examples/broker/simple_broker.cpp
+++ b/examples/broker/simple_broker.cpp
@@ -192,8 +192,8 @@ void run_server(actor_system& system, const config& cfg) {
   auto server_actor = system.middleman().spawn_server(server, cfg.port,
                                                       pong_actor);
   if (!server_actor) {
-    std::cerr << "failed to spawn server: "
-              << system.render(server_actor.error()) << endl;
+    std::cerr << "failed to spawn server: " << to_string(server_actor.error())
+              << endl;
     return;
   }
   print_on_exit(*server_actor, "server");
@@ -205,7 +205,7 @@ void run_client(actor_system& system, const config& cfg) {
   auto io_actor = system.middleman().spawn_client(broker_impl, cfg.host,
                                                   cfg.port, ping_actor);
   if (!io_actor) {
-    std::cerr << "failed to spawn client: " << system.render(io_actor.error())
+    std::cerr << "failed to spawn client: " << to_string(io_actor.error())
               << endl;
     return;
   }

--- a/examples/broker/simple_http_broker.cpp
+++ b/examples/broker/simple_http_broker.cpp
@@ -77,8 +77,8 @@ public:
 void caf_main(actor_system& system, const config& cfg) {
   auto server_actor = system.middleman().spawn_server(server, cfg.port);
   if (!server_actor) {
-    cerr << "*** cannot spawn server: "
-         << system.render(server_actor.error()) << endl;
+    cerr << "*** cannot spawn server: " << to_string(server_actor.error())
+         << endl;
     return;
   }
   cout << "*** listening on port " << cfg.port << endl;

--- a/examples/custom_type/custom_types_1.cpp
+++ b/examples/custom_type/custom_types_1.cpp
@@ -96,14 +96,14 @@ void caf_main(actor_system& sys) {
   binary_serializer bs{sys, buf};
   auto e = bs(f1);
   if (e) {
-    std::cerr << "*** unable to serialize foo2: " << sys.render(e) << std::endl;
+    std::cerr << "*** unable to serialize foo2: " << to_string(e) << '\n';
     return;
   }
   // read f2 back from buffer
   binary_deserializer bd{sys, buf};
   e = bd(f2);
   if (e) {
-    std::cerr << "*** unable to serialize foo2: " << sys.render(e) << std::endl;
+    std::cerr << "*** unable to serialize foo2: " << to_string(e) << '\n';
     return;
   }
   // must be equal

--- a/examples/dynamic_behavior/skip_messages.cpp
+++ b/examples/dynamic_behavior/skip_messages.cpp
@@ -37,7 +37,7 @@ void caf_main(actor_system& system) {
                                                         : "server\n");
       },
       [&](error& err) {
-        aout(self) << "received error " << system.render(err) << " from "
+        aout(self) << "received error " << to_string(err) << " from "
                    << (self->current_sender() == worker ? "worker\n"
                                                         : "server\n");
       });

--- a/examples/message_passing/calculator.cpp
+++ b/examples/message_passing/calculator.cpp
@@ -101,8 +101,7 @@ template <class Handle, class... Ts>
 void tester(scoped_actor& self, const Handle& hdl, int32_t x, int32_t y,
             Ts&&... xs) {
   auto handle_err = [&](const error& err) {
-    aout(self) << "AUT (actor under test) failed: "
-               << self->system().render(err) << endl;
+    aout(self) << "AUT (actor under test) failed: " << to_string(err) << endl;
   };
   // first test: x + y = z
   self->request(hdl, infinite, add_atom_v, x, y)

--- a/examples/message_passing/divider.cpp
+++ b/examples/message_passing/divider.cpp
@@ -27,24 +27,13 @@ std::string to_string(math_error x) {
   }
 }
 
-namespace caf {
+CAF_BEGIN_TYPE_ID_BLOCK(divider, first_custom_type_id)
 
-template <>
-struct error_category<math_error> {
-  static constexpr uint8_t value = 101;
-};
+  CAF_ADD_TYPE_ID(divider, (math_error))
 
-} // namespace caf
+CAF_END_TYPE_ID_BLOCK(divider)
 
-class config : public actor_system_config {
-public:
-  config() {
-    auto renderer = [](uint8_t x, const message&) {
-      return to_string(static_cast<math_error>(x));
-    };
-    add_error_category(caf::error_category<math_error>::value, renderer);
-  }
-};
+CAF_ERROR_CODE_ENUM(math_error)
 
 using divider = typed_actor<result<double>(div_atom, double, double)>;
 
@@ -58,7 +47,7 @@ divider::behavior_type divider_impl() {
   };
 }
 
-void caf_main(actor_system& system, const config&) {
+void caf_main(actor_system& system) {
   double x;
   double y;
   cout << "x: " << flush;
@@ -76,4 +65,4 @@ void caf_main(actor_system& system, const config&) {
       });
 }
 
-CAF_MAIN()
+CAF_MAIN(id_block::divider)

--- a/examples/message_passing/divider.cpp
+++ b/examples/message_passing/divider.cpp
@@ -72,7 +72,7 @@ void caf_main(actor_system& system, const config&) {
       [&](double z) { aout(self) << x << " / " << y << " = " << z << endl; },
       [&](const error& err) {
         aout(self) << "*** cannot compute " << x << " / " << y << " => "
-                   << system.render(err) << endl;
+                   << to_string(err) << endl;
       });
 }
 

--- a/examples/message_passing/fixed_stack.cpp
+++ b/examples/message_passing/fixed_stack.cpp
@@ -3,29 +3,24 @@
 #include <cstdint>
 #include <iostream>
 
+enum class fixed_stack_errc : uint8_t {
+  push_to_full = 1,
+  pop_from_empty,
+};
+
 CAF_BEGIN_TYPE_ID_BLOCK(fixed_stack, first_custom_type_id)
+
+  CAF_ADD_TYPE_ID(fixed_stack, (fixed_stack_errc))
 
   CAF_ADD_ATOM(fixed_stack, pop_atom)
   CAF_ADD_ATOM(fixed_stack, push_atom)
 
 CAF_END_TYPE_ID_BLOCK(fixed_stack)
 
+CAF_ERROR_CODE_ENUM(fixed_stack_errc)
+
 using std::endl;
 using namespace caf;
-
-enum class fixed_stack_errc : uint8_t {
-  push_to_full = 1,
-  pop_from_empty,
-};
-
-namespace caf {
-
-template <>
-struct error_category<fixed_stack_errc> {
-  static constexpr uint8_t value = 100;
-};
-
-} // namespace caf
 
 class fixed_stack : public event_based_actor {
 public:

--- a/examples/message_passing/request.cpp
+++ b/examples/message_passing/request.cpp
@@ -56,8 +56,7 @@ void blocking_testee(blocking_actor* self, vector<cell> cells) {
           aout(self) << "cell #" << x.id() << " -> " << y << endl;
         },
         [&](error& err) {
-          aout(self) << "cell #" << x.id() << " -> "
-                     << self->system().render(err) << endl;
+          aout(self) << "cell #" << x.id() << " -> " << to_string(err) << endl;
         });
 }
 

--- a/examples/message_passing/typed_calculator.cpp
+++ b/examples/message_passing/typed_calculator.cpp
@@ -54,8 +54,8 @@ void tester(event_based_actor* self, const calculator_type& testee) {
         });
       },
       [=](const error& err) {
-        aout(self) << "AUT (actor under test) failed: "
-                   << self->system().render(err) << endl;
+        aout(self) << "AUT (actor under test) failed: " << to_string(err)
+                   << endl;
         self->quit(exit_reason::user_shutdown);
       });
 }

--- a/examples/qtsupport/chatwidget.cpp
+++ b/examples/qtsupport/chatwidget.cpp
@@ -79,7 +79,7 @@ void ChatWidget::sendChatMessage() {
         auto x = system().groups().get(mod, g);
         if (! x)
           print("*** error: "
-                + QString::fromUtf8(system().render(x.error()).c_str()));
+                + QString::fromUtf8(to_string(x.error()).c_str()));
         else
           self()->send(self(), atom("join"), std::move(*x));
       },
@@ -128,7 +128,7 @@ void ChatWidget::joinGroup() {
   string gid = gname.midRef(pos+1).toUtf8().constData();
   auto x = system().groups().get(mod, gid);
   if (! x)
-    QMessageBox::critical(this, "Error", system().render(x.error()).c_str());
+    QMessageBox::critical(this, "Error", to_string(x.error()).c_str());
   else
     self()->send(self(), join_atom::value, std::move(*x));
 }

--- a/examples/qtsupport/qt_group_chat.cpp
+++ b/examples/qtsupport/qt_group_chat.cpp
@@ -59,9 +59,8 @@ int main(int argc, char** argv) {
       auto group_uri = cfg.group_id.substr(p + 1);
       auto g = system.groups().get(module, group_uri);
       if (! g) {
-        cerr << "*** unable to get group " << group_uri
-             << " from module " << module << ": "
-             << system.render(g.error()) << endl;
+        cerr << "*** unable to get group " << group_uri << " from module "
+             << module << ": " << to_string(g.error()) << endl;
         return -1;
       }
       grp = std::move(*g);

--- a/examples/remoting/distributed_calculator.cpp
+++ b/examples/remoting/distributed_calculator.cpp
@@ -145,7 +145,7 @@ void connecting(stateful_actor<state>* self, const std::string& host,
       },
       [=](const error& err) {
         aout(self) << R"(*** cannot connect to ")" << host << R"(":)" << port
-                   << " => " << self->system().render(err) << endl;
+                   << " => " << to_string(err) << endl;
         self->become(unconnected(self));
       });
 }
@@ -286,7 +286,7 @@ void run_server(actor_system& system, const config& cfg) {
   cout << "*** try publish at port " << cfg.port << endl;
   auto expected_port = io::publish(calc, cfg.port);
   if (!expected_port) {
-    std::cerr << "*** publish failed: " << system.render(expected_port.error())
+    std::cerr << "*** publish failed: " << to_string(expected_port.error())
               << endl;
     return;
   }

--- a/examples/remoting/group_chat.cpp
+++ b/examples/remoting/group_chat.cpp
@@ -85,7 +85,7 @@ void run_server(actor_system& system, const config& cfg) {
   auto res = system.middleman().publish_local_groups(cfg.port);
   if (!res) {
     std::cerr << "*** publishing local groups failed: "
-              << system.render(res.error()) << std::endl;
+              << to_string(res.error()) << std::endl;
     return;
   }
   std::cout << "*** listening at port " << *res << std::endl
@@ -112,7 +112,7 @@ void run_client(actor_system& system, const config& cfg) {
       anon_send(client_actor, join_atom_v, std::move(*tmp));
     else
       std::cerr << R"(*** failed to parse ")" << uri << R"(" as group URI: )"
-                << system.render(tmp.error()) << std::endl;
+                << to_string(tmp.error()) << std::endl;
   }
   std::istream_iterator<line> eof;
   std::vector<std::string> words;

--- a/examples/remoting/remote_spawn.cpp
+++ b/examples/remoting/remote_spawn.cpp
@@ -115,7 +115,7 @@ struct config : actor_system_config {
 void server(actor_system& system, const config& cfg) {
   auto res = system.middleman().open(cfg.port);
   if (!res) {
-    cerr << "*** cannot open port: " << system.render(res.error()) << endl;
+    cerr << "*** cannot open port: " << to_string(res.error()) << endl;
     return;
   }
   cout << "*** running on port: " << *res << endl
@@ -127,7 +127,7 @@ void server(actor_system& system, const config& cfg) {
 void client(actor_system& system, const config& cfg) {
   auto node = system.middleman().connect(cfg.host, cfg.port);
   if (!node) {
-    cerr << "*** connect failed: " << system.render(node.error()) << endl;
+    cerr << "*** connect failed: " << to_string(node.error()) << endl;
     return;
   }
   auto type = "calculator";             // type of the actor we wish to spawn
@@ -136,8 +136,7 @@ void client(actor_system& system, const config& cfg) {
   auto worker = system.middleman().remote_spawn<calculator>(*node, type, args,
                                                             tout);
   if (!worker) {
-    cerr << "*** remote spawn failed: " << system.render(worker.error())
-         << endl;
+    cerr << "*** remote spawn failed: " << to_string(worker.error()) << endl;
     return;
   }
   // start using worker in main loop

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -242,7 +242,8 @@ public:
   actor_registry& registry();
 
   /// Returns a string representation for `err`.
-  std::string render(const error& x) const;
+  [[deprecated("please use to_string() on the error")]] std::string
+  render(const error& x) const;
 
   /// Returns the system-wide group manager.
   group_manager& groups();

--- a/libcaf_core/caf/atom.hpp
+++ b/libcaf_core/caf/atom.hpp
@@ -1,0 +1,1 @@
+// Deprecated include. The next CAF release won't include this header.

--- a/libcaf_core/caf/detail/is_complete.hpp
+++ b/libcaf_core/caf/detail/is_complete.hpp
@@ -5,7 +5,7 @@
  *                     | |___ / ___ \|  _|      Framework                     *
  *                      \____/_/   \_|_|                                      *
  *                                                                            *
- * Copyright 2011-2019 Dominik Charousset                                     *
+ * Copyright 2011-2020 Dominik Charousset                                     *
  *                                                                            *
  * Distributed under the terms and conditions of the BSD 3-Clause License or  *
  * (at your option) under the terms and conditions of the Boost Software      *
@@ -16,32 +16,21 @@
  * http://www.boost.org/LICENSE_1_0.txt.                                      *
  ******************************************************************************/
 
-#define CAF_SUITE error
+#pragma once
 
-#include "caf/error.hpp"
+#include <type_traits>
 
-#include "core-test.hpp"
+namespace caf::detail {
 
-using namespace caf;
+template <class T, std::size_t = sizeof(T)>
+std::true_type is_complete_impl(T*);
 
-CAF_TEST(default constructed errors evaluate to false) {
-  error err;
-  CAF_CHECK(!err);
-}
+std::false_type is_complete_impl(...);
 
-CAF_TEST(error code zero is not an error) {
-  CAF_CHECK(!error(sec::none));
-  CAF_CHECK(!make_error(sec::none));
-  CAF_CHECK(!error{error_code<sec>(sec::none)});
-}
+/// Checks whether T is a complete type. For example, passing a forward
+/// declaration or undefined template specialization evaluates to `false`.
+template <class T>
+constexpr bool is_complete
+  = decltype(is_complete_impl(std::declval<T*>()))::value;
 
-CAF_TEST(error codes that are not zero are errors) {
-  CAF_CHECK(error(sec::unexpected_message));
-  CAF_CHECK(make_error(sec::unexpected_message));
-  CAF_CHECK(error{error_code<sec>(sec::unexpected_message)});
-}
-
-CAF_TEST(errors convert enums to their integer value) {
-  CAF_CHECK_EQUAL(make_error(sec::unexpected_message).code(), 1u);
-  CAF_CHECK_EQUAL(error{error_code<sec>(sec::unexpected_message)}.code(), 1u);
-}
+} // namespace caf::detail

--- a/libcaf_core/caf/detail/type_traits.hpp
+++ b/libcaf_core/caf/detail/type_traits.hpp
@@ -27,6 +27,7 @@
 #include <utility>
 #include <vector>
 
+#include "caf/detail/is_complete.hpp"
 #include "caf/detail/is_one_of.hpp"
 #include "caf/detail/type_list.hpp"
 #include "caf/fwd.hpp"
@@ -740,17 +741,6 @@ struct is_stl_tuple_type {
 
 template <class T>
 constexpr bool is_stl_tuple_type_v = is_stl_tuple_type<T>::value;
-
-template <class T, std::size_t = sizeof(T)>
-std::true_type is_complete_impl(T*);
-
-std::false_type is_complete_impl(...);
-
-/// Checks whether T is a complete type. For example, passing a forward
-/// declaration or undefined template specialization evaluates to `false`.
-template <class T>
-constexpr bool is_complete
-  = decltype(is_complete_impl(std::declval<T*>()))::value;
 
 } // namespace caf::detail
 

--- a/libcaf_core/caf/error.hpp
+++ b/libcaf_core/caf/error.hpp
@@ -61,12 +61,10 @@ namespace caf {
 ///
 /// # Why is there no `string()` member function?
 ///
-/// The C++ standard library uses category singletons and virtual dispatching
-/// to correlate error codes to descriptive strings. However, singletons are
-/// a poor choice when it comes to serialization. CAF uses atoms for
-/// categories instead and requires users to register custom error categories
-/// to the actor system. This makes the actor system the natural instance for
-/// rendering error messages via `actor_system::render(const error&)`.
+/// The C++ standard library uses category singletons and virtual dispatching to
+/// correlate error codes to descriptive strings. However, singletons are a poor
+/// choice when it comes to serialization. CAF uses type IDs and meta objects
+/// instead.
 class CAF_CORE_EXPORT error : detail::comparable<error> {
 public:
   // -- constructors, destructors, and assignment operators --------------------

--- a/libcaf_core/caf/error_code.hpp
+++ b/libcaf_core/caf/error_code.hpp
@@ -22,6 +22,7 @@
 #include <type_traits>
 
 #include "caf/fwd.hpp"
+#include "caf/is_error_code_enum.hpp"
 #include "caf/none.hpp"
 
 namespace caf {
@@ -32,7 +33,11 @@ class error_code {
 public:
   using enum_type = Enum;
 
-  using underlying_type = std::underlying_type_t<enum_type>;
+  using underlying_type = typename std::underlying_type<enum_type>::type;
+
+  static_assert(is_error_code_enum_v<Enum>);
+
+  static_assert(std::is_same<underlying_type, uint8_t>::value);
 
   constexpr error_code() noexcept : value_(static_cast<Enum>(0)) {
     // nop
@@ -66,6 +71,12 @@ public:
 private:
   enum_type value_;
 };
+
+/// Returns the value of the underlying integer type of `x`.
+template <class Enum, class = std::enable_if_t<is_error_code_enum_v<Enum>>>
+constexpr auto to_integer(error_code<Enum> x) noexcept {
+  return static_cast<typename error_code<Enum>::underlying_type>(x.value());
+}
 
 /// Converts `x` to a string if `Enum` provides a `to_string` function.
 template <class Enum>

--- a/libcaf_core/caf/error_code.hpp
+++ b/libcaf_core/caf/error_code.hpp
@@ -33,7 +33,7 @@ class error_code {
 public:
   using enum_type = Enum;
 
-  using underlying_type = typename std::underlying_type<enum_type>::type;
+  using underlying_type = std::underlying_type_t<Enum>;
 
   static_assert(is_error_code_enum_v<Enum>);
 
@@ -68,15 +68,13 @@ public:
     return value_;
   }
 
+  friend constexpr underlying_type to_integer(error_code x) noexcept {
+    return static_cast<std::underlying_type_t<Enum>>(x.value());
+  }
+
 private:
   enum_type value_;
 };
-
-/// Returns the value of the underlying integer type of `x`.
-template <class Enum, class = std::enable_if_t<is_error_code_enum_v<Enum>>>
-constexpr auto to_integer(error_code<Enum> x) noexcept {
-  return static_cast<typename error_code<Enum>::underlying_type>(x.value());
-}
 
 /// Converts `x` to a string if `Enum` provides a `to_string` function.
 template <class Enum>

--- a/libcaf_core/caf/exec_main.hpp
+++ b/libcaf_core/caf/exec_main.hpp
@@ -92,8 +92,8 @@ int exec_main(F fun, int argc, char** argv,
   // Pass CLI options to config.
   typename helper::config cfg;
   if (auto err = cfg.parse(argc, argv, config_file_name)) {
-    std::cerr << "error while parsing CLI and file options: "
-              << actor_system_config::render(err) << std::endl;
+    std::cerr << "error while parsing CLI and file options: " << to_string(err)
+              << std::endl;
     return EXIT_FAILURE;
   }
   // Return immediately if a help text was printed.

--- a/libcaf_core/caf/exit_reason.hpp
+++ b/libcaf_core/caf/exit_reason.hpp
@@ -52,12 +52,9 @@ enum class exit_reason : uint8_t {
   unreachable
 };
 
-/// Returns a string representation of given exit reason.
+/// @relates exit_reason
 CAF_CORE_EXPORT std::string to_string(exit_reason);
 
-template <>
-struct is_error_code_enum<exit_reason> {
-  static constexpr bool value = true;
-};
-
 } // namespace caf
+
+CAF_ERROR_CODE_ENUM(exit_reason)

--- a/libcaf_core/caf/exit_reason.hpp
+++ b/libcaf_core/caf/exit_reason.hpp
@@ -26,7 +26,7 @@
 #include <string>
 
 #include "caf/detail/core_export.hpp"
-#include "caf/error_category.hpp"
+#include "caf/is_error_code_enum.hpp"
 
 namespace caf {
 
@@ -56,8 +56,8 @@ enum class exit_reason : uint8_t {
 CAF_CORE_EXPORT std::string to_string(exit_reason);
 
 template <>
-struct error_category<exit_reason> {
-  static constexpr uint8_t value = 3;
+struct is_error_code_enum<exit_reason> {
+  static constexpr bool value = true;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/expected.hpp
+++ b/libcaf_core/caf/expected.hpp
@@ -27,7 +27,7 @@
 
 #include "caf/deep_to_string.hpp"
 #include "caf/error.hpp"
-#include "caf/error_category.hpp"
+#include "caf/is_error_code_enum.hpp"
 #include "caf/unifyn.hpp"
 #include "caf/unit.hpp"
 
@@ -81,9 +81,9 @@ public:
     construct(other);
   }
 
-  template <class Enum, uint8_t Category = error_category<Enum>::value>
+  template <class Enum, class = std::enable_if_t<is_error_code_enum_v<Enum>>>
   expected(Enum code) : engaged_(false) {
-    new (std::addressof(error_)) caf::error(make_error(code));
+    new (std::addressof(error_)) caf::error(code);
   }
 
   expected(expected&& other) noexcept(nothrow_move) {
@@ -157,7 +157,7 @@ public:
     return *this;
   }
 
-  template <class Enum, uint8_t Category = error_category<Enum>::value>
+  template <class Enum, class = std::enable_if_t<is_error_code_enum_v<Enum>>>
   expected& operator=(Enum code) {
     return *this = make_error(code);
   }
@@ -298,14 +298,16 @@ bool operator==(const error& x, const expected<T>& y) {
 }
 
 /// @relates expected
-template <class T, class Enum, uint8_t = error_category<Enum>::value>
-bool operator==(const expected<T>& x, Enum y) {
+template <class T, class Enum>
+std::enable_if_t<is_error_code_enum_v<Enum>, bool>
+operator==(const expected<T>& x, Enum y) {
   return x == make_error(y);
 }
 
 /// @relates expected
-template <class Enum, class T, uint8_t = error_category<Enum>::value>
-bool operator==(Enum x, const expected<T>& y) {
+template <class T, class Enum>
+std::enable_if_t<is_error_code_enum_v<Enum>, bool>
+operator==(Enum x, const expected<T>& y) {
   return y == make_error(x);
 }
 
@@ -341,14 +343,16 @@ bool operator!=(const error& x, const expected<T>& y) {
 }
 
 /// @relates expected
-template <class T, class Enum, uint8_t = error_category<Enum>::value>
-bool operator!=(const expected<T>& x, Enum y) {
+template <class T, class Enum>
+std::enable_if_t<is_error_code_enum_v<Enum>, bool>
+operator!=(const expected<T>& x, Enum y) {
   return !(x == y);
 }
 
 /// @relates expected
-template <class T, class Enum, uint8_t = error_category<Enum>::value>
-bool operator!=(Enum x, const expected<T>& y) {
+template <class T, class Enum>
+std::enable_if_t<is_error_code_enum_v<Enum>, bool>
+operator!=(Enum x, const expected<T>& y) {
   return !(x == y);
 }
 
@@ -375,7 +379,7 @@ public:
     // nop
   }
 
-  template <class Enum, uint8_t = error_category<Enum>::value>
+  template <class Enum, class = std::enable_if_t<is_error_code_enum_v<Enum>>>
   expected(Enum code) : error_(code) {
     // nop
   }

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -181,10 +181,11 @@ config_option make_config_option(T& storage, string_view category,
 // -- enums --------------------------------------------------------------------
 
 enum class byte : uint8_t;
+enum class exit_reason : uint8_t;
+enum class invoke_message_result;
 enum class pec : uint8_t;
 enum class sec : uint8_t;
 enum class stream_priority;
-enum class invoke_message_result;
 
 // -- aliases ------------------------------------------------------------------
 

--- a/libcaf_core/caf/is_error_code_enum.hpp
+++ b/libcaf_core/caf/is_error_code_enum.hpp
@@ -5,7 +5,7 @@
  *                     | |___ / ___ \|  _|      Framework                     *
  *                      \____/_/   \_|_|                                      *
  *                                                                            *
- * Copyright 2011-2019 Dominik Charousset                                     *
+ * Copyright 2011-2020 Dominik Charousset                                     *
  *                                                                            *
  * Distributed under the terms and conditions of the BSD 3-Clause License or  *
  * (at your option) under the terms and conditions of the Boost Software      *

--- a/libcaf_core/caf/is_error_code_enum.hpp
+++ b/libcaf_core/caf/is_error_code_enum.hpp
@@ -32,3 +32,11 @@ template <class T>
 constexpr bool is_error_code_enum_v = is_error_code_enum<T>::value;
 
 } // namespace caf
+
+#define CAF_ERROR_CODE_ENUM(type_name)                                         \
+  namespace caf {                                                              \
+  template <>                                                                  \
+  struct is_error_code_enum<type_name> {                                       \
+    static constexpr bool value = true;                                        \
+  };                                                                           \
+  }

--- a/libcaf_core/caf/is_error_code_enum.hpp
+++ b/libcaf_core/caf/is_error_code_enum.hpp
@@ -18,13 +18,17 @@
 
 #pragma once
 
-#include <cstdint>
-
 namespace caf {
 
 /// Customization point for enabling conversion from an enum type to an
-/// @ref error.
+/// @ref error or @ref error_code.
 template <class T>
-struct error_category;
+struct is_error_code_enum {
+  static constexpr bool value = false;
+};
+
+/// @relates is_error_code_enum
+template <class T>
+constexpr bool is_error_code_enum_v = is_error_code_enum<T>::value;
 
 } // namespace caf

--- a/libcaf_core/caf/make_message.hpp
+++ b/libcaf_core/caf/make_message.hpp
@@ -1,0 +1,1 @@
+// Deprecated include. The next CAF release won't include this header.

--- a/libcaf_core/caf/pec.hpp
+++ b/libcaf_core/caf/pec.hpp
@@ -79,9 +79,6 @@ enum class pec : uint8_t {
 
 CAF_CORE_EXPORT std::string to_string(pec);
 
-template <>
-struct is_error_code_enum<pec> {
-  static constexpr bool value = true;
-};
-
 } // namespace caf
+
+CAF_ERROR_CODE_ENUM(pec)

--- a/libcaf_core/caf/pec.hpp
+++ b/libcaf_core/caf/pec.hpp
@@ -22,8 +22,8 @@
 #include <string>
 
 #include "caf/detail/core_export.hpp"
-#include "caf/error_category.hpp"
 #include "caf/fwd.hpp"
+#include "caf/is_error_code_enum.hpp"
 
 namespace caf {
 
@@ -80,8 +80,8 @@ enum class pec : uint8_t {
 CAF_CORE_EXPORT std::string to_string(pec);
 
 template <>
-struct error_category<pec> {
-  static constexpr uint8_t value = 1;
+struct is_error_code_enum<pec> {
+  static constexpr bool value = true;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/result.hpp
+++ b/libcaf_core/caf/result.hpp
@@ -62,7 +62,7 @@ public:
 
   result_base& operator=(const result_base&) = default;
 
-  template <class Enum, uint8_t = error_category<Enum>::value>
+  template <class Enum, class = std::enable_if_t<is_error_code_enum_v<Enum>>>
   result_base(Enum x) : content_(make_error(x)) {
     // nop
   }

--- a/libcaf_core/caf/sec.hpp
+++ b/libcaf_core/caf/sec.hpp
@@ -150,9 +150,6 @@ enum class sec : uint8_t {
 /// @relates sec
 CAF_CORE_EXPORT std::string to_string(sec);
 
-template <>
-struct is_error_code_enum<sec> {
-  static constexpr bool value = true;
-};
-
 } // namespace caf
+
+CAF_ERROR_CODE_ENUM(sec)

--- a/libcaf_core/caf/sec.hpp
+++ b/libcaf_core/caf/sec.hpp
@@ -26,8 +26,8 @@
 #include <string>
 
 #include "caf/detail/core_export.hpp"
-#include "caf/error_category.hpp"
 #include "caf/fwd.hpp"
+#include "caf/is_error_code_enum.hpp"
 
 namespace caf {
 
@@ -147,11 +147,12 @@ enum class sec : uint8_t {
   all_requests_failed,
 };
 
+/// @relates sec
 CAF_CORE_EXPORT std::string to_string(sec);
 
 template <>
-struct error_category<sec> {
-  static constexpr uint8_t value = 0;
+struct is_error_code_enum<sec> {
+  static constexpr bool value = true;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/type_id.hpp
+++ b/libcaf_core/caf/type_id.hpp
@@ -24,6 +24,7 @@
 #include <utility>
 
 #include "caf/detail/core_export.hpp"
+#include "caf/detail/is_complete.hpp"
 #include "caf/detail/pp.hpp"
 #include "caf/detail/squashed_int.hpp"
 #include "caf/fwd.hpp"
@@ -82,6 +83,10 @@ constexpr const char* type_name_v = type_name<T>::value;
 
 /// The first type ID not reserved by CAF and its modules.
 constexpr type_id_t first_custom_type_id = 200;
+
+/// Checks whether `type_id` is specialized for `T`.
+template <class T>
+constexpr bool has_type_id = detail::is_complete<type_id<T>>;
 
 } // namespace caf
 
@@ -243,6 +248,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(core_module, 0)
   CAF_ADD_TYPE_ID(core_module, (caf::downstream_msg))
   CAF_ADD_TYPE_ID(core_module, (caf::error))
   CAF_ADD_TYPE_ID(core_module, (caf::exit_msg))
+  CAF_ADD_TYPE_ID(core_module, (caf::exit_reason))
   CAF_ADD_TYPE_ID(core_module, (caf::group))
   CAF_ADD_TYPE_ID(core_module, (caf::group_down_msg))
   CAF_ADD_TYPE_ID(core_module, (caf::message))
@@ -250,6 +256,8 @@ CAF_BEGIN_TYPE_ID_BLOCK(core_module, 0)
   CAF_ADD_TYPE_ID(core_module, (caf::node_down_msg))
   CAF_ADD_TYPE_ID(core_module, (caf::node_id))
   CAF_ADD_TYPE_ID(core_module, (caf::open_stream_msg))
+  CAF_ADD_TYPE_ID(core_module, (caf::pec))
+  CAF_ADD_TYPE_ID(core_module, (caf::sec))
   CAF_ADD_TYPE_ID(core_module, (caf::strong_actor_ptr))
   CAF_ADD_TYPE_ID(core_module, (caf::timeout_msg))
   CAF_ADD_TYPE_ID(core_module, (caf::timespan))

--- a/libcaf_core/src/actor_system.cpp
+++ b/libcaf_core/src/actor_system.cpp
@@ -364,12 +364,6 @@ actor_registry& actor_system::registry() {
 }
 
 std::string actor_system::render(const error& x) const {
-  if (!x)
-    return to_string(x);
-  auto& xs = config().error_renderers;
-  auto i = xs.find(x.category());
-  if (i != xs.end())
-    return i->second(x.code(), x.context());
   return to_string(x);
 }
 

--- a/libcaf_core/src/config_option_set.cpp
+++ b/libcaf_core/src/config_option_set.cpp
@@ -157,7 +157,7 @@ auto config_option_set::parse(settings& config, argument_iterator first,
       auto val = opt.parse(slice);
       if (!val) {
         auto& err = val.error();
-        if (err.category() == error_category<pec>::value)
+        if (err.category() == type_id_v<pec>)
           return static_cast<pec>(err.code());
         return pec::invalid_argument;
       }

--- a/libcaf_core/test/actor_registry.cpp
+++ b/libcaf_core/test/actor_registry.cpp
@@ -54,11 +54,11 @@ CAF_TEST(serialization roundtrips go through the registry) {
   byte_buffer buf;
   binary_serializer sink{sys, buf};
   if (auto err = sink(hdl))
-    CAF_FAIL("serialization failed: " << sys.render(err));
+    CAF_FAIL("serialization failed: " << to_string(err));
   actor hdl2;
   binary_deserializer source{sys, buf};
   if (auto err = source(hdl2))
-    CAF_FAIL("serialization failed: " << sys.render(err));
+    CAF_FAIL("serialization failed: " << to_string(err));
   CAF_CHECK_EQUAL(hdl, hdl2);
   anon_send_exit(hdl, exit_reason::user_shutdown);
 }

--- a/libcaf_core/test/actor_system_config.cpp
+++ b/libcaf_core/test/actor_system_config.cpp
@@ -71,7 +71,7 @@ struct fixture {
     cfg.remainder.clear();
     std::istringstream ini{file_content};
     if (auto err = cfg.parse(std::move(args), ini))
-      CAF_FAIL("parse() failed: " << cfg.render(err));
+      CAF_FAIL("parse() failed: " << err);
   }
 };
 

--- a/libcaf_core/test/binary_deserializer.cpp
+++ b/libcaf_core/test/binary_deserializer.cpp
@@ -49,7 +49,7 @@ struct fixture {
     auto result = T{};
     binary_deserializer source{nullptr, buf};
     if (auto err = source(result))
-      CAF_FAIL("binary_deserializer failed to load: " << to_string(err));
+      CAF_FAIL("binary_deserializer failed to load: " << err);
     return result;
   }
 
@@ -57,7 +57,7 @@ struct fixture {
   void load(const std::vector<byte>& buf, Ts&... xs) {
     binary_deserializer source{nullptr, buf};
     if (auto err = source(xs...))
-      CAF_FAIL("binary_deserializer failed to load: " << to_string(err));
+      CAF_FAIL("binary_deserializer failed to load: " << err);
   }
 };
 

--- a/libcaf_core/test/binary_deserializer.cpp
+++ b/libcaf_core/test/binary_deserializer.cpp
@@ -49,8 +49,7 @@ struct fixture {
     auto result = T{};
     binary_deserializer source{nullptr, buf};
     if (auto err = source(result))
-      CAF_FAIL("binary_deserializer failed to load: "
-               << actor_system_config::render(err));
+      CAF_FAIL("binary_deserializer failed to load: " << to_string(err));
     return result;
   }
 
@@ -58,8 +57,7 @@ struct fixture {
   void load(const std::vector<byte>& buf, Ts&... xs) {
     binary_deserializer source{nullptr, buf};
     if (auto err = source(xs...))
-      CAF_FAIL("binary_deserializer failed to load: "
-               << actor_system_config::render(err));
+      CAF_FAIL("binary_deserializer failed to load: " << to_string(err));
   }
 };
 

--- a/libcaf_core/test/binary_serializer.cpp
+++ b/libcaf_core/test/binary_serializer.cpp
@@ -49,8 +49,7 @@ struct fixture {
     byte_buffer result;
     binary_serializer sink{nullptr, result};
     if (auto err = sink(xs...))
-      CAF_FAIL("binary_serializer failed to save: "
-               << actor_system_config::render(err));
+      CAF_FAIL("binary_serializer failed to save: " << err);
     return result;
   }
 
@@ -58,8 +57,7 @@ struct fixture {
   void save_to_buf(byte_buffer& data, const Ts&... xs) {
     binary_serializer sink{nullptr, data};
     if (auto err = sink(xs...))
-      CAF_FAIL("binary_serializer failed to save: "
-               << actor_system_config::render(err));
+      CAF_FAIL("binary_serializer failed to save: " << err);
   }
 };
 

--- a/libcaf_core/test/config_value_adaptor.cpp
+++ b/libcaf_core/test/config_value_adaptor.cpp
@@ -221,7 +221,7 @@ CAF_TEST(adaptor access from actor system config - file input) {
   test_config cfg;
   std::istringstream in{config_text};
   if (auto err = cfg.parse(0, nullptr, in))
-    CAF_FAIL("cfg.parse failed: " << cfg.render(err));
+    CAF_FAIL("cfg.parse failed: " << err);
   CAF_CHECK_EQUAL(cfg.max_delay, my_duration::from_s(123));
 }
 
@@ -232,7 +232,7 @@ CAF_TEST(adaptor access from actor system config - file input and arguments) {
   test_config cfg;
   std::istringstream in{config_text};
   if (auto err = cfg.parse(std::move(args), in))
-    CAF_FAIL("cfg.parse failed: " << cfg.render(err));
+    CAF_FAIL("cfg.parse failed: " << err);
   CAF_CHECK_EQUAL(cfg.max_delay, my_duration::from_ms(20));
 }
 

--- a/libcaf_core/test/decorator/sequencer.cpp
+++ b/libcaf_core/test/decorator/sequencer.cpp
@@ -24,7 +24,7 @@
 
 #include "caf/all.hpp"
 
-#define ERROR_HANDLER [&](error& err) { CAF_FAIL(system.render(err)); }
+#define ERROR_HANDLER [&](error& err) { CAF_FAIL(err); }
 
 using namespace caf;
 

--- a/libcaf_core/test/detail/parser/read_number.cpp
+++ b/libcaf_core/test/detail/parser/read_number.cpp
@@ -345,9 +345,7 @@ CAF_TEST(ranges can use signed integers) {
   if (auto res = r(expr)) {                                                    \
     CAF_FAIL("expected expression to produce to an error");                    \
   } else {                                                                     \
-    auto& err = res.error();                                                   \
-    CAF_CHECK(err.category() == error_category<pec>::value);                   \
-    CAF_CHECK_EQUAL(err.code(), static_cast<uint8_t>(enum_value));             \
+    CAF_CHECK_EQUAL(res.error(), enum_value);                                  \
   }
 
 CAF_TEST(the parser rejects invalid step values) {

--- a/libcaf_core/test/detail/serialized_size.cpp
+++ b/libcaf_core/test/detail/serialized_size.cpp
@@ -40,7 +40,7 @@ struct fixture : test_coordinator_fixture<> {
     byte_buffer buf;
     binary_serializer sink{sys, buf};
     if (auto err = sink(xs...))
-      CAF_FAIL("failed to serialize data: " << sys.render(err));
+      CAF_FAIL("failed to serialize data: " << err);
     return buf.size();
   }
 };

--- a/libcaf_core/test/ipv4_endpoint.cpp
+++ b/libcaf_core/test/ipv4_endpoint.cpp
@@ -55,11 +55,11 @@ struct fixture {
     byte_buffer buf;
     binary_serializer sink(sys, buf);
     if (auto err = sink(x))
-      CAF_FAIL("serialization failed: " << sys.render(err));
+      CAF_FAIL("serialization failed: " << err);
     binary_deserializer source(sys, make_span(buf));
     T y;
     if (auto err = source(y))
-      CAF_FAIL("deserialization failed: " << sys.render(err));
+      CAF_FAIL("deserialization failed: " << err);
     return y;
   }
 };

--- a/libcaf_core/test/ipv6_endpoint.cpp
+++ b/libcaf_core/test/ipv6_endpoint.cpp
@@ -55,11 +55,11 @@ struct fixture {
     byte_buffer buf;
     binary_serializer sink(sys, buf);
     if (auto err = sink(x))
-      CAF_FAIL("serialization failed: " << sys.render(err));
+      CAF_FAIL("serialization failed: " << err);
     binary_deserializer source(sys, make_span(buf));
     T y;
     if (auto err = source(y))
-      CAF_FAIL("deserialization failed: " << sys.render(err));
+      CAF_FAIL("deserialization failed: " << err);
     return y;
   }
 };

--- a/libcaf_core/test/make_config_value_field.cpp
+++ b/libcaf_core/test/make_config_value_field.cpp
@@ -291,7 +291,7 @@ CAF_TEST(object access from actor system config - file input) {
   test_config cfg;
   std::istringstream in{config_text};
   if (auto err = cfg.parse(0, nullptr, in))
-    CAF_FAIL("cfg.parse failed: " << cfg.render(err));
+    CAF_FAIL("cfg.parse failed: " << err);
   CAF_CHECK_EQUAL(cfg.fb.foo, 42);
   CAF_CHECK_EQUAL(cfg.fb.bar, "Don't panic!");
   CAF_CHECK_EQUAL(cfg.fbfb.x.foo, 1);
@@ -308,7 +308,7 @@ CAF_TEST(object access from actor system config - file input and arguments) {
   test_config cfg;
   std::istringstream in{config_text};
   if (auto err = cfg.parse(std::move(args), in))
-    CAF_FAIL("cfg.parse failed: " << cfg.render(err));
+    CAF_FAIL("cfg.parse failed: " << err);
   CAF_CHECK_EQUAL(cfg.fb.foo, 42);
   CAF_CHECK_EQUAL(cfg.fb.bar, "Don't panic!");
   CAF_CHECK_EQUAL(cfg.fbfb.x.foo, 10);

--- a/libcaf_core/test/mixin/requester.cpp
+++ b/libcaf_core/test/mixin/requester.cpp
@@ -74,7 +74,7 @@ struct fixture : test_coordinator_fixture<> {
 
 } // namespace
 
-#define ERROR_HANDLER [&](error& err) { CAF_FAIL(sys.render(err)); }
+#define ERROR_HANDLER [&](error& err) { CAF_FAIL(err); }
 
 #define SUBTEST(message)                                                       \
   *result = none;                                                              \

--- a/libcaf_core/test/or_else.cpp
+++ b/libcaf_core/test/or_else.cpp
@@ -22,7 +22,7 @@
 
 #include "caf/all.hpp"
 
-#define ERROR_HANDLER [&](error& err) { CAF_FAIL(system.render(err)); }
+#define ERROR_HANDLER [&](error& err) { CAF_FAIL(err); }
 
 using namespace caf;
 

--- a/libcaf_core/test/policy/select_all.cpp
+++ b/libcaf_core/test/policy/select_all.cpp
@@ -46,9 +46,7 @@ struct fixture : test_coordinator_fixture<> {
   }
 
   std::function<void(const error&)> make_error_handler() {
-    return [this](const error& err) {
-      CAF_FAIL("unexpected error: " << sys.render(err));
-    };
+    return [](const error& err) { CAF_FAIL("unexpected error: " << err); };
   }
 
   std::function<void(const error&)> make_counting_error_handler(size_t* count) {

--- a/libcaf_core/test/policy/select_any.cpp
+++ b/libcaf_core/test/policy/select_any.cpp
@@ -44,9 +44,7 @@ struct fixture : test_coordinator_fixture<> {
   }
 
   auto make_error_handler() {
-    return [this](const error& err) {
-      CAF_FAIL("unexpected error: " << sys.render(err));
-    };
+    return [](const error& err) { CAF_FAIL("unexpected error: " << err); };
   }
 
   auto make_counting_error_handler(size_t* count) {

--- a/libcaf_core/test/serial_reply.cpp
+++ b/libcaf_core/test/serial_reply.cpp
@@ -71,8 +71,6 @@ CAF_TEST(test_serial_reply) {
   CAF_MESSAGE("ID of main: " << self->id());
   self->request(master, infinite, hi_atom::value)
     .receive([](ho_atom) { CAF_MESSAGE("received 'ho'"); },
-             [&](const error& err) {
-               CAF_ERROR("Error: " << self->system().render(err));
-             });
+             [&](const error& err) { CAF_ERROR("Error: " << to_string(err)); });
   CAF_REQUIRE(self->mailbox().empty());
 }

--- a/libcaf_core/test/serialization.cpp
+++ b/libcaf_core/test/serialization.cpp
@@ -107,7 +107,7 @@ struct fixture : test_coordinator_fixture<> {
     binary_serializer sink{sys, buf};
     if (auto err = sink(xs...))
       CAF_FAIL("serialization failed: "
-               << sys.render(err)
+               << err
                << ", data: " << deep_to_string(std::forward_as_tuple(xs...)));
     return buf;
   }
@@ -116,7 +116,7 @@ struct fixture : test_coordinator_fixture<> {
   void deserialize(const byte_buffer& buf, Ts&... xs) {
     binary_deserializer source{sys, buf};
     if (auto err = source(xs...))
-      CAF_FAIL("deserialization failed: " << sys.render(err));
+      CAF_FAIL("deserialization failed: " << err);
   }
 
   // serializes `x` and then deserializes and returns the serialized value

--- a/libcaf_core/test/typed_spawn.cpp
+++ b/libcaf_core/test/typed_spawn.cpp
@@ -29,7 +29,7 @@
 
 #  include "caf/all.hpp"
 
-#  define ERROR_HANDLER [&](error& err) { CAF_FAIL(sys.render(err)); }
+#  define ERROR_HANDLER [&](error& err) { CAF_FAIL(err); }
 
 using std::string;
 

--- a/libcaf_core/test/variant.cpp
+++ b/libcaf_core/test/variant.cpp
@@ -95,12 +95,12 @@ using v20 = variant<i01, i02, i03, i04, i05, i06, i07, i08, i09, i10,
     byte_buffer buf;                                                           \
     binary_serializer sink{sys.dummy_execution_unit(), buf};                   \
     if (auto err = sink(x3))                                                   \
-      CAF_FAIL("failed to serialize data: " << sys.render(err));               \
+      CAF_FAIL("failed to serialize data: " << err);                           \
     CAF_CHECK_EQUAL(x3, i##n{0x##n});                                          \
     v20 tmp;                                                                   \
     binary_deserializer source{sys.dummy_execution_unit(), buf};               \
     if (auto err = source(tmp))                                                \
-      CAF_FAIL("failed to deserialize data: " << sys.render(err));             \
+      CAF_FAIL("failed to deserialize data: " << err);                         \
     CAF_CHECK_EQUAL(tmp, i##n{0x##n});                                         \
     CAF_CHECK_EQUAL(tmp, x3);                                                  \
   }

--- a/libcaf_io/caf/io/network/ip_endpoint.hpp
+++ b/libcaf_io/caf/io/network/ip_endpoint.hpp
@@ -28,6 +28,7 @@
 #include "caf/meta/load_callback.hpp"
 #include "caf/meta/save_callback.hpp"
 #include "caf/meta/type_name.hpp"
+#include "caf/sec.hpp"
 
 struct sockaddr;
 struct sockaddr_storage;

--- a/libcaf_io/src/io/basp/instance.cpp
+++ b/libcaf_io/src/io/basp/instance.cpp
@@ -318,7 +318,7 @@ connection_state instance::handle(execution_unit* ctx, connection_handle hdl,
       std::set<std::string> sigs;
       if (auto err = bd(source_node, app_ids, aid, sigs)) {
         CAF_LOG_WARNING("unable to deserialize payload of server handshake:"
-                        << ctx->system().render(err));
+                        << to_string(err));
         return serializing_basp_payload_failed;
       }
       // Check the application ID.
@@ -367,7 +367,7 @@ connection_state instance::handle(execution_unit* ctx, connection_handle hdl,
       node_id source_node;
       if (auto err = bd(source_node)) {
         CAF_LOG_WARNING("unable to deserialize payload of client handshake:"
-                        << ctx->system().render(err));
+                        << to_string(err));
         return serializing_basp_payload_failed;
       }
       // Drop repeated handshakes.
@@ -391,7 +391,7 @@ connection_state instance::handle(execution_unit* ctx, connection_handle hdl,
       if (auto err = bd(source_node, dest_node)) {
         CAF_LOG_WARNING(
           "unable to deserialize source and destination for routed message:"
-          << ctx->system().render(err));
+          << to_string(err));
         return serializing_basp_payload_failed;
       }
       if (dest_node != this_node_) {
@@ -449,7 +449,7 @@ connection_state instance::handle(execution_unit* ctx, connection_handle hdl,
       node_id dest_node;
       if (auto err = bd(source_node, dest_node)) {
         CAF_LOG_WARNING("unable to deserialize payload of monitor message:"
-                        << ctx->system().render(err));
+                        << to_string(err));
         return serializing_basp_payload_failed;
       }
       if (dest_node == this_node_)
@@ -465,8 +465,8 @@ connection_state instance::handle(execution_unit* ctx, connection_handle hdl,
       node_id dest_node;
       error fail_state;
       if (auto err = bd(source_node, dest_node, fail_state)) {
-        CAF_LOG_WARNING("unable to deserialize payload of down message:"
-                        << ctx->system().render(err));
+        CAF_LOG_WARNING(
+          "unable to deserialize payload of down message:" << to_string(err));
         return serializing_basp_payload_failed;
       }
       if (dest_node == this_node_) {

--- a/libcaf_io/test/io/basp_broker.cpp
+++ b/libcaf_io/test/io/basp_broker.cpp
@@ -161,7 +161,7 @@ public:
     byte_buffer buf;
     binary_serializer bs{mpx_, buf};
     if (auto err = bs(const_cast<message&>(msg)))
-      CAF_FAIL("returned to serialize message: " << sys.render(err));
+      CAF_FAIL("returned to serialize message: " << to_string(err));
     return static_cast<uint32_t>(buf.size());
   }
 
@@ -219,7 +219,7 @@ public:
   void to_payload(byte_buffer& buf, const Ts&... xs) {
     binary_serializer sink{mpx_, buf};
     if (auto err = sink(xs...))
-      CAF_FAIL("failed to serialize payload: " << sys.render(err));
+      CAF_FAIL("failed to serialize payload: " << to_string(err));
   }
 
   void to_buf(byte_buffer& buf, basp::header& hdr, payload_writer* writer) {
@@ -347,8 +347,7 @@ public:
       { // lifetime scope of source
         binary_deserializer source{this_->mpx(), ob};
         if (auto err = source(hdr))
-          CAF_FAIL("unable to deserialize header: "
-                   << actor_system_config::render(err));
+          CAF_FAIL("unable to deserialize header: " << to_string(err));
       }
       byte_buffer payload;
       if (hdr.payload_len > 0) {
@@ -485,7 +484,7 @@ CAF_TEST(non_empty_server_handshake) {
   std::set<std::string> ifs{"caf::replies_to<@u16>::with<@u16>"};
   binary_serializer sink{nullptr, expected_payload};
   if (auto err = sink(instance().this_node(), app_ids, self()->id(), ifs))
-    CAF_FAIL("serializing handshake failed: " << sys.render(err));
+    CAF_FAIL("serializing handshake failed: " << to_string(err));
   CAF_CHECK_EQUAL(hexstr(payload), hexstr(expected_payload));
 }
 
@@ -608,7 +607,7 @@ CAF_TEST(remote_actor_and_send) {
       CAF_REQUIRE(proxy == res);
       result = actor_cast<actor>(res);
     },
-    [&](error& err) { CAF_FAIL("error: " << sys.render(err)); });
+    [&](error& err) { CAF_FAIL("error: " << to_string(err)); });
   CAF_MESSAGE("send message to proxy");
   anon_send(actor_cast<actor>(result), 42);
   mpx()->flush_runnables();

--- a/libcaf_io/test/io/basp_broker.cpp
+++ b/libcaf_io/test/io/basp_broker.cpp
@@ -161,7 +161,7 @@ public:
     byte_buffer buf;
     binary_serializer bs{mpx_, buf};
     if (auto err = bs(const_cast<message&>(msg)))
-      CAF_FAIL("returned to serialize message: " << to_string(err));
+      CAF_FAIL("returned to serialize message: " << err);
     return static_cast<uint32_t>(buf.size());
   }
 
@@ -219,7 +219,7 @@ public:
   void to_payload(byte_buffer& buf, const Ts&... xs) {
     binary_serializer sink{mpx_, buf};
     if (auto err = sink(xs...))
-      CAF_FAIL("failed to serialize payload: " << to_string(err));
+      CAF_FAIL("failed to serialize payload: " << err);
   }
 
   void to_buf(byte_buffer& buf, basp::header& hdr, payload_writer* writer) {
@@ -347,7 +347,7 @@ public:
       { // lifetime scope of source
         binary_deserializer source{this_->mpx(), ob};
         if (auto err = source(hdr))
-          CAF_FAIL("unable to deserialize header: " << to_string(err));
+          CAF_FAIL("unable to deserialize header: " << err);
       }
       byte_buffer payload;
       if (hdr.payload_len > 0) {
@@ -484,7 +484,7 @@ CAF_TEST(non_empty_server_handshake) {
   std::set<std::string> ifs{"caf::replies_to<@u16>::with<@u16>"};
   binary_serializer sink{nullptr, expected_payload};
   if (auto err = sink(instance().this_node(), app_ids, self()->id(), ifs))
-    CAF_FAIL("serializing handshake failed: " << to_string(err));
+    CAF_FAIL("serializing handshake failed: " << err);
   CAF_CHECK_EQUAL(hexstr(payload), hexstr(expected_payload));
 }
 
@@ -607,7 +607,7 @@ CAF_TEST(remote_actor_and_send) {
       CAF_REQUIRE(proxy == res);
       result = actor_cast<actor>(res);
     },
-    [&](error& err) { CAF_FAIL("error: " << to_string(err)); });
+    [&](error& err) { CAF_FAIL("error: " << err); });
   CAF_MESSAGE("send message to proxy");
   anon_send(actor_cast<actor>(result), 42);
   mpx()->flush_runnables();

--- a/libcaf_io/test/io/network/ip_endpoint.cpp
+++ b/libcaf_io/test/io/network/ip_endpoint.cpp
@@ -50,7 +50,7 @@ struct fixture : test_coordinator_fixture<> {
     byte_buffer buf;
     binary_serializer sink{sys, buf};
     if (auto err = sink(x, xs...))
-      CAF_FAIL("serialization failed: " << to_string(err));
+      CAF_FAIL("serialization failed: " << err);
     return buf;
   }
 
@@ -58,7 +58,7 @@ struct fixture : test_coordinator_fixture<> {
   void deserialize(const Buffer& buf, T& x, Ts&... xs) {
     binary_deserializer source{sys, buf};
     if (auto err = source(x, xs...))
-      CAF_FAIL("serialization failed: " << to_string(err));
+      CAF_FAIL("serialization failed: " << err);
   }
 };
 

--- a/libcaf_io/test/io/network/ip_endpoint.cpp
+++ b/libcaf_io/test/io/network/ip_endpoint.cpp
@@ -50,7 +50,7 @@ struct fixture : test_coordinator_fixture<> {
     byte_buffer buf;
     binary_serializer sink{sys, buf};
     if (auto err = sink(x, xs...))
-      CAF_FAIL("serialization failed: " << sys.render(err));
+      CAF_FAIL("serialization failed: " << to_string(err));
     return buf;
   }
 
@@ -58,7 +58,7 @@ struct fixture : test_coordinator_fixture<> {
   void deserialize(const Buffer& buf, T& x, Ts&... xs) {
     binary_deserializer source{sys, buf};
     if (auto err = source(x, xs...))
-      CAF_FAIL("serialization failed: " << sys.render(err));
+      CAF_FAIL("serialization failed: " << to_string(err));
   }
 };
 

--- a/libcaf_io/test/io/worker.cpp
+++ b/libcaf_io/test/io/worker.cpp
@@ -109,7 +109,7 @@ CAF_TEST(deliver serialized message) {
   std::vector<strong_actor_ptr> stages;
   binary_serializer sink{sys, payload};
   if (auto err = sink(stages, make_message(ok_atom_v)))
-    CAF_FAIL("unable to serialize message: " << sys.render(err));
+    CAF_FAIL("unable to serialize message: " << err);
   io::basp::header hdr{io::basp::message_type::direct_message,
                        0,
                        static_cast<uint32_t>(payload.size()),

--- a/libcaf_test/caf/test/dsl.hpp
+++ b/libcaf_test/caf/test/dsl.hpp
@@ -646,9 +646,7 @@ struct test_coordinator_fixture_fetch_helper {
   operator()(caf::response_handle<Self, Policy<Interface>>& from) const {
     std::tuple<Ts...> result;
     from.receive([&](Ts&... xs) { result = std::make_tuple(std::move(xs)...); },
-                 [&](caf::error& err) {
-                   FAIL(from.self()->system().render(err));
-                 });
+                 [&](caf::error& err) { CAF_FAIL(err); });
     return result;
   }
 };
@@ -659,9 +657,7 @@ struct test_coordinator_fixture_fetch_helper<T> {
   T operator()(caf::response_handle<Self, Policy<Interface>>& from) const {
     T result;
     from.receive([&](T& x) { result = std::move(x); },
-                 [&](caf::error& err) {
-                   FAIL(from.self()->system().render(err));
-                 });
+                 [&](caf::error& err) { CAF_FAIL(err); });
     return result;
   }
 };

--- a/libcaf_test/caf/test/dsl.hpp
+++ b/libcaf_test/caf/test/dsl.hpp
@@ -845,7 +845,7 @@ public:
     caf::byte_buffer buf;
     caf::binary_serializer sink{sys, buf};
     if (auto err = sink(xs...))
-      CAF_FAIL("serialization failed: " << sys.render(err));
+      CAF_FAIL("serialization failed: " << err);
     return buf;
   }
 
@@ -853,7 +853,7 @@ public:
   void deserialize(const caf::byte_buffer& buf, Ts&... xs) {
     caf::binary_deserializer source{sys, buf};
     if (auto err = source(xs...))
-      CAF_FAIL("deserialization failed: " << sys.render(err));
+      CAF_FAIL("deserialization failed: " << err);
   }
 
   template <class T>

--- a/manual/ConfiguringActorApplications.rst
+++ b/manual/ConfiguringActorApplications.rst
@@ -274,8 +274,8 @@ construction arguments passed as message can mismatch, this version of
 
    auto x = system.spawn<calculator>("calculator", make_message());
    if (! x) {
-     std::cerr << "*** unable to spawn calculator: "
-               << system.render(x.error()) << std::endl;
+     std::cerr << "*** unable to spawn calculator: " << to_string(x.error())
+               << std::endl;
      return;
    }
    calculator c = std::move(*x);

--- a/manual/GroupCommunication.rst
+++ b/manual/GroupCommunication.rst
@@ -14,8 +14,8 @@ name, joining, and leaving.
    std::string id = "foo";
    auto expected_grp = system.groups().get(module, id);
    if (! expected_grp) {
-     std::cerr << "*** cannot load group: "
-               << system.render(expected_grp.error()) << std::endl;
+     std::cerr << "*** cannot load group: " << to_string(expected_grp.error())
+               << std::endl;
      return;
    }
    auto grp = std::move(*expected_grp);

--- a/manual/NetworkTransparency.rst
+++ b/manual/NetworkTransparency.rst
@@ -92,12 +92,10 @@ connect to the published actor by calling ``remote_actor``:
 
    // node B
    auto ping = system.middleman().remote_actor("node A", 4242);
-   if (! ping) {
-     cerr << "unable to connect to node A: "
-          << system.render(ping.error()) << std::endl;
-   } else {
+   if (!ping)
+     cerr << "unable to connect to node A: " << to_string(ping.error()) << '\n';
+   else
      self->send(*ping, ping_atom::value);
-   }
 
 There is no difference between server and client after the connection phase.
 Remote actors use the same handle types as local actors and are thus fully

--- a/manual/Testing.rst
+++ b/manual/Testing.rst
@@ -99,7 +99,7 @@ as ``CAF_CHECK`` and provide tests rather than implementing a
        },
        [&](caf::error& err) {
          // Must not happen, stop test.
-         CAF_FAIL(sys.render(err));
+         CAF_FAIL(err);
        });
    }
 

--- a/tools/caf-run.cpp
+++ b/tools/caf-run.cpp
@@ -161,8 +161,8 @@ void bootstrap(actor_system& system, const string& wdir,
   // possible addresses slaves can use to connect to us
   auto port_res = system.middleman().publish(self, 0);
   if (!port_res) {
-    cerr << "fatal: unable to publish actor: "
-         << system.render(port_res.error()) << endl;
+    cerr << "fatal: unable to publish actor: " << to_string(port_res.error())
+         << endl;
     return;
   }
   auto port = *port_res;


### PR DESCRIPTION
- Get rid of `error_category`
- Deprecate error `render` functions (`to_string` works just fine after the redesign)
- Add back some headers to ease migration from CAF 0.17
- Simplify implementation of `error`
- Assign type IDs to our error code enums
- Enable conversion to `error` and `error_code` by specializing the new `is_error_code_enum`