### PR TITLE
Fix datagram servant shutdown

### DIFF
--- a/libcaf_io/src/io/abstract_broker.cpp
+++ b/libcaf_io/src/io/abstract_broker.cpp
@@ -214,6 +214,8 @@ void abstract_broker::add_datagram_servant(datagram_servant_ptr ptr) {
   launch_servant(ptr);
   for (auto& hdl : hdls)
     add_hdl_for_datagram_servant(ptr, hdl);
+  auto hdl = ptr->hdl();
+  add_hdl_for_datagram_servant(std::move(ptr), hdl);
 }
 
 void abstract_broker::add_hdl_for_datagram_servant(datagram_servant_ptr ptr,


### PR DESCRIPTION
In cases where a datagram server did not participate in any communication it did not get added to its broker and wasn't shut down correctly. As a result, the multiplexer would hang in its poll loop and prevent the actor system from shutting down.