### PR TITLE
Fix warnings with clang-10

### DIFF
--- a/libcaf_core/caf/telemetry/metric_registry.hpp
+++ b/libcaf_core/caf/telemetry/metric_registry.hpp
@@ -407,8 +407,8 @@ public:
   ///               as well as prefixes starting with an underscore are
   ///               reserved.
   /// @param name The human-readable name of the metric, e.g., `requests`.
-  /// @param label_names Names for all label dimensions of the metric.
-  /// @param default_upper_bounds Upper bounds for the metric buckets.
+  /// @param labels Names for all label dimensions of the metric.
+  /// @param upper_bounds Upper bounds for the metric buckets.
   /// @param helptext Short explanation of the metric.
   /// @param unit Unit of measurement. Please use base units such as `bytes` or
   ///             `seconds` (prefer lowercase). The pseudo-unit `1` identifies

--- a/libcaf_core/caf/unit.hpp
+++ b/libcaf_core/caf/unit.hpp
@@ -28,13 +28,9 @@ namespace caf {
 /// to enable higher-order abstraction without cluttering code with
 /// exceptions for `void` (which can't be stored, for example).
 struct unit_t : detail::comparable<unit_t> {
-  constexpr unit_t() noexcept {
-    // nop
-  }
+  constexpr unit_t() noexcept = default;
 
-  constexpr unit_t(const unit_t&) noexcept {
-    // nop
-  }
+  constexpr unit_t(const unit_t&) noexcept = default;
 
   template <class T>
   explicit constexpr unit_t(T&&) noexcept {


### PR DESCRIPTION
I've had these fixed for a while locally, so why not push them. This allows for building CAF without warnings using clang-10, thus removing all the unnecessary noise in the compiler output.

@Neverlord did you consider running clang-10 in CI because of the new warnings in `-Wall`?