### PR TITLE
Properly clear the registry on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   encountering `SSL_ERROR_WANT_READ`. The crash manifested if CAF resumed a
   write operation but failed to fully reset its state. The state management (and
   consequently the crash) has been fixed.
+- CAF now clears the actor registry before calling the destructors of loaded
+  modules. This fixes undefined behavior that could occur in rare cases where
+  actor cleanup code could run after loaded modules had been destroyed.
 
 ## [0.18.4] - 2021-07-07
 

--- a/libcaf_core/src/actor_registry.cpp
+++ b/libcaf_core/src/actor_registry.cpp
@@ -148,7 +148,14 @@ void actor_registry::start() {
 }
 
 void actor_registry::stop() {
-  // nop
+  {
+    exclusive_guard guard{instances_mtx_};
+    entries_.clear();
+  }
+  {
+    exclusive_guard guard{named_entries_mtx_};
+    named_entries_.clear();
+  }
 }
 
 } // namespace caf

--- a/libcaf_core/src/actor_system.cpp
+++ b/libcaf_core/src/actor_system.cpp
@@ -384,8 +384,6 @@ actor_system::~actor_system() {
     };
     drop(spawn_serv_);
     drop(config_serv_);
-    registry_.erase("SpawnServ");
-    registry_.erase("ConfigServ");
     // group module is the first one, relies on MM
     groups_.stop();
     // stop modules in reverse order


### PR DESCRIPTION
Just filing for CI. This bug has been reported by Zeek users and the fix already has been tested.