### PR TITLE
Add convenience function for C-style arg remainder

### DIFF
--- a/libcaf_core/caf/actor_system_config.hpp
+++ b/libcaf_core/caf/actor_system_config.hpp
@@ -185,8 +185,19 @@ public:
   /// and instead return from `main` immediately.
   bool cli_helptext_printed;
 
+  /// Stores the content of `argv[0]` from the arguments passed to `parse`.
+  std::string program_name;
+
   /// Stores CLI arguments that were not consumed by CAF.
   string_list remainder;
+
+  /// Returns the remainder including the program name (`argv[0]`) suitable for
+  /// passing the returned pair of arguments to C-style functions that usually
+  /// accept `(argc, argv)` input as passed to `main`. This function creates the
+  /// necessary buffers lazily on first call.
+  /// @note The returned pointer remains valid only as long as the
+  ///       `actor_system_config` object exists.
+  std::pair<int, char**> c_args_remainder();
 
   // -- caf-run parameters -----------------------------------------------------
 
@@ -317,6 +328,9 @@ protected:
   config_option_set custom_options_;
 
 private:
+  std::vector<char*> c_args_remainder_;
+  std::vector<char> c_args_remainder_buf_;
+
   actor_system_config& set_impl(string_view name, config_value value);
 
   error extract_config_file_path(string_list& args);

--- a/libcaf_core/test/actor_system_config.cpp
+++ b/libcaf_core/test/actor_system_config.cpp
@@ -85,6 +85,9 @@ CAF_TEST(parsing - without CLI arguments) {
   parse(text);
   CAF_CHECK(cfg.remainder.empty());
   CAF_CHECK_EQUAL(get_or(cfg, "foo.bar", ""), "hello");
+  auto [argc, argv] = cfg.c_args_remainder();
+  CAF_REQUIRE_EQUAL(argc, 1);
+  CAF_CHECK_EQUAL(argv[0], cfg.program_name);
 }
 
 CAF_TEST(parsing - without CLI cfg.remainder) {
@@ -111,11 +114,15 @@ CAF_TEST(parsing - without CLI cfg.remainder) {
 CAF_TEST(parsing - with CLI cfg.remainder) {
   auto text = "foo{\nbar=\"hello\"}";
   options("?foo").add<std::string>("bar,b", "some string parameter");
-  CAF_MESSAGE("valid cfg.remainder");
   parse(text, {"-b", "test", "hello", "world"});
+  CAF_REQUIRE_EQUAL(cfg.remainder.size(), 2u);
   CAF_CHECK_EQUAL(get_or(cfg, "foo.bar", ""), "test");
   CAF_CHECK_EQUAL(cfg.remainder, string_list({"hello", "world"}));
-  CAF_MESSAGE("invalid cfg.remainder");
+  auto [argc, argv] = cfg.c_args_remainder();
+  CAF_REQUIRE_EQUAL(argc, 3);
+  CAF_CHECK_EQUAL(argv[0], cfg.program_name);
+  CAF_CHECK_EQUAL(argv[1], cfg.remainder[0]);
+  CAF_CHECK_EQUAL(argv[2], cfg.remainder[1]);
 }
 
 CAF_TEST(file input overrides defaults but CLI args always win) {


### PR DESCRIPTION
Intended to interface with functions that require a C-style `(argc, argv)` pair for the args remainder of `actor_system_config`.

@RG-707 let me know if this worked for you in #1165. I'll keep this as draft in the meantime.