### PR TITLE
Close socket if SSL session initialization fails

### DIFF
--- a/libcaf_openssl/src/openssl/middleman_actor.cpp
+++ b/libcaf_openssl/src/openssl/middleman_actor.cpp
@@ -25,6 +25,7 @@
 #include "caf/actor.hpp"
 #include "caf/actor_proxy.hpp"
 #include "caf/actor_system_config.hpp"
+#include "caf/detail/socket_guard.hpp"
 #include "caf/logger.hpp"
 #include "caf/node_id.hpp"
 #include "caf/sec.hpp"
@@ -217,6 +218,7 @@ public:
       return false;
     auto& dm = acceptor_.backend();
     auto fd = acceptor_.accepted_socket();
+    detail::socket_guard sguard{fd};
     io::network::nonblocking(fd, true);
     auto sssn = make_session(parent()->system(), fd, true);
     if (sssn == nullptr) {
@@ -226,7 +228,10 @@ public:
     auto scrb = make_counted<scribe_impl>(dm, fd, std::move(sssn));
     auto hdl = scrb->hdl();
     parent()->add_scribe(std::move(scrb));
-    return doorman::new_connection(&dm, hdl);
+    auto result = doorman::new_connection(&dm, hdl);
+    if (result)
+      sguard.release();
+    return result;
   }
 };
 


### PR DESCRIPTION
Closes #1119.

The hang was caused by CAF "forgetting" about a socket without closing it. If the OpenSSL module has enough data read, it immediately tries to read data for the SSL handshake after accepting a socket. If this fails, the socket gets discarded without creating a `scribe` that claims ownership of the socket. Using a `socket_guard` makes sure that the socket gets closed in case of an error that happens before the `scribe` takes ownership.