### PR TITLE
Align typed_response_promise with response_promise

### DIFF
--- a/libcaf_core/caf/response_promise.hpp
+++ b/libcaf_core/caf/response_promise.hpp
@@ -73,7 +73,7 @@ public:
         make_message(std::forward<T>(x), std::forward<Ts>(xs)...));
   }
 
-  /// Satisfies the promise by sending either an error or a non-erorr response
+  /// Satisfies the promise by sending either an error or a non-error response
   /// message.
   template <class T>
   void deliver(expected<T> x) {
@@ -106,7 +106,6 @@ public:
   }
 
   /// Satisfies the promise by sending an error response message.
-  /// For non-requests, nothing is done.
   void deliver(error x);
 
   /// Satisfies the promise by sending an empty message if this promise has a

--- a/libcaf_core/caf/response_promise.hpp
+++ b/libcaf_core/caf/response_promise.hpp
@@ -73,6 +73,8 @@ public:
         make_message(std::forward<T>(x), std::forward<Ts>(xs)...));
   }
 
+  /// Satisfies the promise by sending either an error or a non-erorr response
+  /// message.
   template <class T>
   void deliver(expected<T> x) {
     if (x)
@@ -92,8 +94,7 @@ public:
       typename std::decay<Ts>::type>::type...>;
     static_assert(response_type_unbox<signatures_of_t<Handle>, token>::valid,
                   "receiver does not accept given message");
-    // TODO: use `if constexpr` when switching to C++17
-    if (P == message_priority::high)
+    if constexpr (P == message_priority::high)
       id_ = id_.with_high_priority();
     if constexpr (std::is_same<detail::type_list<message>,
                                detail::type_list<std::decay_t<Ts>...>>::value)
@@ -105,6 +106,7 @@ public:
   }
 
   /// Satisfies the promise by sending an error response message.
+  /// For non-requests, nothing is done.
   void deliver(error x);
 
   /// Satisfies the promise by sending an empty message if this promise has a

--- a/libcaf_core/caf/typed_response_promise.hpp
+++ b/libcaf_core/caf/typed_response_promise.hpp
@@ -76,7 +76,7 @@ public:
     return *this;
   }
 
-  /// Satisfies the promise by sending either an error or a non-erorr response
+  /// Satisfies the promise by sending either an error or a non-error response
   /// message.
   template <class T>
   void deliver(expected<T> x) {
@@ -98,12 +98,6 @@ public:
   typed_response_promise deliver(error x) {
     promise_.deliver(std::move(x));
     return *this;
-  }
-
-  /// Satisfies the promise by sending an empty message if this promise has a
-  /// valid message ID, i.e., `async() == false`.
-  void deliver(unit_t x) {
-    promise_.deliver(x);
   }
 
   /// Returns whether this response promise replies to an asynchronous message.

--- a/libcaf_core/caf/typed_response_promise.hpp
+++ b/libcaf_core/caf/typed_response_promise.hpp
@@ -30,8 +30,20 @@ namespace caf {
 template <class... Ts>
 class typed_response_promise {
 public:
+  using forwarding_stack = response_promise::forwarding_stack;
+
   /// Constructs an invalid response promise.
   typed_response_promise() = default;
+
+  typed_response_promise(none_t x) : promise_(x) {
+    // nop
+  }
+
+  typed_response_promise(strong_actor_ptr self, strong_actor_ptr source,
+                         forwarding_stack stages, message_id id)
+    : promise_(std::move(self), std::move(source), std::move(stages), id) {
+    // nop
+  }
 
   typed_response_promise(strong_actor_ptr self, mailbox_element& src)
     : promise_(std::move(self), src) {
@@ -44,6 +56,7 @@ public:
   typed_response_promise& operator=(const typed_response_promise&) = default;
 
   /// Implicitly convertible to untyped response promise.
+  [[deprecated("Use the typed_response_promise directly.")]]
   operator response_promise&() {
     return promise_;
   }
@@ -63,6 +76,16 @@ public:
     return *this;
   }
 
+  /// Satisfies the promise by sending either an error or a non-erorr response
+  /// message.
+  template <class T>
+  void deliver(expected<T> x) {
+    if (x)
+      return deliver(std::move(*x));
+    return deliver(std::move(x.error()));
+  }
+
+  /// Satisfies the promise by delegating to another actor.
   template <message_priority P = message_priority::normal, class Handle = actor,
             class... Us>
   typed_response_promise delegate(const Handle& dest, Us&&... xs) {
@@ -77,9 +100,41 @@ public:
     return *this;
   }
 
+  /// Satisfies the promise by sending an empty message if this promise has a
+  /// valid message ID, i.e., `async() == false`.
+  void deliver(unit_t x) {
+    promise_.deliver(x);
+  }
+
+  /// Returns whether this response promise replies to an asynchronous message.
+  bool async() const {
+    return promise_.async();
+  }
+
   /// Queries whether this promise is a valid promise that is not satisfied yet.
   bool pending() const {
     return promise_.pending();
+  }
+
+  /// Returns the source of the corresponding request.
+  const strong_actor_ptr& source() const {
+    return promise_.source();
+  }
+
+  /// Returns the remaining stages for the corresponding request.
+  const forwarding_stack& stages() const {
+    return promise_.stages();
+  }
+
+  /// Returns the actor that will receive the response, i.e.,
+  /// `stages().front()` if `!stages().empty()` or `source()` otherwise.
+  strong_actor_ptr next() const {
+    return promise_.next();
+  }
+
+  /// Returns the message ID of the corresponding request.
+  message_id id() const {
+    return promise_.id();
   }
 
 private:


### PR DESCRIPTION
This aligns the functionality of `typed_response_promise` with the functionality of `response_promise`.