### PR TITLE
Enable structured binding for cow_tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   `/etc/my-app.conf` to `config_file_path_alternatives` in order to follow the
   common practice of looking into the current directory first before looking for
   a system-wide configuration file.
+- The class `cow_tuple` now supports structured bindings.
 
 ### Deprecated
 

--- a/libcaf_core/caf/all.hpp
+++ b/libcaf_core/caf/all.hpp
@@ -39,6 +39,7 @@
 #include "caf/config_value_reader.hpp"
 #include "caf/config_value_writer.hpp"
 #include "caf/const_typed_message_view.hpp"
+#include "caf/cow_tuple.hpp"
 #include "caf/deep_to_string.hpp"
 #include "caf/defaults.hpp"
 #include "caf/deserializer.hpp"

--- a/libcaf_core/test/cow_tuple.cpp
+++ b/libcaf_core/test/cow_tuple.cpp
@@ -13,6 +13,7 @@ using std::string;
 using std::tuple;
 
 using namespace caf;
+using namespace std::literals;
 
 CAF_TEST(default_construction) {
   cow_tuple<string, string> x;
@@ -89,6 +90,31 @@ CAF_TEST(unsharing) {
 CAF_TEST(to_string) {
   auto x = make_cow_tuple(1, string{"abc"});
   CAF_CHECK_EQUAL(deep_to_string(x), R"__([1, "abc"])__");
+}
+
+SCENARIO("COW tuples support structured bindings") {
+  GIVEN("a COW tuple") {
+    auto xs = make_cow_tuple(1, "hello"s);
+    WHEN("using structured bindings to decompose the tuple into values") {
+      THEN("all variables bind to const lvalue references") {
+        auto [a, b] = xs;
+        static_assert(std::is_same_v<const int&, decltype(a)>);
+        static_assert(std::is_same_v<const std::string&, decltype(b)>);
+        CHECK_EQ(a, 1);
+        CHECK_EQ(b, "hello");
+        auto& [c, d] = xs;
+        static_assert(std::is_same_v<const int&, decltype(c)>);
+        static_assert(std::is_same_v<const std::string&, decltype(d)>);
+        CHECK_EQ(c, 1);
+        CHECK_EQ(d, "hello");
+        auto&& [e, f] = xs;
+        static_assert(std::is_same_v<const int&, decltype(e)>);
+        static_assert(std::is_same_v<const std::string&, decltype(f)>);
+        CHECK_EQ(e, 1);
+        CHECK_EQ(f, "hello");
+      }
+    }
+  }
 }
 
 CAF_TEST_FIXTURE_SCOPE(cow_tuple_tests, test_coordinator_fixture<>)


### PR DESCRIPTION
Currently, using structured bindings for `cow_tuple` requires users to use the `.data()` member, e.g.:

```cpp
auto xs = make_cow_tuple(1, 2, 3);
auto [a, b, c] = xs.data();
```

By providing specializations for `std::tuple_size` and `std::tuple_element`, this simplifies to what users probably expected from a tuple-like type:

```cpp
auto xs = make_cow_tuple(1, 2, 3);
auto [a, b, c] = xs;
```

Of course this only grants const access (mutable access requires `xs.unshared()`).