### PR TITLE
Fix `result<T>` constructors resolution during implicit conversions

### DIFF
--- a/libcaf_core/caf/result.hpp
+++ b/libcaf_core/caf/result.hpp
@@ -184,7 +184,9 @@ public:
 
   using super::super;
 
-  result(T x) : super(detail::result_base_message_init{}, std::move(x)) {
+  template <class U, class = std::enable_if_t<std::is_constructible_v<T, U>>>
+  result(U&& x)
+    : super(detail::result_base_message_init{}, T{std::forward<U>(x)}) {
     // nop
   }
 


### PR DESCRIPTION
Convert existing value initializing constructor to templated one enabled
for all types convertible to T.

This change fixes #1245 and similar cases.