### PR TITLE
Add new capabilities for BDD-style unit tests

### DIFF
--- a/libcaf_core/test/broadcast_downstream_manager.cpp
+++ b/libcaf_core/test/broadcast_downstream_manager.cpp
@@ -342,7 +342,7 @@ receive_checker<F> operator<<(receive_checker<F> xs, not_empty_t) {
 
 #define BATCH(first, last) make_batch(first, last)
 
-#define AND <<
+#define AND_RECEIVED <<
 
 // -- unit tests ---------------------------------------------------------------
 
@@ -367,7 +367,7 @@ CAF_TEST(one_path_force) {
   }
   // Give 11 credit (more than 10).
   AFTER ENTITY alice TRIED FORCE_SENDING 11 ELEMENTS {
-    ENTITY bob RECEIVED BATCH(14, 23) AND BATCH(24, 24);
+    ENTITY bob RECEIVED BATCH(14, 23) AND_RECEIVED BATCH(24, 24);
     ENTITY alice HAS 0u CREDIT FOR bob;
   }
   // Drain all elements except the last 5.
@@ -444,15 +444,15 @@ CAF_TEST(two_paths_different_sizes_force) {
   // Give exactly 10 credit.
   AFTER ENTITY alice TRIED FORCE_SENDING 10 ELEMENTS {
     ENTITY bob RECEIVED BATCH(4, 13);
-    ENTITY carl RECEIVED BATCH(4, 10) AND BATCH(11, 13);
+    ENTITY carl RECEIVED BATCH(4, 10) AND_RECEIVED BATCH(11, 13);
     ENTITY alice HAS 0u CREDIT FOR bob;
     ENTITY alice HAS 0u CREDIT FOR carl;
     ENTITY alice HAS 0u CREDIT TOTAL;
   }
   // Give 11 credit (more than 10).
   AFTER ENTITY alice TRIED FORCE_SENDING 11 ELEMENTS {
-    ENTITY bob RECEIVED BATCH(14, 23) AND BATCH(24, 24);
-    ENTITY carl RECEIVED BATCH(14, 20) AND BATCH(21, 24);
+    ENTITY bob RECEIVED BATCH(14, 23) AND_RECEIVED BATCH(24, 24);
+    ENTITY carl RECEIVED BATCH(14, 20) AND_RECEIVED BATCH(21, 24);
     ENTITY alice HAS 0u CREDIT TOTAL;
   }
   // Drain all elements except the last 5.
@@ -511,7 +511,7 @@ CAF_TEST(two_paths_different_sizes_without_force) {
   // Give 11 credit.
   AFTER ENTITY alice TRIED SENDING 11 ELEMENTS {
     ENTITY bob RECEIVED BATCH(11, 20);
-    ENTITY carl RECEIVED BATCH(8, 14) AND BATCH(15, 21);
+    ENTITY carl RECEIVED BATCH(8, 14) AND_RECEIVED BATCH(15, 21);
     ENTITY alice HAS 1u CREDIT FOR bob;
     ENTITY alice HAS 0u CREDIT FOR carl;
     ENTITY alice HAS 1u CREDIT TOTAL;

--- a/libcaf_core/test/core-test.hpp
+++ b/libcaf_core/test/core-test.hpp
@@ -1,5 +1,5 @@
 #include "caf/fwd.hpp"
-#include "caf/test/dsl.hpp"
+#include "caf/test/bdd_dsl.hpp"
 #include "caf/type_id.hpp"
 #include "caf/typed_actor.hpp"
 

--- a/libcaf_core/test/expected.cpp
+++ b/libcaf_core/test/expected.cpp
@@ -26,16 +26,6 @@
 
 using namespace caf;
 
-#define CHECK(x) CAF_CHECK(x);
-
-#define CHECK_EQ(x, y)                                                         \
-  CAF_CHECK(x == y);                                                           \
-  CAF_CHECK(y == x);
-
-#define CHECK_NEQ(x, y)                                                        \
-  CAF_CHECK(x != y);                                                           \
-  CAF_CHECK(y != x);
-
 namespace {
 
 using e_int = expected<int>;
@@ -58,9 +48,9 @@ CAF_TEST(both_engaged_not_equal) {
   e_int y{24};
   CHECK(x);
   CHECK(y);
-  CHECK_NEQ(x, y);
-  CHECK_NEQ(x, sec::unexpected_message);
-  CHECK_NEQ(y, sec::unexpected_message);
+  CHECK_NE(x, y);
+  CHECK_NE(x, sec::unexpected_message);
+  CHECK_NE(y, sec::unexpected_message);
   CHECK_EQ(x, 42);
   CHECK_EQ(y, 24);
 }
@@ -72,10 +62,10 @@ CAF_TEST(engaged_plus_not_engaged) {
   CHECK(!y);
   CHECK_EQ(x, 42);
   CHECK_EQ(y, sec::unexpected_message);
-  CHECK_NEQ(x, sec::unexpected_message);
-  CHECK_NEQ(x, y);
-  CHECK_NEQ(y, 42);
-  CHECK_NEQ(y, sec::unsupported_sys_key);
+  CHECK_NE(x, sec::unexpected_message);
+  CHECK_NE(x, y);
+  CHECK_NE(y, 42);
+  CHECK_NE(y, sec::unsupported_sys_key);
 }
 
 CAF_TEST(both_not_engaged) {
@@ -87,15 +77,15 @@ CAF_TEST(both_not_engaged) {
   CHECK_EQ(x, sec::unexpected_message);
   CHECK_EQ(y, sec::unexpected_message);
   CHECK_EQ(x.error(), y.error());
-  CHECK_NEQ(x, sec::unsupported_sys_key);
-  CHECK_NEQ(y, sec::unsupported_sys_key);
+  CHECK_NE(x, sec::unsupported_sys_key);
+  CHECK_NE(y, sec::unsupported_sys_key);
 }
 
 CAF_TEST(move_and_copy) {
   e_str x{sec::unexpected_message};
   e_str y{"hello"};
   x = "hello";
-  CHECK_NEQ(x, sec::unexpected_message);
+  CHECK_NE(x, sec::unexpected_message);
   CHECK_EQ(x, "hello");
   CHECK_EQ(x, y);
   y = "world";
@@ -107,7 +97,7 @@ CAF_TEST(move_and_copy) {
   CHECK_EQ(z_cpy, "world");
   CHECK_EQ(z, z_cpy);
   z = e_str{sec::unsupported_sys_key};
-  CHECK_NEQ(z, z_cpy);
+  CHECK_NE(z, z_cpy);
   CHECK_EQ(z, sec::unsupported_sys_key);
 }
 

--- a/libcaf_test/caf/test/bdd_dsl.hpp
+++ b/libcaf_test/caf/test/bdd_dsl.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "caf/test/dsl.hpp"
+
+#define SCENARIO(description)                                                  \
+  namespace {                                                                  \
+  struct CAF_UNIQUE(test) : caf_test_case_auto_fixture {                       \
+    void run_test_impl();                                                      \
+  };                                                                           \
+  ::caf::test::detail::adder<::caf::test::test_impl<CAF_UNIQUE(test)>>         \
+    CAF_UNIQUE(a){CAF_XSTR(CAF_SUITE), "SCENARIO " description, false};        \
+  }                                                                            \
+  void CAF_UNIQUE(test)::run_test_impl()
+
+#define GIVEN(description)                                                     \
+  CAF_MESSAGE("GIVEN " description);                                           \
+  if (true)
+
+#define WHEN(description)                                                      \
+  CAF_MESSAGE("WHEN " description);                                            \
+  if (true)
+
+#define THEN(description)                                                      \
+  CAF_MESSAGE("THEN " description);                                            \
+  if (true)
+
+#define AND(description)                                                       \
+  {}                                                                           \
+  CAF_MESSAGE("AND " description);                                             \
+  if (true)
+
+#define CHECK(what) CAF_CHECK(what)
+#define CHECK_EQ(lhs, rhs) CAF_CHECK_EQUAL(lhs, rhs)
+#define CHECK_NE(lhs, rhs) CAF_CHECK_NOT_EQUAL(lhs, rhs)
+#define CHECK_LT(lhs, rhs) CAF_CHECK_LESS(lhs, rhs)
+#define CHECK_LE(lhs, rhs) CAF_CHECK_LESS_OR_EQUAL(lhs, rhs)
+#define CHECK_GT(lhs, rhs) CAF_CHECK_GREATER(lhs, rhs)
+#define CHECK_GE(lhs, rhs) CAF_CHECK_GREATER_OR_EQUAL(lhs, rhs)
+
+#define REQUIRE(what) CAF_REQUIRE(what)
+#define REQUIRE_EQ(lhs, rhs) CAF_REQUIRE_EQUAL(lhs, rhs)
+#define REQUIRE_NE(lhs, rhs) CAF_REQUIRE_NOT_EQUAL(lhs, rhs)
+#define REQUIRE_LT(lhs, rhs) CAF_REQUIRE_LESS(lhs, rhs)
+#define REQUIRE_LE(lhs, rhs) CAF_REQUIRE_LESS_OR_EQUAL(lhs, rhs)
+#define REQUIRE_GT(lhs, rhs) CAF_REQUIRE_GREATER(lhs, rhs)
+#define REQUIRE_GE(lhs, rhs) CAF_REQUIRE_GREATER_OR_EQUAL(lhs, rhs)
+
+#define MESSAGE(what) CAF_MESSAGE(what)


### PR DESCRIPTION
We've recently added a couple BDD-style unit tests to the code base. While I find this style generally working well for structuring tests, our current unit test macros add a lot of noise to these tests.

The new `SCENARIO`, `GIVEN`, `WHEN`, `THEN` macros cut down that noise and make the tests much more readable. I've also added short versions for our check and require macros. Since these additions could break client code, the new BDD-style macros go into a new header. There is of course more we could do (like nicely indenting unit test output based on scenario/given/when/then blocks) but this lets us reap 80% of the benefits with 20% effort right away. 🙂