### PR TITLE
Detect and report broken response promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   string input on the command-line that starts with quotes in the same way it
   would parse strings from a config file, leading to very unintuitive results in
   some cases (#1113).
+- Response promises now implicitly share their state when copied. Once the
+  reference count for the state reaches zero, CAF now produces a
+  `broken_promise` error if the actor failed to fulfill the promise by calling
+  either `dispatch` or `delegate`.
 
 ### Fixed
 

--- a/examples/message_passing/fixed_stack.cpp
+++ b/examples/message_passing/fixed_stack.cpp
@@ -43,7 +43,7 @@ bool from_string(caf::string_view in, fixed_stack_errc& out) {
 }
 
 bool from_integer(uint8_t in, fixed_stack_errc& out) {
-  if (in > 0 && in < 1) {
+  if (in > 0 && in < 3) {
     out = static_cast<fixed_stack_errc>(in);
     return true;
   } else {

--- a/examples/message_passing/promises.cpp
+++ b/examples/message_passing/promises.cpp
@@ -16,7 +16,8 @@ adder_actor::behavior_type server_impl(adder_actor::pointer self,
     [=](add_atom, int32_t y, int32_t z) {
       auto rp = self->make_response_promise<int32_t>();
       self->request(worker, infinite, add_atom_v, y, z)
-        .then([rp](int32_t result) mutable { rp.deliver(result); });
+        .then([rp](int32_t result) mutable { rp.deliver(result); },
+              [rp](error& err) mutable { rp.deliver(std::move(err)); });
       return rp;
     },
   };

--- a/examples/testing/ping_pong.cpp
+++ b/examples/testing/ping_pong.cpp
@@ -13,11 +13,9 @@ namespace {
 behavior ping(event_based_actor* self, actor pong_actor, int n) {
   self->send(pong_actor, ping_atom_v, n);
   return {
-    [=](pong_atom, int x) -> result<ping_atom, int> {
+    [=](pong_atom, int x) {
       if (x > 1)
-        return {ping_atom_v, x - 1};
-      else
-        return {};
+        self->send(pong_actor, ping_atom_v, x - 1);
     },
   };
 }

--- a/examples/testing/ping_pong.cpp
+++ b/examples/testing/ping_pong.cpp
@@ -13,9 +13,11 @@ namespace {
 behavior ping(event_based_actor* self, actor pong_actor, int n) {
   self->send(pong_actor, ping_atom_v, n);
   return {
-    [=](pong_atom, int x) {
+    [=](pong_atom, int x) -> result<ping_atom, int> {
       if (x > 1)
-        self->send(pong_actor, ping_atom_v, x - 1);
+        return {ping_atom_v, x - 1};
+      else
+        return {};
     },
   };
 }

--- a/libcaf_core/caf/detail/default_invoke_result_visitor.hpp
+++ b/libcaf_core/caf/detail/default_invoke_result_visitor.hpp
@@ -27,38 +27,15 @@ public:
 
   void operator()(error& x) override {
     CAF_LOG_TRACE(CAF_ARG(x));
-    delegate(x);
+    self_->respond(x);
   }
 
   void operator()(message& x) override {
     CAF_LOG_TRACE(CAF_ARG(x));
-    delegate(x);
+    self_->respond(x);
   }
 
 private:
-  void deliver(response_promise& rp, error& x) {
-    CAF_LOG_DEBUG("report error back to requesting actor");
-    rp.deliver(std::move(x));
-  }
-
-  void deliver(response_promise& rp, message& x) {
-    CAF_LOG_DEBUG("respond via response_promise");
-    // suppress empty messages for asynchronous messages
-    if (x.empty() && rp.async())
-      return;
-    rp.deliver(std::move(x));
-  }
-
-  template <class T>
-  void delegate(T& x) {
-    auto rp = self_->make_response_promise();
-    if (!rp.pending()) {
-      CAF_LOG_DEBUG("suppress response message: invalid response promise");
-      return;
-    }
-    deliver(rp, x);
-  }
-
   Self* self_;
 };
 

--- a/libcaf_core/caf/detail/typed_actor_util.hpp
+++ b/libcaf_core/caf/detail/typed_actor_util.hpp
@@ -23,13 +23,17 @@ struct make_response_promise_helper {
 };
 
 template <class... Ts>
-struct make_response_promise_helper<typed_response_promise<Ts...>>
-  : make_response_promise_helper<Ts...> {};
+struct make_response_promise_helper<typed_response_promise<Ts...>> {
+  using type = typed_response_promise<Ts...>;
+};
 
 template <>
 struct make_response_promise_helper<response_promise> {
   using type = response_promise;
 };
+
+template <class... Ts>
+using response_promise_t = typename make_response_promise_helper<Ts...>::type;
 
 template <class Output, class F>
 struct type_checker {

--- a/libcaf_core/caf/response_promise.hpp
+++ b/libcaf_core/caf/response_promise.hpp
@@ -163,7 +163,7 @@ public:
 private:
   // Note: response promises must remain local to their owner. Hence, we don't
   //       need a thread-safe reference count for the state.
-  class state {
+  class CAF_CORE_EXPORT state {
   public:
     state() = default;
     state(const state&) = delete;

--- a/libcaf_core/caf/response_promise.hpp
+++ b/libcaf_core/caf/response_promise.hpp
@@ -11,68 +11,129 @@
 #include "caf/actor_cast.hpp"
 #include "caf/check_typed_input.hpp"
 #include "caf/detail/core_export.hpp"
+#include "caf/intrusive_ptr.hpp"
 #include "caf/message.hpp"
 #include "caf/message_id.hpp"
 #include "caf/response_type.hpp"
 
 namespace caf {
 
-/// A response promise can be used to deliver a uniquely identifiable
-/// response message from the server (i.e. receiver of the request)
-/// to the client (i.e. the sender of the request).
+/// Enables actors to delay a response message by capturing the context of a
+/// request message. This is particularly useful when an actor needs to
+/// communicate to other actors in order to fulfill a request for a client.
 class CAF_CORE_EXPORT response_promise {
 public:
+  // -- member types -----------------------------------------------------------
+
   using forwarding_stack = std::vector<strong_actor_ptr>;
 
-  /// Constructs an invalid response promise.
-  response_promise();
-
-  response_promise(none_t);
+  // -- constructors, destructors, and assignment operators --------------------
 
   response_promise(strong_actor_ptr self, strong_actor_ptr source,
                    forwarding_stack stages, message_id id);
 
   response_promise(strong_actor_ptr self, mailbox_element& src);
 
+  response_promise() = default;
+
   response_promise(response_promise&&) = default;
+
   response_promise(const response_promise&) = default;
+
   response_promise& operator=(response_promise&&) = default;
+
   response_promise& operator=(const response_promise&) = default;
 
-  /// Satisfies the promise by sending a non-error response message.
-  template <class T, class... Ts>
-  detail::enable_if_t<((sizeof...(Ts) > 0)
-                       || (!std::is_convertible<T, error>::value
-                           && !std::is_same<detail::decay_t<T>, unit_t>::value))
-                      && !detail::is_expected<detail::decay_t<T>>::value>
-  deliver(T&& x, Ts&&... xs) {
-    using ts = detail::type_list<detail::decay_t<T>, detail::decay_t<Ts>...>;
-    static_assert(!detail::tl_exists<ts, detail::is_result>::value,
-                  "it is not possible to deliver objects of type result<T>");
-    static_assert(!detail::tl_exists<ts, detail::is_expected>::value,
-                  "mixing expected<T> with regular values is not supported");
-    if constexpr (sizeof...(Ts) == 0
-                  && std::is_same<message, std::decay_t<T>>::value)
-      deliver_impl(std::forward<T>(x));
-    else
-      deliver_impl(make_message(std::forward<T>(x), std::forward<Ts>(xs)...));
+  [[deprecated("use the default constructor instead")]] response_promise(none_t)
+    : response_promise() {
+    // nop
   }
 
-  /// Satisfies the promise by sending either an error or a non-error response
-  /// message.
-  template <class T>
-  void deliver(expected<T> x) {
-    if (x) {
-      if constexpr (std::is_same<T, void>::value)
-        deliver();
-      else
-        deliver(std::move(*x));
-    } else {
-      deliver(std::move(x.error()));
+  // -- properties -------------------------------------------------------------
+
+  /// Returns whether this response promise replies to an asynchronous message.
+  bool async() const noexcept;
+
+  /// Queries whether this promise is a valid promise that is not satisfied yet.
+  bool pending() const noexcept;
+
+  /// Returns the source of the corresponding request.
+  strong_actor_ptr source() const noexcept;
+
+  /// Returns the remaining stages for the corresponding request.
+  forwarding_stack stages() const;
+
+  /// Returns the actor that will receive the response, i.e.,
+  /// `stages().front()` if `!stages().empty()` or `source()` otherwise.
+  strong_actor_ptr next() const noexcept;
+
+  /// Returns the message ID of the corresponding request.
+  message_id id() const noexcept;
+
+  // -- delivery ---------------------------------------------------------------
+
+  /// Satisfies the promise by sending the given message.
+  /// @note Drops empty messages silently when responding to an asynchronous
+  ///       request message, i.e., if `async() == true`.
+  /// @post `pending() == false`
+  void deliver(message msg);
+
+  /// Satisfies the promise by sending an error message.
+  /// @post `pending() == false`
+  void deliver(error x);
+
+  /// Satisfies the promise by sending an empty message.
+  /// @note Sends no message if the request message was asynchronous, i.e., if
+  ///       `async() == true`.
+  /// @post `pending() == false`
+  void deliver();
+
+  /// Satisfies the promise by sending an empty message.
+  /// @note Sends no message if the request message was asynchronous, i.e., if
+  ///       `async() == true`.
+  /// @post `pending() == false`
+  void deliver(unit_t) {
+    deliver();
+  }
+
+  /// Satisfies the promise by sending `make_message(xs...)`.
+  /// @post `pending() == false`
+  template <class... Ts>
+  void deliver(Ts... xs) {
+    using arg_types = detail::type_list<Ts...>;
+    static_assert(!detail::tl_exists<arg_types, detail::is_result>::value,
+                  "delivering a result<T> is not supported");
+    static_assert(!detail::tl_exists<arg_types, detail::is_expected>::value,
+                  "mixing expected<T> with regular values is not supported");
+    if (pending()) {
+      state_->deliver_impl(make_message(std::move(xs)...));
+      state_.reset();
     }
   }
 
+  /// Satisfies the promise by sending the content of `x`, i.e., either a value
+  /// of type `T` or an @ref error.
+  /// @post `pending() == false`
+  template <class T>
+  void deliver(expected<T> x) {
+    if (pending()) {
+      if (x) {
+        if constexpr (std::is_same<T, void>::value
+                      || std::is_same<T, unit_t>::value)
+          state_->deliver_impl(make_message());
+        else
+          state_->deliver_impl(make_message(std::move(*x)));
+      } else {
+        state_->deliver_impl(make_message(std::move(x.error())));
+      }
+      state_.reset();
+    }
+  }
+
+  // -- delegation -------------------------------------------------------------
+
   /// Satisfies the promise by delegating to another actor.
+  /// @post `pending() == false`
   template <message_priority P = message_priority::normal, class Handle = actor,
             class... Ts>
   delegated_response_type_t<
@@ -84,73 +145,54 @@ public:
       typename std::decay<Ts>::type>::type...>;
     static_assert(response_type_unbox<signatures_of_t<Handle>, token>::valid,
                   "receiver does not accept given message");
-    if constexpr (P == message_priority::high)
-      id_ = id_.with_high_priority();
-    if constexpr (std::is_same<detail::type_list<message>,
-                               detail::type_list<std::decay_t<Ts>...>>::value)
-      delegate_impl(actor_cast<abstract_actor*>(dest), std::forward<Ts>(xs)...);
-    else
-      delegate_impl(actor_cast<abstract_actor*>(dest),
-                    make_message(std::forward<Ts>(xs)...));
+    if (pending()) {
+      if constexpr (P == message_priority::high)
+        state_->id = state_->id.with_high_priority();
+      if constexpr (std::is_same<detail::type_list<message>,
+                                 detail::type_list<std::decay_t<Ts>...>>::value)
+        state_->delegate_impl(actor_cast<abstract_actor*>(dest),
+                              std::forward<Ts>(xs)...);
+      else
+        state_->delegate_impl(actor_cast<abstract_actor*>(dest),
+                              make_message(std::forward<Ts>(xs)...));
+      state_.reset();
+    }
     return {};
   }
 
-  /// Satisfies the promise by sending an error response message.
-  void deliver(error x);
-
-  /// Satisfies the promise by sending an empty message if this promise has a
-  /// valid message ID, i.e., `async() == false`.
-  void deliver();
-
-  /// Satisfies the promise by sending an empty message if this promise has a
-  /// valid message ID, i.e., `async() == false`.
-  void deliver(unit_t) {
-    deliver();
-  }
-
-  /// Returns whether this response promise replies to an asynchronous message.
-  bool async() const;
-
-  /// Queries whether this promise is a valid promise that is not satisfied yet.
-  bool pending() const {
-    return source_ != nullptr || !stages_.empty();
-  }
-
-  /// Returns the source of the corresponding request.
-  const strong_actor_ptr& source() const {
-    return source_;
-  }
-
-  /// Returns the remaining stages for the corresponding request.
-  const forwarding_stack& stages() const {
-    return stages_;
-  }
-
-  /// Returns the actor that will receive the response, i.e.,
-  /// `stages().front()` if `!stages().empty()` or `source()` otherwise.
-  strong_actor_ptr next() const {
-    return stages_.empty() ? source_ : stages_.front();
-  }
-
-  /// Returns the message ID of the corresponding request.
-  message_id id() const {
-    return id_;
-  }
-
 private:
-  /// Returns a downcasted version of `self_`.
-  local_actor* self_dptr() const;
+  // Note: response promises must remain local to their owner. Hence, we don't
+  //       need a thread-safe reference count for the state.
+  class state {
+  public:
+    state() = default;
+    state(const state&) = delete;
+    state& operator=(const state&) = delete;
+    ~state();
 
-  execution_unit* context();
+    void cancel();
 
-  void deliver_impl(message msg);
+    void deliver_impl(message msg);
 
-  void delegate_impl(abstract_actor* receiver, message msg);
+    void delegate_impl(abstract_actor* receiver, message msg);
 
-  strong_actor_ptr self_;
-  strong_actor_ptr source_;
-  forwarding_stack stages_;
-  message_id id_;
+    mutable size_t ref_count = 1;
+    strong_actor_ptr self;
+    strong_actor_ptr source;
+    forwarding_stack stages;
+    message_id id;
+
+    friend void intrusive_ptr_add_ref(const state* ptr) {
+      ++ptr->ref_count;
+    }
+
+    friend void intrusive_ptr_release(const state* ptr) {
+      if (--ptr->ref_count == 0)
+        delete ptr;
+    }
+  };
+
+  intrusive_ptr<state> state_;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/sec.hpp
+++ b/libcaf_core/caf/sec.hpp
@@ -159,6 +159,8 @@ enum class sec : uint8_t {
   unsupported_operation,
   /// A key lookup failed.
   no_such_key = 65,
+  /// An destroyed a response promise without calling deliver or delegate on it.
+  broken_promise,
 };
 // --(rst-sec-end)--
 

--- a/libcaf_core/caf/typed_response_promise.hpp
+++ b/libcaf_core/caf/typed_response_promise.hpp
@@ -19,22 +19,15 @@ namespace caf {
 template <class... Ts>
 class typed_response_promise {
 public:
+  // -- friends ----------------------------------------------------------------
+
+  friend class local_actor;
+
   // -- member types -----------------------------------------------------------
 
   using forwarding_stack = response_promise::forwarding_stack;
 
   // -- constructors, destructors, and assignment operators --------------------
-
-  typed_response_promise(strong_actor_ptr self, strong_actor_ptr source,
-                         forwarding_stack stages, message_id id)
-    : promise_(std::move(self), std::move(source), std::move(stages), id) {
-    // nop
-  }
-
-  typed_response_promise(strong_actor_ptr self, mailbox_element& src)
-    : promise_(std::move(self), src) {
-    // nop
-  }
 
   typed_response_promise() = default;
 
@@ -129,6 +122,21 @@ public:
   }
 
 private:
+  // -- constructors that are visible only to friends --------------------------
+
+  typed_response_promise(local_actor* self, strong_actor_ptr source,
+                         forwarding_stack stages, message_id id)
+    : promise_(self, std::move(source), std::move(stages), id) {
+    // nop
+  }
+
+  typed_response_promise(local_actor* self, mailbox_element& src)
+    : promise_(self, src) {
+    // nop
+  }
+
+  // -- member variables -------------------------------------------------------
+
   response_promise promise_;
 };
 

--- a/libcaf_core/caf/typed_response_promise.hpp
+++ b/libcaf_core/caf/typed_response_promise.hpp
@@ -12,20 +12,18 @@
 
 namespace caf {
 
-/// A response promise can be used to deliver a uniquely identifiable
-/// response message from the server (i.e. receiver of the request)
-/// to the client (i.e. the sender of the request).
+/// Enables statically typed actors to delay a response message by capturing the
+/// context of a request message. This is particularly useful when an actor
+/// needs to communicate to other actors in order to fulfill a request for a
+/// client.
 template <class... Ts>
 class typed_response_promise {
 public:
+  // -- member types -----------------------------------------------------------
+
   using forwarding_stack = response_promise::forwarding_stack;
 
-  /// Constructs an invalid response promise.
-  typed_response_promise() = default;
-
-  typed_response_promise(none_t x) : promise_(x) {
-    // nop
-  }
+  // -- constructors, destructors, and assignment operators --------------------
 
   typed_response_promise(strong_actor_ptr self, strong_actor_ptr source,
                          forwarding_stack stages, message_id id)
@@ -38,16 +36,60 @@ public:
     // nop
   }
 
+  typed_response_promise() = default;
+
   typed_response_promise(typed_response_promise&&) = default;
+
   typed_response_promise(const typed_response_promise&) = default;
+
   typed_response_promise& operator=(typed_response_promise&&) = default;
+
   typed_response_promise& operator=(const typed_response_promise&) = default;
 
-  /// Implicitly convertible to untyped response promise.
-  [[deprecated("Use the typed_response_promise directly.")]]
+  [[deprecated("use the default constructor instead")]] //
+  typed_response_promise(none_t x)
+    : promise_(x) {
+    // nop
+  }
+
+  // -- properties -------------------------------------------------------------
+
+  /// @copydoc response_promise::async
+  bool async() const {
+    return promise_.async();
+  }
+
+  /// @copydoc response_promise::pending
+  bool pending() const {
+    return promise_.pending();
+  }
+
+  /// @copydoc response_promise::source
+  strong_actor_ptr source() const {
+    return promise_.source();
+  }
+
+  /// @copydoc response_promise::stages
+  forwarding_stack stages() const {
+    return promise_.stages();
+  }
+
+  /// @copydoc response_promise::next
+  strong_actor_ptr next() const {
+    return promise_.next();
+  }
+
+  /// @copydoc response_promise::id
+  message_id id() const {
+    return promise_.id();
+  }
+
+  [[deprecated("use the typed_response_promise directly")]]
   operator response_promise&() {
     return promise_;
   }
+
+  // -- delivery ---------------------------------------------------------------
 
   /// Satisfies the promise by sending a non-error response message.
   template <class... Us>
@@ -77,42 +119,13 @@ public:
     promise_.deliver(std::move(x));
   }
 
+  // -- delegation -------------------------------------------------------------
+
   /// Satisfies the promise by delegating to another actor.
   template <message_priority P = message_priority::normal, class Handle = actor,
             class... Us>
   auto delegate(const Handle& dest, Us&&... xs) {
     return promise_.template delegate<P>(dest, std::forward<Us>(xs)...);
-  }
-
-  /// Returns whether this response promise replies to an asynchronous message.
-  bool async() const {
-    return promise_.async();
-  }
-
-  /// Queries whether this promise is a valid promise that is not satisfied yet.
-  bool pending() const {
-    return promise_.pending();
-  }
-
-  /// Returns the source of the corresponding request.
-  const strong_actor_ptr& source() const {
-    return promise_.source();
-  }
-
-  /// Returns the remaining stages for the corresponding request.
-  const forwarding_stack& stages() const {
-    return promise_.stages();
-  }
-
-  /// Returns the actor that will receive the response, i.e.,
-  /// `stages().front()` if `!stages().empty()` or `source()` otherwise.
-  strong_actor_ptr next() const {
-    return promise_.next();
-  }
-
-  /// Returns the message ID of the corresponding request.
-  message_id id() const {
-    return promise_.id();
   }
 
 private:

--- a/libcaf_core/src/response_promise.cpp
+++ b/libcaf_core/src/response_promise.cpp
@@ -14,25 +14,21 @@
 
 namespace caf {
 
-response_promise::response_promise() : self_(nullptr) {
-  // nop
-}
-
-response_promise::response_promise(none_t) : response_promise() {
-  // nop
-}
+// -- constructors, destructors, and assignment operators ----------------------
 
 response_promise::response_promise(strong_actor_ptr self,
                                    strong_actor_ptr source,
-                                   forwarding_stack stages, message_id mid)
-  : id_(mid) {
+                                   forwarding_stack stages, message_id mid) {
   CAF_ASSERT(self != nullptr);
   // Form an invalid request promise when initialized from a response ID, since
-  // we always drop messages in this case.
-  if (!mid.is_response()) {
-    self_.swap(self);
-    source_.swap(source);
-    stages_.swap(stages);
+  // we always drop messages in this case. Also don't create promises for
+  // anonymous messages since there's nowhere to send the message to anyway.
+  if (!mid.is_response() && (source || !stages.empty())) {
+    state_ = make_counted<state>();
+    state_->self.swap(self);
+    state_->source.swap(source);
+    state_->stages.swap(stages);
+    state_->id = mid;
   }
 }
 
@@ -42,77 +38,114 @@ response_promise::response_promise(strong_actor_ptr self, mailbox_element& src)
   // nop
 }
 
+// -- properties ---------------------------------------------------------------
+
+bool response_promise::async() const noexcept {
+  return id().is_async();
+}
+
+bool response_promise::pending() const noexcept {
+  return state_ != nullptr && state_->self != nullptr;
+}
+
+strong_actor_ptr response_promise::source() const noexcept {
+  if (state_)
+    return state_->source;
+  else
+    return nullptr;
+}
+
+response_promise::forwarding_stack response_promise::stages() const {
+  if (state_)
+    return state_->stages;
+  else
+    return {};
+}
+
+strong_actor_ptr response_promise::next() const noexcept {
+  if (state_)
+    return state_->stages.empty() ? state_->source : state_->stages[0];
+  else
+    return nullptr;
+}
+
+message_id response_promise::id() const noexcept {
+  if (state_)
+    return state_->id;
+  else
+    return make_message_id();
+}
+
+// -- delivery -----------------------------------------------------------------
+
+void response_promise::deliver(message msg) {
+  CAF_LOG_TRACE(CAF_ARG(msg));
+  if (pending()) {
+    state_->deliver_impl(std::move(msg));
+    state_.reset();
+  }
+}
+
 void response_promise::deliver(error x) {
-  deliver_impl(make_message(std::move(x)));
+  CAF_LOG_TRACE(CAF_ARG(x));
+  if (pending()) {
+    state_->deliver_impl(make_message(std::move(x)));
+    state_.reset();
+  }
 }
 
 void response_promise::deliver() {
-  deliver_impl(make_message());
-}
-
-bool response_promise::async() const {
-  return id_.is_async();
-}
-
-local_actor* response_promise::self_dptr() const {
-  // TODO: We require that self_ was constructed by using a local_actor*. The
-  //       type erasure performed by strong_actor_ptr hides that fact. We
-  //       probably should use a different pointer type such as
-  //       intrusive_ptr<local_actor>. However, that would mean we would have to
-  //       include local_actor.hpp in response_promise.hpp or provide overloads
-  //       for intrusive_ptr_add_ref and intrusive_ptr_release.
-  auto self_baseptr = actor_cast<abstract_actor*>(self_);
-  return static_cast<local_actor*>(self_baseptr);
-}
-
-execution_unit* response_promise::context() {
-  return self_ == nullptr ? nullptr : self_dptr()->context();
-}
-
-void response_promise::deliver_impl(message msg) {
-  CAF_LOG_TRACE(CAF_ARG(msg));
-  if (self_ == nullptr) {
-    CAF_LOG_DEBUG("drop response: invalid promise");
-    return;
+  CAF_LOG_TRACE(CAF_ARG(""));
+  if (pending()) {
+    state_->deliver_impl(make_message());
+    state_.reset();
   }
-  if (msg.empty() && id_.is_async()) {
+}
+
+// -- state --------------------------------------------------------------------
+
+response_promise::state::~state() {
+  if (self) {
+    CAF_LOG_DEBUG("broken promise!");
+    deliver_impl(make_message(make_error(sec::broken_promise)));
+  }
+}
+
+void response_promise::state::cancel() {
+  self.reset();
+}
+
+void response_promise::state::deliver_impl(message msg) {
+  CAF_LOG_TRACE(CAF_ARG(msg));
+  if (msg.empty() && id.is_async()) {
     CAF_LOG_DEBUG("drop response: empty response to asynchronous input");
-    self_.reset();
-    return;
+  } else {
+    auto dptr = actor_cast<local_actor*>(self);
+    if (stages.empty()) {
+      detail::profiled_send(dptr, self, source, id.response_id(),
+                            forwarding_stack{}, dptr->context(),
+                            std::move(msg));
+    } else {
+      auto next = std::move(stages.back());
+      stages.pop_back();
+      detail::profiled_send(dptr, std::move(source), next, id,
+                            std::move(stages), dptr->context(), std::move(msg));
+    }
   }
-  auto dptr = self_dptr();
-  if (!stages_.empty()) {
-    auto next = std::move(stages_.back());
-    stages_.pop_back();
-    detail::profiled_send(dptr, std::move(source_), next, id_,
-                          std::move(stages_), dptr->context(), std::move(msg));
-    self_.reset();
-    return;
-  }
-  if (source_) {
-    detail::profiled_send(dptr, self_, source_, id_.response_id(), no_stages,
-                          dptr->context(), std::move(msg));
-    self_.reset();
-    source_.reset();
-    return;
-  }
-  CAF_LOG_WARNING("malformed response promise: self != nullptr && !pending()");
+  cancel();
 }
 
-void response_promise::delegate_impl(abstract_actor* receiver, message msg) {
+void response_promise::state::delegate_impl(abstract_actor* receiver,
+                                            message msg) {
   CAF_LOG_TRACE(CAF_ARG(msg));
-  if (receiver == nullptr) {
+  if (receiver != nullptr) {
+    auto dptr = actor_cast<local_actor*>(self);
+    detail::profiled_send(dptr, std::move(source), receiver, id,
+                          std::move(stages), dptr->context(), std::move(msg));
+  } else {
     CAF_LOG_DEBUG("drop response: invalid delegation target");
-    return;
   }
-  if (self_ == nullptr) {
-    CAF_LOG_DEBUG("drop response: invalid promise");
-    return;
-  }
-  auto dptr = self_dptr();
-  detail::profiled_send(dptr, std::move(source_), receiver, id_,
-                        std::move(stages_), dptr->context(), std::move(msg));
-  self_.reset();
+  cancel();
 }
 
 } // namespace caf

--- a/libcaf_core/src/sec_strings.cpp
+++ b/libcaf_core/src/sec_strings.cpp
@@ -148,6 +148,8 @@ std::string to_string(sec x) {
       return "unsupported_operation";
     case sec::no_such_key:
       return "no_such_key";
+    case sec::broken_promise:
+      return "broken_promise";
   };
 }
 
@@ -350,6 +352,9 @@ bool from_string(string_view in, sec& out) {
   } else if (in == "no_such_key") {
     out = sec::no_such_key;
     return true;
+  } else if (in == "broken_promise") {
+    out = sec::broken_promise;
+    return true;
   } else {
     return false;
   }
@@ -427,6 +432,7 @@ bool from_integer(std::underlying_type_t<sec> in,
     case sec::type_clash:
     case sec::unsupported_operation:
     case sec::no_such_key:
+    case sec::broken_promise:
       out = result;
       return true;
   };

--- a/libcaf_core/src/stream_manager.cpp
+++ b/libcaf_core/src/stream_manager.cpp
@@ -240,7 +240,7 @@ stream_slot
 stream_manager::add_unchecked_outbound_path_impl(strong_actor_ptr next,
                                                  message handshake) {
   CAF_LOG_TRACE(CAF_ARG(next) << CAF_ARG(handshake));
-  response_promise rp{self_->ctrl(), self_->ctrl(), {next}, make_message_id()};
+  response_promise rp{self_, self_->ctrl(), {next}, make_message_id()};
   return add_unchecked_outbound_path_impl(rp, std::move(handshake));
 }
 

--- a/libcaf_core/test/typed_response_promise.cpp
+++ b/libcaf_core/test/typed_response_promise.cpp
@@ -145,6 +145,21 @@ SCENARIO("response promises allow delaying of response messages") {
   }
 }
 
+SCENARIO("response promises send errors when broken") {
+  auto adder_hdl = sys.spawn(adder);
+  auto hdl = sys.spawn(requester_v1, adder_hdl);
+  GIVEN("a dispatcher, and adder and a client") {
+    WHEN("the dispatcher terminates before calling deliver on its promise") {
+      inject((int, int), from(self).to(hdl).with(3, 4));
+      inject((exit_msg),
+             to(hdl).with(exit_msg{hdl.address(), exit_reason::kill}));
+      THEN("clients receive a broken_promise error") {
+        expect((error), from(hdl).to(self).with(sec::broken_promise));
+      }
+    }
+  }
+}
+
 SCENARIO("response promises allow delegation") {
   GIVEN("a dispatcher that calls delegate on its promise") {
     auto adder_hdl = sys.spawn(adder);


### PR DESCRIPTION
Relates #1051.

Consider the following scenario: a client sends a request to the server. When receiving the request, the server creates a response promise and sends request to one or more workers. After receiving all results, the server calls `deliver` on its promise. In the current implementation, the client never receives anything if the server dies before receiving all results. With this change, the client would at least receive a `broken_promise` error instead of nothing. The gist of the changes boils down to keeping track of whether a user called `deliver` on a promise before destroying it.

There is a slight complication, though, because we use promises like this:

```c++
adder_actor::behavior_type server_impl(adder_actor::pointer self,
                                       adder_actor worker) {
  return {
    [=](add_atom, int32_t y, int32_t z) {
      auto rp = self->make_response_promise<int32_t>();
      self->request(worker, infinite, add_atom_v, y, z)
        .then([rp](int32_t result) mutable { rp.deliver(result); },
              [rp](error& err) mutable { rp.deliver(std::move(err)); });
      return rp;
    },
  };
}
```

This snippet creates three copies of the promise: one for the success handler, one for the error handler and one for returning from the message handler to tell CAF that we produce a response message at some later point.

These three promises must stay connected in some way, because we need to check whether a user called `deliver` (or `dispatch`) on *any* of them. Hence the implicit sharing.