### PR TITLE
Fix missing header file in install directory

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -187,6 +187,8 @@ add_library(libcaf_core "${PROJECT_SOURCE_DIR}/cmake/dummy.cpp"
 caf_core_set_default_properties(libcaf_core_obj libcaf_core)
 
 caf_export_and_install_lib(core)
+install(FILES "${CMAKE_BINARY_DIR}/caf/detail/build_config.hpp"
+          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/caf/detail")
 
 # -- build unit tests ----------------------------------------------------------
 


### PR DESCRIPTION
Fixes #1130 

This is a draft, because component-wise `install()` is typically called from within `caf_export_and_install_lib`. Is this fine?

Secondly, this could also call for an immediate staging phase on project's CI, where the framework would be compiled into a simple executable to verify validity of the installation.