### PR TITLE
Tie lifetime of meta objects table to CAF threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   an error. The `includes` and `excludes` filters are now consistently handled
   and accepted in config files as well as on the command line (#1238).
 - Silence a deprecated-enum-conversion warning for `std::byte` (#1230).
+- Fix heap-use-after-free when accessing the meta objects table in applications
+  that leave the `main` function while the actor system and its worker threads
+  are still running (#1241).
 
 ## [0.18.1] - 2021-03-19
 

--- a/libcaf_core/caf/config.hpp
+++ b/libcaf_core/caf/config.hpp
@@ -240,9 +240,18 @@ struct IUnknown;
 // Convenience macros.
 #define CAF_IGNORE_UNUSED(x) static_cast<void>(x)
 
+/// Prints `error` to `stderr` and aborts program execution.
 #define CAF_CRITICAL(error)                                                    \
   do {                                                                         \
-    fprintf(stderr, "[FATAL] %s:%u: critical error: '%s'\n", __FILE__,         \
+    fprintf(stderr, "[FATAL] critical error (%s:%d): %s\n", __FILE__,          \
             __LINE__, error);                                                  \
+    ::abort();                                                                 \
+  } while (false)
+
+/// Prints `error` to `stderr` and aborts program execution.
+#define CAF_CRITICAL_FMT(fmt_str, ...)                                         \
+  do {                                                                         \
+    fprintf(stderr, "[FATAL] critical error (%s:%d): " fmt_str "\n", __FILE__, \
+            __LINE__, __VA_ARGS__);                                            \
     ::abort();                                                                 \
   } while (false)

--- a/libcaf_core/caf/detail/meta_object.hpp
+++ b/libcaf_core/caf/detail/meta_object.hpp
@@ -51,6 +51,15 @@ struct meta_object {
   void (*stringify)(std::string&, const void*);
 };
 
+/// An opaque type for shared object lifetime management of the global meta
+/// objects table.
+using global_meta_objects_guard_type = intrusive_ptr<ref_counted>;
+
+/// Returns a shared ownership wrapper for global state to manage meta objects.
+/// Any thread that accesses the actor system should participate in the lifetime
+/// management of the global state by using a meta objects guard.
+CAF_CORE_EXPORT global_meta_objects_guard_type global_meta_objects_guard();
+
 /// Returns the global storage for all meta objects. The ::type_id of an object
 /// is the index for accessing the corresonding meta object.
 CAF_CORE_EXPORT span<const meta_object> global_meta_objects();

--- a/libcaf_core/caf/detail/private_thread.hpp
+++ b/libcaf_core/caf/detail/private_thread.hpp
@@ -25,8 +25,6 @@ public:
 private:
   void run(actor_system* sys);
 
-  static void exec(actor_system* sys, private_thread* this_ptr);
-
   std::pair<resumable*, bool> await();
 
   std::thread thread_;

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -361,6 +361,8 @@ CAF_CORE_EXPORT void intrusive_ptr_release(const dynamic_message_data*);
 CAF_CORE_EXPORT dynamic_message_data*
 intrusive_cow_ptr_unshare(dynamic_message_data*&);
 
+using global_meta_objects_guard_type = intrusive_ptr<ref_counted>;
+
 } // namespace detail
 
 // -- weak pointer aliases -----------------------------------------------------

--- a/libcaf_core/caf/init_global_meta_objects.hpp
+++ b/libcaf_core/caf/init_global_meta_objects.hpp
@@ -12,6 +12,7 @@
 #include "caf/detail/core_export.hpp"
 #include "caf/detail/make_meta_object.hpp"
 #include "caf/detail/meta_object.hpp"
+#include "caf/fwd.hpp"
 #include "caf/span.hpp"
 #include "caf/type_id.hpp"
 

--- a/libcaf_core/caf/scheduler/coordinator.hpp
+++ b/libcaf_core/caf/scheduler/coordinator.hpp
@@ -60,13 +60,8 @@ protected:
       w->start();
     // Launch an additional background thread for dispatching timeouts and
     // delayed messages.
-    timer_ = std::thread{[&] {
-      CAF_SET_LOGGER_SYS(&system());
-      detail::set_thread_name("caf.clock");
-      system().thread_started();
-      clock_.run_dispatch_loop();
-      system().thread_terminates();
-    }};
+    timer_ = system().launch_thread("caf.clock",
+                                    [this] { clock_.run_dispatch_loop(); });
     // Run remaining startup code.
     super::start();
   }

--- a/libcaf_core/caf/scheduler/worker.hpp
+++ b/libcaf_core/caf/scheduler/worker.hpp
@@ -37,14 +37,7 @@ public:
 
   void start() {
     CAF_ASSERT(this_thread_.get_id() == std::thread::id{});
-    auto this_worker = this;
-    this_thread_ = std::thread{[this_worker] {
-      CAF_SET_LOGGER_SYS(&this_worker->system());
-      detail::set_thread_name("caf.worker");
-      this_worker->system().thread_started();
-      this_worker->run();
-      this_worker->system().thread_terminates();
-    }};
+    this_thread_ = system().launch_thread("caf.worker", [this] { run(); });
   }
 
   worker(const worker&) = delete;

--- a/libcaf_core/src/actor_system.cpp
+++ b/libcaf_core/src/actor_system.cpp
@@ -277,6 +277,9 @@ actor_system::actor_system(actor_system_config& cfg)
     tracing_context_(cfg.tracing_context),
     private_threads_(this) {
   CAF_SET_LOGGER_SYS(this);
+  meta_objects_guard_ = detail::global_meta_objects_guard();
+  if (!meta_objects_guard_)
+    CAF_CRITICAL("unable to obtain the global meta objects guard");
   for (auto& hook : cfg.thread_hooks_)
     hook->init(*this);
   // Cache some configuration parameters for faster lookups at runtime.

--- a/libcaf_core/src/detail/private_thread.cpp
+++ b/libcaf_core/src/detail/private_thread.cpp
@@ -63,16 +63,10 @@ std::pair<resumable*, bool> private_thread::await() {
 
 private_thread* private_thread::launch(actor_system* sys) {
   auto ptr = std::make_unique<private_thread>();
-  ptr->thread_ = std::thread{exec, sys, ptr.get()};
+  auto raw_ptr = ptr.get();
+  ptr->thread_ = sys->launch_thread("caf.thread",
+                                    [raw_ptr, sys] { raw_ptr->run(sys); });
   return ptr.release();
-}
-
-void private_thread::exec(actor_system* sys, private_thread* this_ptr) {
-  CAF_SET_LOGGER_SYS(sys);
-  detail::set_thread_name("caf.thread");
-  sys->thread_started();
-  this_ptr->run(sys);
-  sys->thread_terminates();
 }
 
 } // namespace caf::detail

--- a/libcaf_core/src/detail/private_thread_pool.cpp
+++ b/libcaf_core/src/detail/private_thread_pool.cpp
@@ -18,6 +18,7 @@
 
 #include "caf/detail/private_thread_pool.hpp"
 
+#include "caf/actor_system.hpp"
 #include "caf/config.hpp"
 #include "caf/detail/private_thread.hpp"
 
@@ -28,7 +29,7 @@ private_thread_pool::node::~node() {
 }
 
 void private_thread_pool::start() {
-  loop_ = std::thread{[](private_thread_pool* ptr) { ptr->run_loop(); }, this};
+  loop_ = sys_->launch_thread("caf.pool", [this] { run_loop(); });
 }
 
 void private_thread_pool::stop() {

--- a/libcaf_core/src/logger.cpp
+++ b/libcaf_core/src/logger.cpp
@@ -648,9 +648,9 @@ void logger::start() {
     auto f = [this](auto guard) {
       CAF_IGNORE_UNUSED(guard);
       detail::set_thread_name("caf.logger");
-      this->system_.thread_started();
-      this->run();
-      this->system_.thread_terminates();
+      system_.thread_started();
+      run();
+      system_.thread_terminates();
     };
     thread_ = std::thread{f, detail::global_meta_objects_guard()};
   }

--- a/libcaf_core/src/logger.cpp
+++ b/libcaf_core/src/logger.cpp
@@ -20,6 +20,7 @@
 #include "caf/config.hpp"
 #include "caf/defaults.hpp"
 #include "caf/detail/get_process_id.hpp"
+#include "caf/detail/meta_object.hpp"
 #include "caf/detail/pretty_type_name.hpp"
 #include "caf/detail/set_thread_name.hpp"
 #include "caf/intrusive/task_result.hpp"
@@ -651,7 +652,7 @@ void logger::start() {
       this->run();
       this->system_.thread_terminates();
     };
-    thread_ = std::thread{f, global_meta_objects_guard()};
+    thread_ = std::thread{f, detail::global_meta_objects_guard()};
   }
 }
 

--- a/libcaf_core/src/logger.cpp
+++ b/libcaf_core/src/logger.cpp
@@ -642,12 +642,16 @@ void logger::start() {
     open_file();
     log_first_line();
   } else {
-    thread_ = std::thread{[this] {
+    // Note: we don't call system_->launch_thread here since we don't want to
+    //       set a logger context in the logger thread.
+    auto f = [this](auto guard) {
+      CAF_IGNORE_UNUSED(guard);
       detail::set_thread_name("caf.logger");
       this->system_.thread_started();
       this->run();
       this->system_.thread_terminates();
-    }};
+    };
+    thread_ = std::thread{f, global_meta_objects_guard()};
   }
 }
 

--- a/libcaf_core/test/thread_hook.cpp
+++ b/libcaf_core/test/thread_hook.cpp
@@ -68,7 +68,7 @@ template <class Hook>
 struct config : actor_system_config {
   config() {
     add_thread_hook<Hook>();
-    set("logger.verbosity", "quiet");
+    set("caf.logger.verbosity", "quiet");
   }
 };
 
@@ -103,7 +103,7 @@ CAF_TEST(counting_system_without_actor) {
   assumed_init_calls = 1;
   auto fallback = scheduler::abstract_coordinator::default_thread_count();
   assumed_thread_count = get_or(cfg, "caf.scheduler.max-threads", fallback)
-                         + 1; // caf.clock
+                         + 2; // clock and private thread pool
   auto& sched = sys.scheduler();
   if (sched.detaches_utility_actors())
     assumed_thread_count += sched.num_utility_actors();
@@ -113,7 +113,7 @@ CAF_TEST(counting_system_with_actor) {
   assumed_init_calls = 1;
   auto fallback = scheduler::abstract_coordinator::default_thread_count();
   assumed_thread_count = get_or(cfg, "caf.scheduler.max-threads", fallback)
-                         + 2; // caf.clock and detached actor
+                         + 3; // clock, private thread pool, and  detached actor
   auto& sched = sys.scheduler();
   if (sched.detaches_utility_actors())
     assumed_thread_count += sched.num_utility_actors();
@@ -122,4 +122,3 @@ CAF_TEST(counting_system_with_actor) {
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()
-

--- a/libcaf_test/caf/test/unit_test_impl.hpp
+++ b/libcaf_test/caf/test/unit_test_impl.hpp
@@ -22,6 +22,7 @@
 #include "caf/config_option_adder.hpp"
 #include "caf/config_option_set.hpp"
 #include "caf/config_value.hpp"
+#include "caf/detail/set_thread_name.hpp"
 #include "caf/settings.hpp"
 #include "caf/string_algorithms.hpp"
 #include "caf/test/unit_test.hpp"
@@ -36,6 +37,7 @@ public:
 private:
   watchdog(int secs) {
     thread_ = std::thread{[=] {
+      caf::detail::set_thread_name("test.watchdog");
       auto tp = std::chrono::high_resolution_clock::now()
                 + std::chrono::seconds(secs);
       std::unique_lock<std::mutex> guard{mtx_};


### PR DESCRIPTION
Fixes undefined behavior if an application leaves `main` while the threads started by CAF are still running. Usually, an application destroys the `actor_system` before leaving `main`. However, some applications may use the `main` function only for spinning up threads. In this case, the meta objects table must exceed the lifetime of the static helper object.

Closes #1241.