### PR TITLE
Add crate-ci/typos workflow

### DIFF
--- a/.github/workflows/check-typos.yml
+++ b/.github/workflows/check-typos.yml
@@ -1,0 +1,12 @@
+name: check-typos
+on: [push, pull_request]
+jobs:
+  typos:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@v2
+    - name: Spell checking over all files
+      uses: crate-ci/typos@master
+      with:
+        config: ./typos-config.toml

--- a/typos-config.toml
+++ b/typos-config.toml
@@ -1,0 +1,2 @@
+[files]
+extend-exclude = ["*.pem"]


### PR DESCRIPTION
This pull request adds a create-ci/typos workflow.
I tested the workflow in my fork, see the run without exlusion of pem files which is expected to fail: https://github.com/Hamdor/actor-framework/runs/2860915556?check_suite_focus=true
The final run with exclusion finds no further typos: https://github.com/Hamdor/actor-framework/runs/2860997899?check_suite_focus=true