### PR TITLE
Add logging statements when adjusting actor registry count

### DIFF
--- a/libcaf_core/caf/actor_registry.hpp
+++ b/libcaf_core/caf/actor_registry.hpp
@@ -65,11 +65,11 @@ public:
   /// leaving `reason` for future reference.
   void erase(actor_id key);
 
-  /// Increases running-actors-count by one.
-  void inc_running();
+  /// Increases running-actors-count by one. Returns the increased count.
+  size_t inc_running();
 
-  /// Decreases running-actors-count by one.
-  void dec_running();
+  /// Decreases running-actors-count by one. Returns the decreased count.
+  size_t dec_running();
 
   /// Returns the number of currently running actors.
   size_t running() const;

--- a/libcaf_core/src/abstract_actor.cpp
+++ b/libcaf_core/src/abstract_actor.cpp
@@ -95,14 +95,16 @@ void abstract_actor::register_at_system() {
   if (getf(is_registered_flag))
     return;
   setf(is_registered_flag);
-  home_system().registry().inc_running();
+  [[maybe_unused]] auto count = home_system().registry().inc_running();
+  CAF_LOG_DEBUG("actor " << id() << " increased running count to " << count);
 }
 
 void abstract_actor::unregister_from_system() {
   if (!getf(is_registered_flag))
     return;
   unsetf(is_registered_flag);
-  home_system().registry().dec_running();
+  [[maybe_unused]] auto count = home_system().registry().dec_running();
+  CAF_LOG_DEBUG("actor " << id() << " decreased running count to " << count);
 }
 
 } // namespace caf

--- a/libcaf_core/src/actor_registry.cpp
+++ b/libcaf_core/src/actor_registry.cpp
@@ -94,26 +94,21 @@ void actor_registry::erase(actor_id key) {
   }
 }
 
-void actor_registry::inc_running() {
-# if CAF_LOG_LEVEL >= CAF_LOG_LEVEL_DEBUG
-  auto value = ++*system_.base_metrics().running_actors;
-  CAF_LOG_DEBUG(CAF_ARG(value));
-# else
-  system_.base_metrics().running_actors->inc();
-# endif
+size_t actor_registry::inc_running() {
+  return ++*system_.base_metrics().running_actors;
 }
 
 size_t actor_registry::running() const {
   return static_cast<size_t>(system_.base_metrics().running_actors->value());
 }
 
-void actor_registry::dec_running() {
+size_t actor_registry::dec_running() {
   size_t new_val = --*system_.base_metrics().running_actors;
   if (new_val <= 1) {
     std::unique_lock<std::mutex> guard(running_mtx_);
     running_cv_.notify_all();
   }
-  CAF_LOG_DEBUG(CAF_ARG(new_val));
+  return new_val;
 }
 
 void actor_registry::await_running_count_equal(size_t expected) const {


### PR DESCRIPTION
Add a debug statements printing the actor id whenever the running actor count is adjusted.

This speeds up debugging for errors where the running count does not reach zero at program shutdown but it is not clear which actor is still alive.


NOTE: The compatibility header is based on similar code I wrote at https://mesos.apache.org/api/latest/c++/3rdparty_2stout_2include_2stout_2attributes_8hpp_source.html . If CAF already requires a compiler with support for standard attributes this can also be removed to reduce cruft.
