### PR TITLE
Make message view API more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## [Unreleased]
 
+### Changed
+
+- Message views now perform the type-check in their constructor. With this
+  change, the `make_*` utility functions are no longer mandatory and users may
+  instead simply construct the view directly.
+
 ## Fixed
 
 - Printing a `config_value` that contains a zero duration `timespan` now

--- a/libcaf_core/caf/const_typed_message_view.hpp
+++ b/libcaf_core/caf/const_typed_message_view.hpp
@@ -21,7 +21,7 @@ public:
   }
 
   explicit const_typed_message_view(const message& msg) noexcept
-    : ptr_(msg.cptr()) {
+    : ptr_(msg.types() == make_type_id_list<Ts...>() ? msg.cptr() : nullptr) {
     // nop
   }
 
@@ -63,9 +63,7 @@ auto to_tuple(const_typed_message_view<Ts...> xs) {
 
 template <class... Ts>
 auto make_const_typed_message_view(const message& msg) {
-  if (msg.types() == make_type_id_list<Ts...>())
-    return const_typed_message_view<Ts...>{msg};
-  return const_typed_message_view<Ts...>{};
+  return const_typed_message_view<Ts...>{msg};
 }
 
 template <class... Ts>

--- a/libcaf_core/caf/typed_message_view.hpp
+++ b/libcaf_core/caf/typed_message_view.hpp
@@ -18,7 +18,8 @@ public:
     // nop
   }
 
-  explicit typed_message_view(message& msg) : ptr_(msg.ptr()) {
+  explicit typed_message_view(message& msg)
+    : ptr_(msg.types() == make_type_id_list<Ts...>() ? msg.ptr() : nullptr) {
     // nop
   }
 
@@ -48,9 +49,7 @@ auto& get(typed_message_view<Ts...> x) {
 
 template <class... Ts>
 auto make_typed_message_view(message& msg) {
-  if (msg.types() == make_type_id_list<Ts...>())
-    return typed_message_view<Ts...>{msg};
-  return typed_message_view<Ts...>{};
+  return typed_message_view<Ts...>{msg};
 }
 
 } // namespace caf


### PR DESCRIPTION
Addresses an issue with the message view API that I've recently noticed. Since the constructor for creating a view from a `message` is public, users may well assume it's safe to do something like this:

```cpp
auto msg1 = make_message("hello", "world");
auto msg2 = msg1;
if (auto v = const_typed_message_view<std::string, std::string>{msg1})
  println("v: ", get<0>(v), ", ", get<1>(v));
// Both messages still point to the same data.
assert(msg1.cptr() == msg2.cptr());
```

This isn't safe, though. In fact, this may easily invoke UB as of 0.18.3 since the constructor performs no type checking. The type checking is done in `make_const_typed_message_view` (which returns an invalid view if that type check fails).

With this PR, the code sample does what users probably would expect: `v` is invalid if the message does not contain two strings (and the if-check fails).