### PR TITLE
Check whether CMAKE_INSTALL_PREFIX is absolute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,10 @@ if(MSVC AND CAF_SANITIZERS)
   message(FATAL_ERROR "Sanitizer builds are currently not supported on MSVC")
 endif()
 
+if (NOT IS_ABSOLUTE "${CMAKE_INSTALL_PREFIX}")
+  message(FATAL_ERROR "CMAKE_INSTALL_PREFIX must be absolute")
+endif ()
+
 # -- base target setup ---------------------------------------------------------
 
 # This target propagates compiler flags, extra dependencies, etc. All other CAF


### PR DESCRIPTION
CAF uses `CMAKE_INSTALL_FULL_<GNUInstallDir>` instead of `CMAKE_INSTALL_<GNUInstallDir>`, which by default are the latter prefixed with `CMAKE_INSTALL_PREFIX`. However, there is no further checking in place whether the resulting `CMAKE_INSTALL_FULL_<GNUInstallDir>` is absolute, and if it is not, then using it as a destination in `install(... DESTINATION ${CMAKE_INSTALL_FULL_<GNUInstallDir>})` will cause it to be prefixed with `CMAKE_INSTALL_PREFIX` again.

This PR adds a sanity check whether `CMAKE_INSTALL_PREFIX` is absolute.