### PR TITLE
Use nodiscard attribute where appropriate

### DIFF
--- a/libcaf_core/caf/detail/type_traits.hpp
+++ b/libcaf_core/caf/detail/type_traits.hpp
@@ -711,7 +711,7 @@ template <class T, class Arg>
 struct can_apply {
   template <class U>
   static auto sfinae(U* x)
-    -> decltype(x->apply(std::declval<Arg>()), std::true_type{});
+    -> decltype(CAF_IGNORE_UNUSED(x->apply(std::declval<Arg>())), std::true_type{});
 
   template <class U>
   static auto sfinae(...) -> std::false_type;

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -33,7 +33,7 @@ namespace caf {
 template <class> class behavior_type_of;
 template <class> class dictionary;
 template <class> class downstream;
-template <class> class error_code;
+template <class> class [[nodiscard]] error_code;
 template <class> class expected;
 template <class> class intrusive_cow_ptr;
 template <class> class intrusive_ptr;
@@ -106,7 +106,7 @@ class config_value;
 class deserializer;
 class downstream_manager;
 class downstream_manager_base;
-class error;
+class [[nodiscard]] error;
 class event_based_actor;
 class execution_unit;
 class forwarding_actor_proxy;


### PR DESCRIPTION
Declares `error_code` and `error` in `fwd.hpp` as `[[nodiscard]]`.
This does generate some additional warnings that may or may not indicate bugs.
I've taken the liberty to silence the warning in `libcaf_core/caf/detail/type_traits.hpp` since `x->apply(std::declval<Arg>())` is only used for the sake of expression SFINAE and I don't think the return value matters here.
Closes: #1097
