### PR TITLE
Fix typo

### DIFF
--- a/manual/MessagePassing.rst
+++ b/manual/MessagePassing.rst
@@ -70,7 +70,7 @@ Default and System Message Handlers
 -----------------------------------
 
 CAF has three system-level message types (``down_msg``, ``exit_msg``, and
-``error``) that all actor should handle regardless of there current state.
+``error``) that all actor should handle regardless of their current state.
 Consequently, event-based actors handle such messages in special-purpose message
 handlers. Additionally, event-based actors have a fallback handler for unmatched
 messages. Note that blocking actors have neither of those special-purpose


### PR DESCRIPTION
My default comment applies here as well :-).

(Btw: I'm not sure whether `that all actor should` handle is proper English or whether it should it be `that every actor should...` (or `each`). I'm really very unsure about that one!)