### PR TITLE
Fix shutdown of the Prometheus background task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   the ambiguity, `result<T>` now accepts any type that allows constructing a `T`
   internally without requiring a type conversion to `T` as an argument (#1245).
 - Fix configuration parameter lookup for the `work-stealing` scheduler policy.
+- Applications that expose metrics to Prometheus properly terminate now.
 
 ## [0.18.2] - 2021-03-26
 

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -110,6 +110,7 @@ caf_add_component(
     src/detail/group_tunnel.cpp
     src/detail/invoke_result_visitor.cpp
     src/detail/json.cpp
+    src/detail/latch.cpp
     src/detail/local_group_module.cpp
     src/detail/message_builder_element.cpp
     src/detail/message_data.cpp
@@ -251,6 +252,7 @@ caf_add_component(
     detail.group_tunnel
     detail.ieee_754
     detail.json
+    detail.latch
     detail.limited_vector
     detail.local_group_module
     detail.meta_object

--- a/libcaf_core/caf/detail/latch.hpp
+++ b/libcaf_core/caf/detail/latch.hpp
@@ -1,0 +1,40 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+
+#include "caf/detail/core_export.hpp"
+
+namespace caf::detail {
+
+// Drop-in replacement for C++20's std::latch.
+class CAF_CORE_EXPORT latch {
+public:
+  explicit latch(ptrdiff_t value) : count_(value) {
+    // nop
+  }
+
+  latch(const latch&) = delete;
+
+  latch& operator=(const latch&) = delete;
+
+  void count_down_and_wait();
+
+  void wait();
+
+  void count_down();
+
+  bool is_ready() const noexcept;
+
+private:
+  mutable std::mutex mtx_;
+  std::condition_variable cv_;
+  ptrdiff_t count_;
+};
+
+} // namespace caf::detail

--- a/libcaf_core/src/detail/latch.cpp
+++ b/libcaf_core/src/detail/latch.cpp
@@ -1,0 +1,43 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/detail/latch.hpp"
+
+namespace caf::detail {
+
+namespace {
+
+using guard_type = std::unique_lock<std::mutex>;
+
+} // namespace
+
+void latch::count_down_and_wait() {
+  guard_type guard{mtx_};
+  if (--count_ == 0) {
+    cv_.notify_all();
+  } else {
+    do {
+      cv_.wait(guard);
+    } while (count_ > 0);
+  }
+}
+
+void latch::wait() {
+  guard_type guard{mtx_};
+  while (count_ > 0)
+    cv_.wait(guard);
+}
+
+void latch::count_down() {
+  guard_type guard{mtx_};
+  if (--count_ == 0)
+    cv_.notify_all();
+}
+
+bool latch::is_ready() const noexcept {
+  guard_type guard{mtx_};
+  return count_ == 0;
+}
+
+} // namespace caf::detail

--- a/libcaf_core/test/detail/latch.cpp
+++ b/libcaf_core/test/detail/latch.cpp
@@ -1,0 +1,29 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#define CAF_SUITE detail.latch
+
+#include "caf/detail/latch.hpp"
+
+#include "core-test.hpp"
+
+using namespace caf;
+
+SCENARIO("latches synchronize threads") {
+  GIVEN("a latch and three threads") {
+    detail::latch sync{2};
+    std::vector<std::thread> threads;
+    WHEN("synchronizing the threads via the latch") {
+      THEN("wait() blocks until all threads counted down the latch") {
+        threads.emplace_back([&sync] { sync.count_down(); });
+        threads.emplace_back([&sync] { sync.count_down_and_wait(); });
+        threads.emplace_back([&sync] { sync.wait(); });
+        sync.wait();
+        CHECK(sync.is_ready());
+      }
+    }
+    for (auto& t : threads)
+      t.join();
+  }
+}

--- a/libcaf_io/test/detail/prometheus_broker.cpp
+++ b/libcaf_io/test/detail/prometheus_broker.cpp
@@ -6,7 +6,10 @@
 
 #include "caf/detail/prometheus_broker.hpp"
 
-#include "caf/test/io_dsl.hpp"
+#include "io-test.hpp"
+
+#include "caf/io/network/default_multiplexer.hpp"
+#include "caf/policy/tcp.hpp"
 
 using namespace caf;
 using namespace caf::io;
@@ -42,29 +45,31 @@ bool contains(string_view str, string_view what) {
   return str.find(what) != string_view::npos;
 }
 
+constexpr string_view http_request
+  = "GET /metrics HTTP/1.1\r\n"
+    "Host: localhost:8090\r\n"
+    "User-Agent: Prometheus/2.18.1\r\n"
+    "Accept: application/openmetrics-text; "
+    "version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1\r\n"
+    "Accept-Encoding: gzip\r\n"
+    "X-Prometheus-Scrape-Timeout-Seconds: 5.000000\r\n\r\n";
+
+constexpr string_view http_ok_header = "HTTP/1.1 200 OK\r\n"
+                                       "Content-Type: text/plain\r\n"
+                                       "Connection: Closed\r\n\r\n";
+
 } // namespace
 
 CAF_TEST_FIXTURE_SCOPE(prometheus_broker_tests, fixture)
 
 CAF_TEST(the prometheus broker responds to HTTP get requests) {
-  string_view request
-    = "GET /metrics HTTP/1.1\r\n"
-      "Host: localhost:8090\r\n"
-      "User-Agent: Prometheus/2.18.1\r\n"
-      "Accept: application/openmetrics-text; "
-      "version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1\r\n"
-      "Accept-Encoding: gzip\r\n"
-      "X-Prometheus-Scrape-Timeout-Seconds: 5.000000\r\n\r\n";
-  auto bytes = as_bytes(make_span(request));
+  auto bytes = as_bytes(make_span(http_request));
   mpx.virtual_send(connection, byte_buffer{bytes.begin(), bytes.end()});
   run();
   auto& response_buf = mpx.output_buffer(connection);
   string_view response{reinterpret_cast<char*>(response_buf.data()),
                        response_buf.size()};
-  string_view ok_header = "HTTP/1.1 200 OK\r\n"
-                          "Content-Type: text/plain\r\n"
-                          "Connection: Closed\r\n\r\n";
-  CAF_CHECK(starts_with(response, ok_header));
+  CAF_CHECK(starts_with(response, http_ok_header));
   CAF_CHECK(contains(response, "\ncaf_system_running_actors 2 "));
   if (detail::prometheus_broker::has_process_metrics()) {
     CAF_CHECK(contains(response, "\nprocess_cpu_seconds_total "));
@@ -74,3 +79,66 @@ CAF_TEST(the prometheus broker responds to HTTP get requests) {
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()
+
+namespace {
+
+static constexpr size_t chunk_size = 1024;
+
+using io::network::native_socket;
+
+std::vector<char> read_all(string_view query, native_socket fd) {
+  while (!query.empty()) {
+    size_t written = 0;
+    policy::tcp::write_some(written, fd, query.data(), query.size());
+    query.remove_prefix(written);
+  }
+  std::vector<char> buf;
+  char chunk[chunk_size];
+  memset(chunk, 0, chunk_size);
+  for (;;) {
+    size_t received = 0;
+    auto state = policy::tcp::read_some(received, fd, chunk, chunk_size);
+    if (received > 0)
+      buf.insert(buf.end(), chunk, chunk + received);
+    if (state == io::network::rw_state::failure) {
+      io::network::close_socket(fd);
+      return buf;
+    }
+  }
+}
+
+std::vector<char> read_all(string_view query, const std::string& host,
+                           uint16_t port) {
+  if (auto fd = io::network::new_tcp_connection(host, port))
+    return read_all(query, *fd);
+  else
+    FAIL("new_tcp_connection: " << to_string(fd.error()));
+}
+
+} // namespace
+
+SCENARIO("setting caf.middleman.prometheus-http.port exports metrics to HTTP") {
+  GIVEN("a config with an entry for caf.middleman.prometheus-http.port") {
+    actor_system_config cfg;
+    cfg.load<io::middleman>();
+    cfg.set("caf.scheduler.max-threads", 2);
+    cfg.set("caf.middleman.prometheus-http.port", 0);
+    WHEN("starting an actor system using the config") {
+      actor_system sys{cfg};
+      THEN("the middleman creates a background task for HTTP requests") {
+        auto scraping_port = sys.middleman().prometheus_scraping_port();
+        REQUIRE_NE(scraping_port, 0);
+        auto response_buf = read_all(http_request, "localhost", scraping_port);
+        string_view response{reinterpret_cast<char*>(response_buf.data()),
+                             response_buf.size()};
+        CAF_CHECK(starts_with(response, http_ok_header));
+        CAF_CHECK(contains(response, "\ncaf_system_running_actors "));
+        if (detail::prometheus_broker::has_process_metrics()) {
+          CAF_CHECK(contains(response, "\nprocess_cpu_seconds_total "));
+          CAF_CHECK(contains(response, "\nprocess_resident_memory_bytes "));
+          CAF_CHECK(contains(response, "\nprocess_virtual_memory_bytes "));
+        }
+      }
+    }
+  }
+}

--- a/libcaf_io/test/io-test.hpp
+++ b/libcaf_io/test/io-test.hpp
@@ -1,3 +1,4 @@
+#include "caf/test/bdd_dsl.hpp"
 #include "caf/test/io_dsl.hpp"
 
 using calculator = caf::typed_actor<

--- a/libcaf_test/caf/test/bdd_dsl.hpp
+++ b/libcaf_test/caf/test/bdd_dsl.hpp
@@ -47,6 +47,8 @@
 
 #define MESSAGE(what) CAF_MESSAGE(what)
 
+#define FAIL(what) CAF_FAIL(what)
+
 #define BEGIN_FIXTURE_SCOPE(fixture_class)                                     \
   CAF_TEST_FIXTURE_SCOPE(CAF_UNIFYN(tests), fixture_class)
 


### PR DESCRIPTION
The middleman currently has a bug that may prevent a regular shutdown of the Prometheus background task. This causes the destructor of `actor_system` to hang while waiting for the `caf.io.prom` thread.

This PR fixes the setup for the custom multiplexer and also adds a unit test for it. We can't use the deterministic scaffold here, because that wouldn't actually run the code in question. I also did some refactoring to avoid code duplication (see the new `std::latch` drop-in replacement).

The new unit test opens a local port and connects to it. It really should be an integration test for this reason, but we currently have no such setup. I feel like this pops up more and more frequently, so at some point we should get working on an integration test suite scaffold.