### PR TITLE
Fix sign-compare warnings on GCC

### DIFF
--- a/libcaf_core/caf/config_value.hpp
+++ b/libcaf_core/caf/config_value.hpp
@@ -362,7 +362,7 @@ expected<T> get_as(const config_value& x, inspector_access_type::builtin) {
   } else if constexpr (std::is_integral<T>::value) {
     if (auto result = x.to_integer()) {
       if (detail::bounds_checker<T>::check(*result))
-        return *result;
+        return static_cast<T>(*result);
       else
         return make_error(sec::conversion_failed, "narrowing error");
     } else {

--- a/libcaf_core/caf/defaults.hpp
+++ b/libcaf_core/caf/defaults.hpp
@@ -59,7 +59,7 @@ constexpr auto calibration_interval = int32_t{20};
 
 /// Value between 0 and 1 representing the degree of weighting decrease for
 /// adjusting batch sizes. A higher factor discounts older observations faster.
-constexpr auto smoothing_factor = float{0.6};
+constexpr auto smoothing_factor = 0.6f;
 
 } // namespace caf::defaults::stream::size_policy
 

--- a/libcaf_core/caf/detail/print.hpp
+++ b/libcaf_core/caf/detail/print.hpp
@@ -231,7 +231,8 @@ void print(Buffer& buf,
   // We print in ISO 8601 format, e.g., "2020-09-01T15:58:42.372". 32-Bytes are
   // more than enough space.
   char stack_buffer[32];
-  auto pos = print_timestamp(stack_buffer, 32, secs, msecs);
+  auto pos = print_timestamp(stack_buffer, 32, secs,
+                             static_cast<size_t>(msecs));
   buf.insert(buf.end(), stack_buffer, stack_buffer + pos);
 }
 

--- a/libcaf_core/caf/type_id_list.hpp
+++ b/libcaf_core/caf/type_id_list.hpp
@@ -62,7 +62,8 @@ public:
     int s2 = other.data_[0];
     int diff = s1 - s2;
     if (diff == 0)
-      return memcmp(begin(), other.begin(), s1 * sizeof(type_id_t));
+      return memcmp(begin(), other.begin(),
+                    static_cast<unsigned>(s1) * sizeof(type_id_t));
     return diff;
   }
 


### PR DESCRIPTION
(these fixes are straightforward. Just filing as PR for CI and LGTM)