### PR TITLE
Fix shutdown issue with detached actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   messages.
 - `CAF_ADD_TYPE_ID` now works with types that live in namespaces that also exist
   as nested namespace in CAF such as `detail` or `io` (#1195).
+- Solved a race condition on detached actors that blocked ordinary shutdown of
+  actor systems in some cases (#1196).
 
 ## [0.18.0-rc.1] - 2020-09-09
 

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -118,6 +118,7 @@ caf_add_component(
     src/detail/pretty_type_name.cpp
     src/detail/print.cpp
     src/detail/private_thread.cpp
+    src/detail/private_thread_pool.cpp
     src/detail/ripemd_160.cpp
     src/detail/serialized_size.cpp
     src/detail/set_thread_name.cpp
@@ -258,6 +259,7 @@ caf_add_component(
     detail.parser.read_string
     detail.parser.read_timespan
     detail.parser.read_unsigned_integer
+    detail.private_thread_pool
     detail.ringbuffer
     detail.ripemd_160
     detail.serialized_size

--- a/libcaf_core/caf/blocking_actor.hpp
+++ b/libcaf_core/caf/blocking_actor.hpp
@@ -327,6 +327,8 @@ public:
     });
   }
 
+  using super::fail_state;
+
   /// Sets a user-defined exit reason `err`. This reason
   /// is signalized to other actors after `act()` returns.
   void fail_state(error err);

--- a/libcaf_core/caf/detail/private_thread_pool.hpp
+++ b/libcaf_core/caf/detail/private_thread_pool.hpp
@@ -33,7 +33,8 @@ public:
   struct node {
     virtual ~node();
     node* next = nullptr;
-    // Returns false to signal to the thread pool that it should shut down.
+    // Called by the private thread pool to stop the node. Regular nodes should
+    // return true. Returning false signals the thread pool to shut down.
     virtual bool stop() = 0;
   };
 

--- a/libcaf_core/caf/detail/private_thread_pool.hpp
+++ b/libcaf_core/caf/detail/private_thread_pool.hpp
@@ -1,0 +1,67 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2021 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <forward_list>
+#include <mutex>
+#include <thread>
+
+#include "caf/fwd.hpp"
+
+namespace caf::detail {
+
+class private_thread_pool {
+public:
+  struct node {
+    virtual ~node();
+    node* next = nullptr;
+    // Returns false to signal to the thread pool that it should shut down.
+    virtual bool stop() = 0;
+  };
+
+  explicit private_thread_pool(actor_system* sys) : sys_(sys), running_(0) {
+    // nop
+  }
+
+  void start();
+
+  void stop();
+
+  void run_loop();
+
+  private_thread* acquire();
+
+  void release(private_thread*);
+
+  size_t running() const noexcept;
+
+private:
+  std::pair<node*, size_t> dequeue();
+
+  actor_system* sys_;
+  std::thread loop_;
+  mutable std::mutex mtx_;
+  std::condition_variable cv_;
+  node* head_ = nullptr;
+  size_t running_;
+};
+
+} // namespace caf::detail

--- a/libcaf_core/caf/scheduler/worker.hpp
+++ b/libcaf_core/caf/scheduler/worker.hpp
@@ -99,7 +99,6 @@ private:
       auto job = policy_.dequeue(this);
       CAF_ASSERT(job != nullptr);
       CAF_ASSERT(job->subtype() != resumable::io_actor);
-      CAF_PUSH_AID_FROM_PTR(dynamic_cast<abstract_actor*>(job));
       policy_.before_resume(this, job);
       auto res = job->resume(this, max_throughput_);
       policy_.after_resume(this, job);

--- a/libcaf_core/src/detail/private_thread_pool.cpp
+++ b/libcaf_core/src/detail/private_thread_pool.cpp
@@ -1,0 +1,94 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2021 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/detail/private_thread_pool.hpp"
+
+#include "caf/config.hpp"
+#include "caf/detail/private_thread.hpp"
+
+namespace caf::detail {
+
+private_thread_pool::node::~node() {
+  // nop
+}
+
+void private_thread_pool::start() {
+  loop_ = std::thread{[](private_thread_pool* ptr) { ptr->run_loop(); }, this};
+}
+
+void private_thread_pool::stop() {
+  struct shutdown_helper : node {
+    bool stop() override {
+      return false;
+    }
+  };
+  auto ptr = new shutdown_helper;
+  {
+    std::unique_lock guard{mtx_};
+    ++running_;
+    ptr->next = head_;
+    head_ = ptr;
+    cv_.notify_all();
+  }
+  loop_.join();
+}
+
+void private_thread_pool::run_loop() {
+  bool shutting_down = false;
+  for (;;) {
+    auto [ptr, remaining] = dequeue();
+    CAF_ASSERT(ptr != nullptr);
+    if (!ptr->stop())
+      shutting_down = true;
+    delete ptr;
+    if (remaining == 0 && shutting_down)
+      return;
+  }
+}
+
+private_thread* private_thread_pool::acquire() {
+  {
+    std::unique_lock guard{mtx_};
+    ++running_;
+  }
+  return private_thread::launch(sys_);
+}
+
+void private_thread_pool::release(private_thread* ptr) {
+  std::unique_lock guard{mtx_};
+  ptr->next = head_;
+  head_ = ptr;
+  cv_.notify_all();
+}
+
+size_t private_thread_pool::running() const noexcept {
+  std::unique_lock guard{mtx_};
+  return running_;
+}
+
+std::pair<private_thread_pool::node*, size_t> private_thread_pool::dequeue() {
+  std::unique_lock guard{mtx_};
+  while (head_ == nullptr)
+    cv_.wait(guard);
+  auto ptr = head_;
+  head_ = ptr->next;
+  auto remaining = --running_;
+  return {ptr, remaining};
+}
+
+} // namespace caf::detail

--- a/libcaf_core/test/detail/private_thread_pool.cpp
+++ b/libcaf_core/test/detail/private_thread_pool.cpp
@@ -1,0 +1,99 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2021 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#define CAF_SUITE detail.private_thread_pool
+
+#include "caf/detail/private_thread_pool.hpp"
+
+#include "core-test.hpp"
+
+#include "caf/detail/private_thread.hpp"
+
+using namespace caf;
+
+CAF_TEST_FIXTURE_SCOPE(private_thread_pool_tests, test_coordinator_fixture<>)
+
+SCENARIO("private threads count towards detached actors") {
+  GIVEN("an actor system with a private thread pool") {
+    detail::private_thread* t1 = nullptr;
+    detail::private_thread* t2 = nullptr;
+    WHEN("acquiring new private threads") {
+      THEN("the detached_actors counter increases") {
+        CHECK_EQ(sys.detached_actors(), 0u);
+        t1 = sys.acquire_private_thread();
+        CHECK_EQ(sys.detached_actors(), 1u);
+        t2 = sys.acquire_private_thread();
+        CHECK_EQ(sys.detached_actors(), 2u);
+      }
+    }
+    WHEN("releasing the private threads") {
+      THEN("the detached_actors counter eventually decreases again") {
+        auto next_value = [this, old_value{2u}]() mutable {
+          using namespace std::literals::chrono_literals;
+          size_t result = 0;
+          while ((result = sys.detached_actors()) == old_value)
+            std::this_thread::sleep_for(1ms);
+          old_value = result;
+          return result;
+        };
+        sys.release_private_thread(t2);
+        CHECK_EQ(next_value(), 1u);
+        sys.release_private_thread(t1);
+        CHECK_EQ(next_value(), 0u);
+      }
+    }
+  }
+}
+
+SCENARIO("private threads rerun their resumable when it returns resume_later") {
+  struct testee : resumable {
+    std::atomic<size_t> runs = 0;
+    std::atomic<size_t> refs_added = 0;
+    std::atomic<size_t> refs_released = 0;
+    subtype_t subtype() const override {
+      return resumable::function_object;
+    }
+    resume_result resume(execution_unit*, size_t) override {
+      return ++runs < 2 ? resumable::resume_later : resumable::done;
+    }
+    void intrusive_ptr_add_ref_impl() override {
+      ++refs_added;
+    }
+    void intrusive_ptr_release_impl() override {
+      ++refs_released;
+    }
+  };
+  GIVEN("a resumable f and a private thread t") {
+    testee f;
+    auto t = sys.acquire_private_thread();
+    WHEN("when resuming f with t") {
+      t->resume(&f);
+      THEN("t calls resume until f returns something other than resume_later") {
+        using namespace std::literals::chrono_literals;
+        sys.release_private_thread(t);
+        while (sys.detached_actors() != 0)
+          std::this_thread::sleep_for(1ms);
+        CHECK_EQ(f.runs, 2u);
+        CHECK_EQ(f.refs_added, 0u);
+        CHECK_EQ(f.refs_released, 1u);
+      }
+    }
+  }
+}
+
+CAF_TEST_FIXTURE_SCOPE_END()


### PR DESCRIPTION
Closes #1196.

Aside from the shutdown issue itself, detached actors also behaved slightly different than usual. For scheduled actors, the scheduler only holds a strong reference for as long as the actor runs or is in some job queue. The previous private thread kept this reference until the actor was considered done, which means a detached actor essentially keept itself alive.

The new design makes sure that private threads operate in the same way as a regular scheduling worker. Also, there's a new thread pool class who's primary role is to establish a strict shutdown order. The actor system shuts down / awaits all actors, then joins the thread pool's own thread. This blocks until all private threads were destroyed properly.

The branch has been tested extensible on the code that triggered/revealed the shutdown issue previously and always terminated cleanly. 🙂