### PR TITLE
Deprecate caf::optional

### DIFF
--- a/examples/remoting/distributed_calculator.cpp
+++ b/examples/remoting/distributed_calculator.cpp
@@ -195,12 +195,12 @@ string trim(std::string s) {
 }
 
 // tries to convert `str` to an int
-optional<int> toint(const string& str) {
+std::optional<int> toint(const string& str) {
   char* end;
   auto result = static_cast<int>(strtol(str.c_str(), &end, 10));
   if (end == str.c_str() + str.size())
     return result;
-  return none;
+  return std::nullopt;
 }
 
 // --(rst-config-begin)--

--- a/examples/remoting/remote_spawn.cpp
+++ b/examples/remoting/remote_spawn.cpp
@@ -81,12 +81,12 @@ void client_repl(function_view<calculator> f) {
       usage();
       continue;
     }
-    auto to_int32_t = [](const string& str) -> optional<int32_t> {
+    auto to_int32_t = [](const string& str) -> std::optional<int32_t> {
       char* end = nullptr;
       auto res = strtol(str.c_str(), &end, 10);
       if (end == str.c_str() + str.size())
         return static_cast<int32_t>(res);
-      return none;
+      return std::nullopt;
     };
     auto x = to_int32_t(words[0]);
     auto y = to_int32_t(words[2]);

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -85,8 +85,8 @@ std::string get_rtti_from_mpi() {
 
 namespace caf {
 
-/// Actor environment including scheduler, registry, and optional components
-/// such as a middleman.
+/// Actor environment including scheduler, registry, and optional
+/// components such as a middleman.
 class CAF_CORE_EXPORT actor_system {
 public:
   friend class logger;
@@ -146,7 +146,8 @@ public:
 
   using module_array = std::array<module_ptr, module::num_ids>;
 
-  /// An (optional) component of the actor system with networking capabilities.
+  /// An (optional) component of the actor system with networking
+  /// capabilities.
   class CAF_CORE_EXPORT networking_module : public module {
   public:
     ~networking_module() override;
@@ -659,7 +660,7 @@ private:
 
   expected<strong_actor_ptr>
   dyn_spawn_impl(const std::string& name, message& args, execution_unit* ctx,
-                 bool check_interface, optional<const mpi&> expected_ifs);
+                 bool check_interface, std::optional<const mpi*> expected_ifs);
 
   /// Sets the internal actor for dynamic spawn operations.
   void spawn_serv(strong_actor_ptr x) {

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -660,7 +660,7 @@ private:
 
   expected<strong_actor_ptr>
   dyn_spawn_impl(const std::string& name, message& args, execution_unit* ctx,
-                 bool check_interface, std::optional<const mpi*> expected_ifs);
+                 bool check_interface, const mpi* expected_ifs);
 
   /// Sets the internal actor for dynamic spawn operations.
   void spawn_serv(strong_actor_ptr x) {

--- a/libcaf_core/caf/behavior.hpp
+++ b/libcaf_core/caf/behavior.hpp
@@ -21,7 +21,7 @@ namespace caf {
 class message_handler;
 
 /// Describes the behavior of an actor, i.e., provides a message
-/// handler and an optional timeout.
+/// handler and an std::optional timeout.
 class CAF_CORE_EXPORT behavior {
 public:
   friend class message_handler;
@@ -86,8 +86,8 @@ public:
   }
 
   /// Runs this handler and returns its (optional) result.
-  optional<message> operator()(message& xs) {
-    return impl_ ? impl_->invoke(xs) : none;
+  std::optional<message> operator()(message& xs) {
+    return impl_ ? impl_->invoke(xs) : std::nullopt;
   }
 
   /// Runs this handler with callback.

--- a/libcaf_core/caf/behavior.hpp
+++ b/libcaf_core/caf/behavior.hpp
@@ -21,7 +21,7 @@ namespace caf {
 class message_handler;
 
 /// Describes the behavior of an actor, i.e., provides a message
-/// handler and an std::optional timeout.
+/// handler and an optional timeout.
 class CAF_CORE_EXPORT behavior {
 public:
   friend class message_handler;

--- a/libcaf_core/caf/config_option.hpp
+++ b/libcaf_core/caf/config_option.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "caf/detail/core_export.hpp"
@@ -97,7 +98,7 @@ public:
 
   /// @private
   // TODO: remove with CAF 0.17
-  optional<config_value> get() const;
+  std::optional<config_value> get() const;
 
 private:
   string_view buf_slice(size_t from, size_t to) const noexcept;

--- a/libcaf_core/caf/config_value.hpp
+++ b/libcaf_core/caf/config_value.hpp
@@ -11,6 +11,7 @@
 #include <iosfwd>
 #include <iterator>
 #include <map>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -28,7 +29,6 @@
 #include "caf/fwd.hpp"
 #include "caf/inspector_access.hpp"
 #include "caf/inspector_access_type.hpp"
-#include "caf/optional.hpp"
 #include "caf/raise_error.hpp"
 #include "caf/string_algorithms.hpp"
 #include "caf/string_view.hpp"
@@ -131,7 +131,7 @@ public:
   /// Tries to parse a config value (list) from `str` and to convert it to an
   /// allowed input message type for `Handle`.
   template <class Handle>
-  static optional<message> parse_msg(string_view str, const Handle&) {
+  static std::optional<message> parse_msg(string_view str, const Handle&) {
     auto allowed = Handle::allowed_inputs();
     return parse_msg_impl(str, allowed);
   }
@@ -264,7 +264,7 @@ private:
 
   static const char* type_name_at_index(size_t index) noexcept;
 
-  static optional<message>
+  static std::optional<message>
   parse_msg_impl(string_view str, span<const type_id_list> allowed_types);
 
   // -- auto conversion of related types ---------------------------------------
@@ -561,7 +561,7 @@ auto get_or(const config_value& x, Fallback&& fallback) {
 // -- SumType-like access ------------------------------------------------------
 
 template <class T>
-[[deprecated("use get_as or get_or instead")]] optional<T>
+[[deprecated("use get_as or get_or instead")]] std::optional<T>
 legacy_get_if(const config_value* x) {
   if (auto val = get_as<T>(*x))
     return {std::move(*val)};

--- a/libcaf_core/caf/const_typed_message_view.hpp
+++ b/libcaf_core/caf/const_typed_message_view.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <utility>
 
 #include "caf/detail/message_data.hpp"
@@ -27,8 +28,8 @@ public:
 
   const_typed_message_view(const const_typed_message_view&) noexcept = default;
 
-  const_typed_message_view& operator=(const const_typed_message_view&) noexcept
-    = default;
+  const_typed_message_view&
+  operator=(const const_typed_message_view&) noexcept = default;
 
   const detail::message_data* operator->() const noexcept {
     return ptr_;
@@ -67,10 +68,10 @@ auto make_const_typed_message_view(const message& msg) {
 }
 
 template <class... Ts>
-optional<std::tuple<Ts...>> to_tuple(const message& msg) {
+std::optional<std::tuple<Ts...>> to_tuple(const message& msg) {
   if (auto view = make_const_typed_message_view<Ts...>(msg))
     return to_tuple(view);
-  return none;
+  return std::nullopt;
 }
 
 } // namespace caf

--- a/libcaf_core/caf/detail/base64.hpp
+++ b/libcaf_core/caf/detail/base64.hpp
@@ -7,10 +7,10 @@
 #include "caf/byte_buffer.hpp"
 #include "caf/byte_span.hpp"
 #include "caf/detail/core_export.hpp"
-#include "caf/optional.hpp"
 #include "caf/span.hpp"
 #include "caf/string_view.hpp"
 
+#include <optional>
 #include <string>
 
 namespace caf::detail {
@@ -45,7 +45,7 @@ public:
 
   static bool decode(const_byte_span bytes, byte_buffer& out);
 
-  static optional<std::string> decode(string_view in) {
+  static std::optional<std::string> decode(string_view in) {
     std::string result;
     if (decode(in, result))
       return {std::move(result)};
@@ -53,7 +53,7 @@ public:
       return {};
   }
 
-  static optional<std::string> decode(const_byte_span in) {
+  static std::optional<std::string> decode(const_byte_span in) {
     std::string result;
     if (decode(in, result))
       return {std::move(result)};

--- a/libcaf_core/caf/detail/behavior_impl.hpp
+++ b/libcaf_core/caf/detail/behavior_impl.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -19,7 +20,6 @@
 #include "caf/make_counted.hpp"
 #include "caf/message.hpp"
 #include "caf/none.hpp"
-#include "caf/optional.hpp"
 #include "caf/ref_counted.hpp"
 #include "caf/response_promise.hpp"
 #include "caf/skip.hpp"
@@ -51,7 +51,7 @@ public:
 
   virtual bool invoke(detail::invoke_result_visitor& f, message& xs) = 0;
 
-  optional<message> invoke(message&);
+  std::optional<message> invoke(message&);
 
   virtual void handle_timeout();
 

--- a/libcaf_core/caf/detail/parser/read_floating_point.hpp
+++ b/libcaf_core/caf/detail/parser/read_floating_point.hpp
@@ -38,7 +38,7 @@ void read_floating_point(State& ps, Consumer&& consumer,
   enum sign_t { plus, minus };
   sign_t sign;
   ValueType result;
-  if (start_value == std::nullopt) {
+  if (!start_value) {
     sign = plus;
     result = 0;
   } else if (*start_value < 0) {
@@ -97,7 +97,7 @@ void read_floating_point(State& ps, Consumer&& consumer,
   // Definition of our parser FSM.
   start();
   unstable_state(init) {
-    epsilon_if(start_value == std::nullopt, regular_init)
+    epsilon_if(!start_value, regular_init)
     epsilon(after_dec, "eE.")
     epsilon(after_dot, any_char)
   }

--- a/libcaf_core/caf/detail/parser/read_floating_point.hpp
+++ b/libcaf_core/caf/detail/parser/read_floating_point.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <type_traits>
 
 #include "caf/config.hpp"
@@ -14,7 +15,6 @@
 #include "caf/detail/parser/is_digit.hpp"
 #include "caf/detail/parser/sub_ascii.hpp"
 #include "caf/detail/scope_guard.hpp"
-#include "caf/optional.hpp"
 #include "caf/pec.hpp"
 
 CAF_PUSH_UNUSED_LABEL_WARNING
@@ -30,7 +30,7 @@ namespace caf::detail::parser {
 ///                    the pre-decimal value.
 template <class State, class Consumer, class ValueType>
 void read_floating_point(State& ps, Consumer&& consumer,
-                         optional<ValueType> start_value,
+                         std::optional<ValueType> start_value,
                          bool negative = false) {
   // Any exponent larger than 511 always overflows.
   static constexpr int max_double_exponent = 511;
@@ -38,7 +38,7 @@ void read_floating_point(State& ps, Consumer&& consumer,
   enum sign_t { plus, minus };
   sign_t sign;
   ValueType result;
-  if (start_value == none) {
+  if (start_value == std::nullopt) {
     sign = plus;
     result = 0;
   } else if (*start_value < 0) {
@@ -72,8 +72,8 @@ void read_floating_point(State& ps, Consumer&& consumer,
       }
       // 3) Scale result.
       // Pre-computed powers of 10 for the scaling loop.
-      static double powerTable[]
-        = {1e1, 1e2, 1e4, 1e8, 1e16, 1e32, 1e64, 1e128, 1e256};
+      static double powerTable[] = {1e1,  1e2,  1e4,   1e8,  1e16,
+                                    1e32, 1e64, 1e128, 1e256};
       auto i = 0;
       if (exp < 0) {
         for (auto n = -exp; n != 0; n >>= 1, ++i)
@@ -97,7 +97,7 @@ void read_floating_point(State& ps, Consumer&& consumer,
   // Definition of our parser FSM.
   start();
   unstable_state(init) {
-    epsilon_if(start_value == none, regular_init)
+    epsilon_if(start_value == std::nullopt, regular_init)
     epsilon(after_dec, "eE.")
     epsilon(after_dot, any_char)
   }
@@ -173,7 +173,7 @@ template <class State, class Consumer>
 void read_floating_point(State& ps, Consumer&& consumer) {
   using consumer_type = typename std::decay<Consumer>::type;
   using value_type = typename consumer_type::value_type;
-  return read_floating_point(ps, consumer, optional<value_type>{});
+  return read_floating_point(ps, consumer, std::optional<value_type>{});
 }
 
 } // namespace caf::detail::parser

--- a/libcaf_core/caf/detail/parser/read_number.hpp
+++ b/libcaf_core/caf/detail/parser/read_number.hpp
@@ -50,7 +50,7 @@ void read_number(State& ps, Consumer& consumer, EnableFloat = {},
     if (ps.code <= pec::trailing_character)
       consumer.value(result);
   });
-  using odbl = optional<double>;
+  using odbl = std::optional<double>;
   // clang-format off
   // Definition of our parser FSM.
   start();
@@ -179,8 +179,8 @@ void read_number(State& ps, Consumer& consumer, EnableFloat = {},
 
 template <class State, class Consumer>
 void read_number_range(State& ps, Consumer& consumer, int64_t begin) {
-  optional<int64_t> end;
-  optional<int64_t> step;
+  std::optional<int64_t> end;
+  std::optional<int64_t> step;
   auto end_consumer = make_consumer(end);
   auto step_consumer = make_consumer(step);
   auto generate_2 = [&](int64_t n, int64_t m) {

--- a/libcaf_core/caf/detail/parser/read_timespan.hpp
+++ b/libcaf_core/caf/detail/parser/read_timespan.hpp
@@ -6,12 +6,12 @@
 
 #include <chrono>
 #include <cstdint>
+#include <optional>
 #include <string>
 
 #include "caf/config.hpp"
 #include "caf/detail/parser/read_signed_integer.hpp"
 #include "caf/detail/scope_guard.hpp"
-#include "caf/optional.hpp"
 #include "caf/pec.hpp"
 #include "caf/timestamp.hpp"
 
@@ -24,7 +24,7 @@ namespace caf::detail::parser {
 /// Reads a timespan.
 template <class State, class Consumer>
 void read_timespan(State& ps, Consumer&& consumer,
-                   optional<int64_t> num = none) {
+                   std::optional<int64_t> num = std::nullopt) {
   using namespace std::chrono;
   struct interim_consumer {
     using value_type = int64_t;

--- a/libcaf_core/caf/detail/stringification_inspector.hpp
+++ b/libcaf_core/caf/detail/stringification_inspector.hpp
@@ -191,7 +191,7 @@ public:
   }
 
   template <class T>
-  bool builtin_inspect(const optional<T>& x) {
+  bool builtin_inspect(const std::optional<T>& x) {
     sep();
     if (!x) {
       result_ += "null";

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -25,7 +25,7 @@ template <class> class expected;
 template <class> class inbound_stream_slot;
 template <class> class intrusive_cow_ptr;
 template <class> class intrusive_ptr;
-template <class> class optional;
+template <class> class [[deprecated ("Use `std::optional` instead")]] optional;
 template <class> class param;
 template <class> class span;
 template <class> class stream;

--- a/libcaf_core/caf/inspector_access.hpp
+++ b/libcaf_core/caf/inspector_access.hpp
@@ -329,6 +329,8 @@ struct inspector_access;
 
 // -- inspection support for optional values -----------------------------------
 
+CAF_PUSH_DEPRECATED_WARNING
+
 template <class T>
 struct optional_inspector_traits;
 
@@ -343,6 +345,8 @@ struct optional_inspector_traits<optional<T>> {
     container.emplace(std::forward<Ts>(xs)...);
   }
 };
+
+CAF_POP_WARNINGS
 
 template <class T>
 struct optional_inspector_traits<intrusive_ptr<T>> {
@@ -441,10 +445,14 @@ struct optional_inspector_access {
 
 // -- inspection support for optional<T> ---------------------------------------
 
+CAF_PUSH_DEPRECATED_WARNING
+
 template <class T>
 struct inspector_access<optional<T>> : optional_inspector_access<optional<T>> {
   // nop
 };
+
+CAF_POP_WARNINGS
 
 #ifdef CAF_HAS_STD_OPTIONAL
 

--- a/libcaf_core/caf/message_handler.hpp
+++ b/libcaf_core/caf/message_handler.hpp
@@ -72,8 +72,8 @@ public:
   void assign(message_handler what);
 
   /// Runs this handler and returns its (optional) result.
-  optional<message> operator()(message& arg) {
-    return (impl_) ? impl_->invoke(arg) : none;
+  std::optional<message> operator()(message& arg) {
+    return (impl_) ? impl_->invoke(arg) : std::nullopt;
   }
 
   /// Runs this handler with callback.

--- a/libcaf_core/caf/node_id.hpp
+++ b/libcaf_core/caf/node_id.hpp
@@ -279,8 +279,8 @@ CAF_CORE_EXPORT node_id make_node_id(
 /// @param process_id System-wide unique process identifier.
 /// @param host_hash Unique node ID as hexadecimal string representation.
 /// @relates node_id
-CAF_CORE_EXPORT optional<node_id> make_node_id(uint32_t process_id,
-                                               string_view host_hash);
+CAF_CORE_EXPORT std::optional<node_id> make_node_id(uint32_t process_id,
+                                                    string_view host_hash);
 
 /// @relates node_id
 CAF_CORE_EXPORT error parse(string_view str, node_id& dest);

--- a/libcaf_core/caf/optional.hpp
+++ b/libcaf_core/caf/optional.hpp
@@ -268,6 +268,8 @@ private:
   bool m_value;
 };
 
+CAF_PUSH_DEPRECATED_WARNING
+
 /// @relates optional
 template <class T>
 auto to_string(const optional<T>& x)
@@ -475,5 +477,7 @@ template <class T>
 bool operator>=(const T& lhs, const optional<T>& rhs) {
   return !rhs || !(lhs < *rhs);
 }
+
+CAF_POP_WARNINGS
 
 } // namespace caf

--- a/libcaf_core/caf/uri.hpp
+++ b/libcaf_core/caf/uri.hpp
@@ -189,7 +189,7 @@ public:
   /// Returns a new URI with the `authority` component only.
   /// @returns A new URI in the form `scheme://authority` if the authority
   ///          exists, otherwise `none`.`
-  optional<uri> authority_only() const;
+  std::optional<uri> authority_only() const;
 
   // -- comparison -------------------------------------------------------------
 

--- a/libcaf_core/src/actor_system.cpp
+++ b/libcaf_core/src/actor_system.cpp
@@ -516,7 +516,7 @@ void actor_system::thread_terminates() {
 expected<strong_actor_ptr>
 actor_system::dyn_spawn_impl(const std::string& name, message& args,
                              execution_unit* ctx, bool check_interface,
-                             std::optional<const mpi*> expected_ifs) {
+                             const mpi* expected_ifs) {
   CAF_LOG_TRACE(CAF_ARG(name) << CAF_ARG(args) << CAF_ARG(check_interface)
                               << CAF_ARG(expected_ifs));
   if (name.empty())
@@ -529,7 +529,7 @@ actor_system::dyn_spawn_impl(const std::string& name, message& args,
   auto res = i->second(cfg, args);
   if (!res.first)
     return sec::cannot_spawn_actor_from_arguments;
-  if (check_interface && !assignable(res.second, **expected_ifs))
+  if (check_interface && !assignable(res.second, *expected_ifs))
     return sec::unexpected_actor_messaging_interface;
   return std::move(res.first);
 }

--- a/libcaf_core/src/actor_system.cpp
+++ b/libcaf_core/src/actor_system.cpp
@@ -235,9 +235,10 @@ auto make_actor_metric_families(telemetry::metric_registry& reg) {
     5.,     // 5s
   }};
   return actor_system::actor_metric_families_t{
-    reg.histogram_family<double>(
-      "caf.actor", "processing-time", {"name"}, default_buckets,
-      "Time an actor needs to process messages.", "seconds"),
+    reg.histogram_family<double>("caf.actor", "processing-time", {"name"},
+                                 default_buckets,
+                                 "Time an actor needs to process messages.",
+                                 "seconds"),
     reg.histogram_family<double>(
       "caf.actor", "mailbox-time", {"name"}, default_buckets,
       "Time a message waits in the mailbox before processing.", "seconds"),
@@ -515,7 +516,7 @@ void actor_system::thread_terminates() {
 expected<strong_actor_ptr>
 actor_system::dyn_spawn_impl(const std::string& name, message& args,
                              execution_unit* ctx, bool check_interface,
-                             optional<const mpi&> expected_ifs) {
+                             std::optional<const mpi*> expected_ifs) {
   CAF_LOG_TRACE(CAF_ARG(name) << CAF_ARG(args) << CAF_ARG(check_interface)
                               << CAF_ARG(expected_ifs));
   if (name.empty())
@@ -528,7 +529,7 @@ actor_system::dyn_spawn_impl(const std::string& name, message& args,
   auto res = i->second(cfg, args);
   if (!res.first)
     return sec::cannot_spawn_actor_from_arguments;
-  if (check_interface && !assignable(res.second, *expected_ifs))
+  if (check_interface && !assignable(res.second, **expected_ifs))
     return sec::unexpected_actor_messaging_interface;
   return std::move(res.first);
 }

--- a/libcaf_core/src/config_option.cpp
+++ b/libcaf_core/src/config_option.cpp
@@ -12,7 +12,6 @@
 #include "caf/config_value.hpp"
 #include "caf/error.hpp"
 #include "caf/expected.hpp"
-#include "caf/optional.hpp"
 
 using std::move;
 using std::string;
@@ -24,10 +23,9 @@ namespace caf {
 config_option::config_option(string_view category, string_view name,
                              string_view description, const meta_state* meta,
                              void* value)
-    : meta_(meta),
-      value_(value) {
-  using std::copy;
+  : meta_(meta), value_(value) {
   using std::accumulate;
+  using std::copy;
   auto comma = name.find(',');
   auto long_name = name.substr(0, comma);
   auto short_names = comma == string_view::npos ? string_view{}
@@ -44,9 +42,7 @@ config_option::config_option(string_view category, string_view name,
   // fill the buffer with "<category>.<long-name>,<short-name>,<descriptions>"
   auto first = buf_.get();
   auto i = first;
-  auto pos = [&] {
-    return static_cast<uint16_t>(std::distance(first, i));
-  };
+  auto pos = [&] { return static_cast<uint16_t>(std::distance(first, i)); };
   // <category>.
   i = copy(category.begin(), category.end(), i);
   category_separator_ = pos();
@@ -143,10 +139,10 @@ expected<config_value> config_option::parse(string_view input) const {
     return {std::move(val)};
 }
 
-optional<config_value> config_option::get() const {
+std::optional<config_value> config_option::get() const {
   if (value_ != nullptr && meta_->get != nullptr)
     return meta_->get(value_);
-  return none;
+  return std::nullopt;
 }
 
 string_view config_option::buf_slice(size_t from, size_t to) const noexcept {

--- a/libcaf_core/src/config_value.cpp
+++ b/libcaf_core/src/config_value.cpp
@@ -499,7 +499,7 @@ bool config_value::can_convert_to_dictionary() const {
   return visit(f, data_);
 }
 
-optional<message>
+std::optional<message>
 config_value::parse_msg_impl(string_view str,
                              span<const type_id_list> allowed_types) {
   if (auto val = parse(str)) {
@@ -533,7 +533,7 @@ config_value::parse_msg_impl(string_view str,
     if (std::any_of(allowed_types.begin(), allowed_types.end(), converts))
       return {std::move(result)};
   }
-  return {};
+  return std::nullopt;
 }
 
 // -- related free functions ---------------------------------------------------

--- a/libcaf_core/src/detail/behavior_impl.cpp
+++ b/libcaf_core/src/detail/behavior_impl.cpp
@@ -36,7 +36,7 @@ private:
 
 class maybe_message_visitor : public detail::invoke_result_visitor {
 public:
-  optional<message> value;
+  std::optional<message> value;
 
   void operator()(error& x) override {
     value = make_message(std::move(x));
@@ -66,11 +66,11 @@ bool behavior_impl::invoke_empty(detail::invoke_result_visitor& f) {
   return invoke(f, xs);
 }
 
-optional<message> behavior_impl::invoke(message& xs) {
+std::optional<message> behavior_impl::invoke(message& xs) {
   maybe_message_visitor f;
   if (invoke(f, xs))
     return std::move(f.value);
-  return none;
+  return std::nullopt;
 }
 
 void behavior_impl::handle_timeout() {

--- a/libcaf_core/src/node_id.cpp
+++ b/libcaf_core/src/node_id.cpp
@@ -190,23 +190,24 @@ node_id make_node_id(uint32_t process_id,
   return node_id{node_id::default_data{process_id, host_id}};
 }
 
-optional<node_id> make_node_id(uint32_t process_id, string_view host_hash) {
+std::optional<node_id> make_node_id(uint32_t process_id,
+                                    string_view host_hash) {
   using id_type = hashed_node_id::host_id_type;
   if (host_hash.size() != std::tuple_size<id_type>::value * 2)
-    return none;
+    return std::nullopt;
   detail::parser::ascii_to_int<16, uint8_t> xvalue;
   id_type host_id;
   auto in = host_hash.begin();
   for (auto& byte : host_id) {
     if (!isxdigit(*in))
-      return none;
+      return std::nullopt;
     auto first_nibble = (xvalue(*in++) << 4);
     if (!isxdigit(*in))
-      return none;
+      return std::nullopt;
     byte = static_cast<uint8_t>(first_nibble | xvalue(*in++));
   }
   if (!hashed_node_id::valid(host_id))
-    return none;
+    return std::nullopt;
   return make_node_id(process_id, host_id);
 }
 

--- a/libcaf_core/src/scheduled_actor.cpp
+++ b/libcaf_core/src/scheduled_actor.cpp
@@ -695,7 +695,7 @@ invoke_message_result scheduled_actor::consume(mailbox_element& x) {
     using ptr_t = scheduled_actor*;
     using fun_t = bool (*)(ptr_t, behavior&, mailbox_element&);
     auto ordinary_invoke = [](ptr_t, behavior& f, mailbox_element& in) -> bool {
-      return f(in.content()) != none;
+      return f(in.content()) != std::nullopt;
     };
     auto select_invoke_fun = [&]() -> fun_t { return ordinary_invoke; };
     // Short-circuit awaited responses.

--- a/libcaf_core/src/uri.cpp
+++ b/libcaf_core/src/uri.cpp
@@ -4,6 +4,8 @@
 
 #include "caf/uri.hpp"
 
+#include <optional>
+
 #include "caf/binary_deserializer.hpp"
 #include "caf/binary_serializer.hpp"
 #include "caf/deserializer.hpp"
@@ -15,7 +17,6 @@
 #include "caf/expected.hpp"
 #include "caf/hash/fnv.hpp"
 #include "caf/make_counted.hpp"
-#include "caf/optional.hpp"
 #include "caf/serializer.hpp"
 
 namespace {
@@ -78,9 +79,9 @@ size_t uri::hash_code() const noexcept {
   return hash::fnv<size_t>::compute(str());
 }
 
-optional<uri> uri::authority_only() const {
+std::optional<uri> uri::authority_only() const {
   if (empty() || authority().empty())
-    return none;
+    return std::nullopt;
   auto result = make_counted<uri::impl_type>();
   result->scheme = impl_->scheme;
   result->authority = impl_->authority;

--- a/libcaf_core/test/behavior.cpp
+++ b/libcaf_core/test/behavior.cpp
@@ -10,12 +10,12 @@
 
 #include <functional>
 
-#include "caf/send.hpp"
-#include "caf/behavior.hpp"
 #include "caf/actor_system.hpp"
-#include "caf/message_handler.hpp"
-#include "caf/event_based_actor.hpp"
 #include "caf/actor_system_config.hpp"
+#include "caf/behavior.hpp"
+#include "caf/event_based_actor.hpp"
+#include "caf/message_handler.hpp"
+#include "caf/send.hpp"
 
 using namespace caf;
 
@@ -39,13 +39,13 @@ public:
 };
 
 struct fixture {
-  optional<int32_t> res_of(behavior& bhvr, message& msg) {
+  std::optional<int32_t> res_of(behavior& bhvr, message& msg) {
     auto res = bhvr(msg);
     if (!res)
-      return none;
+      return std::nullopt;
     if (auto view = make_const_typed_message_view<int32_t>(*res))
       return get<0>(view);
-    return none;
+    return std::nullopt;
   }
 
   message m1 = make_message(int32_t{1});
@@ -61,33 +61,35 @@ CAF_TEST_FIXTURE_SCOPE(behavior_tests, fixture)
 
 CAF_TEST(default_construct) {
   behavior f;
-  CAF_CHECK_EQUAL(f(m1), none);
-  CAF_CHECK_EQUAL(f(m2), none);
-  CAF_CHECK_EQUAL(f(m3), none);
+  CAF_CHECK_EQUAL(f(m1), std::nullopt);
+  CAF_CHECK_EQUAL(f(m2), std::nullopt);
+  CAF_CHECK_EQUAL(f(m3), std::nullopt);
 }
 
 CAF_TEST(nocopy_function_object) {
   behavior f{nocopy_fun{}};
-  CAF_CHECK_EQUAL(f(m1), none);
+  CAF_CHECK_EQUAL(f(m1), std::nullopt);
   CAF_CHECK_EQUAL(res_of(f, m2), 3);
-  CAF_CHECK_EQUAL(f(m3), none);
+  CAF_CHECK_EQUAL(f(m3), std::nullopt);
 }
 
 CAF_TEST(single_lambda_construct) {
-  behavior f{[](int x) { return x + 1; }};
+  behavior f{
+    [](int x) { return x + 1; },
+  };
   CAF_CHECK_EQUAL(res_of(f, m1), 2);
-  CAF_CHECK_EQUAL(res_of(f, m2), none);
-  CAF_CHECK_EQUAL(res_of(f, m3), none);
+  CAF_CHECK_EQUAL(res_of(f, m2), std::nullopt);
+  CAF_CHECK_EQUAL(res_of(f, m3), std::nullopt);
 }
 
 CAF_TEST(multiple_lambda_construct) {
   behavior f{
     [](int x) { return x + 1; },
-    [](int x, int y) { return x * y; }
+    [](int x, int y) { return x * y; },
   };
   CAF_CHECK_EQUAL(res_of(f, m1), 2);
   CAF_CHECK_EQUAL(res_of(f, m2), 2);
-  CAF_CHECK_EQUAL(res_of(f, m3), none);
+  CAF_CHECK_EQUAL(res_of(f, m3), std::nullopt);
 }
 
 CAF_TEST(become_empty_behavior) {
@@ -95,7 +97,7 @@ CAF_TEST(become_empty_behavior) {
   actor_system sys{cfg};
   auto make_bhvr = [](event_based_actor* self) -> behavior {
     return {
-      [=](int) { self->become(behavior{}); }
+      [=](int) { self->become(behavior{}); },
     };
   };
   anon_send(sys.spawn(make_bhvr), int{5});

--- a/libcaf_core/test/config_option.cpp
+++ b/libcaf_core/test/config_option.cpp
@@ -10,9 +10,9 @@
 
 #include <sstream>
 
-#include "caf/make_config_option.hpp"
 #include "caf/config_value.hpp"
 #include "caf/expected.hpp"
+#include "caf/make_config_option.hpp"
 
 using namespace caf;
 
@@ -173,25 +173,25 @@ constexpr string_view category = "category";
 constexpr string_view name = "name";
 constexpr string_view explanation = "explanation";
 
-template<class T>
+template <class T>
 constexpr int64_t overflow() {
   return static_cast<int64_t>(std::numeric_limits<T>::max()) + 1;
 }
 
-template<class T>
+template <class T>
 constexpr int64_t underflow() {
   return static_cast<int64_t>(std::numeric_limits<T>::min()) - 1;
 }
 
 template <class T>
-optional<T> read(string_view arg) {
+std::optional<T> read(string_view arg) {
   auto result = T{};
   auto co = make_config_option<T>(result, category, name, explanation);
   config_value val{arg};
   if (auto err = co.sync(val); !err)
     return {std::move(result)};
   else
-    return none;
+    return std::nullopt;
 }
 
 // Unsigned integers.
@@ -203,7 +203,7 @@ void check_integer_options(std::true_type) {
   T xmax = std::numeric_limits<T>::max();
   CAF_CHECK_EQUAL(read<T>(to_string(xzero)), xzero);
   CAF_CHECK_EQUAL(read<T>(to_string(xmax)), xmax);
-  CAF_CHECK_EQUAL(read<T>(to_string(overflow<T>())), none);
+  CAF_CHECK_EQUAL(read<T>(to_string(overflow<T>())), std::nullopt);
 }
 
 // Signed integers.
@@ -216,7 +216,7 @@ void check_integer_options(std::false_type) {
   // Run tests for negative integers.
   auto xmin = std::numeric_limits<T>::min();
   CAF_CHECK_EQUAL(read<T>(to_string(xmin)), xmin);
-  CAF_CHECK_EQUAL(read<T>(to_string(underflow<T>())), none);
+  CAF_CHECK_EQUAL(read<T>(to_string(underflow<T>())), std::nullopt);
 }
 
 // only works with an integral types and double
@@ -250,8 +250,8 @@ CAF_TEST(copy assignment) {
 CAF_TEST(type_bool) {
   CAF_CHECK_EQUAL(read<bool>("true"), true);
   CAF_CHECK_EQUAL(read<bool>("false"), false);
-  CAF_CHECK_EQUAL(read<bool>("0"), none);
-  CAF_CHECK_EQUAL(read<bool>("1"), none);
+  CAF_CHECK_EQUAL(read<bool>("0"), std::nullopt);
+  CAF_CHECK_EQUAL(read<bool>("1"), std::nullopt);
 }
 
 CAF_TEST(type int8_t) {
@@ -280,27 +280,27 @@ CAF_TEST(type uint32_t) {
 
 CAF_TEST(type uint64_t) {
   CAF_CHECK_EQUAL(unbox(read<uint64_t>("0")), 0u);
-  CAF_CHECK_EQUAL(read<uint64_t>("-1"), none);
+  CAF_CHECK_EQUAL(read<uint64_t>("-1"), std::nullopt);
 }
 
 CAF_TEST(type int64_t) {
   CAF_CHECK_EQUAL(unbox(read<int64_t>("-1")), -1);
-  CAF_CHECK_EQUAL(unbox(read<int64_t>("0")),  0);
-  CAF_CHECK_EQUAL(unbox(read<int64_t>("1")),  1);
+  CAF_CHECK_EQUAL(unbox(read<int64_t>("0")), 0);
+  CAF_CHECK_EQUAL(unbox(read<int64_t>("1")), 1);
 }
 
 CAF_TEST(type float) {
-  CAF_CHECK_EQUAL(unbox(read<float>("-1.0")),  -1.0f);
+  CAF_CHECK_EQUAL(unbox(read<float>("-1.0")), -1.0f);
   CAF_CHECK_EQUAL(unbox(read<float>("-0.1")), -0.1f);
   CAF_CHECK_EQUAL(read<float>("0"), 0.f);
-  CAF_CHECK_EQUAL(read<float>("\"0.1\""),  none);
+  CAF_CHECK_EQUAL(read<float>("\"0.1\""), std::nullopt);
 }
 
 CAF_TEST(type double) {
-  CAF_CHECK_EQUAL(unbox(read<double>("-1.0")),  -1.0);
-  CAF_CHECK_EQUAL(unbox(read<double>("-0.1")),  -0.1);
+  CAF_CHECK_EQUAL(unbox(read<double>("-1.0")), -1.0);
+  CAF_CHECK_EQUAL(unbox(read<double>("-0.1")), -0.1);
   CAF_CHECK_EQUAL(read<double>("0"), 0.);
-  CAF_CHECK_EQUAL(read<double>("\"0.1\""), none);
+  CAF_CHECK_EQUAL(read<double>("\"0.1\""), std::nullopt);
 }
 
 CAF_TEST(type string) {

--- a/libcaf_core/test/core-test.hpp
+++ b/libcaf_core/test/core-test.hpp
@@ -380,7 +380,7 @@ bool inspect(Inspector& f, widget& x) {
 
 struct dummy_user {
   std::string name;
-  caf::optional<std::string> nickname;
+  std::optional<std::string> nickname;
 };
 
 template <class Inspector>

--- a/libcaf_core/test/deep_to_string.cpp
+++ b/libcaf_core/test/deep_to_string.cpp
@@ -43,8 +43,8 @@ CAF_TEST(pointers and optionals use dereference syntax) {
   auto i = 42;
   CHECK_DEEP_TO_STRING(&i, "*42");
   CHECK_DEEP_TO_STRING(static_cast<int*>(nullptr), "null");
-  CHECK_DEEP_TO_STRING(optional<int>{}, "null");
-  CHECK_DEEP_TO_STRING(optional<int>{23}, "*23");
+  CHECK_DEEP_TO_STRING(std::optional<int>{}, "null");
+  CHECK_DEEP_TO_STRING(std::optional<int>{23}, "*23");
 }
 
 CAF_TEST(buffers) {

--- a/libcaf_core/test/detail/parser/read_floating_point.cpp
+++ b/libcaf_core/test/detail/parser/read_floating_point.cpp
@@ -28,12 +28,12 @@ struct double_consumer {
   double x;
 };
 
-optional<double> read(string_view str) {
+std::optional<double> read(string_view str) {
   double_consumer consumer;
   string_parser_state ps{str.begin(), str.end()};
   detail::parser::read_floating_point(ps, consumer);
   if (ps.code != pec::success)
-    return none;
+    return std::nullopt;
   return consumer.x;
 }
 

--- a/libcaf_core/test/detail/parser/read_signed_integer.cpp
+++ b/libcaf_core/test/detail/parser/read_signed_integer.cpp
@@ -28,12 +28,12 @@ struct signed_integer_consumer {
 };
 
 template <class T>
-optional<T> read(string_view str) {
+std::optional<T> read(string_view str) {
   signed_integer_consumer<T> consumer;
   string_parser_state ps{str.begin(), str.end()};
   detail::parser::read_signed_integer(ps, consumer);
   if (ps.code != pec::success)
-    return none;
+    return std::nullopt;
   return consumer.x;
 }
 

--- a/libcaf_core/test/detail/parser/read_timespan.cpp
+++ b/libcaf_core/test/detail/parser/read_timespan.cpp
@@ -50,12 +50,12 @@ struct timespan_consumer {
   timespan x;
 };
 
-optional<timespan> read(string_view str) {
+std::optional<timespan> read(string_view str) {
   timespan_consumer consumer;
   string_parser_state ps{str.begin(), str.end()};
   detail::parser::read_timespan(ps, consumer);
   if (ps.code != pec::success)
-    return none;
+    return std::nullopt;
   return consumer.x;
 }
 

--- a/libcaf_core/test/detail/parser/read_unsigned_integer.cpp
+++ b/libcaf_core/test/detail/parser/read_unsigned_integer.cpp
@@ -28,12 +28,12 @@ struct unsigned_integer_consumer {
 };
 
 template <class T>
-optional<T> read(string_view str) {
+std::optional<T> read(string_view str) {
   unsigned_integer_consumer<T> consumer;
   string_parser_state ps{str.begin(), str.end()};
   detail::parser::read_unsigned_integer(ps, consumer);
   if (ps.code != pec::success)
-    return none;
+    return std::nullopt;
   return consumer.x;
 }
 

--- a/libcaf_core/test/inspector-tests.hpp
+++ b/libcaf_core/test/inspector-tests.hpp
@@ -2,9 +2,10 @@
 
 #pragma once
 
-#include "caf/optional.hpp"
 #include "caf/type_id.hpp"
 #include "caf/variant.hpp"
+
+#include <optional>
 
 #include "nasty.hpp"
 
@@ -89,7 +90,7 @@ bool inspect(Inspector& f, duration& x) {
 
 struct person {
   std::string name;
-  caf::optional<std::string> phone;
+  std::optional<std::string> phone;
 };
 
 template <class Inspector>

--- a/libcaf_core/test/load_inspector.cpp
+++ b/libcaf_core/test/load_inspector.cpp
@@ -328,7 +328,7 @@ end object)_");
 }
 
 CAF_TEST(load inspectors support optional) {
-  optional<int32_t> x;
+  std::optional<int32_t> x;
   CAF_CHECK_EQUAL(f.apply(x), true);
   CAF_CHECK_EQUAL(f.log, R"_(
 begin object anonymous
@@ -356,7 +356,7 @@ CAF_TEST(load inspectors support fields with optional values) {
   person p{"Bruce Almighty", std::string{"776-2323"}};
   CAF_CHECK_EQUAL(inspect(f, p), true);
   CAF_CHECK_EQUAL(p.name, "");
-  CAF_CHECK_EQUAL(p.phone, none);
+  CAF_CHECK_EQUAL(p.phone, std::nullopt);
   CAF_CHECK_EQUAL(f.log, R"_(
 begin object person
   begin field name
@@ -752,7 +752,7 @@ SCENARIO("load inspectors support std::byte") {
   GIVEN("a struct with std::byte") {
     struct byte_test {
       std::byte v1 = std::byte{0};
-      optional<std::byte> v2;
+      std::optional<std::byte> v2;
     };
     auto x = byte_test{};
     WHEN("inspecting the struct") {

--- a/libcaf_core/test/mailbox_element.cpp
+++ b/libcaf_core/test/mailbox_element.cpp
@@ -24,44 +24,44 @@ using namespace caf;
 namespace {
 
 template <class... Ts>
-optional<tuple<Ts...>> fetch(const message& x) {
+std::optional<tuple<Ts...>> fetch(const message& x) {
   if (auto view = make_const_typed_message_view<Ts...>(x))
     return to_tuple(view);
-  return none;
+  return std::nullopt;
 }
 
 template <class... Ts>
-optional<tuple<Ts...>> fetch(const mailbox_element& x) {
+std::optional<tuple<Ts...>> fetch(const mailbox_element& x) {
   return fetch<Ts...>(x.content());
 }
 
 } // namespace
 
 CAF_TEST(empty_message) {
-  auto m1 = make_mailbox_element(nullptr, make_message_id(),
-                                 no_stages, make_message());
+  auto m1 = make_mailbox_element(nullptr, make_message_id(), no_stages,
+                                 make_message());
   CAF_CHECK(m1->mid.is_async());
   CAF_CHECK(m1->mid.category() == message_id::normal_message_category);
   CAF_CHECK(m1->content().empty());
 }
 
 CAF_TEST(non_empty_message) {
-  auto m1 = make_mailbox_element(nullptr, make_message_id(),
-                                 no_stages, make_message(1, 2, 3));
+  auto m1 = make_mailbox_element(nullptr, make_message_id(), no_stages,
+                                 make_message(1, 2, 3));
   CAF_CHECK(m1->mid.is_async());
   CAF_CHECK(m1->mid.category() == message_id::normal_message_category);
   CAF_CHECK(!m1->content().empty());
-  CAF_CHECK_EQUAL((fetch<int, int>(*m1)), none);
+  CAF_CHECK_EQUAL((fetch<int, int>(*m1)), std::nullopt);
   CAF_CHECK_EQUAL((fetch<int, int, int>(*m1)), make_tuple(1, 2, 3));
 }
 
 CAF_TEST(tuple) {
-  auto m1 = make_mailbox_element(nullptr, make_message_id(),
-                                 no_stages, 1, 2, 3);
+  auto m1 = make_mailbox_element(nullptr, make_message_id(), no_stages, 1, 2,
+                                 3);
   CAF_CHECK(m1->mid.is_async());
   CAF_CHECK(m1->mid.category() == message_id::normal_message_category);
   CAF_CHECK(!m1->content().empty());
-  CAF_CHECK_EQUAL((fetch<int, int>(*m1)), none);
+  CAF_CHECK_EQUAL((fetch<int, int>(*m1)), std::nullopt);
   CAF_CHECK_EQUAL((fetch<int, int, int>(*m1)), make_tuple(1, 2, 3));
 }
 
@@ -79,9 +79,9 @@ CAF_TEST(upstream_msg_static) {
 }
 
 CAF_TEST(upstream_msg_dynamic) {
-  auto m1 = make_mailbox_element(
-    nullptr, make_message_id(), no_stages,
-    make_message(make<upstream_msg::drop>({0, 0}, nullptr)));
+  auto m1 = make_mailbox_element(nullptr, make_message_id(), no_stages,
+                                 make_message(
+                                   make<upstream_msg::drop>({0, 0}, nullptr)));
   CAF_CHECK(m1->mid.category() == message_id::upstream_message_category);
 }
 

--- a/libcaf_core/test/nasty.hpp
+++ b/libcaf_core/test/nasty.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <tuple>
 
 #include "caf/inspector_access.hpp"
-#include "caf/optional.hpp"
 #include "caf/string_view.hpp"
 #include "caf/variant.hpp"
 
@@ -60,15 +60,15 @@ class nasty {
 public:
   static inline caf::string_view tname = "nasty";
 
-  using optional_type = caf::optional<int32_t>;
+  using optional_type = std::optional<int32_t>;
 
   using variant_type = caf::variant<std::string, int32_t>;
 
   using tuple_type = std::tuple<std::string, int32_t>;
 
-  using optional_variant_type = caf::optional<variant_type>;
+  using optional_variant_type = std::optional<variant_type>;
 
-  using optional_tuple_type = caf::optional<tuple_type>;
+  using optional_tuple_type = std::optional<tuple_type>;
 
   // Plain, direct access.
   int32_t field_01 = 0;
@@ -135,13 +135,13 @@ public:
   // Optional, get/set access.
   ADD_GET_SET_FIELD(optional_type, field_21)
 
-  // // Optional, get/set access, fallback (0).
+  // Optional, get/set access, fallback (0).
   // ADD_GET_SET_FIELD(optional_type, field_22)
 
   // Optional, get/set access, invariant (>= 0).
   ADD_GET_SET_FIELD(optional_type, field_23)
 
-  // // Optional, get/set access, fallback (0), invariant (>= 0).
+  // Optional, get/set access, fallback (0), invariant (>= 0).
   // ADD_GET_SET_FIELD(optional_type, field_24)
 
   // Variant, get/set access.

--- a/libcaf_core/test/optional.cpp
+++ b/libcaf_core/test/optional.cpp
@@ -4,9 +4,9 @@
 
 #define CAF_SUITE optional
 
-#include "caf/optional.hpp"
-
 #include "core-test.hpp"
+
+#include "caf/optional.hpp"
 
 using namespace caf;
 
@@ -25,6 +25,8 @@ bool operator==(const qwertz& lhs, const qwertz& rhs) {
 }
 
 } // namespace
+
+CAF_PUSH_DEPRECATED_WARNING
 
 CAF_TEST(empty) {
   optional<int> x;
@@ -70,7 +72,9 @@ CAF_TEST(custom_type_engaged) {
   optional<qwertz> x = obj;
   CAF_CHECK(x != none);
   CAF_CHECK(obj == x);
-  CAF_CHECK(x == obj );
+  CAF_CHECK(x == obj);
   CAF_CHECK(obj == *x);
   CAF_CHECK(*x == obj);
 }
+
+CAF_POP_WARNINGS

--- a/libcaf_core/test/save_inspector.cpp
+++ b/libcaf_core/test/save_inspector.cpp
@@ -419,7 +419,7 @@ end object)_");
 }
 
 CAF_TEST(save inspectors support optional) {
-  optional<int32_t> x;
+  std::optional<int32_t> x;
   CAF_CHECK_EQUAL(f.apply(x), true);
   CAF_CHECK_EQUAL(f.log, R"_(
 begin object anonymous
@@ -429,7 +429,7 @@ end object)_");
 }
 
 CAF_TEST(save inspectors support fields with optional values) {
-  person p1{"Eduard Example", none};
+  person p1{"Eduard Example", std::nullopt};
   CAF_CHECK_EQUAL(inspect(f, p1), true);
   CAF_CHECK_EQUAL(f.log, R"_(
 begin object person

--- a/libcaf_io/caf/io/abstract_broker.hpp
+++ b/libcaf_io/caf/io/abstract_broker.hpp
@@ -283,7 +283,7 @@ public:
     auto x = by_id(hdl);
     if (!x)
       return false;
-    (*x)->graceful_shutdown();
+    x->graceful_shutdown();
     return true;
   }
 
@@ -386,11 +386,11 @@ protected:
 
   /// Returns a `scribe` or `doorman` identified by `hdl`.
   template <class Handle>
-  auto by_id(Handle hdl) -> std::optional<decltype(ptr_of(hdl))> {
+  auto by_id(Handle hdl) -> decltype(ptr_of(hdl)) {
     auto& elements = get_map(hdl);
     auto i = elements.find(hdl);
     if (i == elements.end())
-      return std::nullopt;
+      return nullptr;
     return std::addressof(*(i->second));
   }
 

--- a/libcaf_io/caf/io/abstract_broker.hpp
+++ b/libcaf_io/caf/io/abstract_broker.hpp
@@ -179,8 +179,8 @@ public:
   /// Tries to connect to `host` on given `port` and creates
   /// a new scribe describing the connection afterwards.
   /// @returns The handle of the new `scribe` on success.
-  expected<connection_handle>
-  add_tcp_scribe(const std::string& host, uint16_t port);
+  expected<connection_handle> add_tcp_scribe(const std::string& host,
+                                             uint16_t port);
 
   /// Moves the initialized `scribe` instance `ptr` from another broker to this
   /// broker.
@@ -207,8 +207,8 @@ public:
   void add_datagram_servant(datagram_servant_ptr ptr);
 
   /// Adds the `datagram_servant` under an additional `hdl`.
-  void
-  add_hdl_for_datagram_servant(datagram_servant_ptr ptr, datagram_handle hdl);
+  void add_hdl_for_datagram_servant(datagram_servant_ptr ptr,
+                                    datagram_handle hdl);
 
   /// Creates and assigns a new `datagram_servant` from a given socket `fd`.
   datagram_handle add_datagram_servant(network::native_socket fd);
@@ -222,8 +222,8 @@ public:
   /// Creates a new `datagram_servant` for the remote endpoint `host` and
   /// `port`.
   /// @returns The handle to the new `datagram_servant`.
-  expected<datagram_handle>
-  add_udp_datagram_servant(const std::string& host, uint16_t port);
+  expected<datagram_handle> add_udp_datagram_servant(const std::string& host,
+                                                     uint16_t port);
 
   /// Tries to open a local port and creates a `datagram_servant` managing it on
   /// success. If `port == 0`, then the broker will ask the operating system to
@@ -283,7 +283,7 @@ public:
     auto x = by_id(hdl);
     if (!x)
       return false;
-    x->graceful_shutdown();
+    (*x)->graceful_shutdown();
     return true;
   }
 
@@ -386,12 +386,12 @@ protected:
 
   /// Returns a `scribe` or `doorman` identified by `hdl`.
   template <class Handle>
-  auto by_id(Handle hdl) -> optional<decltype(*ptr_of(hdl))> {
+  auto by_id(Handle hdl) -> std::optional<decltype(ptr_of(hdl))> {
     auto& elements = get_map(hdl);
     auto i = elements.find(hdl);
     if (i == elements.end())
-      return none;
-    return *(i->second);
+      return std::nullopt;
+    return std::addressof(*(i->second));
   }
 
 private:

--- a/libcaf_io/caf/io/basp/endpoint_context.hpp
+++ b/libcaf_io/caf/io/basp/endpoint_context.hpp
@@ -31,7 +31,7 @@ struct endpoint_context {
   uint16_t remote_port;
   uint16_t local_port;
   // pending operations to be performed after handshake completed
-  optional<response_promise> callback;
+  std::optional<response_promise> callback;
   // keeps track of when we've last received a message from this endpoint
   actor_clock::time_point last_seen;
 };

--- a/libcaf_io/caf/io/basp/instance.hpp
+++ b/libcaf_io/caf/io/basp/instance.hpp
@@ -103,14 +103,14 @@ public:
 
   /// Handles received data and returns a config for receiving the
   /// next data or `none` if an error occurred.
-  connection_state handle(execution_unit* ctx,
-                          new_data_msg& dm, header& hdr, bool is_payload);
+  connection_state handle(execution_unit* ctx, new_data_msg& dm, header& hdr,
+                          bool is_payload);
 
   /// Sends heartbeat messages to all valid nodes those are directly connected.
   void handle_heartbeat(execution_unit* ctx);
 
   /// Returns a route to `target` or `none` on error.
-  optional<routing_table::route> lookup(const node_id& target);
+  std::optional<routing_table::route> lookup(const node_id& target);
 
   /// Flushes the underlying buffer of `path`.
   void flush(const routing_table::route& path);
@@ -125,8 +125,8 @@ public:
                            std::set<std::string> published_interface);
 
   /// Removes the actor currently assigned to `port`.
-  size_t
-  remove_published_actor(uint16_t port, removed_published_actor* cb = nullptr);
+  size_t remove_published_actor(uint16_t port,
+                                removed_published_actor* cb = nullptr);
 
   /// Removes `whom` if it is still assigned to `port` or from all of its
   /// current ports if `port == 0`.
@@ -171,7 +171,7 @@ public:
   /// if no actor is published at this port then a standard handshake is
   /// written (e.g. used when establishing direct connections on-the-fly).
   void write_server_handshake(execution_unit* ctx, byte_buffer& out_buf,
-                              optional<uint16_t> port);
+                              std::optional<uint16_t> port);
 
   /// Writes the client handshake to `buf`.
   void write_client_handshake(execution_unit* ctx, byte_buffer& buf);
@@ -181,9 +181,9 @@ public:
                              const node_id& dest_node, actor_id aid);
 
   /// Writes a `kill_proxy` to `buf`.
-  void
-  write_down_message(execution_unit* ctx, byte_buffer& buf,
-                     const node_id& dest_node, actor_id aid, const error& rsn);
+  void write_down_message(execution_unit* ctx, byte_buffer& buf,
+                          const node_id& dest_node, actor_id aid,
+                          const error& rsn);
 
   /// Writes a `heartbeat` to `buf`.
   void write_heartbeat(execution_unit* ctx, byte_buffer& buf);

--- a/libcaf_io/caf/io/basp/routing_table.hpp
+++ b/libcaf_io/caf/io/basp/routing_table.hpp
@@ -33,7 +33,7 @@ public:
   };
 
   /// Returns a route to `target` or `none` on error.
-  optional<route> lookup(const node_id& target);
+  std::optional<route> lookup(const node_id& target);
 
   /// Returns the ID of the peer connected via `hdl` or
   /// `none` if `hdl` is unknown.
@@ -41,7 +41,7 @@ public:
 
   /// Returns the handle offering a direct connection to `nid` or
   /// `invalid_connection_handle` if no direct connection to `nid` exists.
-  optional<connection_handle> lookup_direct(const node_id& nid) const;
+  std::optional<connection_handle> lookup_direct(const node_id& nid) const;
 
   /// Returns the next hop that would be chosen for `nid`
   /// or `none` if there's no indirect route to `nid`.

--- a/libcaf_io/caf/io/broker_servant.hpp
+++ b/libcaf_io/caf/io/broker_servant.hpp
@@ -32,12 +32,12 @@ public:
   }
 
   void halt() {
-    activity_tokens_ = none;
+    activity_tokens_ = std::nullopt;
     this->remove_from_loop();
   }
 
   void trigger() {
-    activity_tokens_ = none;
+    activity_tokens_ = std::nullopt;
     this->add_to_loop();
   }
 
@@ -50,7 +50,7 @@ public:
     this->add_to_loop();
   }
 
-  optional<size_t> activity_tokens() const {
+  std::optional<size_t> activity_tokens() const {
     return activity_tokens_;
   }
 
@@ -105,7 +105,7 @@ protected:
 
   handle_type hdl_;
   mailbox_element value_;
-  optional<size_t> activity_tokens_;
+  std::optional<size_t> activity_tokens_;
 };
 
 } // namespace caf::io

--- a/libcaf_io/caf/io/middleman_actor_impl.hpp
+++ b/libcaf_io/caf/io/middleman_actor_impl.hpp
@@ -53,18 +53,18 @@ protected:
 
   /// Tries to connect to given `host` and `port`. The default implementation
   /// calls `system().middleman().backend().new_udp`.
-  virtual expected<datagram_servant_ptr>
-  contact(const std::string& host, uint16_t port);
+  virtual expected<datagram_servant_ptr> contact(const std::string& host,
+                                                 uint16_t port);
 
   /// Tries to open a local port. The default implementation calls
   /// `system().middleman().backend().new_tcp_doorman(port, addr, reuse)`.
-  virtual expected<doorman_ptr>
-  open(uint16_t port, const char* addr, bool reuse);
+  virtual expected<doorman_ptr> open(uint16_t port, const char* addr,
+                                     bool reuse);
 
   /// Tries to open a local port. The default implementation calls
   /// `system().middleman().backend().new_tcp_doorman(port, addr, reuse)`.
-  virtual expected<datagram_servant_ptr>
-  open_udp(uint16_t port, const char* addr, bool reuse);
+  virtual expected<datagram_servant_ptr> open_udp(uint16_t port,
+                                                  const char* addr, bool reuse);
 
 private:
   put_res put(uint16_t port, strong_actor_ptr& whom, mpi_set& sigs,
@@ -73,10 +73,10 @@ private:
   put_res put_udp(uint16_t port, strong_actor_ptr& whom, mpi_set& sigs,
                   const char* in = nullptr, bool reuse_addr = false);
 
-  optional<endpoint_data&> cached_tcp(const endpoint& ep);
-  optional<endpoint_data&> cached_udp(const endpoint& ep);
+  std::optional<endpoint_data*> cached_tcp(const endpoint& ep);
+  std::optional<endpoint_data*> cached_udp(const endpoint& ep);
 
-  optional<std::vector<response_promise>&> pending(const endpoint& ep);
+  std::optional<std::vector<response_promise>*> pending(const endpoint& ep);
 
   actor broker_;
   std::map<endpoint, endpoint_data> cached_tcp_;

--- a/libcaf_io/caf/io/middleman_actor_impl.hpp
+++ b/libcaf_io/caf/io/middleman_actor_impl.hpp
@@ -73,10 +73,10 @@ private:
   put_res put_udp(uint16_t port, strong_actor_ptr& whom, mpi_set& sigs,
                   const char* in = nullptr, bool reuse_addr = false);
 
-  std::optional<endpoint_data*> cached_tcp(const endpoint& ep);
-  std::optional<endpoint_data*> cached_udp(const endpoint& ep);
+  endpoint_data* cached_tcp(const endpoint& ep);
+  endpoint_data* cached_udp(const endpoint& ep);
 
-  std::optional<std::vector<response_promise>*> pending(const endpoint& ep);
+  std::vector<response_promise>* pending(const endpoint& ep);
 
   actor broker_;
   std::map<endpoint, endpoint_data> cached_tcp_;

--- a/libcaf_io/caf/io/network/default_multiplexer.hpp
+++ b/libcaf_io/caf/io/network/default_multiplexer.hpp
@@ -101,13 +101,13 @@ public:
 
   scribe_ptr new_scribe(native_socket fd) override;
 
-  expected<scribe_ptr>
-  new_tcp_scribe(const std::string& host, uint16_t port) override;
+  expected<scribe_ptr> new_tcp_scribe(const std::string& host,
+                                      uint16_t port) override;
 
   doorman_ptr new_doorman(native_socket fd) override;
 
-  expected<doorman_ptr>
-  new_tcp_doorman(uint16_t port, const char* in, bool reuse_addr) override;
+  expected<doorman_ptr> new_tcp_doorman(uint16_t port, const char* in,
+                                        bool reuse_addr) override;
 
   datagram_servant_ptr new_datagram_servant(native_socket fd) override;
 
@@ -261,18 +261,20 @@ inline accept_handle accept_hdl_from_socket(native_socket fd) {
 
 CAF_IO_EXPORT expected<native_socket>
 new_tcp_connection(const std::string& host, uint16_t port,
-                   optional<protocol::network> preferred = none);
+                   std::optional<protocol::network> preferred = std::nullopt);
 
 CAF_IO_EXPORT expected<native_socket>
 new_tcp_acceptor_impl(uint16_t port, const char* addr, bool reuse_addr);
 
 expected<std::pair<native_socket, ip_endpoint>>
 new_remote_udp_endpoint_impl(const std::string& host, uint16_t port,
-                             optional<protocol::network> preferred = none);
+                             std::optional<protocol::network> preferred
+                             = std::nullopt);
 
 expected<std::pair<native_socket, protocol::network>>
 new_local_udp_endpoint_impl(uint16_t port, const char* addr,
                             bool reuse_addr = false,
-                            optional<protocol::network> preferred = none);
+                            std::optional<protocol::network> preferred
+                            = std::nullopt);
 
 } // namespace caf::io::network

--- a/libcaf_io/caf/io/network/interfaces.hpp
+++ b/libcaf_io/caf/io/network/interfaces.hpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <initializer_list>
 #include <map>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -14,7 +15,6 @@
 #include "caf/detail/io_export.hpp"
 #include "caf/io/network/ip_endpoint.hpp"
 #include "caf/io/network/protocol.hpp"
-#include "caf/optional.hpp"
 
 namespace caf::io::network {
 
@@ -49,23 +49,23 @@ public:
                  bool include_localhost = true);
 
   /// Returns all addresses for all devices for given protocol.
-  static std::vector<std::string>
-  list_addresses(protocol::network proc, bool include_localhost = true);
+  static std::vector<std::string> list_addresses(protocol::network proc,
+                                                 bool include_localhost = true);
 
   /// Returns a native IPv4 or IPv6 translation of `host`.
-  static optional<std::pair<std::string, protocol::network>>
+  static std::optional<std::pair<std::string, protocol::network>>
   native_address(const std::string& host,
-                 optional<protocol::network> preferred = none);
+                 std::optional<protocol::network> preferred = std::nullopt);
 
   /// Returns the host and protocol available for a local server socket
   static std::vector<std::pair<std::string, protocol::network>>
   server_address(uint16_t port, const char* host,
-                 optional<protocol::network> preferred = none);
+                 std::optional<protocol::network> preferred = std::nullopt);
 
   /// Writes datagram endpoint info for `host`:`port` into ep
   static bool
   get_endpoint(const std::string& host, uint16_t port, ip_endpoint& ep,
-               optional<protocol::network> preferred = none);
+               std::optional<protocol::network> preferred = std::nullopt);
 };
 
 } // namespace caf::io::network

--- a/libcaf_io/src/io/abstract_broker.cpp
+++ b/libcaf_io/src/io/abstract_broker.cpp
@@ -59,19 +59,19 @@ void abstract_broker::configure_read(connection_handle hdl,
                                      receive_policy::config cfg) {
   CAF_LOG_TRACE(CAF_ARG(hdl) << CAF_ARG(cfg));
   if (auto x = by_id(hdl))
-    x->configure_read(cfg);
+    (*x)->configure_read(cfg);
 }
 
 void abstract_broker::ack_writes(connection_handle hdl, bool enable) {
   CAF_LOG_TRACE(CAF_ARG(hdl) << CAF_ARG(enable));
   if (auto x = by_id(hdl))
-    x->ack_writes(enable);
+    (*x)->ack_writes(enable);
 }
 
 byte_buffer& abstract_broker::wr_buf(connection_handle hdl) {
   CAF_ASSERT(hdl != invalid_connection_handle);
   if (auto x = by_id(hdl)) {
-    return x->wr_buf();
+    return (*x)->wr_buf();
   } else {
     CAF_LOG_ERROR("tried to access wr_buf() of an unknown connection_handle:"
                   << CAF_ARG(hdl));
@@ -92,18 +92,18 @@ void abstract_broker::write(connection_handle hdl, span<const byte> buf) {
 
 void abstract_broker::flush(connection_handle hdl) {
   if (auto x = by_id(hdl))
-    x->flush();
+    (*x)->flush();
 }
 
 void abstract_broker::ack_writes(datagram_handle hdl, bool enable) {
   CAF_LOG_TRACE(CAF_ARG(hdl) << CAF_ARG(enable));
   if (auto x = by_id(hdl))
-    x->ack_writes(enable);
+    (*x)->ack_writes(enable);
 }
 
 byte_buffer& abstract_broker::wr_buf(datagram_handle hdl) {
   if (auto x = by_id(hdl)) {
-    return x->wr_buf(hdl);
+    return (*x)->wr_buf(hdl);
   } else {
     CAF_LOG_ERROR("tried to access wr_buf() of an unknown"
                   "datagram_handle");
@@ -113,7 +113,7 @@ byte_buffer& abstract_broker::wr_buf(datagram_handle hdl) {
 
 void abstract_broker::enqueue_datagram(datagram_handle hdl, byte_buffer buf) {
   if (auto x = by_id(hdl))
-    x->enqueue_datagram(hdl, std::move(buf));
+    (*x)->enqueue_datagram(hdl, std::move(buf));
   else
     CAF_LOG_ERROR("tried to access datagram_buffer() of an unknown"
                   "datagram_handle");
@@ -128,7 +128,7 @@ void abstract_broker::write(datagram_handle hdl, size_t bs, const void* buf) {
 
 void abstract_broker::flush(datagram_handle hdl) {
   if (auto x = by_id(hdl))
-    x->flush();
+    (*x)->flush();
 }
 
 std::vector<connection_handle> abstract_broker::connections() const {
@@ -316,7 +316,7 @@ uint16_t abstract_broker::local_port(datagram_handle hdl) {
 
 bool abstract_broker::remove_endpoint(datagram_handle hdl) {
   if (auto x = by_id(hdl)) {
-    x->remove_endpoint(hdl);
+    (*x)->remove_endpoint(hdl);
     return true;
   } else {
     return false;
@@ -339,8 +339,8 @@ resumable::subtype_t abstract_broker::subtype() const {
   return io_actor;
 }
 
-resumable::resume_result
-abstract_broker::resume(execution_unit* ctx, size_t mt) {
+resumable::resume_result abstract_broker::resume(execution_unit* ctx,
+                                                 size_t mt) {
   CAF_ASSERT(ctx != nullptr);
   CAF_ASSERT(ctx == backend_);
   return scheduled_actor::resume(ctx, mt);

--- a/libcaf_io/src/io/abstract_broker.cpp
+++ b/libcaf_io/src/io/abstract_broker.cpp
@@ -59,19 +59,19 @@ void abstract_broker::configure_read(connection_handle hdl,
                                      receive_policy::config cfg) {
   CAF_LOG_TRACE(CAF_ARG(hdl) << CAF_ARG(cfg));
   if (auto x = by_id(hdl))
-    (*x)->configure_read(cfg);
+    x->configure_read(cfg);
 }
 
 void abstract_broker::ack_writes(connection_handle hdl, bool enable) {
   CAF_LOG_TRACE(CAF_ARG(hdl) << CAF_ARG(enable));
   if (auto x = by_id(hdl))
-    (*x)->ack_writes(enable);
+    x->ack_writes(enable);
 }
 
 byte_buffer& abstract_broker::wr_buf(connection_handle hdl) {
   CAF_ASSERT(hdl != invalid_connection_handle);
   if (auto x = by_id(hdl)) {
-    return (*x)->wr_buf();
+    return x->wr_buf();
   } else {
     CAF_LOG_ERROR("tried to access wr_buf() of an unknown connection_handle:"
                   << CAF_ARG(hdl));
@@ -92,18 +92,18 @@ void abstract_broker::write(connection_handle hdl, span<const byte> buf) {
 
 void abstract_broker::flush(connection_handle hdl) {
   if (auto x = by_id(hdl))
-    (*x)->flush();
+    x->flush();
 }
 
 void abstract_broker::ack_writes(datagram_handle hdl, bool enable) {
   CAF_LOG_TRACE(CAF_ARG(hdl) << CAF_ARG(enable));
   if (auto x = by_id(hdl))
-    (*x)->ack_writes(enable);
+    x->ack_writes(enable);
 }
 
 byte_buffer& abstract_broker::wr_buf(datagram_handle hdl) {
   if (auto x = by_id(hdl)) {
-    return (*x)->wr_buf(hdl);
+    return x->wr_buf(hdl);
   } else {
     CAF_LOG_ERROR("tried to access wr_buf() of an unknown"
                   "datagram_handle");
@@ -113,7 +113,7 @@ byte_buffer& abstract_broker::wr_buf(datagram_handle hdl) {
 
 void abstract_broker::enqueue_datagram(datagram_handle hdl, byte_buffer buf) {
   if (auto x = by_id(hdl))
-    (*x)->enqueue_datagram(hdl, std::move(buf));
+    x->enqueue_datagram(hdl, std::move(buf));
   else
     CAF_LOG_ERROR("tried to access datagram_buffer() of an unknown"
                   "datagram_handle");
@@ -128,7 +128,7 @@ void abstract_broker::write(datagram_handle hdl, size_t bs, const void* buf) {
 
 void abstract_broker::flush(datagram_handle hdl) {
   if (auto x = by_id(hdl))
-    (*x)->flush();
+    x->flush();
 }
 
 std::vector<connection_handle> abstract_broker::connections() const {
@@ -316,7 +316,7 @@ uint16_t abstract_broker::local_port(datagram_handle hdl) {
 
 bool abstract_broker::remove_endpoint(datagram_handle hdl) {
   if (auto x = by_id(hdl)) {
-    (*x)->remove_endpoint(hdl);
+    x->remove_endpoint(hdl);
     return true;
   } else {
     return false;

--- a/libcaf_io/src/io/basp/instance.cpp
+++ b/libcaf_io/src/io/basp/instance.cpp
@@ -85,7 +85,7 @@ void instance::handle_heartbeat(execution_unit* ctx) {
   }
 }
 
-optional<routing_table::route> instance::lookup(const node_id& target) {
+std::optional<routing_table::route> instance::lookup(const node_id& target) {
   return tbl_.lookup(target);
 }
 
@@ -112,8 +112,8 @@ void instance::add_published_actor(uint16_t port,
   swap(entry.second, published_interface);
 }
 
-size_t
-instance::remove_published_actor(uint16_t port, removed_published_actor* cb) {
+size_t instance::remove_published_actor(uint16_t port,
+                                        removed_published_actor* cb) {
   CAF_LOG_TRACE(CAF_ARG(port));
   auto i = published_actors_.find(port);
   if (i == published_actors_.end())
@@ -223,7 +223,7 @@ void instance::write(execution_unit* ctx, byte_buffer& buf, header& hdr,
 }
 
 void instance::write_server_handshake(execution_unit* ctx, byte_buffer& out_buf,
-                                      optional<uint16_t> port) {
+                                      std::optional<uint16_t> port) {
   CAF_LOG_TRACE(CAF_ARG(port));
   using namespace detail;
   published_actor* pa = nullptr;

--- a/libcaf_io/src/io/basp/routing_table.cpp
+++ b/libcaf_io/src/io/basp/routing_table.cpp
@@ -16,7 +16,8 @@ routing_table::~routing_table() {
   // nop
 }
 
-optional<routing_table::route> routing_table::lookup(const node_id& target) {
+std::optional<routing_table::route>
+routing_table::lookup(const node_id& target) {
   std::unique_lock<std::mutex> guard{mtx_};
   // Check whether we have a direct path first.
   { // Lifetime scope of first iterator.
@@ -37,7 +38,7 @@ optional<routing_table::route> routing_table::lookup(const node_id& target) {
       hops.erase(hops.begin());
     }
   }
-  return none;
+  return std::nullopt;
 }
 
 node_id routing_table::lookup_direct(const connection_handle& hdl) const {
@@ -48,13 +49,13 @@ node_id routing_table::lookup_direct(const connection_handle& hdl) const {
   return {};
 }
 
-optional<connection_handle>
+std::optional<connection_handle>
 routing_table::lookup_direct(const node_id& nid) const {
   std::unique_lock<std::mutex> guard{mtx_};
   auto i = direct_by_nid_.find(nid);
   if (i != direct_by_nid_.end())
     return i->second;
-  return {};
+  return std::nullopt;
 }
 
 node_id routing_table::lookup_indirect(const node_id& nid) const {

--- a/libcaf_io/src/io/basp_broker.cpp
+++ b/libcaf_io/src/io/basp_broker.cpp
@@ -191,7 +191,7 @@ behavior basp_broker::make_behavior() {
         return;
       }
       auto route = instance.tbl().lookup(proxy->node());
-      if (route == std::nullopt) {
+      if (!route) {
         CAF_LOG_DEBUG("connection to origin already lost, kill proxy");
         instance.proxies().erase(proxy->node(), proxy->id());
         return;
@@ -217,7 +217,7 @@ behavior basp_broker::make_behavior() {
       }
       // Check whether the node is still connected at the moment and send the
       // observer a message immediately otherwise.
-      if (instance.tbl().lookup(node) == std::nullopt) {
+      if (!instance.tbl().lookup(node)) {
         if (auto hdl = actor_cast<actor>(observer)) {
           // TODO: we might want to consider keeping the exit reason for nodes,
           //       at least for some time. Otherwise, we'll have to send a
@@ -472,7 +472,7 @@ void basp_broker::finalize_handshake(const node_id& nid, actor_id aid,
   CAF_ASSERT(this_context != nullptr);
   this_context->id = nid;
   auto& cb = this_context->callback;
-  if (cb == std::nullopt)
+  if (!cb)
     return;
   strong_actor_ptr ptr;
   // aid can be invalid when connecting to the default port of a node

--- a/libcaf_io/src/io/middleman_actor_impl.cpp
+++ b/libcaf_io/src/io/middleman_actor_impl.cpp
@@ -79,14 +79,14 @@ auto middleman_actor_impl::make_behavior() -> behavior_type {
       auto x = cached_tcp(key);
       if (x) {
         CAF_LOG_DEBUG("found cached entry" << CAF_ARG(*x));
-        rp.deliver(get<0>(**x), get<1>(**x), get<2>(**x));
+        rp.deliver(get<0>(*x), get<1>(*x), get<2>(*x));
         return get_delegated{};
       }
       // attach this promise to a pending request if possible
       auto rps = pending(key);
       if (rps) {
         CAF_LOG_DEBUG("attach to pending request");
-        (*rps)->emplace_back(std::move(rp));
+        rps->emplace_back(std::move(rp));
         return get_delegated{};
       }
       // connect to endpoint and initiate handhsake etc.
@@ -216,28 +216,28 @@ middleman_actor_impl::put_udp(uint16_t port, strong_actor_ptr& whom,
   return actual_port;
 }
 
-std::optional<middleman_actor_impl::endpoint_data*>
+middleman_actor_impl::endpoint_data*
 middleman_actor_impl::cached_tcp(const endpoint& ep) {
   auto i = cached_tcp_.find(ep);
   if (i != cached_tcp_.end())
     return std::addressof(i->second);
-  return std::nullopt;
+  return nullptr;
 }
 
-std::optional<middleman_actor_impl::endpoint_data*>
+middleman_actor_impl::endpoint_data*
 middleman_actor_impl::cached_udp(const endpoint& ep) {
   auto i = cached_udp_.find(ep);
   if (i != cached_udp_.end())
     return std::addressof(i->second);
-  return std::nullopt;
+  return nullptr;
 }
 
-std::optional<std::vector<response_promise>*>
+std::vector<response_promise>*
 middleman_actor_impl::pending(const endpoint& ep) {
   auto i = pending_.find(ep);
   if (i != pending_.end())
     return std::addressof(i->second);
-  return std::nullopt;
+  return nullptr;
 }
 
 expected<scribe_ptr> middleman_actor_impl::connect(const std::string& host,

--- a/libcaf_io/src/io/network/interfaces.cpp
+++ b/libcaf_io/src/io/network/interfaces.cpp
@@ -197,14 +197,14 @@ interfaces::list_addresses(std::initializer_list<protocol::network> procs,
   return result;
 }
 
-std::vector<std::string>
-interfaces::list_addresses(protocol::network proc, bool include_localhost) {
+std::vector<std::string> interfaces::list_addresses(protocol::network proc,
+                                                    bool include_localhost) {
   return list_addresses({proc}, include_localhost);
 }
 
-optional<std::pair<std::string, protocol::network>>
+std::optional<std::pair<std::string, protocol::network>>
 interfaces::native_address(const std::string& host,
-                           optional<protocol::network> preferred) {
+                           std::optional<protocol::network> preferred) {
   addrinfo hint;
   memset(&hint, 0, sizeof(hint));
   hint.ai_socktype = SOCK_STREAM;
@@ -212,7 +212,7 @@ interfaces::native_address(const std::string& host,
     hint.ai_family = *preferred == protocol::ipv4 ? AF_INET : AF_INET6;
   addrinfo* tmp = nullptr;
   if (getaddrinfo(host.c_str(), nullptr, &hint, &tmp) != 0)
-    return none;
+    return std::nullopt;
   std::unique_ptr<addrinfo, decltype(freeaddrinfo)*> addrs{tmp, freeaddrinfo};
   char buffer[INET6_ADDRSTRLEN];
   for (auto i = addrs.get(); i != nullptr; i = i->ai_next) {
@@ -221,12 +221,12 @@ interfaces::native_address(const std::string& host,
       return std::make_pair(buffer, family == AF_INET ? protocol::ipv4
                                                       : protocol::ipv6);
   }
-  return none;
+  return std::nullopt;
 }
 
 std::vector<std::pair<std::string, protocol::network>>
 interfaces::server_address(uint16_t port, const char* host,
-                           optional<protocol::network> preferred) {
+                           std::optional<protocol::network> preferred) {
   using addr_pair = std::pair<std::string, protocol::network>;
   addrinfo hint;
   memset(&hint, 0, sizeof(hint));
@@ -261,7 +261,7 @@ interfaces::server_address(uint16_t port, const char* host,
 
 bool interfaces::get_endpoint(const std::string& host, uint16_t port,
                               ip_endpoint& ep,
-                              optional<protocol::network> preferred) {
+                              std::optional<protocol::network> preferred) {
   static_assert(sizeof(uint16_t) == sizeof(unsigned short int),
                 "uint16_t cannot be printed with %hu in snprintf");
   addrinfo hint;

--- a/libcaf_io/test/io/basp_broker.cpp
+++ b/libcaf_io/test/io/basp_broker.cpp
@@ -43,7 +43,7 @@ struct maybe {
     // nop
   }
 
-  caf::optional<T> val;
+  std::optional<T> val;
 };
 
 template <class T>
@@ -241,7 +241,7 @@ public:
     return {hdr, std::move(payload)};
   }
 
-  void connect_node(node& n, optional<accept_handle> ax = none,
+  void connect_node(node& n, std::optional<accept_handle> ax = std::nullopt,
                     actor_id published_actor_id = invalid_actor_id,
                     const std::set<std::string>& published_actor_ifs = {}) {
     auto src = ax ? *ax : ahdl_;
@@ -436,7 +436,7 @@ CAF_TEST(empty_server_handshake) {
   // test whether basp instance correctly sends a
   // server handshake when there's no actor published
   byte_buffer buf;
-  instance().write_server_handshake(mpx(), buf, none);
+  instance().write_server_handshake(mpx(), buf, std::nullopt);
   basp::header hdr;
   byte_buffer payload;
   std::tie(hdr, payload) = from_buf(buf);

--- a/libcaf_test/caf/test/dsl.hpp
+++ b/libcaf_test/caf/test/dsl.hpp
@@ -229,7 +229,7 @@ std::optional<std::tuple<Ts...>> default_extract(caf_handle x) {
 template <class T>
 std::optional<std::tuple<T>> unboxing_extract(caf_handle x) {
   auto tup = default_extract<typename T::outer_type>(x);
-  if (tup == std::nullopt || !is<T>(get<0>(*tup)))
+  if (!tup || !is<T>(get<0>(*tup)))
     return std::nullopt;
   return std::make_tuple(get<T>(get<0>(*tup)));
 }
@@ -266,7 +266,7 @@ std::optional<std::tuple<T, Ts...>> try_extract(caf_handle x) {
 template <class T, class... Ts>
 std::tuple<T, Ts...> extract(caf_handle x) {
   auto result = try_extract<T, Ts...>(x);
-  if (result == std::nullopt) {
+  if (!result) {
     auto ptr = x->peek_at_next_mailbox_element();
     if (ptr == nullptr)
       CAF_FAIL("Mailbox is empty");

--- a/libcaf_test/caf/test/dsl.hpp
+++ b/libcaf_test/caf/test/dsl.hpp
@@ -216,21 +216,21 @@ private:
 
 /// @private
 template <class... Ts>
-caf::optional<std::tuple<Ts...>> default_extract(caf_handle x) {
+std::optional<std::tuple<Ts...>> default_extract(caf_handle x) {
   auto ptr = x->peek_at_next_mailbox_element();
   if (ptr == nullptr)
-    return caf::none;
+    return std::nullopt;
   if (auto view = caf::make_const_typed_message_view<Ts...>(ptr->content()))
     return to_tuple(view);
-  return caf::none;
+  return std::nullopt;
 }
 
 /// @private
 template <class T>
-caf::optional<std::tuple<T>> unboxing_extract(caf_handle x) {
+std::optional<std::tuple<T>> unboxing_extract(caf_handle x) {
   auto tup = default_extract<typename T::outer_type>(x);
-  if (tup == caf::none || !is<T>(get<0>(*tup)))
-    return caf::none;
+  if (tup == std::nullopt || !is<T>(get<0>(*tup)))
+    return std::nullopt;
   return std::make_tuple(get<T>(get<0>(*tup)));
 }
 
@@ -240,22 +240,22 @@ caf::optional<std::tuple<T>> unboxing_extract(caf_handle x) {
 /// @private
 template <class T, bool HasOuterType, class... Ts>
 struct try_extract_impl {
-  caf::optional<std::tuple<T, Ts...>> operator()(caf_handle x) {
+  std::optional<std::tuple<T, Ts...>> operator()(caf_handle x) {
     return default_extract<T, Ts...>(x);
   }
 };
 
 template <class T>
 struct try_extract_impl<T, true> {
-  caf::optional<std::tuple<T>> operator()(caf_handle x) {
+  std::optional<std::tuple<T>> operator()(caf_handle x) {
     return unboxing_extract<T>(x);
   }
 };
 
 /// Returns the content of the next mailbox element as `tuple<T, Ts...>` on a
-/// match. Returns `none` otherwise.
+/// match. Returns `std::nullopt` otherwise.
 template <class T, class... Ts>
-caf::optional<std::tuple<T, Ts...>> try_extract(caf_handle x) {
+std::optional<std::tuple<T, Ts...>> try_extract(caf_handle x) {
   try_extract_impl<T, has_outer_type<T>::value, Ts...> f;
   return f(x);
 }
@@ -266,7 +266,7 @@ caf::optional<std::tuple<T, Ts...>> try_extract(caf_handle x) {
 template <class T, class... Ts>
 std::tuple<T, Ts...> extract(caf_handle x) {
   auto result = try_extract<T, Ts...>(x);
-  if (result == caf::none) {
+  if (result == std::nullopt) {
     auto ptr = x->peek_at_next_mailbox_element();
     if (ptr == nullptr)
       CAF_FAIL("Mailbox is empty");
@@ -278,7 +278,7 @@ std::tuple<T, Ts...> extract(caf_handle x) {
 
 template <class T, class... Ts>
 bool received(caf_handle x) {
-  return try_extract<T, Ts...>(x) != caf::none;
+  return try_extract<T, Ts...>(x) != std::nullopt;
 }
 
 template <class... Ts>
@@ -486,7 +486,7 @@ public:
     : sched_(sched), dest_(nullptr) {
     peek_ = [=] {
       if (dest_ != nullptr)
-        return try_extract<Ts...>(dest_) != caf::none;
+        return try_extract<Ts...>(dest_) != std::nullopt;
       return false;
     };
   }
@@ -524,7 +524,7 @@ public:
       using namespace caf::detail;
       elementwise_compare_inspector<decltype(tmp)> inspector{tmp};
       auto ys = try_extract<Ts...>(dest_);
-      if (ys != caf::none) {
+      if (ys != std::nullopt) {
         auto ys_indices = get_indices(*ys);
         return apply_args(inspector, ys_indices, *ys);
       }
@@ -568,7 +568,7 @@ public:
       if (src_ != nullptr && ptr->sender != src_)
         return;
       auto res = try_extract<Ts...>(dest_);
-      if (res != caf::none)
+      if (res != std::nullopt)
         CAF_FAIL("received disallowed message: " << caf::deep_to_string(*ptr));
     };
   }
@@ -607,7 +607,7 @@ public:
       if (src_ != nullptr && ptr->sender != src_)
         return;
       auto res = try_extract<Ts...>(dest_);
-      if (res != caf::none) {
+      if (res != std::nullopt) {
         using namespace caf::detail;
         elementwise_compare_inspector<decltype(tmp)> inspector{tmp};
         auto& ys = *res;
@@ -873,9 +873,9 @@ T unbox(caf::expected<T> x) {
 
 /// Unboxes an optional value or fails the test if it doesn't exist.
 template <class T>
-T unbox(caf::optional<T> x) {
+T unbox(std::optional<T> x) {
   if (!x)
-    CAF_FAIL("x == none");
+    CAF_FAIL("x == std::nullopt");
   return std::move(*x);
 }
 


### PR DESCRIPTION
This PR deprecates `caf::optional` and refactors the codebase to use `std::optional`.

Relates #1236 