### PR TITLE
Improve to_string output of errors

### DIFF
--- a/libcaf_core/src/exit_reason_strings.cpp
+++ b/libcaf_core/src/exit_reason_strings.cpp
@@ -17,47 +17,47 @@ std::string to_string(exit_reason x) {
     default:
       return "???";
     case exit_reason::normal:
-      return "normal";
+      return "caf::exit_reason::normal";
     case exit_reason::unhandled_exception:
-      return "unhandled_exception";
+      return "caf::exit_reason::unhandled_exception";
     case exit_reason::unknown:
-      return "unknown";
+      return "caf::exit_reason::unknown";
     case exit_reason::out_of_workers:
-      return "out_of_workers";
+      return "caf::exit_reason::out_of_workers";
     case exit_reason::user_shutdown:
-      return "user_shutdown";
+      return "caf::exit_reason::user_shutdown";
     case exit_reason::kill:
-      return "kill";
+      return "caf::exit_reason::kill";
     case exit_reason::remote_link_unreachable:
-      return "remote_link_unreachable";
+      return "caf::exit_reason::remote_link_unreachable";
     case exit_reason::unreachable:
-      return "unreachable";
+      return "caf::exit_reason::unreachable";
   };
 }
 
 bool from_string(string_view in, exit_reason& out) {
-  if (in == "normal") {
+  if (in == "caf::exit_reason::normal") {
     out = exit_reason::normal;
     return true;
-  } else if (in == "unhandled_exception") {
+  } else if (in == "caf::exit_reason::unhandled_exception") {
     out = exit_reason::unhandled_exception;
     return true;
-  } else if (in == "unknown") {
+  } else if (in == "caf::exit_reason::unknown") {
     out = exit_reason::unknown;
     return true;
-  } else if (in == "out_of_workers") {
+  } else if (in == "caf::exit_reason::out_of_workers") {
     out = exit_reason::out_of_workers;
     return true;
-  } else if (in == "user_shutdown") {
+  } else if (in == "caf::exit_reason::user_shutdown") {
     out = exit_reason::user_shutdown;
     return true;
-  } else if (in == "kill") {
+  } else if (in == "caf::exit_reason::kill") {
     out = exit_reason::kill;
     return true;
-  } else if (in == "remote_link_unreachable") {
+  } else if (in == "caf::exit_reason::remote_link_unreachable") {
     out = exit_reason::remote_link_unreachable;
     return true;
-  } else if (in == "unreachable") {
+  } else if (in == "caf::exit_reason::unreachable") {
     out = exit_reason::unreachable;
     return true;
   } else {

--- a/libcaf_core/src/intrusive/inbox_result_strings.cpp
+++ b/libcaf_core/src/intrusive/inbox_result_strings.cpp
@@ -10,30 +10,29 @@ CAF_PUSH_DEPRECATED_WARNING
 
 #include <string>
 
-namespace caf {
-namespace intrusive {
+namespace caf::intrusive {
 
 std::string to_string(inbox_result x) {
   switch(x) {
     default:
       return "???";
     case inbox_result::success:
-      return "success";
+      return "caf::intrusive::inbox_result::success";
     case inbox_result::unblocked_reader:
-      return "unblocked_reader";
+      return "caf::intrusive::inbox_result::unblocked_reader";
     case inbox_result::queue_closed:
-      return "queue_closed";
+      return "caf::intrusive::inbox_result::queue_closed";
   };
 }
 
 bool from_string(string_view in, inbox_result& out) {
-  if (in == "success") {
+  if (in == "caf::intrusive::inbox_result::success") {
     out = inbox_result::success;
     return true;
-  } else if (in == "unblocked_reader") {
+  } else if (in == "caf::intrusive::inbox_result::unblocked_reader") {
     out = inbox_result::unblocked_reader;
     return true;
-  } else if (in == "queue_closed") {
+  } else if (in == "caf::intrusive::inbox_result::queue_closed") {
     out = inbox_result::queue_closed;
     return true;
   } else {
@@ -55,7 +54,6 @@ bool from_integer(std::underlying_type_t<inbox_result> in,
   };
 }
 
-} // namespace intrusive
-} // namespace caf
+} // namespace caf::intrusive
 
 CAF_POP_WARNINGS

--- a/libcaf_core/src/intrusive/task_result_strings.cpp
+++ b/libcaf_core/src/intrusive/task_result_strings.cpp
@@ -10,35 +10,34 @@ CAF_PUSH_DEPRECATED_WARNING
 
 #include <string>
 
-namespace caf {
-namespace intrusive {
+namespace caf::intrusive {
 
 std::string to_string(task_result x) {
   switch(x) {
     default:
       return "???";
     case task_result::resume:
-      return "resume";
+      return "caf::intrusive::task_result::resume";
     case task_result::skip:
-      return "skip";
+      return "caf::intrusive::task_result::skip";
     case task_result::stop:
-      return "stop";
+      return "caf::intrusive::task_result::stop";
     case task_result::stop_all:
-      return "stop_all";
+      return "caf::intrusive::task_result::stop_all";
   };
 }
 
 bool from_string(string_view in, task_result& out) {
-  if (in == "resume") {
+  if (in == "caf::intrusive::task_result::resume") {
     out = task_result::resume;
     return true;
-  } else if (in == "skip") {
+  } else if (in == "caf::intrusive::task_result::skip") {
     out = task_result::skip;
     return true;
-  } else if (in == "stop") {
+  } else if (in == "caf::intrusive::task_result::stop") {
     out = task_result::stop;
     return true;
-  } else if (in == "stop_all") {
+  } else if (in == "caf::intrusive::task_result::stop_all") {
     out = task_result::stop_all;
     return true;
   } else {
@@ -61,7 +60,6 @@ bool from_integer(std::underlying_type_t<task_result> in,
   };
 }
 
-} // namespace intrusive
-} // namespace caf
+} // namespace caf::intrusive
 
 CAF_POP_WARNINGS

--- a/libcaf_core/src/invoke_message_result_strings.cpp
+++ b/libcaf_core/src/invoke_message_result_strings.cpp
@@ -17,22 +17,22 @@ std::string to_string(invoke_message_result x) {
     default:
       return "???";
     case invoke_message_result::consumed:
-      return "consumed";
+      return "caf::invoke_message_result::consumed";
     case invoke_message_result::skipped:
-      return "skipped";
+      return "caf::invoke_message_result::skipped";
     case invoke_message_result::dropped:
-      return "dropped";
+      return "caf::invoke_message_result::dropped";
   };
 }
 
 bool from_string(string_view in, invoke_message_result& out) {
-  if (in == "consumed") {
+  if (in == "caf::invoke_message_result::consumed") {
     out = invoke_message_result::consumed;
     return true;
-  } else if (in == "skipped") {
+  } else if (in == "caf::invoke_message_result::skipped") {
     out = invoke_message_result::skipped;
     return true;
-  } else if (in == "dropped") {
+  } else if (in == "caf::invoke_message_result::dropped") {
     out = invoke_message_result::dropped;
     return true;
   } else {

--- a/libcaf_core/src/message_priority_strings.cpp
+++ b/libcaf_core/src/message_priority_strings.cpp
@@ -17,17 +17,17 @@ std::string to_string(message_priority x) {
     default:
       return "???";
     case message_priority::high:
-      return "high";
+      return "caf::message_priority::high";
     case message_priority::normal:
-      return "normal";
+      return "caf::message_priority::normal";
   };
 }
 
 bool from_string(string_view in, message_priority& out) {
-  if (in == "high") {
+  if (in == "caf::message_priority::high") {
     out = message_priority::high;
     return true;
-  } else if (in == "normal") {
+  } else if (in == "caf::message_priority::normal") {
     out = message_priority::normal;
     return true;
   } else {

--- a/libcaf_core/src/pec_strings.cpp
+++ b/libcaf_core/src/pec_strings.cpp
@@ -17,122 +17,122 @@ std::string to_string(pec x) {
     default:
       return "???";
     case pec::success:
-      return "success";
+      return "caf::pec::success";
     case pec::trailing_character:
-      return "trailing_character";
+      return "caf::pec::trailing_character";
     case pec::unexpected_eof:
-      return "unexpected_eof";
+      return "caf::pec::unexpected_eof";
     case pec::unexpected_character:
-      return "unexpected_character";
+      return "caf::pec::unexpected_character";
     case pec::timespan_overflow:
-      return "timespan_overflow";
+      return "caf::pec::timespan_overflow";
     case pec::fractional_timespan:
-      return "fractional_timespan";
+      return "caf::pec::fractional_timespan";
     case pec::too_many_characters:
-      return "too_many_characters";
+      return "caf::pec::too_many_characters";
     case pec::invalid_escape_sequence:
-      return "invalid_escape_sequence";
+      return "caf::pec::invalid_escape_sequence";
     case pec::unexpected_newline:
-      return "unexpected_newline";
+      return "caf::pec::unexpected_newline";
     case pec::integer_overflow:
-      return "integer_overflow";
+      return "caf::pec::integer_overflow";
     case pec::integer_underflow:
-      return "integer_underflow";
+      return "caf::pec::integer_underflow";
     case pec::exponent_underflow:
-      return "exponent_underflow";
+      return "caf::pec::exponent_underflow";
     case pec::exponent_overflow:
-      return "exponent_overflow";
+      return "caf::pec::exponent_overflow";
     case pec::type_mismatch:
-      return "type_mismatch";
+      return "caf::pec::type_mismatch";
     case pec::not_an_option:
-      return "not_an_option";
+      return "caf::pec::not_an_option";
     case pec::invalid_argument:
-      return "invalid_argument";
+      return "caf::pec::invalid_argument";
     case pec::missing_argument:
-      return "missing_argument";
+      return "caf::pec::missing_argument";
     case pec::invalid_category:
-      return "invalid_category";
+      return "caf::pec::invalid_category";
     case pec::invalid_field_name:
-      return "invalid_field_name";
+      return "caf::pec::invalid_field_name";
     case pec::repeated_field_name:
-      return "repeated_field_name";
+      return "caf::pec::repeated_field_name";
     case pec::missing_field:
-      return "missing_field";
+      return "caf::pec::missing_field";
     case pec::invalid_range_expression:
-      return "invalid_range_expression";
+      return "caf::pec::invalid_range_expression";
     case pec::invalid_state:
-      return "invalid_state";
+      return "caf::pec::invalid_state";
   };
 }
 
 bool from_string(string_view in, pec& out) {
-  if (in == "success") {
+  if (in == "caf::pec::success") {
     out = pec::success;
     return true;
-  } else if (in == "trailing_character") {
+  } else if (in == "caf::pec::trailing_character") {
     out = pec::trailing_character;
     return true;
-  } else if (in == "unexpected_eof") {
+  } else if (in == "caf::pec::unexpected_eof") {
     out = pec::unexpected_eof;
     return true;
-  } else if (in == "unexpected_character") {
+  } else if (in == "caf::pec::unexpected_character") {
     out = pec::unexpected_character;
     return true;
-  } else if (in == "timespan_overflow") {
+  } else if (in == "caf::pec::timespan_overflow") {
     out = pec::timespan_overflow;
     return true;
-  } else if (in == "fractional_timespan") {
+  } else if (in == "caf::pec::fractional_timespan") {
     out = pec::fractional_timespan;
     return true;
-  } else if (in == "too_many_characters") {
+  } else if (in == "caf::pec::too_many_characters") {
     out = pec::too_many_characters;
     return true;
-  } else if (in == "invalid_escape_sequence") {
+  } else if (in == "caf::pec::invalid_escape_sequence") {
     out = pec::invalid_escape_sequence;
     return true;
-  } else if (in == "unexpected_newline") {
+  } else if (in == "caf::pec::unexpected_newline") {
     out = pec::unexpected_newline;
     return true;
-  } else if (in == "integer_overflow") {
+  } else if (in == "caf::pec::integer_overflow") {
     out = pec::integer_overflow;
     return true;
-  } else if (in == "integer_underflow") {
+  } else if (in == "caf::pec::integer_underflow") {
     out = pec::integer_underflow;
     return true;
-  } else if (in == "exponent_underflow") {
+  } else if (in == "caf::pec::exponent_underflow") {
     out = pec::exponent_underflow;
     return true;
-  } else if (in == "exponent_overflow") {
+  } else if (in == "caf::pec::exponent_overflow") {
     out = pec::exponent_overflow;
     return true;
-  } else if (in == "type_mismatch") {
+  } else if (in == "caf::pec::type_mismatch") {
     out = pec::type_mismatch;
     return true;
-  } else if (in == "not_an_option") {
+  } else if (in == "caf::pec::not_an_option") {
     out = pec::not_an_option;
     return true;
-  } else if (in == "invalid_argument") {
+  } else if (in == "caf::pec::invalid_argument") {
     out = pec::invalid_argument;
     return true;
-  } else if (in == "missing_argument") {
+  } else if (in == "caf::pec::missing_argument") {
     out = pec::missing_argument;
     return true;
-  } else if (in == "invalid_category") {
+  } else if (in == "caf::pec::invalid_category") {
     out = pec::invalid_category;
     return true;
-  } else if (in == "invalid_field_name") {
+  } else if (in == "caf::pec::invalid_field_name") {
     out = pec::invalid_field_name;
     return true;
-  } else if (in == "repeated_field_name") {
+  } else if (in == "caf::pec::repeated_field_name") {
     out = pec::repeated_field_name;
     return true;
-  } else if (in == "missing_field") {
+  } else if (in == "caf::pec::missing_field") {
     out = pec::missing_field;
     return true;
-  } else if (in == "invalid_range_expression") {
+  } else if (in == "caf::pec::invalid_range_expression") {
     out = pec::invalid_range_expression;
     return true;
-  } else if (in == "invalid_state") {
+  } else if (in == "caf::pec::invalid_state") {
     out = pec::invalid_state;
     return true;
   } else {

--- a/libcaf_core/src/sec_strings.cpp
+++ b/libcaf_core/src/sec_strings.cpp
@@ -17,342 +17,342 @@ std::string to_string(sec x) {
     default:
       return "???";
     case sec::none:
-      return "none";
+      return "caf::sec::none";
     case sec::unexpected_message:
-      return "unexpected_message";
+      return "caf::sec::unexpected_message";
     case sec::unexpected_response:
-      return "unexpected_response";
+      return "caf::sec::unexpected_response";
     case sec::request_receiver_down:
-      return "request_receiver_down";
+      return "caf::sec::request_receiver_down";
     case sec::request_timeout:
-      return "request_timeout";
+      return "caf::sec::request_timeout";
     case sec::no_such_group_module:
-      return "no_such_group_module";
+      return "caf::sec::no_such_group_module";
     case sec::no_actor_published_at_port:
-      return "no_actor_published_at_port";
+      return "caf::sec::no_actor_published_at_port";
     case sec::unexpected_actor_messaging_interface:
-      return "unexpected_actor_messaging_interface";
+      return "caf::sec::unexpected_actor_messaging_interface";
     case sec::state_not_serializable:
-      return "state_not_serializable";
+      return "caf::sec::state_not_serializable";
     case sec::unsupported_sys_key:
-      return "unsupported_sys_key";
+      return "caf::sec::unsupported_sys_key";
     case sec::unsupported_sys_message:
-      return "unsupported_sys_message";
+      return "caf::sec::unsupported_sys_message";
     case sec::disconnect_during_handshake:
-      return "disconnect_during_handshake";
+      return "caf::sec::disconnect_during_handshake";
     case sec::cannot_forward_to_invalid_actor:
-      return "cannot_forward_to_invalid_actor";
+      return "caf::sec::cannot_forward_to_invalid_actor";
     case sec::no_route_to_receiving_node:
-      return "no_route_to_receiving_node";
+      return "caf::sec::no_route_to_receiving_node";
     case sec::failed_to_assign_scribe_from_handle:
-      return "failed_to_assign_scribe_from_handle";
+      return "caf::sec::failed_to_assign_scribe_from_handle";
     case sec::failed_to_assign_doorman_from_handle:
-      return "failed_to_assign_doorman_from_handle";
+      return "caf::sec::failed_to_assign_doorman_from_handle";
     case sec::cannot_close_invalid_port:
-      return "cannot_close_invalid_port";
+      return "caf::sec::cannot_close_invalid_port";
     case sec::cannot_connect_to_node:
-      return "cannot_connect_to_node";
+      return "caf::sec::cannot_connect_to_node";
     case sec::cannot_open_port:
-      return "cannot_open_port";
+      return "caf::sec::cannot_open_port";
     case sec::network_syscall_failed:
-      return "network_syscall_failed";
+      return "caf::sec::network_syscall_failed";
     case sec::invalid_argument:
-      return "invalid_argument";
+      return "caf::sec::invalid_argument";
     case sec::invalid_protocol_family:
-      return "invalid_protocol_family";
+      return "caf::sec::invalid_protocol_family";
     case sec::cannot_publish_invalid_actor:
-      return "cannot_publish_invalid_actor";
+      return "caf::sec::cannot_publish_invalid_actor";
     case sec::cannot_spawn_actor_from_arguments:
-      return "cannot_spawn_actor_from_arguments";
+      return "caf::sec::cannot_spawn_actor_from_arguments";
     case sec::end_of_stream:
-      return "end_of_stream";
+      return "caf::sec::end_of_stream";
     case sec::no_context:
-      return "no_context";
+      return "caf::sec::no_context";
     case sec::unknown_type:
-      return "unknown_type";
+      return "caf::sec::unknown_type";
     case sec::no_proxy_registry:
-      return "no_proxy_registry";
+      return "caf::sec::no_proxy_registry";
     case sec::runtime_error:
-      return "runtime_error";
+      return "caf::sec::runtime_error";
     case sec::remote_linking_failed:
-      return "remote_linking_failed";
+      return "caf::sec::remote_linking_failed";
     case sec::cannot_add_upstream:
-      return "cannot_add_upstream";
+      return "caf::sec::cannot_add_upstream";
     case sec::upstream_already_exists:
-      return "upstream_already_exists";
+      return "caf::sec::upstream_already_exists";
     case sec::invalid_upstream:
-      return "invalid_upstream";
+      return "caf::sec::invalid_upstream";
     case sec::cannot_add_downstream:
-      return "cannot_add_downstream";
+      return "caf::sec::cannot_add_downstream";
     case sec::downstream_already_exists:
-      return "downstream_already_exists";
+      return "caf::sec::downstream_already_exists";
     case sec::invalid_downstream:
-      return "invalid_downstream";
+      return "caf::sec::invalid_downstream";
     case sec::no_downstream_stages_defined:
-      return "no_downstream_stages_defined";
+      return "caf::sec::no_downstream_stages_defined";
     case sec::stream_init_failed:
-      return "stream_init_failed";
+      return "caf::sec::stream_init_failed";
     case sec::invalid_stream_state:
-      return "invalid_stream_state";
+      return "caf::sec::invalid_stream_state";
     case sec::unhandled_stream_error:
-      return "unhandled_stream_error";
+      return "caf::sec::unhandled_stream_error";
     case sec::bad_function_call:
-      return "bad_function_call";
+      return "caf::sec::bad_function_call";
     case sec::feature_disabled:
-      return "feature_disabled";
+      return "caf::sec::feature_disabled";
     case sec::cannot_open_file:
-      return "cannot_open_file";
+      return "caf::sec::cannot_open_file";
     case sec::socket_invalid:
-      return "socket_invalid";
+      return "caf::sec::socket_invalid";
     case sec::socket_disconnected:
-      return "socket_disconnected";
+      return "caf::sec::socket_disconnected";
     case sec::socket_operation_failed:
-      return "socket_operation_failed";
+      return "caf::sec::socket_operation_failed";
     case sec::unavailable_or_would_block:
-      return "unavailable_or_would_block";
+      return "caf::sec::unavailable_or_would_block";
     case sec::incompatible_versions:
-      return "incompatible_versions";
+      return "caf::sec::incompatible_versions";
     case sec::incompatible_application_ids:
-      return "incompatible_application_ids";
+      return "caf::sec::incompatible_application_ids";
     case sec::malformed_basp_message:
-      return "malformed_basp_message";
+      return "caf::sec::malformed_basp_message";
     case sec::serializing_basp_payload_failed:
-      return "serializing_basp_payload_failed";
+      return "caf::sec::serializing_basp_payload_failed";
     case sec::redundant_connection:
-      return "redundant_connection";
+      return "caf::sec::redundant_connection";
     case sec::remote_lookup_failed:
-      return "remote_lookup_failed";
+      return "caf::sec::remote_lookup_failed";
     case sec::no_tracing_context:
-      return "no_tracing_context";
+      return "caf::sec::no_tracing_context";
     case sec::all_requests_failed:
-      return "all_requests_failed";
+      return "caf::sec::all_requests_failed";
     case sec::field_invariant_check_failed:
-      return "field_invariant_check_failed";
+      return "caf::sec::field_invariant_check_failed";
     case sec::field_value_synchronization_failed:
-      return "field_value_synchronization_failed";
+      return "caf::sec::field_value_synchronization_failed";
     case sec::invalid_field_type:
-      return "invalid_field_type";
+      return "caf::sec::invalid_field_type";
     case sec::unsafe_type:
-      return "unsafe_type";
+      return "caf::sec::unsafe_type";
     case sec::save_callback_failed:
-      return "save_callback_failed";
+      return "caf::sec::save_callback_failed";
     case sec::load_callback_failed:
-      return "load_callback_failed";
+      return "caf::sec::load_callback_failed";
     case sec::conversion_failed:
-      return "conversion_failed";
+      return "caf::sec::conversion_failed";
     case sec::connection_closed:
-      return "connection_closed";
+      return "caf::sec::connection_closed";
     case sec::type_clash:
-      return "type_clash";
+      return "caf::sec::type_clash";
     case sec::unsupported_operation:
-      return "unsupported_operation";
+      return "caf::sec::unsupported_operation";
     case sec::no_such_key:
-      return "no_such_key";
+      return "caf::sec::no_such_key";
     case sec::broken_promise:
-      return "broken_promise";
+      return "caf::sec::broken_promise";
   };
 }
 
 bool from_string(string_view in, sec& out) {
-  if (in == "none") {
+  if (in == "caf::sec::none") {
     out = sec::none;
     return true;
-  } else if (in == "unexpected_message") {
+  } else if (in == "caf::sec::unexpected_message") {
     out = sec::unexpected_message;
     return true;
-  } else if (in == "unexpected_response") {
+  } else if (in == "caf::sec::unexpected_response") {
     out = sec::unexpected_response;
     return true;
-  } else if (in == "request_receiver_down") {
+  } else if (in == "caf::sec::request_receiver_down") {
     out = sec::request_receiver_down;
     return true;
-  } else if (in == "request_timeout") {
+  } else if (in == "caf::sec::request_timeout") {
     out = sec::request_timeout;
     return true;
-  } else if (in == "no_such_group_module") {
+  } else if (in == "caf::sec::no_such_group_module") {
     out = sec::no_such_group_module;
     return true;
-  } else if (in == "no_actor_published_at_port") {
+  } else if (in == "caf::sec::no_actor_published_at_port") {
     out = sec::no_actor_published_at_port;
     return true;
-  } else if (in == "unexpected_actor_messaging_interface") {
+  } else if (in == "caf::sec::unexpected_actor_messaging_interface") {
     out = sec::unexpected_actor_messaging_interface;
     return true;
-  } else if (in == "state_not_serializable") {
+  } else if (in == "caf::sec::state_not_serializable") {
     out = sec::state_not_serializable;
     return true;
-  } else if (in == "unsupported_sys_key") {
+  } else if (in == "caf::sec::unsupported_sys_key") {
     out = sec::unsupported_sys_key;
     return true;
-  } else if (in == "unsupported_sys_message") {
+  } else if (in == "caf::sec::unsupported_sys_message") {
     out = sec::unsupported_sys_message;
     return true;
-  } else if (in == "disconnect_during_handshake") {
+  } else if (in == "caf::sec::disconnect_during_handshake") {
     out = sec::disconnect_during_handshake;
     return true;
-  } else if (in == "cannot_forward_to_invalid_actor") {
+  } else if (in == "caf::sec::cannot_forward_to_invalid_actor") {
     out = sec::cannot_forward_to_invalid_actor;
     return true;
-  } else if (in == "no_route_to_receiving_node") {
+  } else if (in == "caf::sec::no_route_to_receiving_node") {
     out = sec::no_route_to_receiving_node;
     return true;
-  } else if (in == "failed_to_assign_scribe_from_handle") {
+  } else if (in == "caf::sec::failed_to_assign_scribe_from_handle") {
     out = sec::failed_to_assign_scribe_from_handle;
     return true;
-  } else if (in == "failed_to_assign_doorman_from_handle") {
+  } else if (in == "caf::sec::failed_to_assign_doorman_from_handle") {
     out = sec::failed_to_assign_doorman_from_handle;
     return true;
-  } else if (in == "cannot_close_invalid_port") {
+  } else if (in == "caf::sec::cannot_close_invalid_port") {
     out = sec::cannot_close_invalid_port;
     return true;
-  } else if (in == "cannot_connect_to_node") {
+  } else if (in == "caf::sec::cannot_connect_to_node") {
     out = sec::cannot_connect_to_node;
     return true;
-  } else if (in == "cannot_open_port") {
+  } else if (in == "caf::sec::cannot_open_port") {
     out = sec::cannot_open_port;
     return true;
-  } else if (in == "network_syscall_failed") {
+  } else if (in == "caf::sec::network_syscall_failed") {
     out = sec::network_syscall_failed;
     return true;
-  } else if (in == "invalid_argument") {
+  } else if (in == "caf::sec::invalid_argument") {
     out = sec::invalid_argument;
     return true;
-  } else if (in == "invalid_protocol_family") {
+  } else if (in == "caf::sec::invalid_protocol_family") {
     out = sec::invalid_protocol_family;
     return true;
-  } else if (in == "cannot_publish_invalid_actor") {
+  } else if (in == "caf::sec::cannot_publish_invalid_actor") {
     out = sec::cannot_publish_invalid_actor;
     return true;
-  } else if (in == "cannot_spawn_actor_from_arguments") {
+  } else if (in == "caf::sec::cannot_spawn_actor_from_arguments") {
     out = sec::cannot_spawn_actor_from_arguments;
     return true;
-  } else if (in == "end_of_stream") {
+  } else if (in == "caf::sec::end_of_stream") {
     out = sec::end_of_stream;
     return true;
-  } else if (in == "no_context") {
+  } else if (in == "caf::sec::no_context") {
     out = sec::no_context;
     return true;
-  } else if (in == "unknown_type") {
+  } else if (in == "caf::sec::unknown_type") {
     out = sec::unknown_type;
     return true;
-  } else if (in == "no_proxy_registry") {
+  } else if (in == "caf::sec::no_proxy_registry") {
     out = sec::no_proxy_registry;
     return true;
-  } else if (in == "runtime_error") {
+  } else if (in == "caf::sec::runtime_error") {
     out = sec::runtime_error;
     return true;
-  } else if (in == "remote_linking_failed") {
+  } else if (in == "caf::sec::remote_linking_failed") {
     out = sec::remote_linking_failed;
     return true;
-  } else if (in == "cannot_add_upstream") {
+  } else if (in == "caf::sec::cannot_add_upstream") {
     out = sec::cannot_add_upstream;
     return true;
-  } else if (in == "upstream_already_exists") {
+  } else if (in == "caf::sec::upstream_already_exists") {
     out = sec::upstream_already_exists;
     return true;
-  } else if (in == "invalid_upstream") {
+  } else if (in == "caf::sec::invalid_upstream") {
     out = sec::invalid_upstream;
     return true;
-  } else if (in == "cannot_add_downstream") {
+  } else if (in == "caf::sec::cannot_add_downstream") {
     out = sec::cannot_add_downstream;
     return true;
-  } else if (in == "downstream_already_exists") {
+  } else if (in == "caf::sec::downstream_already_exists") {
     out = sec::downstream_already_exists;
     return true;
-  } else if (in == "invalid_downstream") {
+  } else if (in == "caf::sec::invalid_downstream") {
     out = sec::invalid_downstream;
     return true;
-  } else if (in == "no_downstream_stages_defined") {
+  } else if (in == "caf::sec::no_downstream_stages_defined") {
     out = sec::no_downstream_stages_defined;
     return true;
-  } else if (in == "stream_init_failed") {
+  } else if (in == "caf::sec::stream_init_failed") {
     out = sec::stream_init_failed;
     return true;
-  } else if (in == "invalid_stream_state") {
+  } else if (in == "caf::sec::invalid_stream_state") {
     out = sec::invalid_stream_state;
     return true;
-  } else if (in == "unhandled_stream_error") {
+  } else if (in == "caf::sec::unhandled_stream_error") {
     out = sec::unhandled_stream_error;
     return true;
-  } else if (in == "bad_function_call") {
+  } else if (in == "caf::sec::bad_function_call") {
     out = sec::bad_function_call;
     return true;
-  } else if (in == "feature_disabled") {
+  } else if (in == "caf::sec::feature_disabled") {
     out = sec::feature_disabled;
     return true;
-  } else if (in == "cannot_open_file") {
+  } else if (in == "caf::sec::cannot_open_file") {
     out = sec::cannot_open_file;
     return true;
-  } else if (in == "socket_invalid") {
+  } else if (in == "caf::sec::socket_invalid") {
     out = sec::socket_invalid;
     return true;
-  } else if (in == "socket_disconnected") {
+  } else if (in == "caf::sec::socket_disconnected") {
     out = sec::socket_disconnected;
     return true;
-  } else if (in == "socket_operation_failed") {
+  } else if (in == "caf::sec::socket_operation_failed") {
     out = sec::socket_operation_failed;
     return true;
-  } else if (in == "unavailable_or_would_block") {
+  } else if (in == "caf::sec::unavailable_or_would_block") {
     out = sec::unavailable_or_would_block;
     return true;
-  } else if (in == "incompatible_versions") {
+  } else if (in == "caf::sec::incompatible_versions") {
     out = sec::incompatible_versions;
     return true;
-  } else if (in == "incompatible_application_ids") {
+  } else if (in == "caf::sec::incompatible_application_ids") {
     out = sec::incompatible_application_ids;
     return true;
-  } else if (in == "malformed_basp_message") {
+  } else if (in == "caf::sec::malformed_basp_message") {
     out = sec::malformed_basp_message;
     return true;
-  } else if (in == "serializing_basp_payload_failed") {
+  } else if (in == "caf::sec::serializing_basp_payload_failed") {
     out = sec::serializing_basp_payload_failed;
     return true;
-  } else if (in == "redundant_connection") {
+  } else if (in == "caf::sec::redundant_connection") {
     out = sec::redundant_connection;
     return true;
-  } else if (in == "remote_lookup_failed") {
+  } else if (in == "caf::sec::remote_lookup_failed") {
     out = sec::remote_lookup_failed;
     return true;
-  } else if (in == "no_tracing_context") {
+  } else if (in == "caf::sec::no_tracing_context") {
     out = sec::no_tracing_context;
     return true;
-  } else if (in == "all_requests_failed") {
+  } else if (in == "caf::sec::all_requests_failed") {
     out = sec::all_requests_failed;
     return true;
-  } else if (in == "field_invariant_check_failed") {
+  } else if (in == "caf::sec::field_invariant_check_failed") {
     out = sec::field_invariant_check_failed;
     return true;
-  } else if (in == "field_value_synchronization_failed") {
+  } else if (in == "caf::sec::field_value_synchronization_failed") {
     out = sec::field_value_synchronization_failed;
     return true;
-  } else if (in == "invalid_field_type") {
+  } else if (in == "caf::sec::invalid_field_type") {
     out = sec::invalid_field_type;
     return true;
-  } else if (in == "unsafe_type") {
+  } else if (in == "caf::sec::unsafe_type") {
     out = sec::unsafe_type;
     return true;
-  } else if (in == "save_callback_failed") {
+  } else if (in == "caf::sec::save_callback_failed") {
     out = sec::save_callback_failed;
     return true;
-  } else if (in == "load_callback_failed") {
+  } else if (in == "caf::sec::load_callback_failed") {
     out = sec::load_callback_failed;
     return true;
-  } else if (in == "conversion_failed") {
+  } else if (in == "caf::sec::conversion_failed") {
     out = sec::conversion_failed;
     return true;
-  } else if (in == "connection_closed") {
+  } else if (in == "caf::sec::connection_closed") {
     out = sec::connection_closed;
     return true;
-  } else if (in == "type_clash") {
+  } else if (in == "caf::sec::type_clash") {
     out = sec::type_clash;
     return true;
-  } else if (in == "unsupported_operation") {
+  } else if (in == "caf::sec::unsupported_operation") {
     out = sec::unsupported_operation;
     return true;
-  } else if (in == "no_such_key") {
+  } else if (in == "caf::sec::no_such_key") {
     out = sec::no_such_key;
     return true;
-  } else if (in == "broken_promise") {
+  } else if (in == "caf::sec::broken_promise") {
     out = sec::broken_promise;
     return true;
   } else {

--- a/libcaf_core/src/stream_priority_strings.cpp
+++ b/libcaf_core/src/stream_priority_strings.cpp
@@ -17,32 +17,32 @@ std::string to_string(stream_priority x) {
     default:
       return "???";
     case stream_priority::very_high:
-      return "very_high";
+      return "caf::stream_priority::very_high";
     case stream_priority::high:
-      return "high";
+      return "caf::stream_priority::high";
     case stream_priority::normal:
-      return "normal";
+      return "caf::stream_priority::normal";
     case stream_priority::low:
-      return "low";
+      return "caf::stream_priority::low";
     case stream_priority::very_low:
-      return "very_low";
+      return "caf::stream_priority::very_low";
   };
 }
 
 bool from_string(string_view in, stream_priority& out) {
-  if (in == "very_high") {
+  if (in == "caf::stream_priority::very_high") {
     out = stream_priority::very_high;
     return true;
-  } else if (in == "high") {
+  } else if (in == "caf::stream_priority::high") {
     out = stream_priority::high;
     return true;
-  } else if (in == "normal") {
+  } else if (in == "caf::stream_priority::normal") {
     out = stream_priority::normal;
     return true;
-  } else if (in == "low") {
+  } else if (in == "caf::stream_priority::low") {
     out = stream_priority::low;
     return true;
-  } else if (in == "very_low") {
+  } else if (in == "caf::stream_priority::very_low") {
     out = stream_priority::very_low;
     return true;
   } else {

--- a/libcaf_core/test/actor_profiler.cpp
+++ b/libcaf_core/test/actor_profiler.cpp
@@ -18,6 +18,16 @@ namespace {
 
 using string_list = std::vector<std::string>;
 
+std::string short_string(invoke_message_result result) {
+  auto str = to_string(result);
+  string_list components;
+  split(components, str, "::", false);
+  if (components.empty())
+    return str;
+  else
+    return std::move(components.back());
+}
+
 struct recorder : actor_profiler {
   void add_actor(const local_actor& self, const local_actor* parent) override {
     log.emplace_back("new: ");
@@ -47,7 +57,7 @@ struct recorder : actor_profiler {
     log.emplace_back(self.name());
     auto& str = log.back();
     str += " ";
-    str += to_string(result);
+    str += short_string(result);
     str += " the message";
   }
 

--- a/libcaf_core/test/error.cpp
+++ b/libcaf_core/test/error.cpp
@@ -12,22 +12,47 @@ using namespace caf;
 
 CAF_TEST(default constructed errors evaluate to false) {
   error err;
-  CAF_CHECK(!err);
+  CHECK(!err);
 }
 
 CAF_TEST(error code zero is not an error) {
-  CAF_CHECK(!error(sec::none));
-  CAF_CHECK(!make_error(sec::none));
-  CAF_CHECK(!error{error_code<sec>(sec::none)});
+  CHECK(!error(sec::none));
+  CHECK(!make_error(sec::none));
+  CHECK(!error{error_code<sec>(sec::none)});
 }
 
 CAF_TEST(error codes that are not zero are errors) {
-  CAF_CHECK(error(sec::unexpected_message));
-  CAF_CHECK(make_error(sec::unexpected_message));
-  CAF_CHECK(error{error_code<sec>(sec::unexpected_message)});
+  CHECK(error(sec::unexpected_message));
+  CHECK(make_error(sec::unexpected_message));
+  CHECK(error{error_code<sec>(sec::unexpected_message)});
 }
 
 CAF_TEST(errors convert enums to their integer value) {
-  CAF_CHECK_EQUAL(make_error(sec::unexpected_message).code(), 1u);
-  CAF_CHECK_EQUAL(error{error_code<sec>(sec::unexpected_message)}.code(), 1u);
+  CHECK_EQ(make_error(sec::unexpected_message).code(), 1u);
+  CHECK_EQ(error{error_code<sec>(sec::unexpected_message)}.code(), 1u);
+}
+
+SCENARIO("errors provide human-readable to_string output") {
+  auto err_str = [](auto... xs) {
+    return to_string(make_error(std::move(xs)...));
+  };
+  GIVEN("an error object") {
+    WHEN("converting an error without context to a string") {
+      THEN("the output is only the error code") {
+        CHECK_EQ(err_str(sec::invalid_argument), "caf::sec::invalid_argument");
+      }
+    }
+    WHEN("converting an error with a context containing one element") {
+      THEN("the output is the error code plus the context") {
+        CHECK_EQ(err_str(sec::invalid_argument, "foo is not bar"),
+                 R"_(caf::sec::invalid_argument("foo is not bar"))_");
+      }
+    }
+    WHEN("converting an error with a context containing two or more elements") {
+      THEN("the output is the error code plus all elements in the context") {
+        CHECK_EQ(err_str(sec::invalid_argument, "want foo", "got bar"),
+                 R"_(caf::sec::invalid_argument("want foo", "got bar"))_");
+      }
+    }
+  }
 }

--- a/libcaf_io/src/io/basp/message_type_strings.cpp
+++ b/libcaf_io/src/io/basp/message_type_strings.cpp
@@ -10,51 +10,49 @@ CAF_PUSH_DEPRECATED_WARNING
 
 #include <string>
 
-namespace caf {
-namespace io {
-namespace basp {
+namespace caf::io::basp {
 
 std::string to_string(message_type x) {
   switch(x) {
     default:
       return "???";
     case message_type::server_handshake:
-      return "server_handshake";
+      return "caf::io::basp::message_type::server_handshake";
     case message_type::client_handshake:
-      return "client_handshake";
+      return "caf::io::basp::message_type::client_handshake";
     case message_type::direct_message:
-      return "direct_message";
+      return "caf::io::basp::message_type::direct_message";
     case message_type::routed_message:
-      return "routed_message";
+      return "caf::io::basp::message_type::routed_message";
     case message_type::monitor_message:
-      return "monitor_message";
+      return "caf::io::basp::message_type::monitor_message";
     case message_type::down_message:
-      return "down_message";
+      return "caf::io::basp::message_type::down_message";
     case message_type::heartbeat:
-      return "heartbeat";
+      return "caf::io::basp::message_type::heartbeat";
   };
 }
 
 bool from_string(string_view in, message_type& out) {
-  if (in == "server_handshake") {
+  if (in == "caf::io::basp::message_type::server_handshake") {
     out = message_type::server_handshake;
     return true;
-  } else if (in == "client_handshake") {
+  } else if (in == "caf::io::basp::message_type::client_handshake") {
     out = message_type::client_handshake;
     return true;
-  } else if (in == "direct_message") {
+  } else if (in == "caf::io::basp::message_type::direct_message") {
     out = message_type::direct_message;
     return true;
-  } else if (in == "routed_message") {
+  } else if (in == "caf::io::basp::message_type::routed_message") {
     out = message_type::routed_message;
     return true;
-  } else if (in == "monitor_message") {
+  } else if (in == "caf::io::basp::message_type::monitor_message") {
     out = message_type::monitor_message;
     return true;
-  } else if (in == "down_message") {
+  } else if (in == "caf::io::basp::message_type::down_message") {
     out = message_type::down_message;
     return true;
-  } else if (in == "heartbeat") {
+  } else if (in == "caf::io::basp::message_type::heartbeat") {
     out = message_type::heartbeat;
     return true;
   } else {
@@ -80,8 +78,6 @@ bool from_integer(std::underlying_type_t<message_type> in,
   };
 }
 
-} // namespace basp
-} // namespace io
-} // namespace caf
+} // namespace caf::io::basp
 
 CAF_POP_WARNINGS

--- a/libcaf_io/src/io/network/operation_strings.cpp
+++ b/libcaf_io/src/io/network/operation_strings.cpp
@@ -10,31 +10,29 @@ CAF_PUSH_DEPRECATED_WARNING
 
 #include <string>
 
-namespace caf {
-namespace io {
-namespace network {
+namespace caf::io::network {
 
 std::string to_string(operation x) {
   switch(x) {
     default:
       return "???";
     case operation::read:
-      return "read";
+      return "caf::io::network::operation::read";
     case operation::write:
-      return "write";
+      return "caf::io::network::operation::write";
     case operation::propagate_error:
-      return "propagate_error";
+      return "caf::io::network::operation::propagate_error";
   };
 }
 
 bool from_string(string_view in, operation& out) {
-  if (in == "read") {
+  if (in == "caf::io::network::operation::read") {
     out = operation::read;
     return true;
-  } else if (in == "write") {
+  } else if (in == "caf::io::network::operation::write") {
     out = operation::write;
     return true;
-  } else if (in == "propagate_error") {
+  } else if (in == "caf::io::network::operation::propagate_error") {
     out = operation::propagate_error;
     return true;
   } else {
@@ -56,8 +54,6 @@ bool from_integer(std::underlying_type_t<operation> in,
   };
 }
 
-} // namespace network
-} // namespace io
-} // namespace caf
+} // namespace caf::io::network
 
 CAF_POP_WARNINGS


### PR DESCRIPTION
Note: only `cmake/caf-generate-enum-strings.cpp` and `libcaf_core/src/error.cpp` are worth looking at. 🙂

The remaining changes were produced by `update-enum-strings`.