### PR TITLE
Fix handling of excluded-components settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   dependency for `caf_core` to libatomic gets executables to compile and link as
   expected (#1153).
 - Fixed a regression for remote groups introduced in 0.18.0-rc.1 (#1157).
+- CAF 0.18 introduced the option to set different `excluded-components` filters
+  for file and console log output. However, CAF rejected all events that matched
+  either filter. The new implementation uses the *intersection* of both filters
+  to reject log messages immediately (before enqueueing it to the logger's
+  queue) and then applies the filters individually when generating file or
+  console output.
 
 ## [0.18.0-rc.1] - 2020-09-09
 

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -340,8 +340,8 @@ private:
   // Configures verbosity and output generation.
   config cfg_;
 
-  // Filters events by component name before enqueuing a log event. Union of
-  // file_filter_ and console_filter_ if both outputs are enabled.
+  // Filters events by component name before enqueuing a log event. Intersection
+  // of file_filter_ and console_filter_ if both outputs are enabled.
   std::vector<std::string> global_filter_;
 
   // Filters events by component name for file output.

--- a/libcaf_core/src/logger.cpp
+++ b/libcaf_core/src/logger.cpp
@@ -324,9 +324,9 @@ void logger::init(actor_system_config& cfg) {
     read_filter(console_filter_, "caf.logger.console.excluded-components");
     std::sort(file_filter_.begin(), file_filter_.end());
     std::sort(console_filter_.begin(), console_filter_.end());
-    std::set_union(file_filter_.begin(), file_filter_.end(),
-                   console_filter_.begin(), console_filter_.end(),
-                   std::back_inserter(global_filter_));
+    std::set_intersection(file_filter_.begin(), file_filter_.end(),
+                          console_filter_.begin(), console_filter_.end(),
+                          std::back_inserter(global_filter_));
   } else if (cfg_.file_verbosity > CAF_LOG_LEVEL_QUIET) {
     read_filter(file_filter_, "caf.logger.file.excluded-components");
     global_filter_ = file_filter_;


### PR DESCRIPTION
See CHANGELOG entry:

> CAF 0.18 introduced the option to set different `excluded-components` filters
> for file and console log output. However, CAF rejected all events that matched
> either filter. The new implementation uses the *intersection* of both filters
> to reject log messages immediately (before enqueueing it to the logger's
> queue) and then applies the filters individually when generating file or
> console output.