### PR TITLE
Prevent utility types from matching to result<T> templated constructor

### DIFF
--- a/libcaf_core/caf/result.hpp
+++ b/libcaf_core/caf/result.hpp
@@ -184,7 +184,9 @@ public:
 
   using super::super;
 
-  template <class U, class = std::enable_if_t<std::is_constructible_v<T, U>>>
+  template <class U, class = std::enable_if_t<
+    std::is_constructible_v<T, U> && !std::is_constructible_v<super, U>
+  >>
   result(U&& x)
     : super(detail::result_base_message_init{}, T{std::forward<U>(x)}) {
     // nop


### PR DESCRIPTION
Issue #989 has been reintroduced with recent commit 3fe3d5e33f8d985f532789f8dfb9170ca2427f16

Narrow `result<T>` templated constructor by one more condition: disable it for utility types that base class `result_base<T>` can be constructed from.