### PR TITLE
Fix CMakeLists.txt for installing caf-tools

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,7 +2,7 @@ add_custom_target(all_tools)
 
 macro(add name)
   add_executable(${name} ${name}.cpp ${ARGN})
-  install(FILES ${name}.cpp DESTINATION ${CMAKE_INSTALL_DATADIR}/caf/tools)
+  install(TARGETS ${name} DESTINATION ${CMAKE_INSTALL_DATADIR}/caf/tools)
   add_dependencies(${name} all_tools)
 endmacro()
 


### PR DESCRIPTION
This change fixes the outcome of `make install`, which previously would
install the tools' .cpp files to `/usr/local/share/caf/tools`. Now, we
install the built tool binaries instead.