### PR TITLE
Modernize functor_attachable and allow non-const default handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   properly back off, causing high CPU load due to spinning and in some scenarios
   never recovering. This issue has been resolved by properly handling
   `SSL_ERROR_WANT_READ` on the transport (#1060).
+- Scheduled actors now accept default handlers for down messages etc. with
+  non-const apply operator such as lambda expressions declared as `mutable`.
 
 ### Removed
 

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -324,6 +324,7 @@ caf_add_component(
     response_promise
     result
     save_inspector
+    scheduled_actor
     selective_streaming
     serial_reply
     serialization

--- a/libcaf_core/caf/detail/functor_attachable.hpp
+++ b/libcaf_core/caf/detail/functor_attachable.hpp
@@ -11,41 +11,31 @@
 
 namespace caf::detail {
 
-template <class F,
-          int Args = tl_size<typename get_callable_trait<F>::arg_types>::value>
-struct functor_attachable : attachable {
-  static_assert(Args == 1 || Args == 2,
-                "Only 0, 1 or 2 arguments for F are supported");
-  F functor_;
-  functor_attachable(F arg) : functor_(std::move(arg)) {
+template <class F>
+class functor_attachable : public attachable {
+public:
+  static constexpr size_t num_args
+    = tl_size<typename get_callable_trait<F>::arg_types>::value;
+
+  static_assert(num_args < 3, "Only 0, 1 or 2 arguments for F are supported");
+
+  explicit functor_attachable(F fn) : fn_(std::move(fn)) {
     // nop
   }
-  void actor_exited(const error& fail_state, execution_unit*) override {
-    functor_(fail_state);
+
+  void actor_exited(const error& fail_state, execution_unit* host) override {
+    if constexpr (num_args == 0)
+      fn_();
+    else if constexpr (num_args == 1)
+      fn_(fail_state);
+    else
+      fn_(fail_state, host);
   }
+
   static constexpr size_t token_type = attachable::token::anonymous;
-};
 
-template <class F>
-struct functor_attachable<F, 2> : attachable {
-  F functor_;
-  functor_attachable(F arg) : functor_(std::move(arg)) {
-    // nop
-  }
-  void actor_exited(const error& x, execution_unit* y) override {
-    functor_(x, y);
-  }
-};
-
-template <class F>
-struct functor_attachable<F, 0> : attachable {
-  F functor_;
-  functor_attachable(F arg) : functor_(std::move(arg)) {
-    // nop
-  }
-  void actor_exited(const error&, execution_unit*) override {
-    functor_();
-  }
+private:
+  F fn_;
 };
 
 } // namespace caf::detail

--- a/libcaf_core/test/scheduled_actor.cpp
+++ b/libcaf_core/test/scheduled_actor.cpp
@@ -1,0 +1,144 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#define CAF_SUITE scheduled_actor
+
+#include "caf/scheduled_actor.hpp"
+
+#include "caf/test/dsl.hpp"
+
+using namespace caf;
+
+#define ASSERT_COMPILES(expr, msg)                                             \
+  static_assert(std::is_void_v<decltype(expr)>, msg);
+
+namespace {
+
+constexpr scheduled_actor* nil_actor = nullptr;
+
+// -- compile-time checks for set_default_handler ------------------------------
+
+struct mutable_default_fn {
+  skippable_result operator()(message&) {
+    return {};
+  }
+};
+
+ASSERT_COMPILES(nil_actor->set_default_handler(mutable_default_fn{}),
+                "set_default_handler must accept mutable function objects");
+
+struct const_default_fn {
+  skippable_result operator()(message&) const {
+    return {};
+  }
+};
+
+ASSERT_COMPILES(nil_actor->set_default_handler(const_default_fn{}),
+                "set_default_handler must accept const function objects");
+
+// -- compile-time checks for set_error_handler --------------------------------
+
+struct mutable_error_fn {
+  void operator()(error&) {
+    // nop
+  }
+};
+
+ASSERT_COMPILES(nil_actor->set_error_handler(mutable_error_fn{}),
+                "set_error_handler must accept mutable function objects");
+
+struct const_error_fn {
+  void operator()(error&) const {
+    // nop
+  }
+};
+
+ASSERT_COMPILES(nil_actor->set_error_handler(const_error_fn{}),
+                "set_error_handler must accept const function objects");
+
+// -- compile-time checks for set_down_handler ---------------------------------
+
+struct mutable_down_fn {
+  void operator()(down_msg&) {
+    // nop
+  }
+};
+
+ASSERT_COMPILES(nil_actor->set_down_handler(mutable_down_fn{}),
+                "set_down_handler must accept mutable function objects");
+
+struct const_down_fn {
+  void operator()(down_msg&) const {
+    // nop
+  }
+};
+
+ASSERT_COMPILES(nil_actor->set_down_handler(const_down_fn{}),
+                "set_down_handler must accept const function objects");
+
+// -- compile-time checks for set_node_down_handler ----------------------------
+
+struct mutable_node_down_fn {
+  void operator()(node_down_msg&) {
+    // nop
+  }
+};
+
+ASSERT_COMPILES(nil_actor->set_node_down_handler(mutable_node_down_fn{}),
+                "set_node_down_handler must accept mutable function objects");
+
+struct const_node_down_fn {
+  void operator()(node_down_msg&) const {
+    // nop
+  }
+};
+
+ASSERT_COMPILES(nil_actor->set_node_down_handler(const_node_down_fn{}),
+                "set_node_down_handler must accept const function objects");
+
+// -- compile-time checks for set_exit_handler ---------------------------------
+
+struct mutable_exit_fn {
+  void operator()(exit_msg&) {
+    // nop
+  }
+};
+
+ASSERT_COMPILES(nil_actor->set_exit_handler(mutable_exit_fn{}),
+                "set_exit_handler must accept mutable function objects");
+
+struct const_exit_fn {
+  void operator()(exit_msg&) const {
+    // nop
+  }
+};
+
+ASSERT_COMPILES(nil_actor->set_exit_handler(const_exit_fn{}),
+                "set_exit_handler must accept const function objects");
+
+// -- compile-time checks for set_exception_handler ----------------------------
+
+#ifdef CAF_ENABLE_EXCEPTIONS
+
+struct mutable_exception_fn {
+  error operator()(std::exception_ptr&) {
+    return {};
+  }
+};
+
+ASSERT_COMPILES(nil_actor->set_exception_handler(mutable_exception_fn{}),
+                "set_exception_handler must accept mutable function objects");
+
+struct const_exception_fn {
+  error operator()(std::exception_ptr&) const {
+    return {};
+  }
+};
+
+ASSERT_COMPILES(nil_actor->set_exception_handler(const_exception_fn{}),
+                "set_exception_handler must accept const function objects");
+
+#endif // CAF_ENABLE_EXCEPTIONS
+
+} // namespace


### PR DESCRIPTION
I did some refactoring to use more C++17 constructs and also found an issue with the default handlers: passing a lambda declared as `mutable` to any of the `set_..._handler` functions fails to compile because the captured `fun` argument is `const` unless we also declare the lambdas that we use to construct the `std::function` object as `mutable`.