### PR TITLE
Fix handling of expected<T> in response promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   trying to parse the input of `x` if it contains a string. The function
   `get_or` already existed for `settings`, but we have added new overloads for
   generalizing the function to `config_value` as well.
+- The `typed_response_promise` received additional member functions to mirror
+  the interface of the untyped `response_promise`.
 
 ### Deprecated
 
@@ -84,6 +86,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Skipping high-priority messages resulted in CAF lowering the priority to
   normal. This unintentional demotion has been fixed (#1171).
 - Fix undefined behavior in the experimental datagram brokers (#1174).
+- Response promises no longer send empty messages in response to asynchronous
+  messages.
 
 ## [0.18.0-rc.1] - 2020-09-09
 

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -308,6 +308,7 @@ caf_add_component(
     policy.select_all
     policy.select_any
     request_timeout
+    response_promise
     result
     save_inspector
     selective_streaming

--- a/libcaf_core/caf/response_promise.hpp
+++ b/libcaf_core/caf/response_promise.hpp
@@ -64,7 +64,7 @@ public:
   void deliver(expected<T> x) {
     if (x) {
       if constexpr (std::is_same<T, void>::value)
-        deliver_impl(make_message());
+        deliver();
       else
         deliver(std::move(*x));
     } else {

--- a/libcaf_core/caf/response_type.hpp
+++ b/libcaf_core/caf/response_type.hpp
@@ -58,10 +58,17 @@ struct response_type<detail::type_list<Out(In...), Fs...>, In...> {
   using delegated_type = delegated<Out>;
 };
 
-/// Computes the response message for input `In...` from the list of message
-/// passing interfaces `Fs`.
+/// Computes the response message type for input `In...` from the list of
+/// message passing interfaces `Fs`.
 template <class Fs, class... In>
 using response_type_t = typename response_type<Fs, In...>::type;
+
+/// Computes the response message type for input `In...` from the list of
+/// message passing interfaces `Fs` and returns the corresponding
+/// `delegated<T>`.
+template <class Fs, class... In>
+using delegated_response_type_t =
+  typename response_type<Fs, In...>::delegated_type;
 
 /// Unboxes `Xs` and calls `response_type`.
 template <class Ts, class Xs>

--- a/libcaf_core/caf/typed_response_promise.hpp
+++ b/libcaf_core/caf/typed_response_promise.hpp
@@ -4,9 +4,11 @@
 
 #pragma once
 
-#include "caf/response_promise.hpp"
+#include <type_traits>
 
 #include "caf/detail/type_list.hpp"
+#include "caf/make_message.hpp"
+#include "caf/response_promise.hpp"
 
 namespace caf {
 
@@ -48,42 +50,38 @@ public:
   }
 
   /// Satisfies the promise by sending a non-error response message.
-  template <class U, class... Us>
-  typename std::enable_if<(sizeof...(Us) > 0)
-                            || !std::is_convertible<U, error>::value,
-                          typed_response_promise>::type
-  deliver(U&& x, Us&&... xs) {
-    static_assert(
-      std::is_same<detail::type_list<Ts...>,
-                   detail::type_list<typename std::decay<U>::type,
-                                     typename std::decay<Us>::type...>>::value,
-      "typed_response_promise: message type mismatched");
-    promise_.deliver(std::forward<U>(x), std::forward<Us>(xs)...);
-    return *this;
+  template <class... Us>
+  std::enable_if_t<(std::is_constructible<Ts, Us>::value && ...)>
+  deliver(Us... xs) {
+    promise_.deliver(make_message(Ts{std::forward<Us>(xs)}...));
+  }
+
+  /// Satisfies the promise by sending an empty response message.
+  template <class L = detail::type_list<Ts...>>
+  std::enable_if_t<std::is_same<L, detail::type_list<void>>::value> deliver() {
+    promise_.deliver();
+  }
+
+  /// Satisfies the promise by sending an error response message.
+  /// For non-requests, nothing is done.
+  void deliver(error x) {
+    promise_.deliver(std::move(x));
   }
 
   /// Satisfies the promise by sending either an error or a non-error response
   /// message.
   template <class T>
-  void deliver(expected<T> x) {
-    if (x)
-      return deliver(std::move(*x));
-    return deliver(std::move(x.error()));
+  std::enable_if_t<
+    std::is_same<detail::type_list<T>, detail::type_list<Ts...>>::value>
+  deliver(expected<T> x) {
+    promise_.deliver(std::move(x));
   }
 
   /// Satisfies the promise by delegating to another actor.
   template <message_priority P = message_priority::normal, class Handle = actor,
             class... Us>
-  typed_response_promise delegate(const Handle& dest, Us&&... xs) {
-    promise_.template delegate<P>(dest, std::forward<Us>(xs)...);
-    return *this;
-  }
-
-  /// Satisfies the promise by sending an error response message.
-  /// For non-requests, nothing is done.
-  typed_response_promise deliver(error x) {
-    promise_.deliver(std::move(x));
-    return *this;
+  auto delegate(const Handle& dest, Us&&... xs) {
+    return promise_.template delegate<P>(dest, std::forward<Us>(xs)...);
   }
 
   /// Returns whether this response promise replies to an asynchronous message.

--- a/libcaf_core/src/response_promise.cpp
+++ b/libcaf_core/src/response_promise.cpp
@@ -46,7 +46,7 @@ void response_promise::deliver(error x) {
   deliver_impl(make_message(std::move(x)));
 }
 
-void response_promise::deliver(unit_t) {
+void response_promise::deliver() {
   deliver_impl(make_message());
 }
 
@@ -73,6 +73,11 @@ void response_promise::deliver_impl(message msg) {
   CAF_LOG_TRACE(CAF_ARG(msg));
   if (self_ == nullptr) {
     CAF_LOG_DEBUG("drop response: invalid promise");
+    return;
+  }
+  if (msg.empty() && id_.is_async()) {
+    CAF_LOG_DEBUG("drop response: empty response to asynchronous input");
+    self_.reset();
     return;
   }
   auto dptr = self_dptr();

--- a/libcaf_core/test/response_promise.cpp
+++ b/libcaf_core/test/response_promise.cpp
@@ -1,20 +1,6 @@
-/******************************************************************************
- *                       ____    _    _____                                   *
- *                      / ___|  / \  |  ___|    C++                           *
- *                     | |     / _ \ | |_       Actor                         *
- *                     | |___ / ___ \|  _|      Framework                     *
- *                      \____/_/   \_|_|                                      *
- *                                                                            *
- * Copyright 2011-2021 Dominik Charousset                                     *
- *                                                                            *
- * Distributed under the terms and conditions of the BSD 3-Clause License or  *
- * (at your option) under the terms and conditions of the Boost Software      *
- * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
- *                                                                            *
- * If you did not receive a copy of the license files, see                    *
- * http://opensource.org/licenses/BSD-3-Clause and                            *
- * http://www.boost.org/LICENSE_1_0.txt.                                      *
- ******************************************************************************/
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
 
 #define CAF_SUITE response_promise
 

--- a/libcaf_core/test/response_promise.cpp
+++ b/libcaf_core/test/response_promise.cpp
@@ -1,10 +1,24 @@
-// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
-// the main distribution directory for license terms and copyright or visit
-// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2021 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
 
-#define CAF_SUITE typed_response_promise
+#define CAF_SUITE response_promise
 
-#include "caf/typed_response_promise.hpp"
+#include "caf/response_promise.hpp"
 
 #include "core-test.hpp"
 
@@ -12,34 +26,30 @@ using namespace caf;
 
 namespace {
 
-using testee_actor = typed_actor<result<int>(int, int), result<void>(ok_atom)>;
-
-testee_actor::behavior_type adder() {
+behavior adder() {
   return {
     [](int x, int y) { return x + y; },
     [](ok_atom) {},
   };
 }
 
-testee_actor::behavior_type delegator(testee_actor::pointer self,
-                                      testee_actor worker) {
+behavior delegator(event_based_actor* self, actor worker) {
   return {
     [=](int x, int y) {
-      auto promise = self->make_response_promise<int>();
+      auto promise = self->make_response_promise();
       return promise.delegate(worker, x, y);
     },
     [=](ok_atom) {
-      auto promise = self->make_response_promise<void>();
+      auto promise = self->make_response_promise();
       return promise.delegate(worker, ok_atom_v);
     },
   };
 }
 
-testee_actor::behavior_type requester_v1(testee_actor::pointer self,
-                                         testee_actor worker) {
+behavior requester_v1(event_based_actor* self, actor worker) {
   return {
     [=](int x, int y) {
-      auto rp = self->make_response_promise<int>();
+      auto rp = self->make_response_promise();
       self->request(worker, infinite, x, y)
         .then(
           [rp](int result) mutable {
@@ -53,7 +63,7 @@ testee_actor::behavior_type requester_v1(testee_actor::pointer self,
       return rp;
     },
     [=](ok_atom) {
-      auto rp = self->make_response_promise<void>();
+      auto rp = self->make_response_promise();
       self->request(worker, infinite, ok_atom_v)
         .then(
           [rp]() mutable {
@@ -69,11 +79,10 @@ testee_actor::behavior_type requester_v1(testee_actor::pointer self,
   };
 }
 
-testee_actor::behavior_type requester_v2(testee_actor::pointer self,
-                                         testee_actor worker) {
+behavior requester_v2(event_based_actor* self, actor worker) {
   return {
     [=](int x, int y) {
-      auto rp = self->make_response_promise<int>();
+      auto rp = self->make_response_promise();
       auto deliver = [rp](expected<int> x) mutable {
         CHECK(rp.pending());
         rp.deliver(std::move(x));
@@ -84,7 +93,7 @@ testee_actor::behavior_type requester_v2(testee_actor::pointer self,
       return rp;
     },
     [=](ok_atom) {
-      auto rp = self->make_response_promise<void>();
+      auto rp = self->make_response_promise();
       auto deliver = [rp](expected<void> x) mutable {
         CHECK(rp.pending());
         rp.deliver(std::move(x));
@@ -99,11 +108,11 @@ testee_actor::behavior_type requester_v2(testee_actor::pointer self,
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(typed_response_promise_tests, test_coordinator_fixture<>)
+CAF_TEST_FIXTURE_SCOPE(response_promise_tests, test_coordinator_fixture<>)
 
 SCENARIO("response promises allow delaying of response messages") {
   auto adder_hdl = sys.spawn(adder);
-  std::map<std::string, testee_actor> impls;
+  std::map<std::string, actor> impls;
   impls["with a value or an error"] = sys.spawn(requester_v1, adder_hdl);
   impls["with an expected<T>"] = sys.spawn(requester_v2, adder_hdl);
   for (auto& [desc, hdl] : impls) {


### PR DESCRIPTION
Fixes #1197.

I've discovered (and fixed) another bug with the response promises: they must not send empty messages in response to asynchronous messages.

Also, the previous unit tests for the promises were a mess. Or rather: quite dated. So I've ended up implementing a new set of unit tests. The tests for the typed and untyped version are a bit repetitive due to duplicated code, but I think trying to "unify" them would only make the test code worse and less comprehensible.