### PR TITLE
Use CMAKE_INSTALL_FULL_LIBDIR to install CMake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ set(CAF_LOG_LEVEL "QUIET" CACHE STRING "Set log verbosity of CAF components")
 set(CAF_SANITIZERS "" CACHE STRING
     "Comma separated sanitizers, e.g., 'address,undefined'")
 set(CAF_INSTALL_CMAKEDIR
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/CAF" CACHE PATH
+    "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/CAF" CACHE PATH
     "Path for installing CMake files, enables 'find_package(CAF)'")
   set(CAF_BUILD_INFO_FILE_PATH "" CACHE FILEPATH
     "Optional path for writing CMake and compiler version information")


### PR DESCRIPTION
CMAKE_INSTALL_LIBDIR is underspecified and may be set to either a
relative or absolute path by an upstream project or user.  In the case
it's an absolute path, the install path for CAF's CMake files
incorrectly prepend CMAKE_INSTALL_PREFIX.

CMAKE_INSTALL_FULL_LIBDIR is specified to be an absolute path, with
CMAKE_INSTALL_PREFIX prepended if needed, so using it is preferable.