### PR TITLE
Add missing core-export

### DIFF
--- a/libcaf_core/caf/detail/serialized_size.hpp
+++ b/libcaf_core/caf/detail/serialized_size.hpp
@@ -18,12 +18,13 @@
 
 #pragma once
 
+#include "caf/detail/core_export.hpp"
 #include "caf/error.hpp"
 #include "caf/serializer.hpp"
 
 namespace caf::detail {
 
-class serialized_size_inspector final : public serializer {
+class CAF_CORE_EXPORT serialized_size_inspector final : public serializer {
 public:
   using super = serializer;
 


### PR DESCRIPTION
This PR adds a missing `CAF_CORE_EXPORT` to the `serialized_size_inspector`.