### PR TITLE
Fix and improve some issues with the testing DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,34 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## [Unreleased]
 
+### Added
+
+- When adding CAF with exceptions enabled (default), the unit test framework now
+  offers new check macros:
+  - `CAF_CHECK_NOTHROW(expr)`
+  - `CAF_CHECK_THROWS_AS(expr, type)`
+  - `CAF_CHECK_THROWS_WITH(expr, str)`
+  - `CAF_CHECK_THROWS_WITH_AS(expr, str, type)`
+
+### Fixed
+
+- The DSL function `run_until` miscounted the number executed events, also
+  causing `run_once` to report a wrong value. Both functions now return the
+  correct result.
+- Using `allow(...).with(...)` in unit tests without a matching message crashed
+  the program. By adding a missing NULL-check, `allow` is now always safe to
+  use.
+
 ### Changed
 
 - Since support of Qt 5 expired, we have ported the Qt examples to version 6.
   Hence, building the Qt examples now requires Qt in version 6.
+- When compiling CAF with exceptions enabled (default), `REQUIRE*` macros,
+  `expect` and `disallow` no longer call `abort()`. Instead, they throw an
+  exception that only stops the current test instead of stopping the entire test
+  program.
+- Reporting of several unit test macros has been improved to show correct line
+  numbers and provide better diagnostic of test errors.
 
 ## [0.18.5] - 2021-07-16
 

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -268,6 +268,7 @@ caf_add_component(
     detail.unique_function
     detail.unordered_flat_map
     dictionary
+    dsl
     dynamic_spawn
     error
     expected

--- a/libcaf_core/caf/stream_slot.hpp
+++ b/libcaf_core/caf/stream_slot.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 
 #include "caf/detail/comparable.hpp"
+#include "caf/fwd.hpp"
 
 namespace caf {
 

--- a/libcaf_core/test/actor_clock.cpp
+++ b/libcaf_core/test/actor_clock.cpp
@@ -75,18 +75,18 @@ inline bool operator==(const timeout_msg& x, const tid& y) {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(timer_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(single_receive_timeout) {
   // Have AUT call t.set_receive_timeout().
   self->send(aut, ok_atom_v);
   expect((ok_atom), from(self).to(aut).with(_));
-  CAF_CHECK_EQUAL(t.schedule().size(), 1u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 1u);
+  CHECK_EQ(t.schedule().size(), 1u);
+  CHECK_EQ(t.actor_lookup().size(), 1u);
   // Advance time to send timeout message.
   t.advance_time(10s);
-  CAF_CHECK_EQUAL(t.schedule().size(), 0u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 0u);
+  CHECK_EQ(t.schedule().size(), 0u);
+  CHECK_EQ(t.actor_lookup().size(), 0u);
   // Have AUT receive the timeout.
   expect((timeout_msg), from(aut).to(aut).with(tid{42}));
 }
@@ -95,17 +95,17 @@ CAF_TEST(override_receive_timeout) {
   // Have AUT call t.set_receive_timeout().
   self->send(aut, ok_atom_v);
   expect((ok_atom), from(self).to(aut).with(_));
-  CAF_CHECK_EQUAL(t.schedule().size(), 1u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 1u);
+  CHECK_EQ(t.schedule().size(), 1u);
+  CHECK_EQ(t.actor_lookup().size(), 1u);
   // Have AUT call t.set_timeout() again.
   self->send(aut, ok_atom_v);
   expect((ok_atom), from(self).to(aut).with(_));
-  CAF_CHECK_EQUAL(t.schedule().size(), 1u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 1u);
+  CHECK_EQ(t.schedule().size(), 1u);
+  CHECK_EQ(t.actor_lookup().size(), 1u);
   // Advance time to send timeout message.
   t.advance_time(10s);
-  CAF_CHECK_EQUAL(t.schedule().size(), 0u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 0u);
+  CHECK_EQ(t.schedule().size(), 0u);
+  CHECK_EQ(t.actor_lookup().size(), 0u);
   // Have AUT receive the timeout.
   expect((timeout_msg), from(aut).to(aut).with(tid{43}));
 }
@@ -114,25 +114,25 @@ CAF_TEST(multi_timeout) {
   // Have AUT call t.set_multi_timeout().
   self->send(aut, add_atom_v);
   expect((add_atom), from(self).to(aut).with(_));
-  CAF_CHECK_EQUAL(t.schedule().size(), 1u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 1u);
+  CHECK_EQ(t.schedule().size(), 1u);
+  CHECK_EQ(t.actor_lookup().size(), 1u);
   // Advance time just a little bit.
   t.advance_time(5s);
   // Have AUT call t.set_multi_timeout() again.
   self->send(aut, add_atom_v);
   expect((add_atom), from(self).to(aut).with(_));
-  CAF_CHECK_EQUAL(t.schedule().size(), 2u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 2u);
+  CHECK_EQ(t.schedule().size(), 2u);
+  CHECK_EQ(t.actor_lookup().size(), 2u);
   // Advance time to send timeout message.
   t.advance_time(5s);
-  CAF_CHECK_EQUAL(t.schedule().size(), 1u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 1u);
+  CHECK_EQ(t.schedule().size(), 1u);
+  CHECK_EQ(t.actor_lookup().size(), 1u);
   // Have AUT receive the timeout.
   expect((timeout_msg), from(aut).to(aut).with(tid{42}));
   // Advance time to send second timeout message.
   t.advance_time(5s);
-  CAF_CHECK_EQUAL(t.schedule().size(), 0u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 0u);
+  CHECK_EQ(t.schedule().size(), 0u);
+  CHECK_EQ(t.actor_lookup().size(), 0u);
   // Have AUT receive the timeout.
   expect((timeout_msg), from(aut).to(aut).with(tid{43}));
 }
@@ -141,25 +141,25 @@ CAF_TEST(mixed_receive_and_multi_timeouts) {
   // Have AUT call t.set_receive_timeout().
   self->send(aut, add_atom_v);
   expect((add_atom), from(self).to(aut).with(_));
-  CAF_CHECK_EQUAL(t.schedule().size(), 1u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 1u);
+  CHECK_EQ(t.schedule().size(), 1u);
+  CHECK_EQ(t.actor_lookup().size(), 1u);
   // Advance time just a little bit.
   t.advance_time(5s);
   // Have AUT call t.set_multi_timeout() again.
   self->send(aut, ok_atom_v);
   expect((ok_atom), from(self).to(aut).with(_));
-  CAF_CHECK_EQUAL(t.schedule().size(), 2u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 2u);
+  CHECK_EQ(t.schedule().size(), 2u);
+  CHECK_EQ(t.actor_lookup().size(), 2u);
   // Advance time to send timeout message.
   t.advance_time(5s);
-  CAF_CHECK_EQUAL(t.schedule().size(), 1u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 1u);
+  CHECK_EQ(t.schedule().size(), 1u);
+  CHECK_EQ(t.actor_lookup().size(), 1u);
   // Have AUT receive the timeout.
   expect((timeout_msg), from(aut).to(aut).with(tid{42}));
   // Advance time to send second timeout message.
   t.advance_time(5s);
-  CAF_CHECK_EQUAL(t.schedule().size(), 0u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 0u);
+  CHECK_EQ(t.schedule().size(), 0u);
+  CHECK_EQ(t.actor_lookup().size(), 0u);
   // Have AUT receive the timeout.
   expect((timeout_msg), from(aut).to(aut).with(tid{43}));
 }
@@ -168,12 +168,12 @@ CAF_TEST(single_request_timeout) {
   // Have AUT call t.set_request_timeout().
   self->send(aut, put_atom_v);
   expect((put_atom), from(self).to(aut).with(_));
-  CAF_CHECK_EQUAL(t.schedule().size(), 1u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 1u);
+  CHECK_EQ(t.schedule().size(), 1u);
+  CHECK_EQ(t.actor_lookup().size(), 1u);
   // Advance time to send timeout message.
   t.advance_time(10s);
-  CAF_CHECK_EQUAL(t.schedule().size(), 0u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 0u);
+  CHECK_EQ(t.schedule().size(), 0u);
+  CHECK_EQ(t.actor_lookup().size(), 0u);
   // Have AUT receive the timeout.
   expect((error), from(aut).to(aut).with(sec::request_timeout));
 }
@@ -182,25 +182,25 @@ CAF_TEST(mixed_receive_and_request_timeouts) {
   // Have AUT call t.set_receive_timeout().
   self->send(aut, ok_atom_v);
   expect((ok_atom), from(self).to(aut).with(_));
-  CAF_CHECK_EQUAL(t.schedule().size(), 1u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 1u);
+  CHECK_EQ(t.schedule().size(), 1u);
+  CHECK_EQ(t.actor_lookup().size(), 1u);
   // Cause the request timeout to arrive later.
   t.advance_time(5s);
   // Have AUT call t.set_request_timeout().
   self->send(aut, put_atom_v);
   expect((put_atom), from(self).to(aut).with(_));
-  CAF_CHECK_EQUAL(t.schedule().size(), 2u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 2u);
+  CHECK_EQ(t.schedule().size(), 2u);
+  CHECK_EQ(t.actor_lookup().size(), 2u);
   // Advance time to send receive timeout message.
   t.advance_time(5s);
-  CAF_CHECK_EQUAL(t.schedule().size(), 1u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 1u);
+  CHECK_EQ(t.schedule().size(), 1u);
+  CHECK_EQ(t.actor_lookup().size(), 1u);
   // Have AUT receive the timeout.
   expect((timeout_msg), from(aut).to(aut).with(tid{42}));
   // Advance time to send request timeout message.
   t.advance_time(10s);
-  CAF_CHECK_EQUAL(t.schedule().size(), 0u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 0u);
+  CHECK_EQ(t.schedule().size(), 0u);
+  CHECK_EQ(t.actor_lookup().size(), 0u);
   // Have AUT receive the timeout.
   expect((error), from(aut).to(aut).with(sec::request_timeout));
 }
@@ -212,12 +212,12 @@ CAF_TEST(delay_actor_message) {
   t.schedule_message(n, autptr,
                      make_mailbox_element(autptr, make_message_id(), no_stages,
                                           "foo"));
-  CAF_CHECK_EQUAL(t.schedule().size(), 1u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 0u);
+  CHECK_EQ(t.schedule().size(), 1u);
+  CHECK_EQ(t.actor_lookup().size(), 0u);
   // Advance time to send the message.
   t.advance_time(10s);
-  CAF_CHECK_EQUAL(t.schedule().size(), 0u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 0u);
+  CHECK_EQ(t.schedule().size(), 0u);
+  CHECK_EQ(t.actor_lookup().size(), 0u);
   // Have AUT receive the message.
   expect((std::string), from(aut).to(aut).with("foo"));
 }
@@ -231,12 +231,12 @@ CAF_TEST(delay_group_message) {
   auto n = t.now() + 10s;
   auto autptr = actor_cast<strong_actor_ptr>(aut);
   t.schedule_message(n, std::move(grp), autptr, make_message("foo"));
-  CAF_CHECK_EQUAL(t.schedule().size(), 1u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 0u);
+  CHECK_EQ(t.schedule().size(), 1u);
+  CHECK_EQ(t.actor_lookup().size(), 0u);
   // Advance time to send the message.
   t.advance_time(10s);
-  CAF_CHECK_EQUAL(t.schedule().size(), 0u);
-  CAF_CHECK_EQUAL(t.actor_lookup().size(), 0u);
+  CHECK_EQ(t.schedule().size(), 0u);
+  CHECK_EQ(t.actor_lookup().size(), 0u);
   // Have AUT receive the message.
   expect((std::string), from(aut).to(aut).with("foo"));
   // Kill AUT (necessary because the group keeps a reference around).
@@ -244,4 +244,4 @@ CAF_TEST(delay_group_message) {
   expect((exit_msg), from(self).to(aut).with(_));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/actor_factory.cpp
+++ b/libcaf_core/test/actor_factory.cpp
@@ -24,7 +24,7 @@ struct fixture {
   void test_spawn(message args, bool expect_fail = false) {
     actor_system system{cfg};
     scoped_actor self{system};
-    CAF_MESSAGE("set aut");
+    MESSAGE("set aut");
     strong_actor_ptr res;
     std::set<std::string> ifs;
     scoped_execution_unit context{&system};
@@ -36,7 +36,7 @@ struct fixture {
     }
     CAF_REQUIRE(aut);
     self->wait_for(*aut);
-    CAF_MESSAGE("aut done");
+    MESSAGE("aut done");
   }
 };
 
@@ -46,42 +46,36 @@ struct test_actor_no_args : event_based_actor {
 
 struct test_actor_one_arg : event_based_actor {
   test_actor_one_arg(actor_config& conf, int value) : event_based_actor(conf) {
-    CAF_CHECK_EQUAL(value, 42);
+    CHECK_EQ(value, 42);
   }
 };
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(add_actor_type_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(fun_no_args) {
-  auto test_actor_one_arg = [] {
-    CAF_MESSAGE("inside test_actor");
-  };
+  auto test_actor_one_arg = [] { MESSAGE("inside test_actor"); };
   cfg.add_actor_type("test_actor", test_actor_one_arg);
   test_spawn(make_message());
-  CAF_MESSAGE("test_spawn done");
+  MESSAGE("test_spawn done");
 }
 
 CAF_TEST(fun_no_args_selfptr) {
   auto test_actor_one_arg = [](event_based_actor*) {
-    CAF_MESSAGE("inside test_actor");
+    MESSAGE("inside test_actor");
   };
   cfg.add_actor_type("test_actor", test_actor_one_arg);
   test_spawn(make_message());
 }
 CAF_TEST(fun_one_arg) {
-  auto test_actor_one_arg = [](int i) {
-    CAF_CHECK_EQUAL(i, 42);
-  };
+  auto test_actor_one_arg = [](int i) { CHECK_EQ(i, 42); };
   cfg.add_actor_type("test_actor", test_actor_one_arg);
   test_spawn(make_message(42));
 }
 
 CAF_TEST(fun_one_arg_selfptr) {
-  auto test_actor_one_arg = [](event_based_actor*, int i) {
-    CAF_CHECK_EQUAL(i, 42);
-  };
+  auto test_actor_one_arg = [](event_based_actor*, int i) { CHECK_EQ(i, 42); };
   cfg.add_actor_type("test_actor", test_actor_one_arg);
   test_spawn(make_message(42));
 }
@@ -106,4 +100,4 @@ CAF_TEST(class_one_arg_valid) {
   test_spawn(make_message(42));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/actor_lifetime.cpp
+++ b/libcaf_core/test/actor_lifetime.cpp
@@ -55,16 +55,16 @@ behavior tester(event_based_actor* self, const actor& aut) {
   if (std::is_same<ExitMsgType, exit_msg>::value) {
     self->set_exit_handler([self](exit_msg& msg) {
       // must be still alive at this point
-      CAF_CHECK_EQUAL(s_testees.load(), 1);
-      CAF_CHECK_EQUAL(msg.reason, exit_reason::user_shutdown);
+      CHECK_EQ(s_testees.load(), 1);
+      CHECK_EQ(msg.reason, exit_reason::user_shutdown);
       self->send(self, ok_atom_v);
     });
     self->link_to(aut);
   } else {
     self->set_down_handler([self](down_msg& msg) {
       // must be still alive at this point
-      CAF_CHECK_EQUAL(s_testees.load(), 1);
-      CAF_CHECK_EQUAL(msg.reason, exit_reason::user_shutdown);
+      CHECK_EQ(s_testees.load(), 1);
+      CHECK_EQ(msg.reason, exit_reason::user_shutdown);
       // testee might be still running its cleanup code in
       // another worker thread; by waiting some milliseconds, we make sure
       // testee had enough time to return control to the scheduler
@@ -86,8 +86,8 @@ behavior tester(event_based_actor* self, const actor& aut) {
         while (!s_testee_cleanup_done.load())
           s_cv.wait(guard);
       }
-      CAF_CHECK_EQUAL(s_testees.load(), 0);
-      CAF_CHECK_EQUAL(s_pending_on_exits.load(), 0);
+      CHECK_EQ(s_testees.load(), 0);
+      CHECK_EQ(s_pending_on_exits.load(), 0);
       self->quit();
     },
   };
@@ -166,11 +166,11 @@ CAF_TEST(destructor_call) {
     actor_system system{cfg};
     system.spawn<testee>();
   }
-  CAF_CHECK_EQUAL(s_testees.load(), 0);
-  CAF_CHECK_EQUAL(s_pending_on_exits.load(), 0);
+  CHECK_EQ(s_testees.load(), 0);
+  CHECK_EQ(s_pending_on_exits.load(), 0);
 }
 
-CAF_TEST_FIXTURE_SCOPE(actor_lifetime_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(no_spawn_options_and_exit_msg) {
   tst<exit_msg, no_spawn_options, no_spawn_options>();
@@ -188,4 +188,4 @@ CAF_TEST(mixed_spawn_options_and_down_msg) {
   tst<down_msg, detached, no_spawn_options>();
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/actor_profiler.cpp
+++ b/libcaf_core/test/actor_profiler.cpp
@@ -119,36 +119,36 @@ NAMED_ACTOR_STATE(worker);
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(actor_profiler_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(profilers record actor construction) {
-  CAF_MESSAGE("fully initialize CAF, ignore system-internal actors");
+  MESSAGE("fully initialize CAF, ignore system-internal actors");
   run();
   rec.log.clear();
-  CAF_MESSAGE("spawn a foo and a bar");
+  MESSAGE("spawn a foo and a bar");
   auto bar = [](stateful_actor<bar_state>*) {};
   auto foo = [bar](stateful_actor<foo_state>* self) { self->spawn(bar); };
   auto foo_actor = sys.spawn(foo);
   run();
   foo_actor = nullptr;
-  CAF_CHECK_EQUAL(string_list({
-                    "new: foo",
-                    "new: bar, parent: foo",
-                    "delete: bar",
-                    "delete: foo",
-                  }),
-                  rec.log);
+  CHECK_EQ(string_list({
+             "new: foo",
+             "new: bar, parent: foo",
+             "delete: bar",
+             "delete: foo",
+           }),
+           rec.log);
 }
 
 CAF_TEST(profilers record asynchronous messaging) {
-  CAF_MESSAGE("fully initialize CAF, ignore system-internal actors");
+  MESSAGE("fully initialize CAF, ignore system-internal actors");
   run();
   rec.log.clear();
-  CAF_MESSAGE("spawn a foo and a bar");
+  MESSAGE("spawn a foo and a bar");
   auto bar = [](stateful_actor<bar_state>*) -> behavior {
     return {
       [](const std::string& str) {
-        CAF_CHECK_EQUAL(str, "hello bar");
+        CHECK_EQ(str, "hello bar");
         return "hello foo";
       },
     };
@@ -157,31 +157,31 @@ CAF_TEST(profilers record asynchronous messaging) {
     auto b = self->spawn(bar);
     self->send(b, "hello bar");
     return {
-      [](const std::string& str) { CAF_CHECK_EQUAL(str, "hello foo"); },
+      [](const std::string& str) { CHECK_EQ(str, "hello foo"); },
     };
   };
   sys.spawn(foo);
   run();
-  CAF_CHECK_EQUAL(string_list({
-                    R"__(new: foo)__",
-                    R"__(new: bar, parent: foo)__",
-                    R"__(foo sends: message("hello bar"))__",
-                    R"__(bar got: message("hello bar"))__",
-                    R"__(bar sends: message("hello foo"))__",
-                    R"__(bar consumed the message)__",
-                    R"__(foo got: message("hello foo"))__",
-                    R"__(delete: bar)__",
-                    R"__(foo consumed the message)__",
-                    R"__(delete: foo)__",
-                  }),
-                  rec.log);
+  CHECK_EQ(string_list({
+             R"__(new: foo)__",
+             R"__(new: bar, parent: foo)__",
+             R"__(foo sends: message("hello bar"))__",
+             R"__(bar got: message("hello bar"))__",
+             R"__(bar sends: message("hello foo"))__",
+             R"__(bar consumed the message)__",
+             R"__(foo got: message("hello foo"))__",
+             R"__(delete: bar)__",
+             R"__(foo consumed the message)__",
+             R"__(delete: foo)__",
+           }),
+           rec.log);
 }
 
 CAF_TEST(profilers record request / response messaging) {
-  CAF_MESSAGE("fully initialize CAF, ignore system-internal actors");
+  MESSAGE("fully initialize CAF, ignore system-internal actors");
   run();
   rec.log.clear();
-  CAF_MESSAGE("spawn a client and a server with one worker");
+  MESSAGE("spawn a client and a server with one worker");
   auto worker = [](stateful_actor<worker_state>*) -> behavior {
     return {
       [](int x, int y) { return x + y; },
@@ -194,34 +194,34 @@ CAF_TEST(profilers record request / response messaging) {
   };
   auto client = [](stateful_actor<client_state>* self, actor serv) {
     self->request(serv, infinite, 19, 23).then([](int result) {
-      CAF_CHECK_EQUAL(result, 42);
+      CHECK_EQ(result, 42);
     });
   };
   sys.spawn(client, sys.spawn(server, sys.spawn(worker)));
   run();
   for (const auto& line : rec.log) {
-    CAF_MESSAGE(line);
+    MESSAGE(line);
   }
-  CAF_CHECK_EQUAL(string_list({
-                    "new: worker",
-                    "new: server",
-                    "new: client",
-                    "client sends: message(19, 23)",
-                    "server got: message(19, 23)",
-                    "server sends: message(19, 23)",
-                    "server consumed the message",
-                    "delete: server",
-                    "worker got: message(19, 23)",
-                    "worker sends: message(42)",
-                    "worker consumed the message",
-                    "client got: message(42)",
-                    "client consumed the message",
-                    "delete: worker",
-                    "delete: client",
-                  }),
-                  rec.log);
+  CHECK_EQ(string_list({
+             "new: worker",
+             "new: server",
+             "new: client",
+             "client sends: message(19, 23)",
+             "server got: message(19, 23)",
+             "server sends: message(19, 23)",
+             "server consumed the message",
+             "delete: server",
+             "worker got: message(19, 23)",
+             "worker sends: message(42)",
+             "worker consumed the message",
+             "client got: message(42)",
+             "client consumed the message",
+             "delete: worker",
+             "delete: client",
+           }),
+           rec.log);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()
 
 #endif // CAF_ENABLE_ACTOR_PROFILER

--- a/libcaf_core/test/actor_registry.cpp
+++ b/libcaf_core/test/actor_registry.cpp
@@ -21,34 +21,34 @@ behavior dummy() {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(actor_registry_tests, test_coordinator_fixture<>)
+BEGIN_FIXTURE_SCOPE(test_coordinator_fixture<>)
 
 CAF_TEST(erase) {
   // CAF registers a few actors by itself.
   auto baseline = sys.registry().named_actors().size();
   sys.registry().put("foo", sys.spawn(dummy));
-  CAF_CHECK_EQUAL(sys.registry().named_actors().size(), baseline + 1u);
+  CHECK_EQ(sys.registry().named_actors().size(), baseline + 1u);
   self->send(sys.registry().get<actor>("foo"), 42);
   run();
   expect((int), from(_).to(self).with(42));
   sys.registry().erase("foo");
-  CAF_CHECK_EQUAL(sys.registry().named_actors().size(), baseline);
+  CHECK_EQ(sys.registry().named_actors().size(), baseline);
 }
 
 CAF_TEST(serialization roundtrips go through the registry) {
   auto hdl = sys.spawn(dummy);
-  CAF_MESSAGE("hdl.id: " << hdl->id());
+  MESSAGE("hdl.id: " << hdl->id());
   byte_buffer buf;
   binary_serializer sink{sys, buf};
   if (!sink.apply(hdl))
     CAF_FAIL("serialization failed: " << sink.get_error());
-  CAF_MESSAGE("buf: " << buf);
+  MESSAGE("buf: " << buf);
   actor hdl2;
   binary_deserializer source{sys, buf};
   if (!source.apply(hdl2))
     CAF_FAIL("deserialization failed: " << source.get_error());
-  CAF_CHECK_EQUAL(hdl, hdl2);
+  CHECK_EQ(hdl, hdl2);
   anon_send_exit(hdl, exit_reason::user_shutdown);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/actor_system_config.cpp
+++ b/libcaf_core/test/actor_system_config.cpp
@@ -64,38 +64,38 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(actor_system_config_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(parsing - without CLI arguments) {
   auto text = "foo{\nbar=\"hello\"}";
   options("?foo").add<std::string>("bar,b", "some string parameter");
   parse(text);
-  CAF_CHECK(cfg.remainder.empty());
-  CAF_CHECK_EQUAL(get_or(cfg, "foo.bar", ""), "hello");
+  CHECK(cfg.remainder.empty());
+  CHECK_EQ(get_or(cfg, "foo.bar", ""), "hello");
   auto [argc, argv] = cfg.c_args_remainder();
   CAF_REQUIRE_EQUAL(argc, 1);
-  CAF_CHECK_EQUAL(argv[0], cfg.program_name);
+  CHECK_EQ(argv[0], cfg.program_name);
 }
 
 CAF_TEST(parsing - without CLI cfg.remainder) {
   auto text = "foo{\nbar=\"hello\"}";
   options("?foo").add<std::string>("bar,b", "some string parameter");
-  CAF_MESSAGE("CLI long name");
+  MESSAGE("CLI long name");
   parse(text, {"--foo.bar=test"});
-  CAF_CHECK(cfg.remainder.empty());
-  CAF_CHECK_EQUAL(get_or(cfg, "foo.bar", ""), "test");
-  CAF_MESSAGE("CLI abbreviated long name");
+  CHECK(cfg.remainder.empty());
+  CHECK_EQ(get_or(cfg, "foo.bar", ""), "test");
+  MESSAGE("CLI abbreviated long name");
   parse(text, {"--bar=test"});
-  CAF_CHECK(cfg.remainder.empty());
-  CAF_CHECK_EQUAL(get_or(cfg, "foo.bar", ""), "test");
-  CAF_MESSAGE("CLI short name");
+  CHECK(cfg.remainder.empty());
+  CHECK_EQ(get_or(cfg, "foo.bar", ""), "test");
+  MESSAGE("CLI short name");
   parse(text, {"-b", "test"});
-  CAF_CHECK(cfg.remainder.empty());
-  CAF_CHECK_EQUAL(get_or(cfg, "foo.bar", ""), "test");
-  CAF_MESSAGE("CLI short name without whitespace");
+  CHECK(cfg.remainder.empty());
+  CHECK_EQ(get_or(cfg, "foo.bar", ""), "test");
+  MESSAGE("CLI short name without whitespace");
   parse(text, {"-btest"});
-  CAF_CHECK(cfg.remainder.empty());
-  CAF_CHECK_EQUAL(get_or(cfg, "foo.bar", ""), "test");
+  CHECK(cfg.remainder.empty());
+  CHECK_EQ(get_or(cfg, "foo.bar", ""), "test");
 }
 
 CAF_TEST(parsing - with CLI cfg.remainder) {
@@ -103,13 +103,13 @@ CAF_TEST(parsing - with CLI cfg.remainder) {
   options("?foo").add<std::string>("bar,b", "some string parameter");
   parse(text, {"-b", "test", "hello", "world"});
   CAF_REQUIRE_EQUAL(cfg.remainder.size(), 2u);
-  CAF_CHECK_EQUAL(get_or(cfg, "foo.bar", ""), "test");
-  CAF_CHECK_EQUAL(cfg.remainder, string_list({"hello", "world"}));
+  CHECK_EQ(get_or(cfg, "foo.bar", ""), "test");
+  CHECK_EQ(cfg.remainder, string_list({"hello", "world"}));
   auto [argc, argv] = cfg.c_args_remainder();
   CAF_REQUIRE_EQUAL(argc, 3);
-  CAF_CHECK_EQUAL(argv[0], cfg.program_name);
-  CAF_CHECK_EQUAL(argv[1], cfg.remainder[0]);
-  CAF_CHECK_EQUAL(argv[2], cfg.remainder[1]);
+  CHECK_EQ(argv[0], cfg.program_name);
+  CHECK_EQ(argv[1], cfg.remainder[0]);
+  CHECK_EQ(argv[2], cfg.remainder[1]);
 }
 
 CAF_TEST(file input overrides defaults but CLI args always win) {
@@ -137,17 +137,17 @@ CAF_TEST(file input overrides defaults but CLI args always win) {
   string_list args{"--group1.arg2=123", "--group2.arg1=bye"};
   std::istringstream input{file_input};
   auto err = cfg.parse(std::move(args), input);
-  CAF_CHECK_EQUAL(err, error{});
-  CAF_CHECK_EQUAL(grp1.arg1, "foobar");
-  CAF_CHECK_EQUAL(grp1.arg2, 123);
-  CAF_CHECK_EQUAL(grp2.arg1, "bye");
-  CAF_CHECK_EQUAL(grp2.arg2, 2);
+  CHECK_EQ(err, error{});
+  CHECK_EQ(grp1.arg1, "foobar");
+  CHECK_EQ(grp1.arg2, 123);
+  CHECK_EQ(grp2.arg1, "bye");
+  CHECK_EQ(grp2.arg2, 2);
   settings res;
   put(res, "group1.arg1", "foobar");
   put(res, "group1.arg2", 123);
   put(res, "group2.arg1", "bye");
   put(res, "group2.arg2", 2);
-  CAF_CHECK_EQUAL(content(cfg), res);
+  CHECK_EQ(content(cfg), res);
 }
 
 // Checks whether both a synced variable and the corresponding entry in
@@ -156,9 +156,9 @@ CAF_TEST(file input overrides defaults but CLI args always win) {
   do {                                                                         \
     using ref_value_type = std::decay_t<decltype(var)>;                        \
     ref_value_type value{__VA_ARGS__};                                         \
-    CAF_CHECK_EQUAL(var, value);                                               \
+    CHECK_EQ(var, value);                                                      \
     if (auto maybe_val = get_as<decltype(var)>(cfg, #var)) {                   \
-      CAF_CHECK_EQUAL(*maybe_val, value);                                      \
+      CHECK_EQ(*maybe_val, value);                                             \
     } else {                                                                   \
       auto cv = get_if(std::addressof(cfg.content), #var);                     \
       CAF_ERROR("expected type "                                               \
@@ -169,7 +169,7 @@ CAF_TEST(file input overrides defaults but CLI args always win) {
 
 // Checks whether an entry in content(cfg) is equal to `value`.
 #define CHECK_TEXT_ONLY(type, var, value)                                      \
-  CAF_CHECK_EQUAL(get_as<type>(cfg, #var), value)
+  CHECK_EQ(get_as<type>(cfg, #var), value)
 
 #define ADD(var) add(var, #var, "...")
 
@@ -271,21 +271,21 @@ CAF_TEST(basic and basic containers options) {
   VAR(uri_map);
   VAR(string_map);
   parse(text);
-  CAF_MESSAGE("check primitive types");
+  MESSAGE("check primitive types");
   CHECK_SYNCED(some_int, 42);
   CHECK_SYNCED(some_bool, true);
   CHECK_SYNCED(some_double, 1e23);
   CHECK_SYNCED(some_timespan, 123_ms);
   CHECK_SYNCED(some_uri, "foo:bar"_u);
   CHECK_SYNCED(some_string, "string"s);
-  CAF_MESSAGE("check list types");
+  MESSAGE("check list types");
   CHECK_SYNCED(some_int_list, 1, 2, 3);
   CHECK_SYNCED(some_bool_list, false, true);
   CHECK_SYNCED(some_double_list, 1., 2., 3.);
   CHECK_SYNCED(some_timespan_list, 123_ms, 234_ms, 345_ms);
   CHECK_SYNCED(some_uri_list, "foo:a"_u, "foo:b"_u, "foo:c"_u);
   CHECK_SYNCED(some_string_list, "a", "b", "c");
-  CAF_MESSAGE("check dictionary types");
+  MESSAGE("check dictionary types");
   CHECK_SYNCED(some_int_map, {"a", 1}, {"b", 2}, {"c", 3});
   CHECK_SYNCED(some_bool_map, {"a", true}, {"b", false});
   CHECK_SYNCED(some_double_map, {"a", 1.}, {"b", 2.}, {"c", 3.});
@@ -335,4 +335,4 @@ SCENARIO("config files allow both nested and dot-separated values") {
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/actor_termination.cpp
+++ b/libcaf_core/test/actor_termination.cpp
@@ -19,7 +19,7 @@ behavior mirror_impl(event_based_actor* self) {
   };
 }
 
-struct fixture :  test_coordinator_fixture<> {
+struct fixture : test_coordinator_fixture<> {
   actor mirror;
   actor testee;
 
@@ -41,7 +41,7 @@ struct fixture :  test_coordinator_fixture<> {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(actor_termination_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(single_multiplexed_request) {
   auto f = [&](event_based_actor* self, actor server) {
@@ -78,11 +78,9 @@ CAF_TEST(multiple_multiplexed_requests) {
 
 CAF_TEST(single_awaited_request) {
   auto f = [&](event_based_actor* self, actor server) {
-    self->request(server, infinite, 42).await(
-      [=](int x) {
-        CAF_REQUIRE_EQUAL(x, 42);
-      }
-    );
+    self->request(server, infinite, 42).await([=](int x) {
+      CAF_REQUIRE_EQUAL(x, 42);
+    });
   };
   spawn(f, mirror);
   // run initialization code of testee
@@ -94,12 +92,10 @@ CAF_TEST(single_awaited_request) {
 CAF_TEST(multiple_awaited_requests) {
   auto f = [&](event_based_actor* self, actor server) {
     for (int i = 0; i < 3; ++i)
-      self->request(server, infinite, i).await(
-        [=](int x) {
-          CAF_MESSAGE("received response #" << (i + 1));
-          CAF_REQUIRE_EQUAL(x, i);
-        }
-      );
+      self->request(server, infinite, i).await([=](int x) {
+        MESSAGE("received response #" << (i + 1));
+        CAF_REQUIRE_EQUAL(x, i);
+      });
   };
   spawn(f, mirror);
   // run initialization code of testee
@@ -114,4 +110,4 @@ CAF_TEST(multiple_awaited_requests) {
   expect((down_msg), from(testee).to(self).with(_));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/behavior.cpp
+++ b/libcaf_core/test/behavior.cpp
@@ -10,12 +10,12 @@
 
 #include <functional>
 
-#include "caf/send.hpp"
-#include "caf/behavior.hpp"
 #include "caf/actor_system.hpp"
-#include "caf/message_handler.hpp"
-#include "caf/event_based_actor.hpp"
 #include "caf/actor_system_config.hpp"
+#include "caf/behavior.hpp"
+#include "caf/event_based_actor.hpp"
+#include "caf/message_handler.hpp"
+#include "caf/send.hpp"
 
 using namespace caf;
 
@@ -57,48 +57,43 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(behavior_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(default_construct) {
   behavior f;
-  CAF_CHECK_EQUAL(f(m1), none);
-  CAF_CHECK_EQUAL(f(m2), none);
-  CAF_CHECK_EQUAL(f(m3), none);
+  CHECK_EQ(f(m1), none);
+  CHECK_EQ(f(m2), none);
+  CHECK_EQ(f(m3), none);
 }
 
 CAF_TEST(nocopy_function_object) {
   behavior f{nocopy_fun{}};
-  CAF_CHECK_EQUAL(f(m1), none);
-  CAF_CHECK_EQUAL(res_of(f, m2), 3);
-  CAF_CHECK_EQUAL(f(m3), none);
+  CHECK_EQ(f(m1), none);
+  CHECK_EQ(res_of(f, m2), 3);
+  CHECK_EQ(f(m3), none);
 }
 
 CAF_TEST(single_lambda_construct) {
   behavior f{[](int x) { return x + 1; }};
-  CAF_CHECK_EQUAL(res_of(f, m1), 2);
-  CAF_CHECK_EQUAL(res_of(f, m2), none);
-  CAF_CHECK_EQUAL(res_of(f, m3), none);
+  CHECK_EQ(res_of(f, m1), 2);
+  CHECK_EQ(res_of(f, m2), none);
+  CHECK_EQ(res_of(f, m3), none);
 }
 
 CAF_TEST(multiple_lambda_construct) {
-  behavior f{
-    [](int x) { return x + 1; },
-    [](int x, int y) { return x * y; }
-  };
-  CAF_CHECK_EQUAL(res_of(f, m1), 2);
-  CAF_CHECK_EQUAL(res_of(f, m2), 2);
-  CAF_CHECK_EQUAL(res_of(f, m3), none);
+  behavior f{[](int x) { return x + 1; }, [](int x, int y) { return x * y; }};
+  CHECK_EQ(res_of(f, m1), 2);
+  CHECK_EQ(res_of(f, m2), 2);
+  CHECK_EQ(res_of(f, m3), none);
 }
 
 CAF_TEST(become_empty_behavior) {
   actor_system_config cfg{};
   actor_system sys{cfg};
   auto make_bhvr = [](event_based_actor* self) -> behavior {
-    return {
-      [=](int) { self->become(behavior{}); }
-    };
+    return {[=](int) { self->become(behavior{}); }};
   };
   anon_send(sys.spawn(make_bhvr), int{5});
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/binary_deserializer.cpp
+++ b/libcaf_core/test/binary_deserializer.cpp
@@ -60,16 +60,13 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(binary_deserializer_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 #define SUBTEST(msg)                                                           \
-  CAF_MESSAGE(msg);                                                            \
-  for (int subtest_dummy = 0; subtest_dummy < 1; ++subtest_dummy)
+  MESSAGE(msg);                                                                \
+  if (true)
 
-#define CHECK_EQ(lhs, rhs) CAF_CHECK_EQUAL(lhs, rhs)
-
-#define CHECK_LOAD(type, value, ...)                                           \
-  CAF_CHECK_EQUAL(load<type>({__VA_ARGS__}), value)
+#define CHECK_LOAD(type, value, ...) CHECK_EQ(load<type>({__VA_ARGS__}), value)
 
 CAF_TEST(binary deserializer handles all primitive types) {
   SUBTEST("8-bit integers") {
@@ -112,8 +109,8 @@ CAF_TEST(concatenation) {
     int8_t x = 0;
     int16_t y = 0;
     load(byte_buffer({7_b, 0x80_b, 0x55_b}), x, y);
-    CAF_CHECK_EQUAL(x, 7);
-    CAF_CHECK_EQUAL(y, -32683);
+    CHECK_EQ(x, 7);
+    CHECK_EQ(y, -32683);
     load(byte_buffer({0x80_b, 0x55_b, 7_b}), y, x);
     load(byte_buffer({7_b, 0x80_b, 0x55_b}), x, y);
   }
@@ -136,9 +133,9 @@ CAF_TEST(concatenation) {
   SUBTEST("arrays behave like tuples") {
     arr xs{{0, 0, 0}};
     load(byte_buffer({1_b, 2_b, 3_b}), xs);
-    CAF_CHECK_EQUAL(xs[0], 1);
-    CAF_CHECK_EQUAL(xs[1], 2);
-    CAF_CHECK_EQUAL(xs[2], 3);
+    CHECK_EQ(xs[0], 1);
+    CHECK_EQ(xs[1], 2);
+    CHECK_EQ(xs[2], 3);
   }
 }
 
@@ -166,14 +163,14 @@ CAF_TEST(binary serializer picks up inspect functions) {
                10_b, 11_b, 12_b, 13_b, 14_b, 15_b, 16_b, 17_b, 18_b, 19_b);
   }
   SUBTEST("custom struct") {
-    test_data value{
-      -345,
-      -1234567890123456789ll,
-      3.45,
-      54.3,
-      caf::timestamp{caf::timestamp::duration{1478715821 * 1000000000ll}},
-      test_enum::b,
-      "Lorem ipsum dolor sit amet."};
+    test_data value{-345,
+                    -1234567890123456789ll,
+                    3.45,
+                    54.3,
+                    caf::timestamp{
+                      caf::timestamp::duration{1478715821 * 1000000000ll}},
+                    test_enum::b,
+                    "Lorem ipsum dolor sit amet."};
     CHECK_LOAD(test_data, value,
                // 32-bit i32_ member: -345
                0xFF_b, 0xFF_b, 0xFE_b, 0xA7_b,
@@ -199,4 +196,4 @@ CAF_TEST(binary serializer picks up inspect functions) {
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/binary_serializer.cpp
+++ b/libcaf_core/test/binary_serializer.cpp
@@ -59,14 +59,14 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(binary_serializer_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 #define SUBTEST(msg)                                                           \
-  CAF_MESSAGE(msg);                                                            \
-  for (int subtest_dummy = 0; subtest_dummy < 1; ++subtest_dummy)
+  MESSAGE(msg);                                                                \
+  if (true)
 
 #define CHECK_SAVE(type, value, ...)                                           \
-  CAF_CHECK_EQUAL(save(type{value}), byte_buffer({__VA_ARGS__}))
+  CHECK_EQ(save(type{value}), byte_buffer({__VA_ARGS__}))
 
 CAF_TEST(primitive types) {
   SUBTEST("8-bit integers") {
@@ -106,17 +106,17 @@ CAF_TEST(primitive types) {
 
 CAF_TEST(concatenation) {
   SUBTEST("calling f(a, b) writes a and b into the buffer in order") {
-    CAF_CHECK_EQUAL(save(int8_t{7}, int16_t{-32683}),
-                    byte_buffer({7_b, 0x80_b, 0x55_b}));
-    CAF_CHECK_EQUAL(save(int16_t{-32683}, int8_t{7}),
-                    byte_buffer({0x80_b, 0x55_b, 7_b}));
+    CHECK_EQ(save(int8_t{7}, int16_t{-32683}),
+             byte_buffer({7_b, 0x80_b, 0x55_b}));
+    CHECK_EQ(save(int16_t{-32683}, int8_t{7}),
+             byte_buffer({0x80_b, 0x55_b, 7_b}));
   }
   SUBTEST("calling f(a) and then f(b) is equal to calling f(a, b)") {
     byte_buffer data;
     binary_serializer sink{nullptr, data};
     save_to_buf(data, int8_t{7});
     save_to_buf(data, int16_t{-32683});
-    CAF_CHECK_EQUAL(data, byte_buffer({7_b, 0x80_b, 0x55_b}));
+    CHECK_EQ(data, byte_buffer({7_b, 0x80_b, 0x55_b}));
   }
   SUBTEST("calling f(make_pair(a, b)) is equal to calling f(a, b)") {
     using i8i16_pair = std::pair<int8_t, int16_t>;
@@ -136,7 +136,7 @@ CAF_TEST(concatenation) {
   }
   SUBTEST("arrays behave like tuples") {
     arr xs{{1, 2, 3}};
-    CAF_CHECK_EQUAL(save(xs), byte_buffer({1_b, 2_b, 3_b}));
+    CHECK_EQ(save(xs), byte_buffer({1_b, 2_b, 3_b}));
   }
 }
 
@@ -165,13 +165,8 @@ CAF_TEST(binary serializer picks up inspect functions) {
   }
   SUBTEST("custom struct") {
     caf::timestamp ts{caf::timestamp::duration{1478715821 * 1000000000ll}};
-    test_data value{-345,
-                    -1234567890123456789ll,
-                    3.45,
-                    54.3,
-                    ts,
-                    test_enum::b,
-                    "Lorem ipsum dolor sit amet."};
+    test_data value{-345,         -1234567890123456789ll,       3.45, 54.3, ts,
+                    test_enum::b, "Lorem ipsum dolor sit amet."};
     CHECK_SAVE(test_data, value,
                // 32-bit i32_ member: -345
                0xFF_b, 0xFF_b, 0xFE_b, 0xA7_b,
@@ -197,4 +192,4 @@ CAF_TEST(binary serializer picks up inspect functions) {
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/blocking_actor.cpp
+++ b/libcaf_core/test/blocking_actor.cpp
@@ -24,28 +24,21 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(blocking_actor_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(catch_all) {
   self->send(self, 42);
   self->receive([](float) { CAF_FAIL("received unexpected float"); },
                 others >> [](message& msg) -> skippable_result {
-                  CAF_CHECK_EQUAL(to_tuple<int32_t>(msg), std::make_tuple(42));
+                  CHECK_EQ(to_tuple<int32_t>(msg), std::make_tuple(42));
                   return make_error(sec::unexpected_message);
                 });
   self->receive(
-    [](const error& err) {
-      CAF_CHECK_EQUAL(err, sec::unexpected_message);
-    }
-  );
+    [](const error& err) { CHECK_EQ(err, sec::unexpected_message); });
 }
 
 CAF_TEST(behavior_ref) {
-  behavior bhvr{
-    [](int i) {
-      CAF_CHECK_EQUAL(i, 42);
-    }
-  };
+  behavior bhvr{[](int i) { CHECK_EQ(i, 42); }};
   self->send(self, 42);
   self->receive(bhvr);
 }
@@ -53,12 +46,9 @@ CAF_TEST(behavior_ref) {
 CAF_TEST(timeout_in_scoped_actor) {
   bool timeout_called = false;
   scoped_actor self{system};
-  self->receive(
-    after(std::chrono::milliseconds(20)) >> [&] {
-      timeout_called = true;
-    }
-  );
-  CAF_CHECK(timeout_called);
+  self->receive(after(std::chrono::milliseconds(20)) >>
+                [&] { timeout_called = true; });
+  CHECK(timeout_called);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/broadcast_downstream_manager.cpp
+++ b/libcaf_core/test/broadcast_downstream_manager.cpp
@@ -60,10 +60,7 @@ public:
   using behavior_type = behavior;
 
   entity(actor_config& cfg, const char* cstr)
-      : super(cfg),
-        cstr_name(cstr),
-        mgr(this),
-        next_slot(1) {
+    : super(cfg), cstr_name(cstr), mgr(this), next_slot(1) {
     // nop
   }
 
@@ -108,9 +105,7 @@ public:
   }
 
   size_t credit_for(entity& x) {
-    auto pred = [&](outbound_path* ptr) {
-      return ptr->hdl == &x;
-    };
+    auto pred = [&](outbound_path* ptr) { return ptr->hdl == &x; };
     auto i = std::find_if(paths.begin(), paths.end(), pred);
     CAF_REQUIRE(i != paths.end());
     return static_cast<size_t>((*i)->open_credit);
@@ -181,13 +176,13 @@ struct fixture {
   }
 
   fixture()
-      : sys(cfg),
-        alice_hdl(spawn(sys, 0, "alice")),
-        bob_hdl(spawn(sys, 1, "bob")),
-        carl_hdl(spawn(sys, 2, "carl")),
-        alice(fetch(alice_hdl)),
-        bob(fetch(bob_hdl)),
-        carl(fetch(carl_hdl)) {
+    : sys(cfg),
+      alice_hdl(spawn(sys, 0, "alice")),
+      bob_hdl(spawn(sys, 1, "bob")),
+      carl_hdl(spawn(sys, 2, "carl")),
+      alice(fetch(alice_hdl)),
+      bob(fetch(bob_hdl)),
+      carl(fetch(carl_hdl)) {
     // nop
   }
 
@@ -226,10 +221,10 @@ struct receive_checker {
   }
 
   receive_checker(receive_checker&& x)
-      : f(x.f),
-        xs(std::move(x.xs)),
-        moved_from(false),
-        check_not_empty(x.check_not_empty) {
+    : f(x.f),
+      xs(std::move(x.xs)),
+      moved_from(false),
+      check_not_empty(x.check_not_empty) {
     x.moved_from = true;
   }
 
@@ -278,16 +273,18 @@ receive_checker<F> operator<<(receive_checker<F> xs, not_empty_t) {
   ;                                                                            \
   make_receive_checker([&](fixture::batches_type& xs, bool check_not_empty) {  \
     if (!check_not_empty)                                                      \
-      CAF_CHECK_EQUAL(batches(CONCAT(who, __LINE__)), xs);                     \
+      CHECK_EQ(batches(CONCAT(who, __LINE__)), xs);                            \
     else                                                                       \
-      CAF_CHECK(!batches(CONCAT(who, __LINE__)).empty());                      \
+      CHECK(!batches(CONCAT(who, __LINE__)).empty());                          \
   }) <<
 
 #define ENTITY auto& CONCAT(who, __LINE__) =
 
 #define AFTER
 
-#define HAS ; size_t CONCAT(amount, __LINE__) =
+#define HAS                                                                    \
+  ;                                                                            \
+  size_t CONCAT(amount, __LINE__) =
 
 #define CREDIT ;
 
@@ -305,16 +302,15 @@ receive_checker<F> operator<<(receive_checker<F> xs, not_empty_t) {
   ;                                                                            \
   CONCAT(who, __LINE__)                                                        \
     .new_round(CONCAT(amount, __LINE__), CONCAT(force, __LINE__));             \
-  CAF_MESSAGE(CONCAT(who, __LINE__).name()                                     \
-              << " tried sending " << CONCAT(amount, __LINE__)                 \
-              << " elements");
+  MESSAGE(CONCAT(who, __LINE__).name()                                         \
+          << " tried sending " << CONCAT(amount, __LINE__) << " elements");
 
 #define FOR                                                                    \
   struct CONCAT(for_helper_, __LINE__) {                                       \
     entity& who;                                                               \
     size_t amount;                                                             \
     void operator<<(entity& x) const {                                         \
-      CAF_CHECK_EQUAL(who.credit_for(x), amount);                              \
+      CHECK_EQ(who.credit_for(x), amount);                                     \
     }                                                                          \
   };                                                                           \
   CONCAT(for_helper_, __LINE__){CONCAT(who, __LINE__),                         \
@@ -322,8 +318,8 @@ receive_checker<F> operator<<(receive_checker<F> xs, not_empty_t) {
     <<
 
 #define TOTAL                                                                  \
-  CAF_CHECK_EQUAL(CONCAT(who, __LINE__).mgr.out().total_credit(),              \
-                  CONCAT(amount, __LINE__))
+  CHECK_EQ(CONCAT(who, __LINE__).mgr.out().total_credit(),                     \
+           CONCAT(amount, __LINE__))
 
 #define BATCH(first, last) make_batch(first, last)
 
@@ -331,7 +327,7 @@ receive_checker<F> operator<<(receive_checker<F> xs, not_empty_t) {
 
 // -- unit tests ---------------------------------------------------------------
 
-CAF_TEST_FIXTURE_SCOPE(broadcast_downstream_manager, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(one_path_force) {
   // Give alice 100 elements to send and a path to bob with desired batch size
@@ -503,4 +499,4 @@ CAF_TEST(two_paths_different_sizes_without_force) {
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/byte.cpp
+++ b/libcaf_core/test/byte.cpp
@@ -46,61 +46,61 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(byte_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(to integer) {
-  CAF_CHECK_EQUAL(to_integer<int>("0110'1001"_b), 0x69);
+  CHECK_EQ(to_integer<int>("0110'1001"_b), 0x69);
 }
 
 CAF_TEST(left shift) {
   auto x = "0000'0001"_b;
   x <<= 1;
-  CAF_CHECK_EQUAL(x, "0000'0010"_b);
-  CAF_CHECK_EQUAL("0000'0010"_b << 1, "0000'0100"_b);
-  CAF_CHECK_EQUAL("0000'0010"_b << 2, "0000'1000"_b);
-  CAF_CHECK_EQUAL("0000'0010"_b << 3, "0001'0000"_b);
-  CAF_CHECK_EQUAL("0000'0010"_b << 4, "0010'0000"_b);
-  CAF_CHECK_EQUAL("0000'0010"_b << 5, "0100'0000"_b);
-  CAF_CHECK_EQUAL("0000'0010"_b << 6, "1000'0000"_b);
-  CAF_CHECK_EQUAL("0000'0010"_b << 7, "0000'0000"_b);
+  CHECK_EQ(x, "0000'0010"_b);
+  CHECK_EQ("0000'0010"_b << 1, "0000'0100"_b);
+  CHECK_EQ("0000'0010"_b << 2, "0000'1000"_b);
+  CHECK_EQ("0000'0010"_b << 3, "0001'0000"_b);
+  CHECK_EQ("0000'0010"_b << 4, "0010'0000"_b);
+  CHECK_EQ("0000'0010"_b << 5, "0100'0000"_b);
+  CHECK_EQ("0000'0010"_b << 6, "1000'0000"_b);
+  CHECK_EQ("0000'0010"_b << 7, "0000'0000"_b);
 }
 
 CAF_TEST(right shift) {
   auto x = "0100'0000"_b;
   x >>= 1;
-  CAF_CHECK_EQUAL(x, "0010'0000"_b);
-  CAF_CHECK_EQUAL("0100'0000"_b >> 1, "0010'0000"_b);
-  CAF_CHECK_EQUAL("0100'0000"_b >> 2, "0001'0000"_b);
-  CAF_CHECK_EQUAL("0100'0000"_b >> 3, "0000'1000"_b);
-  CAF_CHECK_EQUAL("0100'0000"_b >> 4, "0000'0100"_b);
-  CAF_CHECK_EQUAL("0100'0000"_b >> 5, "0000'0010"_b);
-  CAF_CHECK_EQUAL("0100'0000"_b >> 6, "0000'0001"_b);
-  CAF_CHECK_EQUAL("0100'0000"_b >> 7, "0000'0000"_b);
+  CHECK_EQ(x, "0010'0000"_b);
+  CHECK_EQ("0100'0000"_b >> 1, "0010'0000"_b);
+  CHECK_EQ("0100'0000"_b >> 2, "0001'0000"_b);
+  CHECK_EQ("0100'0000"_b >> 3, "0000'1000"_b);
+  CHECK_EQ("0100'0000"_b >> 4, "0000'0100"_b);
+  CHECK_EQ("0100'0000"_b >> 5, "0000'0010"_b);
+  CHECK_EQ("0100'0000"_b >> 6, "0000'0001"_b);
+  CHECK_EQ("0100'0000"_b >> 7, "0000'0000"_b);
 }
 
 CAF_TEST(bitwise or) {
   auto x = "0001'1110"_b;
   x |= "0111'1000"_b;
-  CAF_CHECK_EQUAL(x, "0111'1110"_b);
-  CAF_CHECK_EQUAL("0001'1110"_b | "0111'1000"_b, "0111'1110"_b);
+  CHECK_EQ(x, "0111'1110"_b);
+  CHECK_EQ("0001'1110"_b | "0111'1000"_b, "0111'1110"_b);
 }
 
 CAF_TEST(bitwise and) {
   auto x = "0001'1110"_b;
   x &= "0111'1000"_b;
-  CAF_CHECK_EQUAL(x, "0001'1000"_b);
-  CAF_CHECK_EQUAL("0001'1110"_b & "0111'1000"_b, "0001'1000"_b);
+  CHECK_EQ(x, "0001'1000"_b);
+  CHECK_EQ("0001'1110"_b & "0111'1000"_b, "0001'1000"_b);
 }
 
 CAF_TEST(bitwise xor) {
   auto x = "0001'1110"_b;
   x ^= "0111'1000"_b;
-  CAF_CHECK_EQUAL(x, "0110'0110"_b);
-  CAF_CHECK_EQUAL("0001'1110"_b ^ "0111'1000"_b, "0110'0110"_b);
+  CHECK_EQ(x, "0110'0110"_b);
+  CHECK_EQ("0001'1110"_b ^ "0111'1000"_b, "0110'0110"_b);
 }
 
-CAF_TEST(bitwise not) {
-  CAF_CHECK_EQUAL(~"0111'1110"_b, "1000'0001"_b);
+CAF_TEST(bitwise not ) {
+  CHECK_EQ(~"0111'1110"_b, "1000'0001"_b);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/composition.cpp
+++ b/libcaf_core/test/composition.cpp
@@ -13,40 +13,24 @@ using namespace caf;
 namespace {
 
 behavior multiplier(int x) {
-  return {
-    [=](int y) {
-      return x * y;
-    },
-    [=](int y1, int y2) {
-      return x * y1 * y2;
-    }
-  };
+  return {[=](int y) { return x * y; },
+          [=](int y1, int y2) { return x * y1 * y2; }};
 }
 
 behavior adder(int x) {
-  return {
-    [=](int y) {
-      return x + y;
-    },
-    [=](int y1, int y2) {
-      return x + y1 + y2;
-    }
-  };
+  return {[=](int y) { return x + y; },
+          [=](int y1, int y2) { return x + y1 + y2; }};
 }
 
 behavior float_adder(float x) {
-  return {
-    [=](float y) {
-      return x + y;
-    }
-  };
+  return {[=](float y) { return x + y; }};
 }
 
 using fixture = test_coordinator_fixture<>;
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(composition_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(depth2) {
   auto stage1 = sys.spawn(multiplier, 4);
@@ -79,4 +63,4 @@ CAF_TEST(depth2_type_mismatch) {
   expect((error), from(stage2).to(self).with(sec::unexpected_message));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/config_option.cpp
+++ b/libcaf_core/test/config_option.cpp
@@ -10,9 +10,9 @@
 
 #include <sstream>
 
-#include "caf/make_config_option.hpp"
 #include "caf/config_value.hpp"
 #include "caf/expected.hpp"
+#include "caf/make_config_option.hpp"
 
 using namespace caf;
 
@@ -173,12 +173,12 @@ constexpr string_view category = "category";
 constexpr string_view name = "name";
 constexpr string_view explanation = "explanation";
 
-template<class T>
+template <class T>
 constexpr int64_t overflow() {
   return static_cast<int64_t>(std::numeric_limits<T>::max()) + 1;
 }
 
-template<class T>
+template <class T>
 constexpr int64_t underflow() {
   return static_cast<int64_t>(std::numeric_limits<T>::min()) - 1;
 }
@@ -201,9 +201,9 @@ void check_integer_options(std::true_type) {
   // Run tests for positive integers.
   T xzero = 0;
   T xmax = std::numeric_limits<T>::max();
-  CAF_CHECK_EQUAL(read<T>(to_string(xzero)), xzero);
-  CAF_CHECK_EQUAL(read<T>(to_string(xmax)), xmax);
-  CAF_CHECK_EQUAL(read<T>(to_string(overflow<T>())), none);
+  CHECK_EQ(read<T>(to_string(xzero)), xzero);
+  CHECK_EQ(read<T>(to_string(xmax)), xmax);
+  CHECK_EQ(read<T>(to_string(overflow<T>())), none);
 }
 
 // Signed integers.
@@ -215,8 +215,8 @@ void check_integer_options(std::false_type) {
   check_integer_options<T>(tk);
   // Run tests for negative integers.
   auto xmin = std::numeric_limits<T>::min();
-  CAF_CHECK_EQUAL(read<T>(to_string(xmin)), xmin);
-  CAF_CHECK_EQUAL(read<T>(to_string(underflow<T>())), none);
+  CHECK_EQ(read<T>(to_string(xmin)), xmin);
+  CHECK_EQ(read<T>(to_string(underflow<T>())), none);
 }
 
 // only works with an integral types and double
@@ -227,11 +227,11 @@ void check_integer_options() {
 }
 
 void compare(const config_option& lhs, const config_option& rhs) {
-  CAF_CHECK_EQUAL(lhs.category(), rhs.category());
-  CAF_CHECK_EQUAL(lhs.long_name(), rhs.long_name());
-  CAF_CHECK_EQUAL(lhs.short_names(), rhs.short_names());
-  CAF_CHECK_EQUAL(lhs.description(), rhs.description());
-  CAF_CHECK_EQUAL(lhs.full_name(), rhs.full_name());
+  CHECK_EQ(lhs.category(), rhs.category());
+  CHECK_EQ(lhs.long_name(), rhs.long_name());
+  CHECK_EQ(lhs.short_names(), rhs.short_names());
+  CHECK_EQ(lhs.description(), rhs.description());
+  CHECK_EQ(lhs.full_name(), rhs.full_name());
 }
 
 CAF_TEST(copy constructor) {
@@ -248,10 +248,10 @@ CAF_TEST(copy assignment) {
 }
 
 CAF_TEST(type_bool) {
-  CAF_CHECK_EQUAL(read<bool>("true"), true);
-  CAF_CHECK_EQUAL(read<bool>("false"), false);
-  CAF_CHECK_EQUAL(read<bool>("0"), none);
-  CAF_CHECK_EQUAL(read<bool>("1"), none);
+  CHECK_EQ(read<bool>("true"), true);
+  CHECK_EQ(read<bool>("false"), false);
+  CHECK_EQ(read<bool>("0"), none);
+  CHECK_EQ(read<bool>("1"), none);
 }
 
 CAF_TEST(type int8_t) {
@@ -279,74 +279,74 @@ CAF_TEST(type uint32_t) {
 }
 
 CAF_TEST(type uint64_t) {
-  CAF_CHECK_EQUAL(unbox(read<uint64_t>("0")), 0u);
-  CAF_CHECK_EQUAL(read<uint64_t>("-1"), none);
+  CHECK_EQ(unbox(read<uint64_t>("0")), 0u);
+  CHECK_EQ(read<uint64_t>("-1"), none);
 }
 
 CAF_TEST(type int64_t) {
-  CAF_CHECK_EQUAL(unbox(read<int64_t>("-1")), -1);
-  CAF_CHECK_EQUAL(unbox(read<int64_t>("0")),  0);
-  CAF_CHECK_EQUAL(unbox(read<int64_t>("1")),  1);
+  CHECK_EQ(unbox(read<int64_t>("-1")), -1);
+  CHECK_EQ(unbox(read<int64_t>("0")), 0);
+  CHECK_EQ(unbox(read<int64_t>("1")), 1);
 }
 
 CAF_TEST(type float) {
-  CAF_CHECK_EQUAL(unbox(read<float>("-1.0")),  -1.0f);
-  CAF_CHECK_EQUAL(unbox(read<float>("-0.1")), -0.1f);
-  CAF_CHECK_EQUAL(read<float>("0"), 0.f);
-  CAF_CHECK_EQUAL(read<float>("\"0.1\""),  none);
+  CHECK_EQ(unbox(read<float>("-1.0")), -1.0f);
+  CHECK_EQ(unbox(read<float>("-0.1")), -0.1f);
+  CHECK_EQ(read<float>("0"), 0.f);
+  CHECK_EQ(read<float>("\"0.1\""), none);
 }
 
 CAF_TEST(type double) {
-  CAF_CHECK_EQUAL(unbox(read<double>("-1.0")),  -1.0);
-  CAF_CHECK_EQUAL(unbox(read<double>("-0.1")),  -0.1);
-  CAF_CHECK_EQUAL(read<double>("0"), 0.);
-  CAF_CHECK_EQUAL(read<double>("\"0.1\""), none);
+  CHECK_EQ(unbox(read<double>("-1.0")), -1.0);
+  CHECK_EQ(unbox(read<double>("-0.1")), -0.1);
+  CHECK_EQ(read<double>("0"), 0.);
+  CHECK_EQ(read<double>("\"0.1\""), none);
 }
 
 CAF_TEST(type string) {
-  CAF_CHECK_EQUAL(unbox(read<string>("foo")), "foo");
-  CAF_CHECK_EQUAL(unbox(read<string>(R"_("foo")_")), R"_("foo")_");
+  CHECK_EQ(unbox(read<string>("foo")), "foo");
+  CHECK_EQ(unbox(read<string>(R"_("foo")_")), R"_("foo")_");
 }
 
 CAF_TEST(type timespan) {
   timespan dur{500};
-  CAF_CHECK_EQUAL(read<timespan>("500ns"), dur);
+  CHECK_EQ(read<timespan>("500ns"), dur);
 }
 
 CAF_TEST(lists) {
   using int_list = std::vector<int>;
-  CAF_CHECK_EQUAL(read<int_list>("[]"), int_list({}));
-  CAF_CHECK_EQUAL(read<int_list>("1, 2, 3"), int_list({1, 2, 3}));
-  CAF_CHECK_EQUAL(read<int_list>("[1, 2, 3]"), int_list({1, 2, 3}));
+  CHECK_EQ(read<int_list>("[]"), int_list({}));
+  CHECK_EQ(read<int_list>("1, 2, 3"), int_list({1, 2, 3}));
+  CHECK_EQ(read<int_list>("[1, 2, 3]"), int_list({1, 2, 3}));
 }
 
 CAF_TEST(flat CLI parsing) {
   auto x = make_config_option<std::string>("?foo", "bar,b", "test option");
-  CAF_CHECK_EQUAL(x.category(), "foo");
-  CAF_CHECK_EQUAL(x.long_name(), "bar");
-  CAF_CHECK_EQUAL(x.short_names(), "b");
-  CAF_CHECK_EQUAL(x.full_name(), "foo.bar");
-  CAF_CHECK_EQUAL(x.has_flat_cli_name(), true);
+  CHECK_EQ(x.category(), "foo");
+  CHECK_EQ(x.long_name(), "bar");
+  CHECK_EQ(x.short_names(), "b");
+  CHECK_EQ(x.full_name(), "foo.bar");
+  CHECK_EQ(x.has_flat_cli_name(), true);
 }
 
 CAF_TEST(flat CLI parsing with nested categories) {
   auto x = make_config_option<std::string>("?foo.goo", "bar,b", "test option");
-  CAF_CHECK_EQUAL(x.category(), "foo.goo");
-  CAF_CHECK_EQUAL(x.long_name(), "bar");
-  CAF_CHECK_EQUAL(x.short_names(), "b");
-  CAF_CHECK_EQUAL(x.full_name(), "foo.goo.bar");
-  CAF_CHECK_EQUAL(x.has_flat_cli_name(), true);
+  CHECK_EQ(x.category(), "foo.goo");
+  CHECK_EQ(x.long_name(), "bar");
+  CHECK_EQ(x.short_names(), "b");
+  CHECK_EQ(x.full_name(), "foo.goo.bar");
+  CHECK_EQ(x.has_flat_cli_name(), true);
 }
 
 CAF_TEST(find by long opt) {
   auto needle = make_config_option<std::string>("?foo", "bar,b", "test option");
   auto check = [&](std::vector<string> args, bool found_opt, bool has_opt) {
     auto res = find_by_long_name(needle, std::begin(args), std::end(args));
-    CAF_CHECK_EQUAL(res.first != std::end(args), found_opt);
+    CHECK_EQ(res.first != std::end(args), found_opt);
     if (has_opt)
-      CAF_CHECK_EQUAL(res.second, "val2");
+      CHECK_EQ(res.second, "val2");
     else
-      CAF_CHECK(res.second.empty());
+      CHECK(res.second.empty());
   };
   // Well formed, find val2.
   check({"--foo=val1", "--bar=val2", "--baz=val3"}, true, true);

--- a/libcaf_core/test/config_option_set.cpp
+++ b/libcaf_core/test/config_option_set.cpp
@@ -51,23 +51,23 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(config_option_set_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(lookup) {
   opts.add<int>("opt1,1", "test option 1")
     .add<float>("test", "opt2,2", "test option 2")
     .add<bool>("test", "flag,fl3", "test flag");
-  CAF_CHECK_EQUAL(opts.size(), 3u);
-  CAF_MESSAGE("lookup by long name");
-  CAF_CHECK_NOT_EQUAL(opts.cli_long_name_lookup("opt1"), nullptr);
-  CAF_CHECK_NOT_EQUAL(opts.cli_long_name_lookup("test.opt2"), nullptr);
-  CAF_CHECK_NOT_EQUAL(opts.cli_long_name_lookup("test.flag"), nullptr);
-  CAF_MESSAGE("lookup by short name");
-  CAF_CHECK_NOT_EQUAL(opts.cli_short_name_lookup('1'), nullptr);
-  CAF_CHECK_NOT_EQUAL(opts.cli_short_name_lookup('2'), nullptr);
-  CAF_CHECK_NOT_EQUAL(opts.cli_short_name_lookup('f'), nullptr);
-  CAF_CHECK_NOT_EQUAL(opts.cli_short_name_lookup('l'), nullptr);
-  CAF_CHECK_NOT_EQUAL(opts.cli_short_name_lookup('3'), nullptr);
+  CHECK_EQ(opts.size(), 3u);
+  MESSAGE("lookup by long name");
+  CHECK_NE(opts.cli_long_name_lookup("opt1"), nullptr);
+  CHECK_NE(opts.cli_long_name_lookup("test.opt2"), nullptr);
+  CHECK_NE(opts.cli_long_name_lookup("test.flag"), nullptr);
+  MESSAGE("lookup by short name");
+  CHECK_NE(opts.cli_short_name_lookup('1'), nullptr);
+  CHECK_NE(opts.cli_short_name_lookup('2'), nullptr);
+  CHECK_NE(opts.cli_short_name_lookup('f'), nullptr);
+  CHECK_NE(opts.cli_short_name_lookup('l'), nullptr);
+  CHECK_NE(opts.cli_short_name_lookup('3'), nullptr);
 }
 
 CAF_TEST(parse with ref syncing) {
@@ -94,68 +94,68 @@ CAF_TEST(parse with ref syncing) {
                       "-d",
                       "{a=\"a\",b=\"b\"}",
                       "-b"};
-  CAF_MESSAGE("parse arguments");
+  MESSAGE("parse arguments");
   auto res = opts.parse(cfg, args);
-  CAF_CHECK_EQUAL(res.first, pec::success);
+  CHECK_EQ(res.first, pec::success);
   if (res.second != args.end())
     CAF_FAIL("parser stopped at: " << *res.second);
-  CAF_MESSAGE("verify referenced values");
-  CAF_CHECK_EQUAL(foo_i, 42);
-  CAF_CHECK_EQUAL(foo_f, 1e2);
-  CAF_CHECK_EQUAL(foo_b, true);
-  CAF_CHECK_EQUAL(bar_s, "hello");
-  CAF_CHECK_EQUAL(bar_l, ls({"hello", "world"}));
-  CAF_CHECK_EQUAL(bar_d, ds({{"a", "a"}, {"b", "b"}}));
-  CAF_MESSAGE("verify dictionary content");
-  CAF_CHECK_EQUAL(get_as<int>(cfg, "foo.i"), 42);
+  MESSAGE("verify referenced values");
+  CHECK_EQ(foo_i, 42);
+  CHECK_EQ(foo_f, 1e2);
+  CHECK_EQ(foo_b, true);
+  CHECK_EQ(bar_s, "hello");
+  CHECK_EQ(bar_l, ls({"hello", "world"}));
+  CHECK_EQ(bar_d, ds({{"a", "a"}, {"b", "b"}}));
+  MESSAGE("verify dictionary content");
+  CHECK_EQ(get_as<int>(cfg, "foo.i"), 42);
 }
 
 CAF_TEST(string parameters) {
   opts.add<std::string>("value,v", "some value");
-  CAF_CHECK_EQUAL(read<std::string>({"--value=foobar"}), "foobar");
-  CAF_CHECK_EQUAL(read<std::string>({"-v", "foobar"}), "foobar");
-  CAF_CHECK_EQUAL(read<std::string>({"-vfoobar"}), "foobar");
+  CHECK_EQ(read<std::string>({"--value=foobar"}), "foobar");
+  CHECK_EQ(read<std::string>({"-v", "foobar"}), "foobar");
+  CHECK_EQ(read<std::string>({"-vfoobar"}), "foobar");
 }
 
 CAF_TEST(flat CLI options) {
   key = "foo.bar";
   opts.add<std::string>("?foo", "bar,b", "some value");
-  CAF_CHECK(opts.begin()->has_flat_cli_name());
-  CAF_CHECK_EQUAL(read<std::string>({"-b", "foobar"}), "foobar");
-  CAF_CHECK_EQUAL(read<std::string>({"--bar=foobar"}), "foobar");
-  CAF_CHECK_EQUAL(read<std::string>({"--foo.bar=foobar"}), "foobar");
+  CHECK(opts.begin()->has_flat_cli_name());
+  CHECK_EQ(read<std::string>({"-b", "foobar"}), "foobar");
+  CHECK_EQ(read<std::string>({"--bar=foobar"}), "foobar");
+  CHECK_EQ(read<std::string>({"--foo.bar=foobar"}), "foobar");
 }
 
 CAF_TEST(flat CLI parsing with nested categories) {
   key = "foo.goo.bar";
   opts.add<std::string>("?foo.goo", "bar,b", "some value");
-  CAF_CHECK(opts.begin()->has_flat_cli_name());
-  CAF_CHECK_EQUAL(read<std::string>({"-b", "foobar"}), "foobar");
-  CAF_CHECK_EQUAL(read<std::string>({"--bar=foobar"}), "foobar");
-  CAF_CHECK_EQUAL(read<std::string>({"--foo.goo.bar=foobar"}), "foobar");
+  CHECK(opts.begin()->has_flat_cli_name());
+  CHECK_EQ(read<std::string>({"-b", "foobar"}), "foobar");
+  CHECK_EQ(read<std::string>({"--bar=foobar"}), "foobar");
+  CHECK_EQ(read<std::string>({"--foo.goo.bar=foobar"}), "foobar");
 }
 
 CAF_TEST(square brackets are optional on the command line) {
   using int_list = std::vector<int>;
   opts.add<int_list>("global", "value,v", "some list");
-  CAF_CHECK_EQUAL(read<int_list>({"--value=[1]"}), int_list({1}));
-  CAF_CHECK_EQUAL(read<int_list>({"--value=[1,]"}), int_list({1}));
-  CAF_CHECK_EQUAL(read<int_list>({"--value=[ 1 , ]"}), int_list({1}));
-  CAF_CHECK_EQUAL(read<int_list>({"--value=[1,2]"}), int_list({1, 2}));
-  CAF_CHECK_EQUAL(read<int_list>({"--value=[1, 2, 3]"}), int_list({1, 2, 3}));
-  CAF_CHECK_EQUAL(read<int_list>({"--value=[1, 2, 3, ]"}), int_list({1, 2, 3}));
-  CAF_CHECK_EQUAL(read<int_list>({"--value=1"}), int_list({1}));
-  CAF_CHECK_EQUAL(read<int_list>({"--value=1,2,3"}), int_list({1, 2, 3}));
-  CAF_CHECK_EQUAL(read<int_list>({"--value=1, 2 , 3 , "}), int_list({1, 2, 3}));
-  CAF_CHECK_EQUAL(read<int_list>({"-v", "[1]"}), int_list({1}));
-  CAF_CHECK_EQUAL(read<int_list>({"-v", "[1,]"}), int_list({1}));
-  CAF_CHECK_EQUAL(read<int_list>({"-v", "[ 1 , ]"}), int_list({1}));
-  CAF_CHECK_EQUAL(read<int_list>({"-v", "[1,2]"}), int_list({1, 2}));
-  CAF_CHECK_EQUAL(read<int_list>({"-v", "[1, 2, 3]"}), int_list({1, 2, 3}));
-  CAF_CHECK_EQUAL(read<int_list>({"-v", "[1, 2, 3, ]"}), int_list({1, 2, 3}));
-  CAF_CHECK_EQUAL(read<int_list>({"-v", "1"}), int_list({1}));
-  CAF_CHECK_EQUAL(read<int_list>({"-v", "1,2,3"}), int_list({1, 2, 3}));
-  CAF_CHECK_EQUAL(read<int_list>({"-v", "1, 2 , 3 , "}), int_list({1, 2, 3}));
+  CHECK_EQ(read<int_list>({"--value=[1]"}), int_list({1}));
+  CHECK_EQ(read<int_list>({"--value=[1,]"}), int_list({1}));
+  CHECK_EQ(read<int_list>({"--value=[ 1 , ]"}), int_list({1}));
+  CHECK_EQ(read<int_list>({"--value=[1,2]"}), int_list({1, 2}));
+  CHECK_EQ(read<int_list>({"--value=[1, 2, 3]"}), int_list({1, 2, 3}));
+  CHECK_EQ(read<int_list>({"--value=[1, 2, 3, ]"}), int_list({1, 2, 3}));
+  CHECK_EQ(read<int_list>({"--value=1"}), int_list({1}));
+  CHECK_EQ(read<int_list>({"--value=1,2,3"}), int_list({1, 2, 3}));
+  CHECK_EQ(read<int_list>({"--value=1, 2 , 3 , "}), int_list({1, 2, 3}));
+  CHECK_EQ(read<int_list>({"-v", "[1]"}), int_list({1}));
+  CHECK_EQ(read<int_list>({"-v", "[1,]"}), int_list({1}));
+  CHECK_EQ(read<int_list>({"-v", "[ 1 , ]"}), int_list({1}));
+  CHECK_EQ(read<int_list>({"-v", "[1,2]"}), int_list({1, 2}));
+  CHECK_EQ(read<int_list>({"-v", "[1, 2, 3]"}), int_list({1, 2, 3}));
+  CHECK_EQ(read<int_list>({"-v", "[1, 2, 3, ]"}), int_list({1, 2, 3}));
+  CHECK_EQ(read<int_list>({"-v", "1"}), int_list({1}));
+  CHECK_EQ(read<int_list>({"-v", "1,2,3"}), int_list({1, 2, 3}));
+  CHECK_EQ(read<int_list>({"-v", "1, 2 , 3 , "}), int_list({1, 2, 3}));
 }
 
 #define SUBTEST(msg)                                                           \
@@ -169,54 +169,50 @@ CAF_TEST(CLI arguments override defaults) {
     settings cfg;
     int_list ints;
     string_list strings;
-    CAF_MESSAGE("add --foo and --bar options");
+    MESSAGE("add --foo and --bar options");
     opts.add(strings, "global", "foo,f", "some list");
     opts.add(ints, "global", "bar,b", "some list");
-    CAF_MESSAGE("test integer lists");
+    MESSAGE("test integer lists");
     ints = int_list{1, 2, 3};
     cfg["bar"] = config_value{ints};
-    CAF_CHECK_EQUAL(get_as<int_list>(cfg, "bar"), int_list({1, 2, 3}));
-    CAF_CHECK_EQUAL(read<int_list>(cfg, {"--bar=[10, 20, 30]"}), none);
-    CAF_CHECK_EQUAL(ints, int_list({10, 20, 30}));
-    CAF_CHECK_EQUAL(get_as<int_list>(cfg, "bar"), int_list({10, 20, 30}));
-    CAF_MESSAGE("test string lists");
+    CHECK_EQ(get_as<int_list>(cfg, "bar"), int_list({1, 2, 3}));
+    CHECK_EQ(read<int_list>(cfg, {"--bar=[10, 20, 30]"}), none);
+    CHECK_EQ(ints, int_list({10, 20, 30}));
+    CHECK_EQ(get_as<int_list>(cfg, "bar"), int_list({10, 20, 30}));
+    MESSAGE("test string lists");
     strings = string_list{"one", "two", "three"};
     cfg["foo"] = config_value{strings};
-    CAF_CHECK_EQUAL(get_as<string_list>(cfg, "foo"),
-                    string_list({"one", "two", "three"}));
-    CAF_CHECK_EQUAL(read<string_list>(cfg, {R"_(--foo=["hello", "world"])_"}),
-                    none);
-    CAF_CHECK_EQUAL(strings, string_list({"hello", "world"}));
-    CAF_CHECK_EQUAL(get_as<string_list>(cfg, "foo"),
-                    string_list({"hello", "world"}));
+    CHECK_EQ(get_as<string_list>(cfg, "foo"),
+             string_list({"one", "two", "three"}));
+    CHECK_EQ(read<string_list>(cfg, {R"_(--foo=["hello", "world"])_"}), none);
+    CHECK_EQ(strings, string_list({"hello", "world"}));
+    CHECK_EQ(get_as<string_list>(cfg, "foo"), string_list({"hello", "world"}));
   }
   SUBTEST("without ref syncing") {
     settings cfg;
-    CAF_MESSAGE("add --foo and --bar options");
+    MESSAGE("add --foo and --bar options");
     opts.add<string_list>("global", "foo,f", "some list");
     opts.add<int_list>("global", "bar,b", "some list");
-    CAF_MESSAGE("test integer lists");
+    MESSAGE("test integer lists");
     cfg["bar"] = config_value{int_list{1, 2, 3}};
-    CAF_CHECK_EQUAL(get_as<int_list>(cfg, "bar"), int_list({1, 2, 3}));
-    CAF_CHECK_EQUAL(read<int_list>(cfg, {"--bar=[10, 20, 30]"}), none);
-    CAF_CHECK_EQUAL(get_as<int_list>(cfg, "bar"), int_list({10, 20, 30}));
-    CAF_MESSAGE("test string lists");
+    CHECK_EQ(get_as<int_list>(cfg, "bar"), int_list({1, 2, 3}));
+    CHECK_EQ(read<int_list>(cfg, {"--bar=[10, 20, 30]"}), none);
+    CHECK_EQ(get_as<int_list>(cfg, "bar"), int_list({10, 20, 30}));
+    MESSAGE("test string lists");
     cfg["foo"] = config_value{string_list{"one", "two", "three"}};
-    CAF_CHECK_EQUAL(get_as<string_list>(cfg, "foo"),
-                    string_list({"one", "two", "three"}));
-    CAF_CHECK_EQUAL(read<string_list>(cfg, {R"_(--foo=["hello", "world"])_"}),
-                    none);
-    CAF_CHECK_EQUAL(get_as<string_list>(cfg, "foo"),
-                    string_list({"hello", "world"}));
+    CHECK_EQ(get_as<string_list>(cfg, "foo"),
+             string_list({"one", "two", "three"}));
+    CHECK_EQ(read<string_list>(cfg, {R"_(--foo=["hello", "world"])_"}), none);
+    CHECK_EQ(get_as<string_list>(cfg, "foo"), string_list({"hello", "world"}));
   }
 }
 
 CAF_TEST(CLI arguments may use custom types) {
   settings cfg;
   opts.add<foobar>("global", "foobar,f", "test option");
-  CAF_CHECK_EQUAL(read<foobar>(cfg, {"-f{foo=\"hello\",bar=\"world\"}"}), none);
-  if (auto fb = get_as<foobar>(cfg, "foobar"); CAF_CHECK(fb))
-    CAF_CHECK_EQUAL(*fb, foobar("hello", "world"));
+  CHECK_EQ(read<foobar>(cfg, {"-f{foo=\"hello\",bar=\"world\"}"}), none);
+  if (auto fb = get_as<foobar>(cfg, "foobar"); CHECK(fb))
+    CHECK_EQ(*fb, foobar("hello", "world"));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/config_value.cpp
+++ b/libcaf_core/test/config_value.cpp
@@ -65,7 +65,7 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(config_value_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 SCENARIO("default-constructed config values represent null") {
   GIVEN("a default-constructed config value") {
@@ -145,14 +145,14 @@ SCENARIO("get_as can convert config values to integers") {
     auto x = config_value{-5};
     WHEN("using get_as with integer types") {
       THEN("conversion fails for all unsigned types") {
-        CAF_CHECK_EQUAL(get_as<uint64_t>(x), sec::conversion_failed);
-        CAF_CHECK_EQUAL(get_as<int64_t>(x), -5);
-        CAF_CHECK_EQUAL(get_as<uint32_t>(x), sec::conversion_failed);
-        CAF_CHECK_EQUAL(get_as<int32_t>(x), -5);
-        CAF_CHECK_EQUAL(get_as<uint16_t>(x), sec::conversion_failed);
-        CAF_CHECK_EQUAL(get_as<int16_t>(x), -5);
-        CAF_CHECK_EQUAL(get_as<uint8_t>(x), sec::conversion_failed);
-        CAF_CHECK_EQUAL(get_as<int8_t>(x), -5);
+        CHECK_EQ(get_as<uint64_t>(x), sec::conversion_failed);
+        CHECK_EQ(get_as<int64_t>(x), -5);
+        CHECK_EQ(get_as<uint32_t>(x), sec::conversion_failed);
+        CHECK_EQ(get_as<int32_t>(x), -5);
+        CHECK_EQ(get_as<uint16_t>(x), sec::conversion_failed);
+        CHECK_EQ(get_as<int16_t>(x), -5);
+        CHECK_EQ(get_as<uint8_t>(x), sec::conversion_failed);
+        CHECK_EQ(get_as<int8_t>(x), -5);
       }
     }
   }
@@ -160,14 +160,14 @@ SCENARIO("get_as can convert config values to integers") {
     auto x = config_value{"50000"s};
     WHEN("using get_as with integer types") {
       THEN("CAF parses the string and performs a bound check") {
-        CAF_CHECK_EQUAL(get_as<uint64_t>(x), 50'000u);
-        CAF_CHECK_EQUAL(get_as<int64_t>(x), 50'000);
-        CAF_CHECK_EQUAL(get_as<uint32_t>(x), 50'000u);
-        CAF_CHECK_EQUAL(get_as<int32_t>(x), 50'000);
-        CAF_CHECK_EQUAL(get_as<uint16_t>(x), 50'000u);
-        CAF_CHECK_EQUAL(get_as<int16_t>(x), sec::conversion_failed);
-        CAF_CHECK_EQUAL(get_as<uint8_t>(x), sec::conversion_failed);
-        CAF_CHECK_EQUAL(get_as<int8_t>(x), sec::conversion_failed);
+        CHECK_EQ(get_as<uint64_t>(x), 50'000u);
+        CHECK_EQ(get_as<int64_t>(x), 50'000);
+        CHECK_EQ(get_as<uint32_t>(x), 50'000u);
+        CHECK_EQ(get_as<int32_t>(x), 50'000);
+        CHECK_EQ(get_as<uint16_t>(x), 50'000u);
+        CHECK_EQ(get_as<int16_t>(x), sec::conversion_failed);
+        CHECK_EQ(get_as<uint8_t>(x), sec::conversion_failed);
+        CHECK_EQ(get_as<int8_t>(x), sec::conversion_failed);
       }
     }
   }
@@ -865,7 +865,7 @@ SCENARIO("config_value::parse returns an error for invalid inputs") {
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()
 
 // -- end of scenario testing, here come several baseline checks for parsing ---
 

--- a/libcaf_core/test/config_value_reader.cpp
+++ b/libcaf_core/test/config_value_reader.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/config_value_reader.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include "inspector-tests.hpp"
 
@@ -66,14 +66,14 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(config_value_reader_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(readers deserialize builtin types from config values) {
   std::string value;
   auto& xs = x.as_dictionary();
   put(xs, "foo", "bar");
   deserialize(xs["foo"], value);
-  CAF_CHECK_EQUAL(value, "bar");
+  CHECK_EQ(value, "bar");
 }
 
 CAF_TEST(readers deserialize simple objects from configs) {
@@ -82,12 +82,12 @@ CAF_TEST(readers deserialize simple objects from configs) {
   put(xs, "bar", "world");
   foobar fb;
   deserialize(fb);
-  CAF_CHECK_EQUAL(fb.foo(), "hello"s);
-  CAF_CHECK_EQUAL(fb.bar(), "world"s);
+  CHECK_EQ(fb.foo(), "hello"s);
+  CHECK_EQ(fb.bar(), "world"s);
 }
 
 CAF_TEST(readers deserialize complex objects from configs) {
-  CAF_MESSAGE("fill a dictionary with data for a 'basics' object");
+  MESSAGE("fill a dictionary with data for a 'basics' object");
   auto& xs = x.as_dictionary();
   put(xs, "v1", settings{});
   put(xs, "v2", 42_i64);
@@ -108,26 +108,26 @@ CAF_TEST(readers deserialize complex objects from configs) {
   put(xs, "v7.two", i64{2});
   put(xs, "v7.three", i64{3});
   put(xs, "v8", i64_list());
-  CAF_MESSAGE("deserialize and verify the 'basics' object");
+  MESSAGE("deserialize and verify the 'basics' object");
   basics obj;
   deserialize(obj);
-  CAF_CHECK_EQUAL(obj.v2, 42);
-  CAF_CHECK_EQUAL(obj.v3[0], 1);
-  CAF_CHECK_EQUAL(obj.v3[1], 2);
-  CAF_CHECK_EQUAL(obj.v3[2], 3);
-  CAF_CHECK_EQUAL(obj.v3[3], 4);
-  CAF_CHECK_EQUAL(obj.v4[0], dummy_message{{2.0}});
-  CAF_CHECK_EQUAL(obj.v4[1], dummy_message{{"foobar"s}});
-  CAF_CHECK_EQUAL(obj.v5[0], i64{10});
-  CAF_CHECK_EQUAL(obj.v5[1], i64{20});
-  CAF_CHECK_EQUAL(obj.v6, std::make_tuple(int32_t{123}, dummy_message{{2.0}}));
-  CAF_CHECK_EQUAL(obj.v7["one"], 1);
-  CAF_CHECK_EQUAL(obj.v7["two"], 2);
-  CAF_CHECK_EQUAL(obj.v7["three"], 3);
+  CHECK_EQ(obj.v2, 42);
+  CHECK_EQ(obj.v3[0], 1);
+  CHECK_EQ(obj.v3[1], 2);
+  CHECK_EQ(obj.v3[2], 3);
+  CHECK_EQ(obj.v3[3], 4);
+  CHECK_EQ(obj.v4[0], dummy_message{{2.0}});
+  CHECK_EQ(obj.v4[1], dummy_message{{"foobar"s}});
+  CHECK_EQ(obj.v5[0], i64{10});
+  CHECK_EQ(obj.v5[1], i64{20});
+  CHECK_EQ(obj.v6, std::make_tuple(int32_t{123}, dummy_message{{2.0}}));
+  CHECK_EQ(obj.v7["one"], 1);
+  CHECK_EQ(obj.v7["two"], 2);
+  CHECK_EQ(obj.v7["three"], 3);
 }
 
 CAF_TEST(readers deserialize objects from the output of writers) {
-  CAF_MESSAGE("serialize the 'line' object");
+  MESSAGE("serialize the 'line' object");
   {
     line l{{10, 20, 30}, {70, 60, 50}};
     config_value tmp;
@@ -138,17 +138,17 @@ CAF_TEST(readers deserialize objects from the output of writers) {
       CAF_FAIL("writer failed to produce a dictionary");
     x.as_dictionary() = std::move(caf::get<settings>(tmp));
   }
-  CAF_MESSAGE("serialize and verify the 'line' object");
+  MESSAGE("serialize and verify the 'line' object");
   {
     line l{{0, 0, 0}, {0, 0, 0}};
     deserialize(l);
-    CAF_CHECK_EQUAL(l.p1.x, 10);
-    CAF_CHECK_EQUAL(l.p1.y, 20);
-    CAF_CHECK_EQUAL(l.p1.z, 30);
-    CAF_CHECK_EQUAL(l.p2.x, 70);
-    CAF_CHECK_EQUAL(l.p2.y, 60);
-    CAF_CHECK_EQUAL(l.p2.z, 50);
+    CHECK_EQ(l.p1.x, 10);
+    CHECK_EQ(l.p1.y, 20);
+    CHECK_EQ(l.p1.z, 30);
+    CHECK_EQ(l.p2.x, 70);
+    CHECK_EQ(l.p2.y, 60);
+    CHECK_EQ(l.p2.z, 50);
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/config_value_writer.cpp
+++ b/libcaf_core/test/config_value_writer.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/config_value_writer.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include "inspector-tests.hpp"
 
@@ -47,22 +47,22 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(config_value_writer_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(structs become dictionaries) {
   set(foobar{"hello", "world"});
-  CAF_CHECK_EQUAL(get_as<std::string>(xs(), "foo"), "hello"s);
-  CAF_CHECK_EQUAL(get_as<std::string>(xs(), "bar"), "world"s);
+  CHECK_EQ(get_as<std::string>(xs(), "foo"), "hello"s);
+  CHECK_EQ(get_as<std::string>(xs(), "bar"), "world"s);
 }
 
 CAF_TEST(nested structs become nested dictionaries) {
   set(line{{10, 20, 30}, {70, 60, 50}});
-  CAF_CHECK_EQUAL(get_as<i64>(xs(), "p1.x"), 10_i64);
-  CAF_CHECK_EQUAL(get_as<i64>(xs(), "p1.y"), 20_i64);
-  CAF_CHECK_EQUAL(get_as<i64>(xs(), "p1.z"), 30_i64);
-  CAF_CHECK_EQUAL(get_as<i64>(xs(), "p2.x"), 70_i64);
-  CAF_CHECK_EQUAL(get_as<i64>(xs(), "p2.y"), 60_i64);
-  CAF_CHECK_EQUAL(get_as<i64>(xs(), "p2.z"), 50_i64);
+  CHECK_EQ(get_as<i64>(xs(), "p1.x"), 10_i64);
+  CHECK_EQ(get_as<i64>(xs(), "p1.y"), 20_i64);
+  CHECK_EQ(get_as<i64>(xs(), "p1.z"), 30_i64);
+  CHECK_EQ(get_as<i64>(xs(), "p2.x"), 70_i64);
+  CHECK_EQ(get_as<i64>(xs(), "p2.y"), 60_i64);
+  CHECK_EQ(get_as<i64>(xs(), "p2.z"), 50_i64);
 }
 
 CAF_TEST(empty types and maps become dictionaries) {
@@ -79,36 +79,36 @@ CAF_TEST(empty types and maps become dictionaries) {
   tst.v7["two"] = 2;
   tst.v7["three"] = 3;
   set(tst);
-  CAF_CHECK_EQUAL(get_as<settings>(xs(), "v1"), settings{});
-  CAF_CHECK_EQUAL(get_as<i64>(xs(), "v2"), 42_i64);
-  CAF_CHECK_EQUAL(get_as<i64_list>(xs(), "v3"), i64_list({-1, -2, -3, -4}));
+  CHECK_EQ(get_as<settings>(xs(), "v1"), settings{});
+  CHECK_EQ(get_as<i64>(xs(), "v2"), 42_i64);
+  CHECK_EQ(get_as<i64_list>(xs(), "v3"), i64_list({-1, -2, -3, -4}));
   if (auto v4 = get_as<config_value::list>(xs(), "v4");
-      CAF_CHECK(v4 && v4->size() == 2u)) {
-    if (auto v1 = v4->front(); CAF_CHECK(holds_alternative<settings>(v1))) {
+      CHECK(v4 && v4->size() == 2u)) {
+    if (auto v1 = v4->front(); CHECK(holds_alternative<settings>(v1))) {
       auto& v1_xs = get<settings>(v1);
-      CAF_CHECK_EQUAL(get<double>(v1_xs, "content"), 0.0);
-      CAF_CHECK_EQUAL(get<std::string>(v1_xs, "@content-type"),
-                      to_string(type_name_v<double>));
+      CHECK_EQ(get<double>(v1_xs, "content"), 0.0);
+      CHECK_EQ(get<std::string>(v1_xs, "@content-type"),
+               to_string(type_name_v<double>));
     }
-    if (auto v2 = v4->back(); CAF_CHECK(holds_alternative<settings>(v2))) {
+    if (auto v2 = v4->back(); CHECK(holds_alternative<settings>(v2))) {
       auto& v2_xs = get<settings>(v2);
-      CAF_CHECK_EQUAL(get<double>(v2_xs, "content"), 1.0);
-      CAF_CHECK_EQUAL(get<std::string>(v2_xs, "@content-type"),
-                      to_string(type_name_v<double>));
+      CHECK_EQ(get<double>(v2_xs, "content"), 1.0);
+      CHECK_EQ(get<std::string>(v2_xs, "@content-type"),
+               to_string(type_name_v<double>));
     }
   }
-  CAF_CHECK_EQUAL(get_as<i64_list>(xs(), "v5"), i64_list({10, 20}));
+  CHECK_EQ(get_as<i64_list>(xs(), "v5"), i64_list({10, 20}));
   // TODO: check v6
-  CAF_CHECK_EQUAL(get_as<i64>(xs(), "v7.one"), 1_i64);
-  CAF_CHECK_EQUAL(get_as<i64>(xs(), "v7.two"), 2_i64);
-  CAF_CHECK_EQUAL(get_as<i64>(xs(), "v7.three"), 3_i64);
-  CAF_CHECK_EQUAL(get_as<config_value::list>(xs(), "v8"), config_value::list());
+  CHECK_EQ(get_as<i64>(xs(), "v7.one"), 1_i64);
+  CHECK_EQ(get_as<i64>(xs(), "v7.two"), 2_i64);
+  CHECK_EQ(get_as<i64>(xs(), "v7.three"), 3_i64);
+  CHECK_EQ(get_as<config_value::list>(xs(), "v8"), config_value::list());
 }
 
 CAF_TEST(custom inspect overloads may produce single values) {
   auto tue = weekday::tuesday;
   set(tue);
-  CAF_CHECK_EQUAL(get_as<std::string>(x), "tuesday"s);
+  CHECK_EQ(get_as<std::string>(x), "tuesday"s);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/const_typed_message_view.cpp
+++ b/libcaf_core/test/const_typed_message_view.cpp
@@ -12,25 +12,25 @@
 
 using namespace caf;
 
-CAF_TEST_FIXTURE_SCOPE(message_tests, test_coordinator_fixture<>)
+BEGIN_FIXTURE_SCOPE(test_coordinator_fixture<>)
 
 CAF_TEST(const message views never detach their content) {
   auto msg1 = make_message(1, 2, 3, "four");
   auto msg2 = msg1;
   CAF_REQUIRE(msg1.cptr() == msg2.cptr());
-  CAF_REQUIRE(msg1.match_elements<int, int, int, std::string>());
+  CAF_REQUIRE((msg1.match_elements<int, int, int, std::string>()));
   const_typed_message_view<int, int, int, std::string> view{msg1};
   CAF_REQUIRE(msg1.cptr() == msg2.cptr());
 }
 
 CAF_TEST(const message views allow access via get) {
   auto msg = make_message(1, 2, 3, "four");
-  CAF_REQUIRE(msg.match_elements<int, int, int, std::string>());
+  CAF_REQUIRE((msg.match_elements<int, int, int, std::string>()));
   const_typed_message_view<int, int, int, std::string> view{msg};
-  CAF_CHECK_EQUAL(get<0>(view), 1);
-  CAF_CHECK_EQUAL(get<1>(view), 2);
-  CAF_CHECK_EQUAL(get<2>(view), 3);
-  CAF_CHECK_EQUAL(get<3>(view), "four");
+  CHECK_EQ(get<0>(view), 1);
+  CHECK_EQ(get<1>(view), 2);
+  CHECK_EQ(get<2>(view), 3);
+  CHECK_EQ(get<3>(view), "four");
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/constructor_attach.cpp
+++ b/libcaf_core/test/constructor_attach.cpp
@@ -21,7 +21,7 @@ public:
   behavior make_behavior() override {
     return {
       [=](delete_atom) {
-        CAF_MESSAGE("testee received delete");
+        MESSAGE("testee received delete");
         quit(exit_reason::user_shutdown);
       },
     };
@@ -32,8 +32,8 @@ class spawner : public event_based_actor {
 public:
   spawner(actor_config& cfg) : event_based_actor(cfg), downs_(0) {
     set_down_handler([=](down_msg& msg) {
-      CAF_CHECK_EQUAL(msg.reason, exit_reason::user_shutdown);
-      CAF_CHECK_EQUAL(msg.source, testee_.address());
+      CHECK_EQ(msg.reason, exit_reason::user_shutdown);
+      CHECK_EQ(msg.source, testee_.address());
       if (++downs_ == 2)
         quit(msg.reason);
     });
@@ -43,13 +43,13 @@ public:
     testee_ = spawn<testee, monitored>(this);
     return {
       [=](ok_atom, const error& reason) {
-        CAF_CHECK_EQUAL(reason, exit_reason::user_shutdown);
+        CHECK_EQ(reason, exit_reason::user_shutdown);
         if (++downs_ == 2) {
           quit(reason);
         }
       },
       [=](delete_atom x) {
-        CAF_MESSAGE("spawner received delete");
+        MESSAGE("spawner received delete");
         return delegate(testee_, x);
       },
     };

--- a/libcaf_core/test/continuous_streaming.cpp
+++ b/libcaf_core/test/continuous_streaming.cpp
@@ -37,8 +37,8 @@ TESTEE_STATE(file_reader) {
 VARARGS_TESTEE(file_reader, size_t buf_size) {
   return {
     [=](string& fname) -> result<stream<int32_t>, string> {
-      CAF_CHECK_EQUAL(fname, "numbers.txt");
-      CAF_CHECK_EQUAL(self->mailbox().empty(), true);
+      CHECK_EQ(fname, "numbers.txt");
+      CHECK_EQ(self->mailbox().empty(), true);
       return attach_stream_source(
         self,
         // forward file name in handshake to next stage
@@ -52,7 +52,7 @@ VARARGS_TESTEE(file_reader, size_t buf_size) {
         // get next element
         [=](unit_t&, downstream<int32_t>& out, size_t num) {
           auto& xs = self->state.buf;
-          CAF_MESSAGE("push " << num << " messages downstream");
+          MESSAGE("push " << num << " messages downstream");
           auto n = std::min(num, xs.size());
           for (size_t i = 0; i < n; ++i)
             out.push(xs[i]);
@@ -61,7 +61,7 @@ VARARGS_TESTEE(file_reader, size_t buf_size) {
         // check whether we reached the end
         [=](const unit_t&) {
           if (self->state.buf.empty()) {
-            CAF_MESSAGE(self->name() << " is done");
+            MESSAGE(self->name() << " is done");
             return true;
           }
           return false;
@@ -77,7 +77,7 @@ TESTEE_STATE(sum_up) {
 TESTEE(sum_up) {
   return {
     [=](stream<int32_t>& in, const string& fname) {
-      CAF_CHECK_EQUAL(fname, "numbers.txt");
+      CHECK_EQ(fname, "numbers.txt");
       using int_ptr = int32_t*;
       return attach_stream_sink(
         self,
@@ -88,12 +88,10 @@ TESTEE(sum_up) {
         // processing step
         [](int_ptr& x, int32_t y) { *x += y; },
         // cleanup
-        [=](int_ptr&, const error&) {
-          CAF_MESSAGE(self->name() << " is done");
-        });
+        [=](int_ptr&, const error&) { MESSAGE(self->name() << " is done"); });
     },
     [=](join_atom atm, actor src) {
-      CAF_MESSAGE(self->name() << " joins a stream");
+      MESSAGE(self->name() << " joins a stream");
       self->send(self * src, atm);
     },
   };
@@ -113,15 +111,15 @@ TESTEE(stream_multiplexer) {
     // processing step
     [](unit_t&, downstream<int32_t>& out, int32_t x) { out.push(x); },
     // cleanup
-    [=](unit_t&, const error&) { CAF_MESSAGE(self->name() << " is done"); });
+    [=](unit_t&, const error&) { MESSAGE(self->name() << " is done"); });
   return {
     [=](join_atom) {
-      CAF_MESSAGE("received 'join' request");
+      MESSAGE("received 'join' request");
       return self->state.stage->add_outbound_path(
         std::make_tuple("numbers.txt"));
     },
     [=](const stream<int32_t>& in, std::string& fname) {
-      CAF_CHECK_EQUAL(fname, "numbers.txt");
+      CHECK_EQ(fname, "numbers.txt");
       return self->state.stage->add_inbound_path(in);
     },
     [=](close_atom, int32_t sink_index) {
@@ -137,7 +135,7 @@ using fixture = test_coordinator_fixture<>;
 
 // -- unit tests ---------------------------------------------------------------
 
-CAF_TEST_FIXTURE_SCOPE(local_streaming_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(depth_3_pipeline_with_fork) {
   auto src = sys.spawn(file_reader, 60u);
@@ -145,21 +143,21 @@ CAF_TEST(depth_3_pipeline_with_fork) {
   auto snk1 = sys.spawn(sum_up);
   auto snk2 = sys.spawn(sum_up);
   auto& st = deref<stream_multiplexer_actor>(stg).state;
-  CAF_MESSAGE("connect sinks to the stage (fork)");
+  MESSAGE("connect sinks to the stage (fork)");
   self->send(snk1, join_atom_v, stg);
   self->send(snk2, join_atom_v, stg);
   consume_messages();
-  CAF_CHECK_EQUAL(st.stage->out().num_paths(), 2u);
-  CAF_MESSAGE("connect source to the stage (fork)");
+  CHECK_EQ(st.stage->out().num_paths(), 2u);
+  MESSAGE("connect source to the stage (fork)");
   self->send(stg * src, "numbers.txt");
   consume_messages();
-  CAF_CHECK_EQUAL(st.stage->out().num_paths(), 2u);
-  CAF_CHECK_EQUAL(st.stage->inbound_paths().size(), 1u);
+  CHECK_EQ(st.stage->out().num_paths(), 2u);
+  CHECK_EQ(st.stage->inbound_paths().size(), 1u);
   run();
-  CAF_CHECK_EQUAL(st.stage->out().num_paths(), 2u);
-  CAF_CHECK_EQUAL(st.stage->inbound_paths().size(), 0u);
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk1).state.x, sum(60));
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk2).state.x, sum(60));
+  CHECK_EQ(st.stage->out().num_paths(), 2u);
+  CHECK_EQ(st.stage->inbound_paths().size(), 0u);
+  CHECK_EQ(deref<sum_up_actor>(snk1).state.x, sum(60));
+  CHECK_EQ(deref<sum_up_actor>(snk2).state.x, sum(60));
   self->send_exit(stg, exit_reason::kill);
 }
 
@@ -169,21 +167,21 @@ CAF_TEST(depth_3_pipeline_with_join) {
   auto stg = sys.spawn(stream_multiplexer);
   auto snk = sys.spawn(sum_up);
   auto& st = deref<stream_multiplexer_actor>(stg).state;
-  CAF_MESSAGE("connect sink to the stage");
+  MESSAGE("connect sink to the stage");
   self->send(snk, join_atom_v, stg);
   consume_messages();
-  CAF_CHECK_EQUAL(st.stage->out().num_paths(), 1u);
-  CAF_MESSAGE("connect sources to the stage (join)");
+  CHECK_EQ(st.stage->out().num_paths(), 1u);
+  MESSAGE("connect sources to the stage (join)");
   self->send(stg * src1, "numbers.txt");
   self->send(stg * src2, "numbers.txt");
   consume_messages();
-  CAF_CHECK_EQUAL(st.stage->out().num_paths(), 1u);
-  CAF_CHECK_EQUAL(st.stage->inbound_paths().size(), 2u);
+  CHECK_EQ(st.stage->out().num_paths(), 1u);
+  CHECK_EQ(st.stage->inbound_paths().size(), 2u);
   run();
-  CAF_CHECK_EQUAL(st.stage->out().num_paths(), 1u);
-  CAF_CHECK_EQUAL(st.stage->inbound_paths().size(), 0u);
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk).state.x, sum(60) * 2);
+  CHECK_EQ(st.stage->out().num_paths(), 1u);
+  CHECK_EQ(st.stage->inbound_paths().size(), 0u);
+  CHECK_EQ(deref<sum_up_actor>(snk).state.x, sum(60) * 2);
   self->send_exit(stg, exit_reason::kill);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/cow_tuple.cpp
+++ b/libcaf_core/test/cow_tuple.cpp
@@ -16,90 +16,90 @@ using namespace caf;
 
 CAF_TEST(default_construction) {
   cow_tuple<string, string> x;
-  CAF_CHECK_EQUAL(x.unique(), true);
-  CAF_CHECK_EQUAL(get<0>(x), "");
-  CAF_CHECK_EQUAL(get<1>(x), "");
+  CHECK_EQ(x.unique(), true);
+  CHECK_EQ(get<0>(x), "");
+  CHECK_EQ(get<1>(x), "");
 }
 
 CAF_TEST(value_construction) {
   cow_tuple<int, int> x{1, 2};
-  CAF_CHECK_EQUAL(x.unique(), true);
-  CAF_CHECK_EQUAL(get<0>(x), 1);
-  CAF_CHECK_EQUAL(get<1>(x), 2);
-  CAF_CHECK_EQUAL(x, make_cow_tuple(1, 2));
+  CHECK_EQ(x.unique(), true);
+  CHECK_EQ(get<0>(x), 1);
+  CHECK_EQ(get<1>(x), 2);
+  CHECK_EQ(x, make_cow_tuple(1, 2));
 }
 
 CAF_TEST(copy_construction) {
   cow_tuple<int, int> x{1, 2};
   cow_tuple<int, int> y{x};
-  CAF_CHECK_EQUAL(x, y);
-  CAF_CHECK_EQUAL(x.ptr(), y.ptr());
-  CAF_CHECK_EQUAL(x.unique(), false);
-  CAF_CHECK_EQUAL(y.unique(), false);
+  CHECK_EQ(x, y);
+  CHECK_EQ(x.ptr(), y.ptr());
+  CHECK_EQ(x.unique(), false);
+  CHECK_EQ(y.unique(), false);
 }
 
 CAF_TEST(move_construction) {
   cow_tuple<int, int> x{1, 2};
   cow_tuple<int, int> y{std::move(x)};
-  CAF_CHECK_EQUAL(x.ptr(), nullptr);
-  CAF_CHECK_EQUAL(y, make_tuple(1, 2));
-  CAF_CHECK_EQUAL(y.unique(), true);
+  CHECK_EQ(x.ptr(), nullptr);
+  CHECK_EQ(y, make_tuple(1, 2));
+  CHECK_EQ(y.unique(), true);
 }
 
 CAF_TEST(copy_assignment) {
   cow_tuple<int, int> x{1, 2};
   cow_tuple<int, int> y{3, 4};
-  CAF_CHECK_NOT_EQUAL(x, y);
+  CHECK_NE(x, y);
   x = y;
-  CAF_CHECK_EQUAL(x, y);
-  CAF_CHECK_EQUAL(x.ptr(), y.ptr());
-  CAF_CHECK_EQUAL(x.unique(), false);
-  CAF_CHECK_EQUAL(y.unique(), false);
+  CHECK_EQ(x, y);
+  CHECK_EQ(x.ptr(), y.ptr());
+  CHECK_EQ(x.unique(), false);
+  CHECK_EQ(y.unique(), false);
 }
 
 CAF_TEST(move_assignment) {
   cow_tuple<int, int> x{1, 2};
   cow_tuple<int, int> y{3, 4};
-  CAF_CHECK_NOT_EQUAL(x, y);
+  CHECK_NE(x, y);
   x = std::move(y);
-  CAF_CHECK_EQUAL(x, make_tuple(3, 4));
-  CAF_CHECK_EQUAL(x.unique(), true);
+  CHECK_EQ(x, make_tuple(3, 4));
+  CHECK_EQ(x.unique(), true);
 }
 
 CAF_TEST(make_cow_tuple) {
   cow_tuple<int, int> x{1, 2};
   auto y = make_cow_tuple(1, 2);
-  CAF_CHECK_EQUAL(x, y);
-  CAF_CHECK_EQUAL(x.unique(), true);
-  CAF_CHECK_EQUAL(y.unique(), true);
+  CHECK_EQ(x, y);
+  CHECK_EQ(x.unique(), true);
+  CHECK_EQ(y.unique(), true);
 }
 
 CAF_TEST(unsharing) {
   auto x = make_cow_tuple(string{"old"}, string{"school"});
   auto y = x;
-  CAF_CHECK_EQUAL(x.unique(), false);
-  CAF_CHECK_EQUAL(y.unique(), false);
+  CHECK_EQ(x.unique(), false);
+  CHECK_EQ(y.unique(), false);
   get<0>(y.unshared()) = "new";
-  CAF_CHECK_EQUAL(x.unique(), true);
-  CAF_CHECK_EQUAL(y.unique(), true);
-  CAF_CHECK_EQUAL(x.data(), make_tuple("old", "school"));
-  CAF_CHECK_EQUAL(y.data(), make_tuple("new", "school"));
+  CHECK_EQ(x.unique(), true);
+  CHECK_EQ(y.unique(), true);
+  CHECK_EQ(x.data(), make_tuple("old", "school"));
+  CHECK_EQ(y.data(), make_tuple("new", "school"));
 }
 
 CAF_TEST(to_string) {
   auto x = make_cow_tuple(1, string{"abc"});
-  CAF_CHECK_EQUAL(deep_to_string(x), R"__([1, "abc"])__");
+  CHECK_EQ(deep_to_string(x), R"__([1, "abc"])__");
 }
 
-CAF_TEST_FIXTURE_SCOPE(cow_tuple_tests, test_coordinator_fixture<>)
+BEGIN_FIXTURE_SCOPE(test_coordinator_fixture<>)
 
 CAF_TEST(serialization) {
   auto x = make_cow_tuple(1, 2, 3);
   auto y = roundtrip(x);
-  CAF_CHECK_EQUAL(x, y);
-  CAF_CHECK_EQUAL(x.unique(), true);
-  CAF_CHECK_EQUAL(y.unique(), true);
-  CAF_CHECK_NOT_EQUAL(x.ptr(), y.ptr());
+  CHECK_EQ(x, y);
+  CHECK_EQ(x.unique(), true);
+  CHECK_EQ(y.unique(), true);
+  CHECK_NE(x.ptr(), y.ptr());
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/custom_exception_handler.cpp
+++ b/libcaf_core/test/custom_exception_handler.cpp
@@ -51,7 +51,7 @@ CAF_TEST(the default exception handler includes the error message) {
       [](const error& err) {
         auto msg = err.context();
         if (auto view = make_typed_message_view<string, string>(msg)) {
-          CAF_CHECK_EQUAL(get<1>(view), "whatever");
+          CHECK_EQ(get<1>(view), "whatever");
         } else {
           CAF_FAIL("unexpected error contest: " << err.context());
         }
@@ -64,11 +64,9 @@ CAF_TEST(actors can override the default exception handler) {
   auto handler = [](std::exception_ptr& eptr) -> error {
     try {
       std::rethrow_exception(eptr);
-    }
-    catch (std::runtime_error&) {
+    } catch (std::runtime_error&) {
       return exit_reason::normal;
-    }
-    catch (...) {
+    } catch (...) {
       // "fall through"
     }
     return sec::runtime_error;

--- a/libcaf_core/test/decorator/sequencer.cpp
+++ b/libcaf_core/test/decorator/sequencer.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/decorator/sequencer.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include "caf/all.hpp"
 
@@ -60,7 +60,7 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(sequencer_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(identity) {
   actor_system_config cfg_g;
@@ -69,14 +69,14 @@ CAF_TEST(identity) {
   actor_system system_of_f{cfg_f};
   auto g = system_of_g.spawn(typed_first_stage);
   auto f = system_of_f.spawn(typed_second_stage);
-  CAF_CHECK_EQUAL(system_of_g.registry().running(), 1u);
+  CHECK_EQ(system_of_g.registry().running(), 1u);
   auto h = f * g;
-  CAF_CHECK_EQUAL(system_of_g.registry().running(), 1u);
-  CAF_CHECK_EQUAL(&h->home_system(), &g->home_system());
-  CAF_CHECK_EQUAL(h->node(), g->node());
-  CAF_CHECK_NOT_EQUAL(h->id(), g->id());
-  CAF_CHECK_NOT_EQUAL(h.address(), g.address());
-  CAF_CHECK_EQUAL(h->message_types(), g->home_system().message_types(h));
+  CHECK_EQ(system_of_g.registry().running(), 1u);
+  CHECK_EQ(&h->home_system(), &g->home_system());
+  CHECK_EQ(h->node(), g->node());
+  CHECK_NE(h->id(), g->id());
+  CHECK_NE(h.address(), g.address());
+  CHECK_EQ(h->message_types(), g->home_system().message_types(h));
 }
 
 // spawned dead if `g` is already dead upon spawning
@@ -86,7 +86,7 @@ CAF_TEST(lifetime_1a) {
   anon_send_exit(g, exit_reason::kill);
   self->wait_for(g);
   auto h = f * g;
-  CAF_CHECK(exited(h));
+  CHECK(exited(h));
 }
 
 // spawned dead if `f` is already dead upon spawning
@@ -96,7 +96,7 @@ CAF_TEST(lifetime_1b) {
   anon_send_exit(f, exit_reason::kill);
   self->wait_for(f);
   auto h = f * g;
-  CAF_CHECK(exited(h));
+  CHECK(exited(h));
 }
 
 // `f.g` exits when `g` exits
@@ -122,12 +122,12 @@ CAF_TEST(request_response_promise) {
   auto f = system.spawn(testee);
   auto h = f * g;
   anon_send_exit(h, exit_reason::kill);
-  CAF_CHECK(exited(h));
+  CHECK(exited(h));
   self->request(h, infinite, 1)
-    .receive([](int) { CAF_CHECK(false); },
+    .receive([](int) { CHECK(false); },
              [](error err) {
-               CAF_CHECK_EQUAL(err.code(), static_cast<uint8_t>(
-                                             sec::request_receiver_down));
+               CHECK_EQ(err.code(),
+                        static_cast<uint8_t>(sec::request_receiver_down));
              });
 }
 
@@ -137,7 +137,7 @@ CAF_TEST(dot_composition_1) {
   auto second = system.spawn(typed_second_stage);
   auto first_then_second = second * first;
   self->request(first_then_second, infinite, 42)
-    .receive([](double res) { CAF_CHECK_EQUAL(res, (42 * 2.0) * (42 * 4.0)); },
+    .receive([](double res) { CHECK_EQ(res, (42 * 2.0) * (42 * 4.0)); },
              ERROR_HANDLER);
 }
 
@@ -146,7 +146,7 @@ CAF_TEST(dot_composition_2) {
   auto dbl_actor = system.spawn(testee);
   auto dbl_x4_actor = dbl_actor * dbl_actor * dbl_actor * dbl_actor;
   self->request(dbl_x4_actor, infinite, 1)
-    .receive([](int v) { CAF_CHECK_EQUAL(v, 16); }, ERROR_HANDLER);
+    .receive([](int v) { CHECK_EQ(v, 16); }, ERROR_HANDLER);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/deep_to_string.cpp
+++ b/libcaf_core/test/deep_to_string.cpp
@@ -10,7 +10,7 @@
 
 using namespace caf;
 
-#define CHECK_DEEP_TO_STRING(val, str) CAF_CHECK_EQUAL(deep_to_string(val), str)
+#define CHECK_DEEP_TO_STRING(val, str) CHECK_EQ(deep_to_string(val), str)
 
 CAF_TEST(timespans use the highest unit available when printing) {
   CHECK_EQ(to_string(config_value{timespan{0}}), "0s");
@@ -50,15 +50,15 @@ CAF_TEST(pointers and optionals use dereference syntax) {
 CAF_TEST(buffers) {
   // Use `signed char` explicitly to make sure all compilers agree.
   std::vector<signed char> buf;
-  CAF_CHECK_EQUAL(deep_to_string(buf), "[]");
+  CHECK_EQ(deep_to_string(buf), "[]");
   buf.push_back(-1);
-  CAF_CHECK_EQUAL(deep_to_string(buf), "[-1]");
+  CHECK_EQ(deep_to_string(buf), "[-1]");
   buf.push_back(0);
-  CAF_CHECK_EQUAL(deep_to_string(buf), "[-1, 0]");
+  CHECK_EQ(deep_to_string(buf), "[-1, 0]");
   buf.push_back(127);
-  CAF_CHECK_EQUAL(deep_to_string(buf), "[-1, 0, 127]");
+  CHECK_EQ(deep_to_string(buf), "[-1, 0, 127]");
   buf.push_back(10);
-  CAF_CHECK_EQUAL(deep_to_string(buf), "[-1, 0, 127, 10]");
+  CHECK_EQ(deep_to_string(buf), "[-1, 0, 127, 10]");
   buf.push_back(16);
-  CAF_CHECK_EQUAL(deep_to_string(buf), "[-1, 0, 127, 10, 16]");
+  CHECK_EQ(deep_to_string(buf), "[-1, 0, 127, 10, 16]");
 }

--- a/libcaf_core/test/detached_actors.cpp
+++ b/libcaf_core/test/detached_actors.cpp
@@ -26,16 +26,16 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(detached_actors, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(shutdown) {
-  CAF_MESSAGE("does sys shut down after spawning a detached actor?");
+  MESSAGE("does sys shut down after spawning a detached actor?");
   sys.spawn<detached>([] {});
 }
 
 CAF_TEST(shutdown_with_delayed_send) {
-  CAF_MESSAGE("does sys shut down after spawning a detached actor that used "
-              "delayed_send?");
+  MESSAGE("does sys shut down after spawning a detached actor that used "
+          "delayed_send?");
   auto f = [](event_based_actor* self) -> behavior {
     self->delayed_send(self, std::chrono::nanoseconds(1), ok_atom_v);
     return {
@@ -46,8 +46,8 @@ CAF_TEST(shutdown_with_delayed_send) {
 }
 
 CAF_TEST(shutdown_with_unhandled_delayed_send) {
-  CAF_MESSAGE("does sys shut down after spawning a detached actor that used "
-              "delayed_send but didn't bother waiting for it?");
+  MESSAGE("does sys shut down after spawning a detached actor that used "
+          "delayed_send but didn't bother waiting for it?");
   auto f = [](event_based_actor* self) {
     self->delayed_send(self, std::chrono::nanoseconds(1), ok_atom_v);
   };
@@ -55,8 +55,8 @@ CAF_TEST(shutdown_with_unhandled_delayed_send) {
 }
 
 CAF_TEST(shutdown_with_after) {
-  CAF_MESSAGE("does sys shut down after spawning a detached actor that used "
-              "after()?");
+  MESSAGE("does sys shut down after spawning a detached actor that used "
+          "after()?");
   auto f = [](event_based_actor* self) -> behavior {
     return {
       after(std::chrono::nanoseconds(1)) >> [=] { self->quit(); },
@@ -66,8 +66,8 @@ CAF_TEST(shutdown_with_after) {
 }
 
 CAF_TEST(shutdown_delayed_send_loop) {
-  CAF_MESSAGE("does sys shut down after spawning a detached actor that used "
-              "a delayed send loop and was interrupted via exit message?");
+  MESSAGE("does sys shut down after spawning a detached actor that used "
+          "a delayed send loop and was interrupted via exit message?");
   auto f = [](event_based_actor* self) -> behavior {
     self->delayed_send(self, std::chrono::milliseconds(1), ok_atom_v);
     return {
@@ -81,4 +81,4 @@ CAF_TEST(shutdown_delayed_send_loop) {
     [&] { self->send_exit(a, exit_reason::user_shutdown); });
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/detail/bounds_checker.cpp
+++ b/libcaf_core/test/detail/bounds_checker.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/bounds_checker.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 namespace {
 
@@ -18,26 +18,26 @@ bool check(int64_t x) {
 } // namespace
 
 CAF_TEST(small integers) {
-  CAF_CHECK_EQUAL(check<int8_t>(128), false);
-  CAF_CHECK_EQUAL(check<int8_t>(127), true);
-  CAF_CHECK_EQUAL(check<int8_t>(-128), true);
-  CAF_CHECK_EQUAL(check<int8_t>(-129), false);
-  CAF_CHECK_EQUAL(check<uint8_t>(-1), false);
-  CAF_CHECK_EQUAL(check<uint8_t>(0), true);
-  CAF_CHECK_EQUAL(check<uint8_t>(255), true);
-  CAF_CHECK_EQUAL(check<uint8_t>(256), false);
-  CAF_CHECK_EQUAL(check<int16_t>(-32769), false);
-  CAF_CHECK_EQUAL(check<int16_t>(-32768), true);
-  CAF_CHECK_EQUAL(check<int16_t>(32767), true);
-  CAF_CHECK_EQUAL(check<int16_t>(32768), false);
-  CAF_CHECK_EQUAL(check<uint16_t>(-1), false);
-  CAF_CHECK_EQUAL(check<uint16_t>(0), true);
-  CAF_CHECK_EQUAL(check<uint16_t>(65535), true);
-  CAF_CHECK_EQUAL(check<uint16_t>(65536), false);
+  CHECK_EQ(check<int8_t>(128), false);
+  CHECK_EQ(check<int8_t>(127), true);
+  CHECK_EQ(check<int8_t>(-128), true);
+  CHECK_EQ(check<int8_t>(-129), false);
+  CHECK_EQ(check<uint8_t>(-1), false);
+  CHECK_EQ(check<uint8_t>(0), true);
+  CHECK_EQ(check<uint8_t>(255), true);
+  CHECK_EQ(check<uint8_t>(256), false);
+  CHECK_EQ(check<int16_t>(-32769), false);
+  CHECK_EQ(check<int16_t>(-32768), true);
+  CHECK_EQ(check<int16_t>(32767), true);
+  CHECK_EQ(check<int16_t>(32768), false);
+  CHECK_EQ(check<uint16_t>(-1), false);
+  CHECK_EQ(check<uint16_t>(0), true);
+  CHECK_EQ(check<uint16_t>(65535), true);
+  CHECK_EQ(check<uint16_t>(65536), false);
 }
 
 CAF_TEST(large unsigned integers) {
-  CAF_CHECK_EQUAL(check<uint64_t>(-1), false);
-  CAF_CHECK_EQUAL(check<uint64_t>(0), true);
-  CAF_CHECK_EQUAL(check<uint64_t>(std::numeric_limits<int64_t>::max()), true);
+  CHECK_EQ(check<uint64_t>(-1), false);
+  CHECK_EQ(check<uint64_t>(0), true);
+  CHECK_EQ(check<uint64_t>(std::numeric_limits<int64_t>::max()), true);
 }

--- a/libcaf_core/test/detail/config_consumer.cpp
+++ b/libcaf_core/test/detail/config_consumer.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/config_consumer.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include "caf/detail/parser/read_config.hpp"
 
@@ -59,39 +59,39 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(config_consumer_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(config_consumer) {
   string_view str = test_config1;
   detail::config_consumer consumer{options, config};
   string_parser_state res{str.begin(), str.end()};
   detail::parser::read_config(res, consumer);
-  CAF_CHECK_EQUAL(res.code, pec::success);
-  CAF_CHECK_EQUAL(string_view(res.i, res.e), string_view());
-  CAF_CHECK_EQUAL(get_as<bool>(config, "is_server"), true);
-  CAF_CHECK_EQUAL(get_as<uint16_t>(config, "port"), 4242u);
-  CAF_CHECK_EQUAL(get_as<ls>(config, "nodes"), ls({"sun", "venus"}));
-  CAF_CHECK_EQUAL(get_as<string>(config, "logger.file-name"), "foobar.conf");
-  CAF_CHECK_EQUAL(get_as<timespan>(config, "scheduler.timing"), timespan(2000));
+  CHECK_EQ(res.code, pec::success);
+  CHECK_EQ(string_view(res.i, res.e), string_view());
+  CHECK_EQ(get_as<bool>(config, "is_server"), true);
+  CHECK_EQ(get_as<uint16_t>(config, "port"), 4242u);
+  CHECK_EQ(get_as<ls>(config, "nodes"), ls({"sun", "venus"}));
+  CHECK_EQ(get_as<string>(config, "logger.file-name"), "foobar.conf");
+  CHECK_EQ(get_as<timespan>(config, "scheduler.timing"), timespan(2000));
 }
 
 CAF_TEST(simplified syntax) {
-  CAF_MESSAGE("read test_config");
+  MESSAGE("read test_config");
   {
     detail::config_consumer consumer{options, config};
     string_parser_state res{test_config1.begin(), test_config1.end()};
     detail::parser::read_config(res, consumer);
-    CAF_CHECK_EQUAL(res.code, pec::success);
+    CHECK_EQ(res.code, pec::success);
   }
   settings config2;
-  CAF_MESSAGE("read test_config2");
+  MESSAGE("read test_config2");
   {
     detail::config_consumer consumer{options, config2};
     string_parser_state res{test_config2.begin(), test_config2.end()};
     detail::parser::read_config(res, consumer);
-    CAF_CHECK_EQUAL(res.code, pec::success);
+    CHECK_EQ(res.code, pec::success);
   }
-  CAF_CHECK_EQUAL(config, config2);
+  CHECK_EQ(config, config2);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/detail/group_tunnel.cpp
+++ b/libcaf_core/test/detail/group_tunnel.cpp
@@ -120,7 +120,7 @@ struct fixture : test_coordinator_fixture<> {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(group_tunnel_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 SCENARIO("tunnels automatically subscribe to their origin on first subscribe") {
   GIVEN("a group with two subscribers and a tunnel") {
@@ -263,4 +263,4 @@ SCENARIO("tunnels cache messages until connected") {
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/detail/ieee_754.cpp
+++ b/libcaf_core/test/detail/ieee_754.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/ieee_754.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include <limits>
 
@@ -26,15 +26,15 @@ using dlimits = std::numeric_limits<double>;
 
 } // namespace
 
-#define CHECK_RT(value) CAF_CHECK_EQUAL(roundtrip(value), value)
+#define CHECK_RT(value) CHECK_EQ(roundtrip(value), value)
 
-#define CHECK_PRED_RT(pred, value) CAF_CHECK(pred(roundtrip(value)))
+#define CHECK_PRED_RT(pred, value) CHECK(pred(roundtrip(value)))
 
 #define CHECK_SIGN_RT(value)                                                   \
-  CAF_CHECK_EQUAL(std::signbit(roundtrip(value)), std::signbit(value))
+  CHECK_EQ(std::signbit(roundtrip(value)), std::signbit(value))
 
 CAF_TEST(packing and then unpacking floats returns the original value) {
-  CAF_MESSAGE("finite values compare equal");
+  MESSAGE("finite values compare equal");
   CHECK_RT(0.f);
   CHECK_RT(0xCAFp1);
   CHECK_RT(flimits::epsilon());
@@ -45,11 +45,11 @@ CAF_TEST(packing and then unpacking floats returns the original value) {
   CHECK_RT(-flimits::epsilon());
   CHECK_RT(-flimits::min());
   CHECK_RT(-flimits::max());
-  CAF_MESSAGE("packing and unpacking preserves infinity and NaN");
+  MESSAGE("packing and unpacking preserves infinity and NaN");
   CHECK_PRED_RT(std::isinf, flimits::infinity());
   CHECK_PRED_RT(std::isinf, -flimits::infinity());
   CHECK_PRED_RT(std::isnan, flimits::quiet_NaN());
-  CAF_MESSAGE("packing and unpacking preserves the sign bit");
+  MESSAGE("packing and unpacking preserves the sign bit");
   CHECK_SIGN_RT(0.f);
   CHECK_SIGN_RT(0xCAFp1);
   CHECK_SIGN_RT(flimits::epsilon());
@@ -65,7 +65,7 @@ CAF_TEST(packing and then unpacking floats returns the original value) {
 }
 
 CAF_TEST(packing and then unpacking doubles returns the original value) {
-  CAF_MESSAGE("finite values compare equal");
+  MESSAGE("finite values compare equal");
   CHECK_RT(0.);
   CHECK_RT(0xCAFp1);
   CHECK_RT(dlimits::epsilon());
@@ -76,11 +76,11 @@ CAF_TEST(packing and then unpacking doubles returns the original value) {
   CHECK_RT(-dlimits::epsilon());
   CHECK_RT(-dlimits::min());
   CHECK_RT(-dlimits::max());
-  CAF_MESSAGE("packing and unpacking preserves infinity and NaN");
+  MESSAGE("packing and unpacking preserves infinity and NaN");
   CHECK_PRED_RT(std::isinf, dlimits::infinity());
   CHECK_PRED_RT(std::isinf, -dlimits::infinity());
   CHECK_PRED_RT(std::isnan, dlimits::quiet_NaN());
-  CAF_MESSAGE("packing and unpacking preserves the sign bit");
+  MESSAGE("packing and unpacking preserves the sign bit");
   CHECK_SIGN_RT(0.);
   CHECK_SIGN_RT(0xCAFp1);
   CHECK_SIGN_RT(dlimits::epsilon());

--- a/libcaf_core/test/detail/limited_vector.cpp
+++ b/libcaf_core/test/detail/limited_vector.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/limited_vector.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include <algorithm>
 
@@ -24,39 +24,38 @@ CAF_TEST(basics) {
   limited_vector<int, 2> vec5{3, 4};
   vec4.insert(vec4.end(), vec5.begin(), vec5.end());
   auto vec6 = vec4;
-  CAF_CHECK_EQUAL(vec1.size(), 4u);
-  CAF_CHECK_EQUAL(vec2.size(), 4u);
-  CAF_CHECK_EQUAL(vec3.size(), 4u);
-  CAF_CHECK_EQUAL(vec4.size(), 4u);
-  CAF_CHECK_EQUAL(vec5.size(), 2u);
-  CAF_CHECK_EQUAL(vec6.size(), 4u);
-  CAF_CHECK_EQUAL(vec1.full(), true);
-  CAF_CHECK_EQUAL(vec2.full(), false);
-  CAF_CHECK_EQUAL(vec3.full(), true);
-  CAF_CHECK_EQUAL(vec4.full(), true);
-  CAF_CHECK_EQUAL(vec5.full(), true);
-  CAF_CHECK_EQUAL(vec6.full(), true);
-  CAF_CHECK(std::equal(vec1.begin(), vec1.end(), arr1));
-  CAF_CHECK(std::equal(vec2.rbegin(), vec2.rend(), arr1));
-  CAF_CHECK(std::equal(vec4.begin(), vec4.end(), arr1));
-  CAF_CHECK(std::equal(vec6.begin(), vec6.end(), arr1));
-  CAF_CHECK(std::equal(vec6.begin(), vec6.end(), vec2.rbegin()));
+  CHECK_EQ(vec1.size(), 4u);
+  CHECK_EQ(vec2.size(), 4u);
+  CHECK_EQ(vec3.size(), 4u);
+  CHECK_EQ(vec4.size(), 4u);
+  CHECK_EQ(vec5.size(), 2u);
+  CHECK_EQ(vec6.size(), 4u);
+  CHECK_EQ(vec1.full(), true);
+  CHECK_EQ(vec2.full(), false);
+  CHECK_EQ(vec3.full(), true);
+  CHECK_EQ(vec4.full(), true);
+  CHECK_EQ(vec5.full(), true);
+  CHECK_EQ(vec6.full(), true);
+  CHECK(std::equal(vec1.begin(), vec1.end(), arr1));
+  CHECK(std::equal(vec2.rbegin(), vec2.rend(), arr1));
+  CHECK(std::equal(vec4.begin(), vec4.end(), arr1));
+  CHECK(std::equal(vec6.begin(), vec6.end(), arr1));
+  CHECK(std::equal(vec6.begin(), vec6.end(), vec2.rbegin()));
   limited_vector<int, 10> vec7{5, 9};
   limited_vector<int, 10> vec8{1, 2, 3, 4};
   limited_vector<int, 10> vec9{6, 7, 8};
   vec7.insert(vec7.begin() + 1, vec9.begin(), vec9.end());
   vec7.insert(vec7.begin(), vec8.begin(), vec8.end());
-  CAF_CHECK_EQUAL(vec7.full(), false);
+  CHECK_EQ(vec7.full(), false);
   limited_vector<int, 1> vec10{10};
   vec7.insert(vec7.end(), vec10.begin(), vec10.end());
-  CAF_CHECK_EQUAL(vec7.full(), true);
-  CAF_CHECK((std::is_sorted(vec7.begin(), vec7.end())));
+  CHECK_EQ(vec7.full(), true);
+  CHECK((std::is_sorted(vec7.begin(), vec7.end())));
   int arr2[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  CAF_CHECK((std::equal(vec7.begin(), vec7.end(), std::begin(arr2))));
+  CHECK((std::equal(vec7.begin(), vec7.end(), std::begin(arr2))));
   vec7.assign(std::begin(arr2), std::end(arr2));
-  CAF_CHECK((std::equal(vec7.begin(), vec7.end(), std::begin(arr2))));
+  CHECK((std::equal(vec7.begin(), vec7.end(), std::begin(arr2))));
   vec7.assign(5, 0);
-  CAF_CHECK_EQUAL(vec7.size(), 5u);
-  CAF_CHECK(
-    (std::all_of(vec7.begin(), vec7.end(), [](int i) { return i == 0; })));
+  CHECK_EQ(vec7.size(), 5u);
+  CHECK((std::all_of(vec7.begin(), vec7.end(), [](int i) { return i == 0; })));
 }

--- a/libcaf_core/test/detail/meta_object.cpp
+++ b/libcaf_core/test/detail/meta_object.cpp
@@ -35,15 +35,15 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(meta_object_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(meta objects allow construction and destruction of objects) {
   auto meta_i32_wrapper = make_meta_object<i32_wrapper>("i32_wrapper");
   std::aligned_storage_t<sizeof(i32_wrapper), alignof(i32_wrapper)> storage;
   meta_i32_wrapper.default_construct(&storage);
-  CAF_CHECK_EQUAL(i32_wrapper::instances, 1u);
+  CHECK_EQ(i32_wrapper::instances, 1u);
   meta_i32_wrapper.destroy(&storage);
-  CAF_CHECK_EQUAL(i32_wrapper::instances, 0u);
+  CHECK_EQ(i32_wrapper::instances, 0u);
 }
 
 CAF_TEST(meta objects allow serialization of objects) {
@@ -52,32 +52,32 @@ CAF_TEST(meta objects allow serialization of objects) {
   std::aligned_storage_t<sizeof(i32_wrapper), alignof(i32_wrapper)> storage;
   binary_serializer sink{nullptr, buf};
   meta_i32_wrapper.default_construct(&storage);
-  CAF_CHECK_EQUAL(i32_wrapper::instances, 1u);
-  CAF_CHECK(meta_i32_wrapper.save_binary(sink, &storage));
+  CHECK_EQ(i32_wrapper::instances, 1u);
+  CHECK(meta_i32_wrapper.save_binary(sink, &storage));
   i32_wrapper copy;
-  CAF_CHECK_EQUAL(i32_wrapper::instances, 2u);
+  CHECK_EQ(i32_wrapper::instances, 2u);
   copy.value = 42;
   binary_deserializer source{nullptr, buf};
-  CAF_CHECK(meta_i32_wrapper.load_binary(source, &copy));
-  CAF_CHECK_EQUAL(copy.value, 0);
+  CHECK(meta_i32_wrapper.load_binary(source, &copy));
+  CHECK_EQ(copy.value, 0);
   meta_i32_wrapper.destroy(&storage);
-  CAF_CHECK_EQUAL(i32_wrapper::instances, 1u);
+  CHECK_EQ(i32_wrapper::instances, 1u);
 }
 
 CAF_TEST(init_global_meta_objects takes care of creating a meta object table) {
   auto xs = global_meta_objects();
   CAF_REQUIRE_EQUAL(xs.size(), caf::id_block::core_test::end);
-  CAF_CHECK_EQUAL(type_name_by_id_v<type_id_v<i32_wrapper>>, "i32_wrapper"s);
-  CAF_CHECK_EQUAL(type_name_by_id_v<type_id_v<i64_wrapper>>, "i64_wrapper"s);
-  CAF_CHECK_EQUAL(xs[type_id_v<i32_wrapper>].type_name, "i32_wrapper"s);
-  CAF_CHECK_EQUAL(xs[type_id_v<i64_wrapper>].type_name, "i64_wrapper"s);
-  CAF_MESSAGE("calling init_global_meta_objects again is a no-op");
+  CHECK_EQ(type_name_by_id_v<type_id_v<i32_wrapper>>, "i32_wrapper"s);
+  CHECK_EQ(type_name_by_id_v<type_id_v<i64_wrapper>>, "i64_wrapper"s);
+  CHECK_EQ(xs[type_id_v<i32_wrapper>].type_name, "i32_wrapper"s);
+  CHECK_EQ(xs[type_id_v<i64_wrapper>].type_name, "i64_wrapper"s);
+  MESSAGE("calling init_global_meta_objects again is a no-op");
   init_global_meta_objects<id_block::core_test>();
   auto ys = global_meta_objects();
   auto same = [](const auto& x, const auto& y) {
     return x.type_name == y.type_name;
   };
-  CAF_CHECK(std::equal(xs.begin(), xs.end(), ys.begin(), ys.end(), same));
+  CHECK(std::equal(xs.begin(), xs.end(), ys.begin(), ys.end(), same));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/detail/parser/read_bool.cpp
+++ b/libcaf_core/test/detail/parser/read_bool.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/parser/read_bool.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include <string>
 
@@ -45,26 +45,26 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(read_bool_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(valid booleans) {
-  CAF_CHECK_EQUAL(p("true"), res_t{true});
-  CAF_CHECK_EQUAL(p("false"), res_t{false});
+  CHECK_EQ(p("true"), res_t{true});
+  CHECK_EQ(p("false"), res_t{false});
 }
 
 CAF_TEST(invalid booleans) {
-  CAF_CHECK_EQUAL(p(""), res_t{pec::unexpected_eof});
-  CAF_CHECK_EQUAL(p("t"), res_t{pec::unexpected_eof});
-  CAF_CHECK_EQUAL(p("tr"), res_t{pec::unexpected_eof});
-  CAF_CHECK_EQUAL(p("tru"), res_t{pec::unexpected_eof});
-  CAF_CHECK_EQUAL(p(" true"), res_t{pec::unexpected_character});
-  CAF_CHECK_EQUAL(p("f"), res_t{pec::unexpected_eof});
-  CAF_CHECK_EQUAL(p("fa"), res_t{pec::unexpected_eof});
-  CAF_CHECK_EQUAL(p("fal"), res_t{pec::unexpected_eof});
-  CAF_CHECK_EQUAL(p("fals"), res_t{pec::unexpected_eof});
-  CAF_CHECK_EQUAL(p(" false"), res_t{pec::unexpected_character});
-  CAF_CHECK_EQUAL(p("tr\nue"), res_t{pec::unexpected_newline});
-  CAF_CHECK_EQUAL(p("trues"), res_t{pec::trailing_character});
+  CHECK_EQ(p(""), res_t{pec::unexpected_eof});
+  CHECK_EQ(p("t"), res_t{pec::unexpected_eof});
+  CHECK_EQ(p("tr"), res_t{pec::unexpected_eof});
+  CHECK_EQ(p("tru"), res_t{pec::unexpected_eof});
+  CHECK_EQ(p(" true"), res_t{pec::unexpected_character});
+  CHECK_EQ(p("f"), res_t{pec::unexpected_eof});
+  CHECK_EQ(p("fa"), res_t{pec::unexpected_eof});
+  CHECK_EQ(p("fal"), res_t{pec::unexpected_eof});
+  CHECK_EQ(p("fals"), res_t{pec::unexpected_eof});
+  CHECK_EQ(p(" false"), res_t{pec::unexpected_character});
+  CHECK_EQ(p("tr\nue"), res_t{pec::unexpected_newline});
+  CHECK_EQ(p("trues"), res_t{pec::trailing_character});
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/detail/parser/read_config.cpp
+++ b/libcaf_core/test/detail/parser/read_config.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/parser/read_config.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include "caf/config_value.hpp"
 #include "caf/parser_state.hpp"
@@ -70,8 +70,8 @@ struct fixture {
     string_parser_state res{str.begin(), str.end()};
     detail::parser::read_config(res, f);
     if ((res.code == pec::success) != expect_success) {
-      CAF_MESSAGE("unexpected parser result state: " << res.code);
-      CAF_MESSAGE("input remainder: " << std::string(res.i, res.e));
+      MESSAGE("unexpected parser result state: " << res.code);
+      MESSAGE("input remainder: " << std::string(res.i, res.e));
     }
     return std::move(f.log);
   }
@@ -213,11 +213,11 @@ const auto conf1_log = make_log(
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(read_config_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(read_config feeds into a consumer) {
-  CAF_CHECK_EQUAL(parse(conf0), conf0_log);
-  CAF_CHECK_EQUAL(parse(conf1), conf1_log);
+  CHECK_EQ(parse(conf0), conf0_log);
+  CHECK_EQ(parse(conf1), conf1_log);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/detail/parser/read_floating_point.cpp
+++ b/libcaf_core/test/detail/parser/read_floating_point.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/parser/read_floating_point.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include <string>
 
@@ -40,51 +40,51 @@ optional<double> read(string_view str) {
 } // namespace
 
 CAF_TEST(predecimal only) {
-  CAF_CHECK_EQUAL(read("0"), 0.);
-  CAF_CHECK_EQUAL(read("+0"), 0.);
-  CAF_CHECK_EQUAL(read("-0"), 0.);
-  CAF_CHECK_EQUAL(read("1"), 1.);
-  CAF_CHECK_EQUAL(read("+1"), 1.);
-  CAF_CHECK_EQUAL(read("-1"), -1.);
-  CAF_CHECK_EQUAL(read("12"), 12.);
-  CAF_CHECK_EQUAL(read("+12"), 12.);
-  CAF_CHECK_EQUAL(read("-12"), -12.);
+  CHECK_EQ(read("0"), 0.);
+  CHECK_EQ(read("+0"), 0.);
+  CHECK_EQ(read("-0"), 0.);
+  CHECK_EQ(read("1"), 1.);
+  CHECK_EQ(read("+1"), 1.);
+  CHECK_EQ(read("-1"), -1.);
+  CHECK_EQ(read("12"), 12.);
+  CHECK_EQ(read("+12"), 12.);
+  CHECK_EQ(read("-12"), -12.);
 }
 
 CAF_TEST(trailing dot) {
-  CAF_CHECK_EQUAL(read("0."), 0.);
-  CAF_CHECK_EQUAL(read("1."), 1.);
-  CAF_CHECK_EQUAL(read("+1."), 1.);
-  CAF_CHECK_EQUAL(read("-1."), -1.);
-  CAF_CHECK_EQUAL(read("12."), 12.);
-  CAF_CHECK_EQUAL(read("+12."), 12.);
-  CAF_CHECK_EQUAL(read("-12."), -12.);
+  CHECK_EQ(read("0."), 0.);
+  CHECK_EQ(read("1."), 1.);
+  CHECK_EQ(read("+1."), 1.);
+  CHECK_EQ(read("-1."), -1.);
+  CHECK_EQ(read("12."), 12.);
+  CHECK_EQ(read("+12."), 12.);
+  CHECK_EQ(read("-12."), -12.);
 }
 
 CAF_TEST(leading dot) {
-  CAF_CHECK_EQUAL(read(".0"), .0);
-  CAF_CHECK_EQUAL(read(".1"), .1);
-  CAF_CHECK_EQUAL(read("+.1"), .1);
-  CAF_CHECK_EQUAL(read("-.1"), -.1);
-  CAF_CHECK_EQUAL(read(".12"), .12);
-  CAF_CHECK_EQUAL(read("+.12"), .12);
-  CAF_CHECK_EQUAL(read("-.12"), -.12);
+  CHECK_EQ(read(".0"), .0);
+  CHECK_EQ(read(".1"), .1);
+  CHECK_EQ(read("+.1"), .1);
+  CHECK_EQ(read("-.1"), -.1);
+  CHECK_EQ(read(".12"), .12);
+  CHECK_EQ(read("+.12"), .12);
+  CHECK_EQ(read("-.12"), -.12);
 }
 
 CAF_TEST(regular noation) {
-  CAF_CHECK_EQUAL(read("0.0"), .0);
-  CAF_CHECK_EQUAL(read("1.2"), 1.2);
-  CAF_CHECK_EQUAL(read("1.23"), 1.23);
-  CAF_CHECK_EQUAL(read("12.34"), 12.34);
+  CHECK_EQ(read("0.0"), .0);
+  CHECK_EQ(read("1.2"), 1.2);
+  CHECK_EQ(read("1.23"), 1.23);
+  CHECK_EQ(read("12.34"), 12.34);
 }
 
 CAF_TEST(scientific noation) {
-  CAF_CHECK_EQUAL(read("1e2"), 1e2);
-  CAF_CHECK_EQUAL(read("+1e2"), 1e2);
-  CAF_CHECK_EQUAL(read("+1e+2"), 1e2);
-  CAF_CHECK_EQUAL(read("-1e2"), -1e2);
-  CAF_CHECK_EQUAL(read("-1e+2"), -1e2);
-  CAF_CHECK_EQUAL(read("12e-3"), 12e-3);
-  CAF_CHECK_EQUAL(read("+12e-3"), 12e-3);
-  CAF_CHECK_EQUAL(read("-12e-3"), -12e-3);
+  CHECK_EQ(read("1e2"), 1e2);
+  CHECK_EQ(read("+1e2"), 1e2);
+  CHECK_EQ(read("+1e+2"), 1e2);
+  CHECK_EQ(read("-1e2"), -1e2);
+  CHECK_EQ(read("-1e+2"), -1e2);
+  CHECK_EQ(read("12e-3"), 12e-3);
+  CHECK_EQ(read("+12e-3"), 12e-3);
+  CHECK_EQ(read("-12e-3"), -12e-3);
 }

--- a/libcaf_core/test/detail/parser/read_number.cpp
+++ b/libcaf_core/test/detail/parser/read_number.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/parser/read_number.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include <string>
 
@@ -108,9 +108,9 @@ struct fixture {
 
 } // namespace
 
-#define CHECK_NUMBER(x) CAF_CHECK_EQUAL(p(#x), res(x))
+#define CHECK_NUMBER(x) CHECK_EQ(p(#x), res(x))
 
-CAF_TEST_FIXTURE_SCOPE(read_number_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(add ascii - unsigned) {
   using detail::parser::add_ascii;
@@ -122,9 +122,9 @@ CAF_TEST(add ascii - unsigned) {
     return x;
   };
   for (int i = 0; i < 256; ++i)
-    CAF_CHECK_EQUAL(rd(std::to_string(i)), static_cast<uint8_t>(i));
+    CHECK_EQ(rd(std::to_string(i)), static_cast<uint8_t>(i));
   for (int i = 256; i < 513; ++i)
-    CAF_CHECK_EQUAL(rd(std::to_string(i)), pec::integer_overflow);
+    CHECK_EQ(rd(std::to_string(i)), pec::integer_overflow);
 }
 
 CAF_TEST(add ascii - signed) {
@@ -136,9 +136,9 @@ CAF_TEST(add ascii - signed) {
     return x;
   };
   for (int i = 0; i < 128; ++i)
-    CAF_CHECK_EQUAL(rd(std::to_string(i)), static_cast<int8_t>(i));
+    CHECK_EQ(rd(std::to_string(i)), static_cast<int8_t>(i));
   for (int i = 128; i < 513; ++i)
-    CAF_CHECK_EQUAL(rd(std::to_string(i)), pec::integer_overflow);
+    CHECK_EQ(rd(std::to_string(i)), pec::integer_overflow);
 }
 
 CAF_TEST(sub ascii) {
@@ -152,9 +152,9 @@ CAF_TEST(sub ascii) {
   // Using sub_ascii in this way behaves as if we'd prefix the number with a
   // minus sign, i.e., "123" will result in -123.
   for (int i = 1; i < 129; ++i)
-    CAF_CHECK_EQUAL(rd(std::to_string(i)), static_cast<int8_t>(-i));
+    CHECK_EQ(rd(std::to_string(i)), static_cast<int8_t>(-i));
   for (int i = 129; i < 513; ++i)
-    CAF_CHECK_EQUAL(rd(std::to_string(i)), pec::integer_underflow);
+    CHECK_EQ(rd(std::to_string(i)), pec::integer_underflow);
 }
 
 CAF_TEST(binary numbers) {
@@ -176,7 +176,7 @@ CAF_TEST(octal numbers) {
   CHECK_NUMBER(-00);
   CHECK_NUMBER(-0123);
   // invalid numbers
-  CAF_CHECK_EQUAL(p("018"), pec::trailing_character);
+  CHECK_EQ(p("018"), pec::trailing_character);
 }
 
 CAF_TEST(decimal numbers) {
@@ -197,11 +197,9 @@ CAF_TEST(hexadecimal numbers) {
   CHECK_NUMBER(-0x123);
   CHECK_NUMBER(-0xaf01);
   // invalid numbers
-  CAF_CHECK_EQUAL(p("0xFG"), pec::trailing_character);
-  CAF_CHECK_EQUAL(p("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
-                  pec::integer_overflow);
-  CAF_CHECK_EQUAL(p("-0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
-                  pec::integer_underflow);
+  CHECK_EQ(p("0xFG"), pec::trailing_character);
+  CHECK_EQ(p("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), pec::integer_overflow);
+  CHECK_EQ(p("-0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), pec::integer_underflow);
 }
 
 CAF_TEST(floating point numbers) {
@@ -252,8 +250,8 @@ CAF_TEST(integer mantissa with negative exponent) {
   CHECK_NUMBER(1e-5);
   CHECK_NUMBER(1e-6);
   // invalid numbers
-  CAF_CHECK_EQUAL(p("-9.9999e-e511"), pec::unexpected_character);
-  CAF_CHECK_EQUAL(p("-9.9999e-511"), pec::exponent_underflow);
+  CHECK_EQ(p("-9.9999e-e511"), pec::unexpected_character);
+  CHECK_EQ(p("-9.9999e-511"), pec::exponent_underflow);
 }
 
 CAF_TEST(fractional mantissa with positive exponent) {
@@ -279,7 +277,7 @@ CAF_TEST(fractional mantissa with negative exponent) {
 }
 
 #define CHECK_RANGE(expr, ...)                                                 \
-  CAF_CHECK_EQUAL(r(expr), std::vector<int64_t>({__VA_ARGS__}))
+  CHECK_EQ(r(expr), std::vector<int64_t>({__VA_ARGS__}))
 
 CAF_TEST(a range from n to n is just n) {
   CHECK_RANGE("0..0", 0);
@@ -322,7 +320,7 @@ CAF_TEST(ranges can use signed integers) {
   if (auto res = r(expr)) {                                                    \
     CAF_FAIL("expected expression to produce to an error");                    \
   } else {                                                                     \
-    CAF_CHECK_EQUAL(res.error(), enum_value);                                  \
+    CHECK_EQ(res.error(), enum_value);                                         \
   }
 
 CAF_TEST(the parser rejects invalid step values) {
@@ -330,4 +328,4 @@ CAF_TEST(the parser rejects invalid step values) {
   CHECK_ERR("+2..-2..+2", pec::invalid_range_expression);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/detail/parser/read_number_or_timespan.cpp
+++ b/libcaf_core/test/detail/parser/read_number_or_timespan.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/parser/read_number_or_timespan.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include <string>
 
@@ -88,33 +88,33 @@ res_t res(std::chrono::duration<Rep, Period> x) {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(read_number_or_timespan_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(valid numbers and timespans) {
-  CAF_CHECK_EQUAL(p("123"), res(123));
-  CAF_CHECK_EQUAL(p("123.456"), res(123.456));
-  CAF_CHECK_EQUAL(p("123s"), res(seconds(123)));
-  CAF_CHECK_EQUAL(p("123ns"), res(nanoseconds(123)));
-  CAF_CHECK_EQUAL(p("123ms"), res(milliseconds(123)));
-  CAF_CHECK_EQUAL(p("123us"), res(microseconds(123)));
-  CAF_CHECK_EQUAL(p("123min"), res(minutes(123)));
+  CHECK_EQ(p("123"), res(123));
+  CHECK_EQ(p("123.456"), res(123.456));
+  CHECK_EQ(p("123s"), res(seconds(123)));
+  CHECK_EQ(p("123ns"), res(nanoseconds(123)));
+  CHECK_EQ(p("123ms"), res(milliseconds(123)));
+  CHECK_EQ(p("123us"), res(microseconds(123)));
+  CHECK_EQ(p("123min"), res(minutes(123)));
 }
 
 CAF_TEST(invalid timespans) {
-  CAF_CHECK_EQUAL(p("12.3s"), pec::fractional_timespan);
-  CAF_CHECK_EQUAL(p("12.3n"), pec::fractional_timespan);
-  CAF_CHECK_EQUAL(p("12.3ns"), pec::fractional_timespan);
-  CAF_CHECK_EQUAL(p("12.3m"), pec::fractional_timespan);
-  CAF_CHECK_EQUAL(p("12.3ms"), pec::fractional_timespan);
-  CAF_CHECK_EQUAL(p("12.3n"), pec::fractional_timespan);
-  CAF_CHECK_EQUAL(p("12.3ns"), pec::fractional_timespan);
-  CAF_CHECK_EQUAL(p("12.3mi"), pec::fractional_timespan);
-  CAF_CHECK_EQUAL(p("12.3min"), pec::fractional_timespan);
-  CAF_CHECK_EQUAL(p("123ss"), pec::trailing_character);
-  CAF_CHECK_EQUAL(p("123m"), pec::unexpected_eof);
-  CAF_CHECK_EQUAL(p("123mi"), pec::unexpected_eof);
-  CAF_CHECK_EQUAL(p("123u"), pec::unexpected_eof);
-  CAF_CHECK_EQUAL(p("123n"), pec::unexpected_eof);
+  CHECK_EQ(p("12.3s"), pec::fractional_timespan);
+  CHECK_EQ(p("12.3n"), pec::fractional_timespan);
+  CHECK_EQ(p("12.3ns"), pec::fractional_timespan);
+  CHECK_EQ(p("12.3m"), pec::fractional_timespan);
+  CHECK_EQ(p("12.3ms"), pec::fractional_timespan);
+  CHECK_EQ(p("12.3n"), pec::fractional_timespan);
+  CHECK_EQ(p("12.3ns"), pec::fractional_timespan);
+  CHECK_EQ(p("12.3mi"), pec::fractional_timespan);
+  CHECK_EQ(p("12.3min"), pec::fractional_timespan);
+  CHECK_EQ(p("123ss"), pec::trailing_character);
+  CHECK_EQ(p("123m"), pec::unexpected_eof);
+  CHECK_EQ(p("123mi"), pec::unexpected_eof);
+  CHECK_EQ(p("123u"), pec::unexpected_eof);
+  CHECK_EQ(p("123n"), pec::unexpected_eof);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/detail/parser/read_signed_integer.cpp
+++ b/libcaf_core/test/detail/parser/read_signed_integer.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/parser/read_signed_integer.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include "caf/parser_state.hpp"
 #include "caf/string_view.hpp"
@@ -65,26 +65,25 @@ T max_val() {
 
 } // namespace
 
-#define ZERO_VALUE(type, literal)                                              \
-  CAF_CHECK_EQUAL(read<type>(#literal), type(0));
+#define ZERO_VALUE(type, literal) CHECK_EQ(read<type>(#literal), type(0));
 
 #define MAX_VALUE(type, literal)                                               \
-  CAF_CHECK_EQUAL(read<type>(#literal), max_val<type>());
+  CHECK_EQ(read<type>(#literal), max_val<type>());
 
 #define MIN_VALUE(type, literal)                                               \
-  CAF_CHECK_EQUAL(read<type>(#literal), min_val<type>());
+  CHECK_EQ(read<type>(#literal), min_val<type>());
 
 #ifdef OVERFLOW
 #  undef OVERFLOW
 #endif // OVERFLOW
 
-#define OVERFLOW(type, literal) CAF_CHECK(overflow<type>(#literal));
+#define OVERFLOW(type, literal) CHECK(overflow<type>(#literal));
 
 #ifdef UNDERFLOW
 #  undef UNDERFLOW
 #endif // UNDERFLOW
 
-#define UNDERFLOW(type, literal) CAF_CHECK(underflow<type>(#literal));
+#define UNDERFLOW(type, literal) CHECK(underflow<type>(#literal));
 
 CAF_TEST(read zeros) {
   ZERO_VALUE(int8_t, 0);

--- a/libcaf_core/test/detail/parser/read_string.cpp
+++ b/libcaf_core/test/detail/parser/read_string.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/parser/read_string.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include <string>
 
@@ -44,59 +44,59 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(read_string_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(empty string) {
-  CAF_CHECK_EQUAL(p(R"("")"), ""s);
-  CAF_CHECK_EQUAL(p(R"( "")"), ""s);
-  CAF_CHECK_EQUAL(p(R"(  "")"), ""s);
-  CAF_CHECK_EQUAL(p(R"("" )"), ""s);
-  CAF_CHECK_EQUAL(p(R"(""  )"), ""s);
-  CAF_CHECK_EQUAL(p(R"(  ""  )"), ""s);
-  CAF_CHECK_EQUAL(p("\t \"\" \t\t\t "), ""s);
-  CAF_CHECK_EQUAL(p(R"('')"), ""s);
-  CAF_CHECK_EQUAL(p(R"( '')"), ""s);
-  CAF_CHECK_EQUAL(p(R"(  '')"), ""s);
-  CAF_CHECK_EQUAL(p(R"('' )"), ""s);
-  CAF_CHECK_EQUAL(p(R"(''  )"), ""s);
-  CAF_CHECK_EQUAL(p(R"(  ''  )"), ""s);
-  CAF_CHECK_EQUAL(p("\t '' \t\t\t "), ""s);
+  CHECK_EQ(p(R"("")"), ""s);
+  CHECK_EQ(p(R"( "")"), ""s);
+  CHECK_EQ(p(R"(  "")"), ""s);
+  CHECK_EQ(p(R"("" )"), ""s);
+  CHECK_EQ(p(R"(""  )"), ""s);
+  CHECK_EQ(p(R"(  ""  )"), ""s);
+  CHECK_EQ(p("\t \"\" \t\t\t "), ""s);
+  CHECK_EQ(p(R"('')"), ""s);
+  CHECK_EQ(p(R"( '')"), ""s);
+  CHECK_EQ(p(R"(  '')"), ""s);
+  CHECK_EQ(p(R"('' )"), ""s);
+  CHECK_EQ(p(R"(''  )"), ""s);
+  CHECK_EQ(p(R"(  ''  )"), ""s);
+  CHECK_EQ(p("\t '' \t\t\t "), ""s);
 }
 
 CAF_TEST(nonempty quoted string) {
-  CAF_CHECK_EQUAL(p(R"("abc")"), "abc"s);
-  CAF_CHECK_EQUAL(p(R"("a b c")"), "a b c"s);
-  CAF_CHECK_EQUAL(p(R"(   "abcdefABCDEF"   )"), "abcdefABCDEF"s);
-  CAF_CHECK_EQUAL(p(R"('abc')"), "abc"s);
-  CAF_CHECK_EQUAL(p(R"('a b c')"), "a b c"s);
-  CAF_CHECK_EQUAL(p(R"(   'abcdefABCDEF'   )"), "abcdefABCDEF"s);
+  CHECK_EQ(p(R"("abc")"), "abc"s);
+  CHECK_EQ(p(R"("a b c")"), "a b c"s);
+  CHECK_EQ(p(R"(   "abcdefABCDEF"   )"), "abcdefABCDEF"s);
+  CHECK_EQ(p(R"('abc')"), "abc"s);
+  CHECK_EQ(p(R"('a b c')"), "a b c"s);
+  CHECK_EQ(p(R"(   'abcdefABCDEF'   )"), "abcdefABCDEF"s);
 }
 
 CAF_TEST(quoted string with escaped characters) {
-  CAF_CHECK_EQUAL(p(R"("a\tb\tc")"), "a\tb\tc"s);
-  CAF_CHECK_EQUAL(p(R"("a\nb\r\nc")"), "a\nb\r\nc"s);
-  CAF_CHECK_EQUAL(p(R"("a\\b")"), "a\\b"s);
-  CAF_CHECK_EQUAL(p("\"'hello' \\\"world\\\"\""), "'hello' \"world\""s);
-  CAF_CHECK_EQUAL(p(R"('a\tb\tc')"), "a\tb\tc"s);
-  CAF_CHECK_EQUAL(p(R"('a\nb\r\nc')"), "a\nb\r\nc"s);
-  CAF_CHECK_EQUAL(p(R"('a\\b')"), "a\\b"s);
-  CAF_CHECK_EQUAL(p(R"('\'hello\' "world"')"), "'hello' \"world\""s);
+  CHECK_EQ(p(R"("a\tb\tc")"), "a\tb\tc"s);
+  CHECK_EQ(p(R"("a\nb\r\nc")"), "a\nb\r\nc"s);
+  CHECK_EQ(p(R"("a\\b")"), "a\\b"s);
+  CHECK_EQ(p("\"'hello' \\\"world\\\"\""), "'hello' \"world\""s);
+  CHECK_EQ(p(R"('a\tb\tc')"), "a\tb\tc"s);
+  CHECK_EQ(p(R"('a\nb\r\nc')"), "a\nb\r\nc"s);
+  CHECK_EQ(p(R"('a\\b')"), "a\\b"s);
+  CHECK_EQ(p(R"('\'hello\' "world"')"), "'hello' \"world\""s);
 }
 
 CAF_TEST(unquoted strings) {
-  CAF_CHECK_EQUAL(p(R"(foo)"), "foo"s);
-  CAF_CHECK_EQUAL(p(R"( foo )"), "foo"s);
-  CAF_CHECK_EQUAL(p(R"( 123 )"), "123"s);
+  CHECK_EQ(p(R"(foo)"), "foo"s);
+  CHECK_EQ(p(R"( foo )"), "foo"s);
+  CHECK_EQ(p(R"( 123 )"), "123"s);
 }
 
 CAF_TEST(invalid strings) {
-  CAF_CHECK_EQUAL(p(R"("abc)"), pec::unexpected_eof);
-  CAF_CHECK_EQUAL(p(R"('abc)"), pec::unexpected_eof);
-  CAF_CHECK_EQUAL(p("\"ab\nc\""), pec::unexpected_newline);
-  CAF_CHECK_EQUAL(p("'ab\nc'"), pec::unexpected_newline);
-  CAF_CHECK_EQUAL(p(R"("abc" def)"), pec::trailing_character);
-  CAF_CHECK_EQUAL(p(R"('abc' def)"), pec::trailing_character);
-  CAF_CHECK_EQUAL(p(R"( 123, )"), pec::trailing_character);
+  CHECK_EQ(p(R"("abc)"), pec::unexpected_eof);
+  CHECK_EQ(p(R"('abc)"), pec::unexpected_eof);
+  CHECK_EQ(p("\"ab\nc\""), pec::unexpected_newline);
+  CHECK_EQ(p("'ab\nc'"), pec::unexpected_newline);
+  CHECK_EQ(p(R"("abc" def)"), pec::trailing_character);
+  CHECK_EQ(p(R"('abc' def)"), pec::trailing_character);
+  CHECK_EQ(p(R"( 123, )"), pec::trailing_character);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/detail/parser/read_timespan.cpp
+++ b/libcaf_core/test/detail/parser/read_timespan.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/parser/read_timespan.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include <chrono>
 
@@ -62,10 +62,10 @@ optional<timespan> read(string_view str) {
 } // namespace
 
 CAF_TEST(todo) {
-  CAF_CHECK_EQUAL(read("12ns"), 12_ns);
-  CAF_CHECK_EQUAL(read("34us"), 34_us);
-  CAF_CHECK_EQUAL(read("56ms"), 56_ms);
-  CAF_CHECK_EQUAL(read("78s"), 78_s);
-  CAF_CHECK_EQUAL(read("60min"), 1_h);
-  CAF_CHECK_EQUAL(read("90h"), 90_h);
+  CHECK_EQ(read("12ns"), 12_ns);
+  CHECK_EQ(read("34us"), 34_us);
+  CHECK_EQ(read("56ms"), 56_ms);
+  CHECK_EQ(read("78s"), 78_s);
+  CHECK_EQ(read("60min"), 1_h);
+  CHECK_EQ(read("90h"), 90_h);
 }

--- a/libcaf_core/test/detail/parser/read_unsigned_integer.cpp
+++ b/libcaf_core/test/detail/parser/read_unsigned_integer.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/parser/read_unsigned_integer.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include "caf/parser_state.hpp"
 #include "caf/string_view.hpp"
@@ -52,17 +52,16 @@ T max_val() {
 
 } // namespace
 
-#define ZERO_VALUE(type, literal)                                              \
-  CAF_CHECK_EQUAL(read<type>(#literal), type(0));
+#define ZERO_VALUE(type, literal) CHECK_EQ(read<type>(#literal), type(0));
 
 #define MAX_VALUE(type, literal)                                               \
-  CAF_CHECK_EQUAL(read<type>(#literal), max_val<type>());
+  CHECK_EQ(read<type>(#literal), max_val<type>());
 
 #ifdef OVERFLOW
 #  undef OVERFLOW
 #endif // OVERFLOW
 
-#define OVERFLOW(type, literal) CAF_CHECK(overflow<type>(#literal));
+#define OVERFLOW(type, literal) CHECK(overflow<type>(#literal));
 
 CAF_TEST(read zeros) {
   ZERO_VALUE(uint8_t, 0);

--- a/libcaf_core/test/detail/private_thread_pool.cpp
+++ b/libcaf_core/test/detail/private_thread_pool.cpp
@@ -26,7 +26,7 @@
 
 using namespace caf;
 
-CAF_TEST_FIXTURE_SCOPE(private_thread_pool_tests, test_coordinator_fixture<>)
+BEGIN_FIXTURE_SCOPE(test_coordinator_fixture<>)
 
 SCENARIO("private threads count towards detached actors") {
   GIVEN("an actor system with a private thread pool") {
@@ -97,4 +97,4 @@ SCENARIO("private threads rerun their resumable when it returns resume_later") {
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/detail/ringbuffer.cpp
+++ b/libcaf_core/test/detail/ringbuffer.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/ringbuffer.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include <algorithm>
 
@@ -39,33 +39,33 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(ringbuffer_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(construction) {
-  CAF_CHECK_EQUAL(buf.empty(), true);
-  CAF_CHECK_EQUAL(buf.full(), false);
-  CAF_CHECK_EQUAL(buf.size(), 0u);
+  CHECK_EQ(buf.empty(), true);
+  CHECK_EQ(buf.full(), false);
+  CHECK_EQ(buf.size(), 0u);
 }
 
 CAF_TEST(push_back) {
-  CAF_MESSAGE("add one element");
+  MESSAGE("add one element");
   buf.push_back(42);
-  CAF_CHECK_EQUAL(buf.empty(), false);
-  CAF_CHECK_EQUAL(buf.full(), false);
-  CAF_CHECK_EQUAL(buf.size(), 1u);
-  CAF_CHECK_EQUAL(buf.front(), 42);
-  CAF_MESSAGE("remove element");
+  CHECK_EQ(buf.empty(), false);
+  CHECK_EQ(buf.full(), false);
+  CHECK_EQ(buf.size(), 1u);
+  CHECK_EQ(buf.front(), 42);
+  MESSAGE("remove element");
   buf.pop_front();
-  CAF_CHECK_EQUAL(buf.empty(), true);
-  CAF_CHECK_EQUAL(buf.full(), false);
-  CAF_CHECK_EQUAL(buf.size(), 0u);
-  CAF_MESSAGE("fill buffer");
+  CHECK_EQ(buf.empty(), true);
+  CHECK_EQ(buf.full(), false);
+  CHECK_EQ(buf.size(), 0u);
+  MESSAGE("fill buffer");
   for (int i = 0; i < static_cast<int>(buf_size - 1); ++i)
     buf.push_back(std::move(i));
-  CAF_CHECK_EQUAL(buf.empty(), false);
-  CAF_CHECK_EQUAL(buf.full(), true);
-  CAF_CHECK_EQUAL(buf.size(), buf_size - 1);
-  CAF_CHECK_EQUAL(buf.front(), 0);
+  CHECK_EQ(buf.empty(), false);
+  CHECK_EQ(buf.full(), true);
+  CHECK_EQ(buf.size(), buf_size - 1);
+  CHECK_EQ(buf.front(), 0);
 }
 
 CAF_TEST(get all) {
@@ -77,29 +77,29 @@ CAF_TEST(get all) {
     auto e = buf.get_all(i);
     return vector_type(i, e);
   };
-  CAF_MESSAGE("add five element");
+  MESSAGE("add five element");
   for (int i = 0; i < 5; ++i)
     buf.push_back(std::move(i));
-  CAF_CHECK_EQUAL(buf.empty(), false);
-  CAF_CHECK_EQUAL(buf.full(), false);
-  CAF_CHECK_EQUAL(buf.size(), 5u);
-  CAF_CHECK_EQUAL(buf.front(), 0);
-  CAF_MESSAGE("drain elements");
-  CAF_CHECK_EQUAL(fetch_all(), vector_type({0, 1, 2, 3, 4}));
-  CAF_CHECK_EQUAL(buf.empty(), true);
-  CAF_CHECK_EQUAL(buf.full(), false);
-  CAF_CHECK_EQUAL(buf.size(), 0u);
-  CAF_MESSAGE("add 60 elements (wraps around)");
+  CHECK_EQ(buf.empty(), false);
+  CHECK_EQ(buf.full(), false);
+  CHECK_EQ(buf.size(), 5u);
+  CHECK_EQ(buf.front(), 0);
+  MESSAGE("drain elements");
+  CHECK_EQ(fetch_all(), vector_type({0, 1, 2, 3, 4}));
+  CHECK_EQ(buf.empty(), true);
+  CHECK_EQ(buf.full(), false);
+  CHECK_EQ(buf.size(), 0u);
+  MESSAGE("add 60 elements (wraps around)");
   vector_type expected;
   for (int i = 0; i < 60; ++i) {
     expected.push_back(i);
     buf.push_back(std::move(i));
   }
-  CAF_CHECK_EQUAL(buf.size(), 60u);
-  CAF_CHECK_EQUAL(fetch_all(), expected);
-  CAF_CHECK_EQUAL(buf.empty(), true);
-  CAF_CHECK_EQUAL(buf.full(), false);
-  CAF_CHECK_EQUAL(buf.size(), 0u);
+  CHECK_EQ(buf.size(), 60u);
+  CHECK_EQ(fetch_all(), expected);
+  CHECK_EQ(buf.empty(), true);
+  CHECK_EQ(buf.full(), false);
+  CHECK_EQ(buf.size(), 0u);
 }
 
 CAF_TEST(concurrent access) {
@@ -109,12 +109,12 @@ CAF_TEST(concurrent access) {
   producers.emplace_back(producer, std::ref(buf), 200, 300);
   auto vec = consumer(buf, 300);
   std::sort(vec.begin(), vec.end());
-  CAF_CHECK(std::is_sorted(vec.begin(), vec.end()));
-  CAF_CHECK_EQUAL(vec.size(), 300u);
-  CAF_CHECK_EQUAL(vec.front(), 0);
-  CAF_CHECK_EQUAL(vec.back(), 299);
+  CHECK(std::is_sorted(vec.begin(), vec.end()));
+  CHECK_EQ(vec.size(), 300u);
+  CHECK_EQ(vec.front(), 0);
+  CHECK_EQ(vec.back(), 299);
   for (auto& t : producers)
     t.join();
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/detail/ripemd_160.cpp
+++ b/libcaf_core/test/detail/ripemd_160.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/ripemd_160.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include <iomanip>
 #include <iostream>
@@ -31,20 +31,20 @@ std::string str_hash(const std::string& what) {
 // verify ripemd implementation with example hash results from
 // http://homes.esat.kuleuven.be/~bosselae/ripemd160.html
 CAF_TEST(hash_results) {
-  CAF_CHECK_EQUAL("9c1185a5c5e9fc54612808977ee8f548b2258d31", str_hash(""));
-  CAF_CHECK_EQUAL("0bdc9d2d256b3ee9daae347be6f4dc835a467ffe", str_hash("a"));
-  CAF_CHECK_EQUAL("8eb208f7e05d987a9b044a8e98c6b087f15a0bfc", str_hash("abc"));
-  CAF_CHECK_EQUAL("5d0689ef49d2fae572b881b123a85ffa21595f36",
-                  str_hash("message digest"));
-  CAF_CHECK_EQUAL("f71c27109c692c1b56bbdceb5b9d2865b3708dbc",
-                  str_hash("abcdefghijklmnopqrstuvwxyz"));
-  CAF_CHECK_EQUAL("12a053384a9c0c88e405a06c27dcf49ada62eb2b",
-                  str_hash("abcdbcdecdefdefgefghfghighij"
-                           "hijkijkljklmklmnlmnomnopnopq"));
-  CAF_CHECK_EQUAL("b0e20b6e3116640286ed3a87a5713079b21f5189",
-                  str_hash("ABCDEFGHIJKLMNOPQRSTUVWXYZabcde"
-                           "fghijklmnopqrstuvwxyz0123456789"));
-  CAF_CHECK_EQUAL("9b752e45573d4b39f4dbd3323cab82bf63326bfb",
-                  str_hash("1234567890123456789012345678901234567890"
-                           "1234567890123456789012345678901234567890"));
+  CHECK_EQ("9c1185a5c5e9fc54612808977ee8f548b2258d31", str_hash(""));
+  CHECK_EQ("0bdc9d2d256b3ee9daae347be6f4dc835a467ffe", str_hash("a"));
+  CHECK_EQ("8eb208f7e05d987a9b044a8e98c6b087f15a0bfc", str_hash("abc"));
+  CHECK_EQ("5d0689ef49d2fae572b881b123a85ffa21595f36",
+           str_hash("message digest"));
+  CHECK_EQ("f71c27109c692c1b56bbdceb5b9d2865b3708dbc",
+           str_hash("abcdefghijklmnopqrstuvwxyz"));
+  CHECK_EQ("12a053384a9c0c88e405a06c27dcf49ada62eb2b",
+           str_hash("abcdbcdecdefdefgefghfghighij"
+                    "hijkijkljklmklmnlmnomnopnopq"));
+  CHECK_EQ("b0e20b6e3116640286ed3a87a5713079b21f5189",
+           str_hash("ABCDEFGHIJKLMNOPQRSTUVWXYZabcde"
+                    "fghijklmnopqrstuvwxyz0123456789"));
+  CHECK_EQ("9b752e45573d4b39f4dbd3323cab82bf63326bfb",
+           str_hash("1234567890123456789012345678901234567890"
+                    "1234567890123456789012345678901234567890"));
 }

--- a/libcaf_core/test/detail/serialized_size.cpp
+++ b/libcaf_core/test/detail/serialized_size.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/serialized_size.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include <vector>
 
@@ -34,9 +34,9 @@ struct fixture : test_coordinator_fixture<> {
 } // namespace
 
 #define CHECK_SAME_SIZE(value)                                                 \
-  CAF_CHECK_EQUAL(serialized_size(value), actual_size(value))
+  CHECK_EQ(serialized_size(value), actual_size(value))
 
-CAF_TEST_FIXTURE_SCOPE(serialized_size_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(numbers) {
   CHECK_SAME_SIZE(int8_t{42});
@@ -63,4 +63,4 @@ CAF_TEST(messages) {
   CHECK_SAME_SIZE(make_message("hello", "world"));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/detail/tick_emitter.cpp
+++ b/libcaf_core/test/detail/tick_emitter.cpp
@@ -18,7 +18,7 @@
 
 #include "caf/detail/tick_emitter.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include <vector>
 
@@ -43,22 +43,22 @@ CAF_TEST(start_and_stop) {
   detail::tick_emitter y{time_point{timespan{100}}};
   detail::tick_emitter z;
   z.start(time_point{timespan{100}});
-  CAF_CHECK_EQUAL(x.started(), false);
-  CAF_CHECK_EQUAL(y.started(), true);
-  CAF_CHECK_EQUAL(z.started(), true);
+  CHECK_EQ(x.started(), false);
+  CHECK_EQ(y.started(), true);
+  CHECK_EQ(z.started(), true);
   for (auto t : {&x, &y, &z})
     t->stop();
-  CAF_CHECK_EQUAL(x.started(), false);
-  CAF_CHECK_EQUAL(y.started(), false);
-  CAF_CHECK_EQUAL(z.started(), false);
+  CHECK_EQ(x.started(), false);
+  CHECK_EQ(y.started(), false);
+  CHECK_EQ(z.started(), false);
 }
 
 CAF_TEST(ticks) {
   auto cycle = detail::gcd(credit_interval.count(),
                            force_batch_interval.count());
-  CAF_CHECK_EQUAL(cycle, 50);
-  auto force_batch_frequency = static_cast<size_t>(force_batch_interval.count()
-                                                   / cycle);
+  CHECK_EQ(cycle, 50);
+  auto force_batch_frequency
+    = static_cast<size_t>(force_batch_interval.count() / cycle);
   auto credit_frequency = static_cast<size_t>(credit_interval.count() / cycle);
   detail::tick_emitter tctrl{time_point{timespan{100}}};
   tctrl.interval(timespan{cycle});
@@ -72,16 +72,16 @@ CAF_TEST(ticks) {
     if (tick_id % credit_frequency == 0)
       ++credit_triggers;
   };
-  CAF_MESSAGE("trigger 4 ticks");
+  MESSAGE("trigger 4 ticks");
   tctrl.update(time_point{timespan{300}}, f);
-  CAF_CHECK_EQUAL(deep_to_string(ticks), "[1, 2, 3, 4]");
-  CAF_CHECK_EQUAL(force_batch_triggers, 4lu);
-  CAF_CHECK_EQUAL(credit_triggers, 1lu);
-  CAF_MESSAGE("trigger 3 more ticks");
+  CHECK_EQ(deep_to_string(ticks), "[1, 2, 3, 4]");
+  CHECK_EQ(force_batch_triggers, 4lu);
+  CHECK_EQ(credit_triggers, 1lu);
+  MESSAGE("trigger 3 more ticks");
   tctrl.update(time_point{timespan{475}}, f);
-  CAF_CHECK_EQUAL(deep_to_string(ticks), "[1, 2, 3, 4, 5, 6, 7]");
-  CAF_CHECK_EQUAL(force_batch_triggers, 7lu);
-  CAF_CHECK_EQUAL(credit_triggers, 1lu);
+  CHECK_EQ(deep_to_string(ticks), "[1, 2, 3, 4, 5, 6, 7]");
+  CHECK_EQ(force_batch_triggers, 7lu);
+  CHECK_EQ(credit_triggers, 1lu);
 }
 
 CAF_TEST(timeouts) {
@@ -90,26 +90,26 @@ CAF_TEST(timeouts) {
   auto now = start;
   detail::tick_emitter tctrl{now};
   tctrl.interval(interval);
-  CAF_MESSAGE("advance until the first 5-tick-period ends");
+  MESSAGE("advance until the first 5-tick-period ends");
   now += interval * 5;
   auto bitmask = tctrl.timeouts(now, {5, 7});
-  CAF_CHECK_EQUAL(bitmask, 0x01u);
-  CAF_MESSAGE("advance until the first 7-tick-period ends");
+  CHECK_EQ(bitmask, 0x01u);
+  MESSAGE("advance until the first 7-tick-period ends");
   now += interval * 2;
   bitmask = tctrl.timeouts(now, {5, 7});
-  CAF_CHECK_EQUAL(bitmask, 0x02u);
-  CAF_MESSAGE("advance until both tick period ends");
+  CHECK_EQ(bitmask, 0x02u);
+  MESSAGE("advance until both tick period ends");
   now += interval * 7;
   bitmask = tctrl.timeouts(now, {5, 7});
-  CAF_CHECK_EQUAL(bitmask, 0x03u);
-  CAF_MESSAGE("advance until both tick period end multiple times");
+  CHECK_EQ(bitmask, 0x03u);
+  MESSAGE("advance until both tick period end multiple times");
   now += interval * 21;
   bitmask = tctrl.timeouts(now, {5, 7});
-  CAF_CHECK_EQUAL(bitmask, 0x03u);
-  CAF_MESSAGE("advance without any timeout");
+  CHECK_EQ(bitmask, 0x03u);
+  MESSAGE("advance without any timeout");
   now += interval * 1;
   bitmask = tctrl.timeouts(now, {5, 7});
-  CAF_CHECK_EQUAL(bitmask, 0x00u);
+  CHECK_EQ(bitmask, 0x00u);
 }
 
 CAF_TEST(next_timeout) {
@@ -118,19 +118,19 @@ CAF_TEST(next_timeout) {
   auto now = start;
   detail::tick_emitter tctrl{now};
   tctrl.interval(interval);
-  CAF_MESSAGE("advance until the first 5-tick-period ends");
+  MESSAGE("advance until the first 5-tick-period ends");
   auto next = tctrl.next_timeout(now, {5, 7});
-  CAF_CHECK_EQUAL(next, start + timespan(5 * interval));
-  CAF_MESSAGE("advance until the first 7-tick-period ends");
+  CHECK_EQ(next, start + timespan(5 * interval));
+  MESSAGE("advance until the first 7-tick-period ends");
   now = start + timespan(5 * interval);
   next = tctrl.next_timeout(now, {5, 7});
-  CAF_CHECK_EQUAL(next, start + timespan(7 * interval));
-  CAF_MESSAGE("advance until the second 5-tick-period ends");
+  CHECK_EQ(next, start + timespan(7 * interval));
+  MESSAGE("advance until the second 5-tick-period ends");
   now = start + timespan(7 * interval);
   next = tctrl.next_timeout(now, {5, 7});
-  CAF_CHECK_EQUAL(next, start + timespan((2 * 5) * interval));
-  CAF_MESSAGE("advance until the second 7-tick-period ends");
+  CHECK_EQ(next, start + timespan((2 * 5) * interval));
+  MESSAGE("advance until the second 7-tick-period ends");
   now = start + timespan(11 * interval);
   next = tctrl.next_timeout(now, {5, 7});
-  CAF_CHECK_EQUAL(next, start + timespan((2 * 7) * interval));
+  CHECK_EQ(next, start + timespan((2 * 7) * interval));
 }

--- a/libcaf_core/test/detail/type_id_list_builder.cpp
+++ b/libcaf_core/test/detail/type_id_list_builder.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/type_id_list_builder.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 using namespace caf;
 
@@ -16,10 +16,10 @@ struct fixture {};
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(type_id_list_builder_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(todo) {
   // implement me
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/detail/unique_function.cpp
+++ b/libcaf_core/test/detail/unique_function.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/unique_function.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 namespace {
 
@@ -38,22 +38,22 @@ private:
 } // namespace
 
 #define CHECK_VALID(f)                                                         \
-  CAF_CHECK(!f.is_nullptr());                                                  \
-  CAF_CHECK(f);                                                                \
-  CAF_CHECK(f != nullptr);                                                     \
-  CAF_CHECK(nullptr != f);                                                     \
-  CAF_CHECK(!(f == nullptr));                                                  \
-  CAF_CHECK(!(nullptr == f));                                                  \
-  CAF_CHECK(f() == 42)
+  CHECK(!f.is_nullptr());                                                      \
+  CHECK(f);                                                                    \
+  CHECK_NE(f, nullptr);                                                        \
+  CHECK_NE(nullptr, f);                                                        \
+  CHECK(!(f == nullptr));                                                      \
+  CHECK(!(nullptr == f));                                                      \
+  CHECK_EQ(f(), 42)
 
 #define CHECK_INVALID(f)                                                       \
-  CAF_CHECK(f.is_nullptr());                                                   \
-  CAF_CHECK(!f);                                                               \
-  CAF_CHECK(f == nullptr);                                                     \
-  CAF_CHECK(nullptr == f);                                                     \
-  CAF_CHECK(!(f != nullptr));                                                  \
-  CAF_CHECK(!(nullptr != f));                                                  \
-  CAF_CHECK(!f.holds_wrapper())
+  CHECK(f.is_nullptr());                                                       \
+  CHECK(!f);                                                                   \
+  CHECK_EQ(f, nullptr);                                                        \
+  CHECK_EQ(nullptr, f);                                                        \
+  CHECK(!(f != nullptr));                                                      \
+  CHECK(!(nullptr != f));                                                      \
+  CHECK(!f.holds_wrapper())
 
 CAF_TEST(default construction) {
   int_fun f;
@@ -68,14 +68,14 @@ CAF_TEST(raw function pointer construction) {
 CAF_TEST(stateless lambda construction) {
   int_fun f{[] { return 42; }};
   CHECK_VALID(f);
-  CAF_CHECK(!f.holds_wrapper());
+  CHECK(!f.holds_wrapper());
 }
 
 CAF_TEST(stateful lambda construction) {
   int i = 42;
   int_fun f{[=] { return i; }};
   CHECK_VALID(f);
-  CAF_CHECK(f.holds_wrapper());
+  CHECK(f.holds_wrapper());
 }
 
 CAF_TEST(custom wrapper construction) {
@@ -83,10 +83,10 @@ CAF_TEST(custom wrapper construction) {
   { // lifetime scope of our counting wrapper
     int_fun f{new instance_counting_wrapper(&instances)};
     CHECK_VALID(f);
-    CAF_CHECK(f.holds_wrapper());
-    CAF_CHECK(instances == 1);
+    CHECK(f.holds_wrapper());
+    CHECK(instances == 1);
   }
-  CAF_CHECK(instances == 0);
+  CHECK(instances == 0);
 }
 
 CAF_TEST(function move construction) {
@@ -94,7 +94,7 @@ CAF_TEST(function move construction) {
   int_fun g{std::move(f)};
   CHECK_INVALID(f);
   CHECK_VALID(g);
-  CAF_CHECK(!g.holds_wrapper());
+  CHECK(!g.holds_wrapper());
 }
 
 CAF_TEST(stateful lambda move construction) {
@@ -103,7 +103,7 @@ CAF_TEST(stateful lambda move construction) {
   int_fun g{std::move(f)};
   CHECK_INVALID(f);
   CHECK_VALID(g);
-  CAF_CHECK(g.holds_wrapper());
+  CHECK(g.holds_wrapper());
 }
 
 CAF_TEST(custom wrapper move construction) {
@@ -113,10 +113,10 @@ CAF_TEST(custom wrapper move construction) {
     int_fun g{std::move(f)};
     CHECK_INVALID(f);
     CHECK_VALID(g);
-    CAF_CHECK(g.holds_wrapper());
-    CAF_CHECK(instances == 1);
+    CHECK(g.holds_wrapper());
+    CHECK(instances == 1);
   }
-  CAF_CHECK(instances == 0);
+  CHECK(instances == 0);
 }
 
 CAF_TEST(function assign) {
@@ -124,14 +124,14 @@ CAF_TEST(function assign) {
   int_fun f;
   int_fun g{forty_two};
   int_fun h{new instance_counting_wrapper(&instances)};
-  CAF_CHECK(instances == 1);
+  CHECK(instances == 1);
   CHECK_INVALID(f);
   CHECK_VALID(g);
   CHECK_VALID(h);
   f = forty_two;
   g = forty_two;
   h = forty_two;
-  CAF_CHECK(instances == 0);
+  CHECK(instances == 0);
   CHECK_VALID(f);
   CHECK_VALID(g);
   CHECK_VALID(h);
@@ -142,22 +142,22 @@ CAF_TEST(move assign) {
   int_fun f;
   int_fun g{forty_two};
   int_fun h{new instance_counting_wrapper(&instances)};
-  CAF_CHECK(instances == 1);
+  CHECK(instances == 1);
   CHECK_INVALID(f);
   CHECK_VALID(g);
   CHECK_VALID(h);
   g = std::move(h);
-  CAF_CHECK(instances == 1);
+  CHECK(instances == 1);
   CHECK_INVALID(f);
   CHECK_VALID(g);
   CHECK_INVALID(h);
   f = std::move(g);
-  CAF_CHECK(instances == 1);
+  CHECK(instances == 1);
   CHECK_VALID(f);
   CHECK_INVALID(g);
   CHECK_INVALID(h);
   f = int_fun{};
-  CAF_CHECK(instances == 0);
+  CHECK(instances == 0);
   CHECK_INVALID(f);
   CHECK_INVALID(g);
   CHECK_INVALID(h);

--- a/libcaf_core/test/detail/unordered_flat_map.cpp
+++ b/libcaf_core/test/detail/unordered_flat_map.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/detail/unordered_flat_map.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include <string>
 #include <utility>
@@ -80,36 +80,36 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(unordered_flat_map_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(default_constructed) {
   // A default-constructed map must be empty, i.e., have size 0.
-  CAF_CHECK_EQUAL(xs.empty(), true);
-  CAF_CHECK_EQUAL(xs.size(), 0u);
+  CHECK_EQ(xs.empty(), true);
+  CHECK_EQ(xs.size(), 0u);
   // The begin() and end() iterators must compare equal.
-  CAF_CHECK_EQUAL(xs.begin(), xs.end());
-  CAF_CHECK_EQUAL(xs.cbegin(), xs.begin());
-  CAF_CHECK_EQUAL(xs.cend(), xs.end());
-  CAF_CHECK_EQUAL(xs.cbegin(), xs.cend());
-  CAF_CHECK_EQUAL(xs.rbegin(), xs.rend());
+  CHECK_EQ(xs.begin(), xs.end());
+  CHECK_EQ(xs.cbegin(), xs.begin());
+  CHECK_EQ(xs.cend(), xs.end());
+  CHECK_EQ(xs.cbegin(), xs.cend());
+  CHECK_EQ(xs.rbegin(), xs.rend());
   // Calling begin() and end() on a const reference must return the same as
   // cbegin() and cend().
   const auto& cxs = xs;
-  CAF_CHECK_EQUAL(cxs.begin(), xs.cbegin());
-  CAF_CHECK_EQUAL(cxs.end(), xs.cend());
+  CHECK_EQ(cxs.begin(), xs.cbegin());
+  CHECK_EQ(cxs.end(), xs.cend());
 }
 
 CAF_TEST(initializer_list_constructed) {
   unordered_flat_map<int, int> zs{{1, 10}, {2, 20}, {3, 30}, {4, 40}};
-  CAF_CHECK_EQUAL(zs.size(), 4u);
-  CAF_CHECK_EQUAL(zs, ivec({{1, 10}, {2, 20}, {3, 30}, {4, 40}}));
+  CHECK_EQ(zs.size(), 4u);
+  CHECK_EQ(zs, ivec({{1, 10}, {2, 20}, {3, 30}, {4, 40}}));
 }
 
 CAF_TEST(range_constructed) {
   kvp_vec<int> tmp{{1, 10}, {2, 20}, {3, 30}, {4, 40}};
   unordered_flat_map<int, int> zs(tmp.begin(), tmp.end());
-  CAF_CHECK_EQUAL(zs.size(), 4u);
-  CAF_CHECK_EQUAL(zs, tmp);
+  CHECK_EQ(zs.size(), 4u);
+  CHECK_EQ(zs, tmp);
 }
 
 CAF_TEST(integer_insertion) {
@@ -118,34 +118,34 @@ CAF_TEST(integer_insertion) {
   xs.insert(xs.cbegin(), kvp(1, 10));
   xs.emplace(5, 50);
   xs.emplace_hint(xs.cend() - 1, 4, 40);
-  CAF_CHECK_EQUAL(xs, ivec({{1, 10}, {2, 20}, {3, 30}, {4, 40}, {5, 50}}));
+  CHECK_EQ(xs, ivec({{1, 10}, {2, 20}, {3, 30}, {4, 40}, {5, 50}}));
 }
 
 CAF_TEST(integer_removal) {
   fill_xs();
-  CAF_CHECK_EQUAL(xs, ivec({{1, 10}, {2, 20}, {3, 30}, {4, 40}}));
+  CHECK_EQ(xs, ivec({{1, 10}, {2, 20}, {3, 30}, {4, 40}}));
   xs.erase(xs.begin());
-  CAF_CHECK_EQUAL(xs, ivec({{2, 20}, {3, 30}, {4, 40}}));
+  CHECK_EQ(xs, ivec({{2, 20}, {3, 30}, {4, 40}}));
   xs.erase(xs.begin(), xs.begin() + 2);
-  CAF_CHECK_EQUAL(xs, ivec({{4, 40}}));
+  CHECK_EQ(xs, ivec({{4, 40}}));
   xs.erase(4);
-  CAF_CHECK_EQUAL(xs.empty(), true);
-  CAF_CHECK_EQUAL(xs.size(), 0u);
+  CHECK_EQ(xs.empty(), true);
+  CHECK_EQ(xs.size(), 0u);
 }
 
 CAF_TEST(lookup) {
   fill_xs();
-  CAF_CHECK_EQUAL(xs.count(2), 1u);
-  CAF_CHECK_EQUAL(xs.count(6), 0u);
+  CHECK_EQ(xs.count(2), 1u);
+  CHECK_EQ(xs.count(6), 0u);
   // trigger non-const member functions
-  CAF_CHECK_EQUAL(xs.at(3), 30);
-  CAF_CHECK_EQUAL(xs.find(1), xs.begin());
-  CAF_CHECK_EQUAL(xs.find(2), xs.begin() + 1);
+  CHECK_EQ(xs.at(3), 30);
+  CHECK_EQ(xs.find(1), xs.begin());
+  CHECK_EQ(xs.find(2), xs.begin() + 1);
   // trigger const member functions
   const auto& cxs = xs;
-  CAF_CHECK_EQUAL(cxs.at(2), 20);
-  CAF_CHECK_EQUAL(cxs.find(4), xs.end() - 1);
-  CAF_CHECK_EQUAL(cxs.find(5), xs.end());
+  CHECK_EQ(cxs.at(2), 20);
+  CHECK_EQ(cxs.find(4), xs.end() - 1);
+  CHECK_EQ(cxs.find(5), xs.end());
 }
 
 #ifdef CAF_ENABLE_EXCEPTIONS
@@ -155,7 +155,7 @@ CAF_TEST(exceptions) {
     auto x = xs.at(10);
     CAF_FAIL("got an unexpected value: " << x);
   } catch (std::out_of_range&) {
-    CAF_MESSAGE("got expected out_of_range exception");
+    MESSAGE("got expected out_of_range exception");
   } catch (...) {
     CAF_FAIL("got an expected exception");
   }
@@ -172,19 +172,19 @@ CAF_TEST(string_insertion) {
   ys.emplace(5, "e");
   ys.emplace_hint(ys.cend() - 1, 4, "d");
   kvp_vec<string> tmp{{1, "a"}, {2, "b"}, {3, "c"}, {4, "d"}, {5, "e"}};
-  CAF_CHECK_EQUAL(ys, tmp);
+  CHECK_EQ(ys, tmp);
 }
 
 CAF_TEST(string_removal) {
   fill_ys();
-  CAF_CHECK_EQUAL(ys, svec({{1, "a"}, {2, "b"}, {3, "c"}, {4, "d"}}));
+  CHECK_EQ(ys, svec({{1, "a"}, {2, "b"}, {3, "c"}, {4, "d"}}));
   ys.erase(ys.begin());
-  CAF_CHECK_EQUAL(ys, svec({{2, "b"}, {3, "c"}, {4, "d"}}));
+  CHECK_EQ(ys, svec({{2, "b"}, {3, "c"}, {4, "d"}}));
   ys.erase(ys.begin(), ys.begin() + 2);
-  CAF_CHECK_EQUAL(ys, svec({{4, "d"}}));
+  CHECK_EQ(ys, svec({{4, "d"}}));
   ys.erase(4);
-  CAF_CHECK_EQUAL(ys.empty(), true);
-  CAF_CHECK_EQUAL(ys.size(), 0u);
+  CHECK_EQ(ys.empty(), true);
+  CHECK_EQ(ys.size(), 0u);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/dictionary.cpp
+++ b/libcaf_core/test/dictionary.cpp
@@ -18,20 +18,20 @@ using int_dict = dictionary<int>;
 
 CAF_TEST(construction and comparison) {
   int_dict xs;
-  CAF_CHECK_EQUAL(xs.empty(), true);
-  CAF_CHECK_EQUAL(xs.size(), 0u);
+  CHECK_EQ(xs.empty(), true);
+  CHECK_EQ(xs.size(), 0u);
   int_dict ys{{"foo", 1}, {"bar", 2}};
-  CAF_CHECK_EQUAL(ys.empty(), false);
-  CAF_CHECK_EQUAL(ys.size(), 2u);
-  CAF_CHECK_NOT_EQUAL(xs, ys);
+  CHECK_EQ(ys.empty(), false);
+  CHECK_EQ(ys.size(), 2u);
+  CHECK_NE(xs, ys);
   int_dict zs{ys.begin(), ys.end()};
-  CAF_CHECK_EQUAL(zs.empty(), false);
-  CAF_CHECK_EQUAL(zs.size(), 2u);
-  CAF_CHECK_EQUAL(ys, zs);
+  CHECK_EQ(zs.empty(), false);
+  CHECK_EQ(zs.size(), 2u);
+  CHECK_EQ(ys, zs);
   zs.clear();
-  CAF_CHECK_EQUAL(zs.empty(), true);
-  CAF_CHECK_EQUAL(zs.size(), 0u);
-  CAF_CHECK_EQUAL(xs, zs);
+  CHECK_EQ(zs.empty(), true);
+  CHECK_EQ(zs.size(), 0u);
+  CHECK_EQ(xs, zs);
 }
 
 CAF_TEST(iterators) {
@@ -39,44 +39,44 @@ CAF_TEST(iterators) {
   using vector_type = std::vector<int_dict::value_type>;
   int_dict xs{{"a", 1}, {"b", 2}, {"c", 3}};
   vector_type ys{{"a", 1}, {"b", 2}, {"c", 3}};
-  CAF_CHECK(equal(xs.begin(), xs.end(), ys.begin()));
-  CAF_CHECK(equal(xs.cbegin(), xs.cend(), ys.cbegin()));
-  CAF_CHECK(equal(xs.rbegin(), xs.rend(), ys.rbegin()));
-  CAF_CHECK(equal(xs.crbegin(), xs.crend(), ys.crbegin()));
+  CHECK(equal(xs.begin(), xs.end(), ys.begin()));
+  CHECK(equal(xs.cbegin(), xs.cend(), ys.cbegin()));
+  CHECK(equal(xs.rbegin(), xs.rend(), ys.rbegin()));
+  CHECK(equal(xs.crbegin(), xs.crend(), ys.crbegin()));
 }
 
 CAF_TEST(swapping) {
   int_dict xs{{"foo", 1}, {"bar", 2}};
   int_dict ys;
   int_dict zs{{"foo", 1}, {"bar", 2}};
-  CAF_CHECK_NOT_EQUAL(xs, ys);
-  CAF_CHECK_NOT_EQUAL(ys, zs);
-  CAF_CHECK_EQUAL(xs, zs);
+  CHECK_NE(xs, ys);
+  CHECK_NE(ys, zs);
+  CHECK_EQ(xs, zs);
   xs.swap(ys);
-  CAF_CHECK_NOT_EQUAL(xs, ys);
-  CAF_CHECK_EQUAL(ys, zs);
-  CAF_CHECK_NOT_EQUAL(xs, zs);
+  CHECK_NE(xs, ys);
+  CHECK_EQ(ys, zs);
+  CHECK_NE(xs, zs);
 }
 
 CAF_TEST(emplacing) {
   int_dict xs;
-  CAF_CHECK_EQUAL(xs.emplace("x", 1).second, true);
-  CAF_CHECK_EQUAL(xs.emplace("y", 2).second, true);
-  CAF_CHECK_EQUAL(xs.emplace("y", 3).second, false);
+  CHECK_EQ(xs.emplace("x", 1).second, true);
+  CHECK_EQ(xs.emplace("y", 2).second, true);
+  CHECK_EQ(xs.emplace("y", 3).second, false);
 }
 
 CAF_TEST(insertion) {
   int_dict xs;
-  CAF_CHECK_EQUAL(xs.insert("a", 1).second, true);
-  CAF_CHECK_EQUAL(xs.insert("b", 2).second, true);
-  CAF_CHECK_EQUAL(xs.insert("c", 3).second, true);
-  CAF_CHECK_EQUAL(xs.insert("c", 4).second, false);
+  CHECK_EQ(xs.insert("a", 1).second, true);
+  CHECK_EQ(xs.insert("b", 2).second, true);
+  CHECK_EQ(xs.insert("c", 3).second, true);
+  CHECK_EQ(xs.insert("c", 4).second, false);
   int_dict ys;
-  CAF_CHECK_EQUAL(ys.insert_or_assign("a", 1).second, true);
-  CAF_CHECK_EQUAL(ys.insert_or_assign("b", 2).second, true);
-  CAF_CHECK_EQUAL(ys.insert_or_assign("c", 0).second, true);
-  CAF_CHECK_EQUAL(ys.insert_or_assign("c", 3).second, false);
-  CAF_CHECK_EQUAL(xs, ys);
+  CHECK_EQ(ys.insert_or_assign("a", 1).second, true);
+  CHECK_EQ(ys.insert_or_assign("b", 2).second, true);
+  CHECK_EQ(ys.insert_or_assign("c", 0).second, true);
+  CHECK_EQ(ys.insert_or_assign("c", 3).second, false);
+  CHECK_EQ(xs, ys);
 }
 
 CAF_TEST(insertion with hint) {
@@ -98,32 +98,32 @@ CAF_TEST(insertion with hint) {
   ys_insert_or_assign("c", 0);
   ys_insert_or_assign("b", 2);
   ys_insert_or_assign("c", 3);
-  CAF_CHECK_EQUAL(xs, ys);
+  CHECK_EQ(xs, ys);
 }
 
 CAF_TEST(bounds) {
   int_dict xs{{"a", 1}, {"b", 2}, {"c", 3}, {"d", 4}};
   const int_dict& const_xs = xs;
-  CAF_CHECK_EQUAL(xs.lower_bound("c")->first, "c");
-  CAF_CHECK_EQUAL(xs.upper_bound("c")->first, "d");
-  CAF_CHECK_EQUAL(const_xs.lower_bound("c")->first, "c");
-  CAF_CHECK_EQUAL(const_xs.upper_bound("c")->first, "d");
+  CHECK_EQ(xs.lower_bound("c")->first, "c");
+  CHECK_EQ(xs.upper_bound("c")->first, "d");
+  CHECK_EQ(const_xs.lower_bound("c")->first, "c");
+  CHECK_EQ(const_xs.upper_bound("c")->first, "d");
 }
 
 CAF_TEST(find) {
   int_dict xs{{"a", 1}, {"b", 2}, {"c", 3}, {"d", 4}};
   const int_dict& const_xs = xs;
-  CAF_CHECK_EQUAL(xs.find("e"), xs.end());
-  CAF_CHECK_EQUAL(xs.find("a")->second, 1);
-  CAF_CHECK_EQUAL(xs.find("c")->second, 3);
-  CAF_CHECK_EQUAL(const_xs.find("e"), xs.end());
-  CAF_CHECK_EQUAL(const_xs.find("a")->second, 1);
-  CAF_CHECK_EQUAL(const_xs.find("c")->second, 3);
+  CHECK_EQ(xs.find("e"), xs.end());
+  CHECK_EQ(xs.find("a")->second, 1);
+  CHECK_EQ(xs.find("c")->second, 3);
+  CHECK_EQ(const_xs.find("e"), xs.end());
+  CHECK_EQ(const_xs.find("a")->second, 1);
+  CHECK_EQ(const_xs.find("c")->second, 3);
 }
 
 CAF_TEST(element access) {
   int_dict xs{{"a", 1}, {"b", 2}, {"c", 3}, {"d", 4}};
-  CAF_CHECK_EQUAL(xs["a"], 1);
-  CAF_CHECK_EQUAL(xs["b"], 2);
-  CAF_CHECK_EQUAL(xs["e"], 0);
+  CHECK_EQ(xs["a"], 1);
+  CHECK_EQ(xs["b"], 2);
+  CHECK_EQ(xs["e"], 0);
 }

--- a/libcaf_core/test/dsl.cpp
+++ b/libcaf_core/test/dsl.cpp
@@ -1,0 +1,399 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+// This test suite checks the testing DSL itself.
+
+#define CAF_SUITE dsl
+
+#include "core-test.hpp"
+
+using namespace caf;
+
+namespace {
+
+struct testee_state {
+  behavior make_behavior() {
+    return {
+      [](add_atom, int32_t x, int32_t y) { return x + y; },
+      [](sub_atom, int32_t x, int32_t y) { return x - y; },
+    };
+  }
+};
+
+using testee_actor = stateful_actor<testee_state>;
+
+struct bool_list {
+  std::vector<bool> values;
+  auto begin() {
+    return values.begin();
+  }
+  auto end() {
+    return values.end();
+  }
+};
+
+bool_list& operator<<(bool_list& ls, bool value) {
+  ls.values.push_back(value);
+  return ls;
+}
+
+} // namespace
+
+BEGIN_FIXTURE_SCOPE(test_coordinator_fixture<>)
+
+SCENARIO("successful checks increment the 'good' counter") {
+  GIVEN("a unit test") {
+    auto this_test = test::engine::current_test();
+    WHEN("using any CHECK macro with a true statement") {
+      THEN("the 'good' counter increments by one per check") {
+        bool_list results;
+        results << CHECK_EQ(this_test->good(), 0u);
+        results << CHECK_EQ(this_test->good(), 1u);
+        results << CHECK_EQ(this_test->good(), 2u);
+        results << CHECK(true);
+        results << CHECK_NE(1, 2);
+        results << CHECK_LT(1, 2);
+        results << CHECK_LE(1, 2);
+        results << CHECK_GT(2, 1);
+        results << CHECK_GE(2, 1);
+        results << CHECK_EQ(this_test->good(), 9u);
+        results << CHECK_EQ(this_test->bad(), 0u);
+        auto is_true = [](bool x) { return x; };
+        CHECK(std::all_of(results.begin(), results.end(), is_true));
+      }
+    }
+  }
+}
+
+SCENARIO("unsuccessful checks increment the 'bad' counter") {
+  GIVEN("a unit test") {
+    auto this_test = test::engine::current_test();
+    WHEN("using any CHECK macro with a false statement") {
+      THEN("the 'bad' counter increments by one per check") {
+        // Run the known-to-fail tests with suppressed output.
+        auto bk = caf::test::logger::instance().make_quiet();
+        bool_list results;
+        results << CHECK_EQ(this_test->good(), 1u);
+        results << CHECK(false);
+        results << CHECK_NE(1, 1);
+        results << CHECK_LT(2, 1);
+        results << CHECK_LE(2, 1);
+        results << CHECK_GT(1, 2);
+        results << CHECK_GE(1, 2);
+        caf::test::logger::instance().levels(bk);
+        auto failed_checks = this_test->bad();
+        this_test->reset(); // Prevent the unit test from actually failing.
+        CHECK_EQ(failed_checks, 7u);
+        REQUIRE_EQ(results.values.size(), 7u);
+        auto is_false = [](bool x) { return !x; };
+        CHECK(std::all_of(results.begin(), results.end(), is_false));
+      }
+    }
+  }
+}
+
+SCENARIO("the test scheduler allows manipulating the control flow") {
+  GIVEN("some event-based  actors") {
+    auto aut1 = sys.spawn<testee_actor>();
+    auto aut2 = sys.spawn<testee_actor>();
+    auto aut3 = sys.spawn<testee_actor>();
+    run();
+    WHEN("sending messages to event-based actors") {
+      THEN("the actors become jobs in the scheduler") {
+        CHECK(!sched.has_job());
+        self->send(aut1, add_atom_v, 1, 2);
+        CHECK(sched.has_job());
+        CHECK_EQ(sched.jobs.size(), 1u);
+        self->send(aut2, add_atom_v, 2, 3);
+        CHECK_EQ(sched.jobs.size(), 2u);
+        self->send(aut3, add_atom_v, 3, 4);
+        CHECK_EQ(sched.jobs.size(), 3u);
+      }
+      AND("prioritize allows moving actors to the head of the job queue") {
+        auto ptr = [](const actor& hdl) {
+          auto actor_ptr = actor_cast<caf::abstract_actor*>(hdl);
+          return dynamic_cast<resumable*>(actor_ptr);
+        };
+        CHECK_EQ(&sched.next_job(), ptr(aut1));
+        CHECK(sched.prioritize(aut2));
+        CHECK_EQ(&sched.next_job(), ptr(aut2));
+        CHECK(sched.prioritize(aut3));
+        CHECK_EQ(&sched.next_job(), ptr(aut3));
+        CHECK(sched.prioritize(aut1));
+        CHECK_EQ(&sched.next_job(), ptr(aut1));
+      }
+      AND("peek allows inspecting the mailbox of the next job") {
+        using std::make_tuple;
+        auto peek = [this] { return sched.peek<add_atom, int, int>(); };
+        CHECK_EQ(peek(), make_tuple(add_atom_v, 1, 2));
+        CHECK(sched.prioritize(aut2));
+        CHECK_EQ(peek(), make_tuple(add_atom_v, 2, 3));
+        CHECK(sched.prioritize(aut3));
+        CHECK_EQ(peek(), make_tuple(add_atom_v, 3, 4));
+      }
+      AND("run_until and run_once allows executing jobs selectively") {
+        CHECK_EQ(run_until([this] { return sched.jobs.size() == 1; }), 2u);
+        CHECK(run_once());
+        CHECK(!sched.has_job());
+        CHECK(!run_once());
+      }
+    }
+  }
+}
+
+SCENARIO("allow() turns into a no-op on mismatch") {
+  GIVEN("an event-based actor") {
+    auto aut = sys.spawn<testee_actor>();
+    run();
+    WHEN("allow()-ing a message if no message is waiting in any mailbox") {
+      THEN("allow() becomes a no-op and returns false") {
+        CHECK(!(allow((add_atom, int32_t, int32_t), from(self).to(aut))));
+        CHECK(!(allow((add_atom, int32_t, int32_t),
+                      from(self).to(aut).with(_, _, _))));
+      }
+    }
+    WHEN("allow()-ing a message but a different message is waiting") {
+      THEN("allow() becomes a no-op and returns false") {
+        self->send(aut, sub_atom_v, 4, 3);
+        auto fake_sender = sys.spawn<testee_actor>();
+        // Wrong type.
+        CHECK(!(allow((add_atom, int32_t, int32_t), from(self).to(aut))));
+        // Wrong type plus .with() check.
+        CHECK(!(allow((add_atom, int32_t, int32_t),
+                      from(self).to(aut).with(_, 4, 3))));
+        // Correct type but .with() check expects different values.
+        CHECK(!(allow((sub_atom, int32_t, int32_t),
+                      from(self).to(aut).with(_, 1, 2))));
+        // Correct type and matching .with() but wrong sender.
+        CHECK(!(allow((sub_atom, int32_t, int32_t),
+                      from(fake_sender).to(aut).with(_, 4, 3))));
+        // Message must still wait in the mailbox.
+        auto& aut_dref = sched.next_job<testee_actor>();
+        REQUIRE_EQ(actor_cast<abstract_actor*>(aut), &aut_dref);
+        auto msg_ptr = aut_dref.peek_at_next_mailbox_element();
+        REQUIRE_NE(msg_ptr, nullptr);
+        CHECK(msg_ptr->payload.matches(sub_atom_v, 4, 3));
+        // Drop test message.
+        run();
+        while (!self->mailbox().empty())
+          self->dequeue();
+      }
+    }
+    WHEN("allow()-ing and a matching message arrives") {
+      THEN("the actor processes the message and allow() returns true") {
+        self->send(aut, sub_atom_v, 4, 3);
+        CHECK(sched.has_job());
+        CHECK(allow((sub_atom, int32_t, int32_t),
+                    from(self).to(aut).with(_, 4, 3)));
+        CHECK(!sched.has_job());
+        CHECK(allow((int32_t), from(aut).to(self).with(1)));
+      }
+    }
+  }
+}
+
+#ifdef CAF_ENABLE_EXCEPTIONS
+
+SCENARIO("tests may check for exceptions") {
+  GIVEN("a unit test") {
+    auto this_test = test::engine::current_test();
+    WHEN("using any CHECK_THROWS macro with a matching exception") {
+      THEN("the 'good' counter increments by one per check") {
+        auto f = [] { throw std::runtime_error("foo"); };
+        CHECK_THROWS_AS(f(), std::runtime_error);
+        CHECK_THROWS_WITH(f(), "foo");
+        CHECK_THROWS_WITH_AS(f(), "foo", std::runtime_error);
+        CHECK_NOTHROW([] {}());
+      }
+    }
+    WHEN("using any CHECK_THROWS macro with a unexpected exception") {
+      THEN("the 'bad' counter increments by one per check") {
+        auto f = [] { throw std::logic_error("bar"); };
+        auto bk = caf::test::logger::instance().make_quiet();
+        CHECK_THROWS_AS(f(), std::runtime_error);
+        CHECK_THROWS_WITH(f(), "foo");
+        CHECK_THROWS_WITH_AS(f(), "foo", std::runtime_error);
+        CHECK_THROWS_WITH_AS(f(), "foo", std::logic_error);
+        CHECK_NOTHROW(f());
+        caf::test::logger::instance().levels(bk);
+        CHECK_EQ(this_test->bad(), 5u);
+        this_test->reset_bad();
+      }
+    }
+  }
+}
+
+SCENARIO("passing requirements increment the 'good' counter") {
+  GIVEN("a unit test") {
+    auto this_test = test::engine::current_test();
+    WHEN("using any REQUIRE macro with a true statement") {
+      THEN("the 'good' counter increments by one per requirement") {
+        REQUIRE_EQ(this_test->good(), 0u);
+        REQUIRE_EQ(this_test->good(), 1u);
+        REQUIRE_EQ(this_test->good(), 2u);
+        REQUIRE(true);
+        REQUIRE_NE(1, 2);
+        REQUIRE_LT(1, 2);
+        REQUIRE_LE(1, 2);
+        REQUIRE_GT(2, 1);
+        REQUIRE_GE(2, 1);
+        REQUIRE_EQ(this_test->good(), 9u);
+        REQUIRE_EQ(this_test->bad(), 0u);
+      }
+    }
+  }
+}
+
+#  define CHECK_FAILS(expr)                                                    \
+    if (true) {                                                                \
+      auto silent_expr = [&] {                                                 \
+        auto bk = caf::test::logger::instance().make_quiet();                  \
+        auto guard = caf::detail::make_scope_guard(                            \
+          [bk] { caf::test::logger::instance().levels(bk); });                 \
+        expr;                                                                  \
+      };                                                                       \
+      CHECK_THROWS_AS(silent_expr(), test::requirement_error);                 \
+    }                                                                          \
+    if (CHECK_EQ(this_test->bad(), 1u))                                        \
+    this_test->reset_bad()
+
+SCENARIO("failing requirements increment the 'bad' counter and throw") {
+  GIVEN("a unit test") {
+    auto this_test = test::engine::current_test();
+    WHEN("using any REQUIRE macro with a true statement") {
+      THEN("the 'good' counter increments by one per requirement") {
+        CHECK_FAILS(REQUIRE_EQ(1, 2));
+        CHECK_FAILS(REQUIRE_EQ(this_test->good(), 42u));
+        CHECK_FAILS(REQUIRE(false));
+        CHECK_FAILS(REQUIRE_NE(1, 1));
+        CHECK_FAILS(REQUIRE_LT(2, 1));
+        CHECK_FAILS(REQUIRE_LE(2, 1));
+        CHECK_FAILS(REQUIRE_GT(1, 2));
+        CHECK_FAILS(REQUIRE_GE(1, 2));
+      }
+    }
+  }
+}
+
+SCENARIO("disallow() throws when finding a prohibited message") {
+  GIVEN("an event-based actor") {
+    auto aut = sys.spawn<testee_actor>();
+    run();
+    WHEN("disallow()-ing a message if no message is waiting in any mailbox") {
+      THEN("disallow() becomes a no-op") {
+        CHECK_NOTHROW(disallow((add_atom, int32_t, int32_t), //
+                               from(self).to(aut)));
+        CHECK_NOTHROW(disallow((add_atom, int32_t, int32_t),
+                               from(self).to(aut).with(_, _, _)));
+      }
+    }
+    WHEN("disallow()-ing a message if no matching message exists") {
+      THEN("disallow() becomes a no-op") {
+        self->send(aut, sub_atom_v, 4, 3);
+        auto fake_sender = sys.spawn<testee_actor>();
+        CHECK_NOTHROW(disallow((add_atom, int32_t, int32_t), to(aut)));
+        CHECK_NOTHROW(disallow((add_atom, int32_t, int32_t), //
+                               to(aut).with(_, _, _)));
+        CHECK_NOTHROW(disallow((add_atom, int32_t, int32_t), //
+                               from(self).to(aut)));
+        CHECK_NOTHROW(disallow((add_atom, int32_t, int32_t),
+                               from(self).to(aut).with(_, _, _)));
+        CHECK_NOTHROW(disallow((sub_atom, int32_t, int32_t),
+                               from(self).to(aut).with(_, 1, 2)));
+        CHECK_NOTHROW(disallow((sub_atom, int32_t, int32_t), //
+                               from(fake_sender).to(aut)));
+        CHECK_NOTHROW(disallow((sub_atom, int32_t, int32_t), //
+                               from(fake_sender).to(aut).with(_, 4, 3)));
+        // Drop test message.
+        run();
+        while (!self->mailbox().empty())
+          self->dequeue();
+      }
+    }
+    WHEN("disallow()-ing an existing message") {
+      THEN("disallow() throws and increment the 'bad' counter") {
+        auto this_test = test::engine::current_test();
+        self->send(aut, sub_atom_v, 4, 3);
+        CHECK_FAILS(disallow((sub_atom, int32_t, int32_t), to(aut)));
+        CHECK_FAILS(disallow((sub_atom, int32_t, int32_t), //
+                             to(aut).with(_, _, _)));
+        CHECK_FAILS(disallow((sub_atom, int32_t, int32_t), from(self).to(aut)));
+        CHECK_FAILS(disallow((sub_atom, int32_t, int32_t), //
+                             from(self).to(aut).with(_, _, _)));
+      }
+    }
+  }
+}
+
+SCENARIO("expect() throws when not finding the required message") {
+  GIVEN("an event-based actor") {
+    auto this_test = test::engine::current_test();
+    auto aut = sys.spawn<testee_actor>();
+    run();
+    WHEN("expect()-ing a message if no message is waiting in any mailbox") {
+      THEN("expect() throws and increment the 'bad' counter") {
+        CHECK_FAILS(expect((add_atom, int32_t, int32_t), to(aut)));
+        CHECK_FAILS(expect((add_atom, int32_t, int32_t), //
+                           to(aut).with(_, _, _)));
+        CHECK_FAILS(expect((add_atom, int32_t, int32_t), //
+                           from(self).to(aut)));
+        CHECK_FAILS(expect((add_atom, int32_t, int32_t),
+                           from(self).to(aut).with(_, _, _)));
+        auto aut2 = sys.spawn<testee_actor>();
+        CHECK_FAILS(expect((add_atom, int32_t, int32_t), to(aut2)));
+        CHECK_FAILS(expect((add_atom, int32_t, int32_t), //
+                           to(aut2).with(_, _, _)));
+        CHECK_FAILS(expect((add_atom, int32_t, int32_t), //
+                           from(self).to(aut2)));
+        CHECK_FAILS(expect((add_atom, int32_t, int32_t),
+                           from(self).to(aut2).with(_, _, _)));
+      }
+    }
+    WHEN("expect()-ing a message if no matching message exists") {
+      THEN("expect() throws and increment the 'bad' counter") {
+        self->send(aut, sub_atom_v, 4, 3);
+        auto fake_sender = sys.spawn<testee_actor>();
+        CHECK_FAILS(expect((add_atom, int32_t, int32_t), to(aut)));
+        CHECK_FAILS(expect((add_atom, int32_t, int32_t), //
+                           to(aut).with(_, _, _)));
+        CHECK_FAILS(expect((add_atom, int32_t, int32_t), //
+                           from(self).to(aut)));
+        CHECK_FAILS(expect((add_atom, int32_t, int32_t),
+                           from(self).to(aut).with(_, _, _)));
+        CHECK_FAILS(expect((sub_atom, int32_t, int32_t),
+                           from(self).to(aut).with(_, 1, 2)));
+        CHECK_FAILS(expect((sub_atom, int32_t, int32_t), //
+                           from(fake_sender).to(aut)));
+        CHECK_FAILS(expect((sub_atom, int32_t, int32_t), //
+                           from(fake_sender).to(aut).with(_, 4, 3)));
+        // Drop test message.
+        run();
+        while (!self->mailbox().empty())
+          self->dequeue();
+      }
+    }
+    WHEN("expect()-ing an existing message") {
+      THEN("expect() processes the message") {
+        self->send(aut, add_atom_v, 4, 3);
+        CHECK_NOTHROW(expect((add_atom, int32_t, int32_t), to(aut)));
+        CHECK_NOTHROW(expect((int32_t), to(self)));
+        self->send(aut, add_atom_v, 4, 3);
+        CHECK_NOTHROW(expect((add_atom, int32_t, int32_t), //
+                             to(aut).with(_, _, _)));
+        CHECK_NOTHROW(expect((int32_t), to(self).with(7)));
+        self->send(aut, add_atom_v, 4, 3);
+        CHECK_NOTHROW(expect((add_atom, int32_t, int32_t), from(self).to(aut)));
+        CHECK_NOTHROW(expect((int32_t), from(aut).to(self)));
+        self->send(aut, add_atom_v, 4, 3);
+        CHECK_NOTHROW(expect((add_atom, int32_t, int32_t), //
+                             from(self).to(aut).with(_, _, _)));
+        CHECK_NOTHROW(expect((int32_t), from(aut).to(self).with(7)));
+      }
+    }
+  }
+}
+
+#endif
+
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/function_view.cpp
+++ b/libcaf_core/test/function_view.cpp
@@ -74,43 +74,43 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(function_view_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(empty_function_fiew) {
   function_view<calculator> f;
-  CAF_CHECK_EQUAL(f(10, 20), sec::bad_function_call);
+  CHECK_EQ(f(10, 20), sec::bad_function_call);
 }
 
 CAF_TEST(single_res_function_view) {
   auto f = make_function_view(system.spawn(adder));
-  CAF_CHECK_EQUAL(f(3, 4), 7);
-  CAF_CHECK(f != nullptr);
-  CAF_CHECK(nullptr != f);
+  CHECK_EQ(f(3, 4), 7);
+  CHECK(f != nullptr);
+  CHECK(nullptr != f);
   function_view<calculator> g;
   g = std::move(f);
-  CAF_CHECK(f == nullptr);
-  CAF_CHECK(nullptr == f);
-  CAF_CHECK(g != nullptr);
-  CAF_CHECK(nullptr != g);
-  CAF_CHECK_EQUAL(g(10, 20), 30);
+  CHECK(f == nullptr);
+  CHECK(nullptr == f);
+  CHECK(g != nullptr);
+  CHECK(nullptr != g);
+  CHECK_EQ(g(10, 20), 30);
   g.assign(system.spawn(multiplier));
-  CAF_CHECK_EQUAL(g(10, 20), 200);
+  CHECK_EQ(g(10, 20), 200);
   g.assign(system.spawn(divider));
-  CAF_CHECK(!g(1, 0));
+  CHECK(!g(1, 0));
   g.assign(system.spawn(divider));
-  CAF_CHECK_EQUAL(g(4, 2), 2);
+  CHECK_EQ(g(4, 2), 2);
 }
 
 CAF_TEST(tuple_res_function_view) {
   auto f = make_function_view(system.spawn(simple_doubler));
-  CAF_CHECK_EQUAL(f(10), std::make_tuple(10, 10));
+  CHECK_EQ(f(10), std::make_tuple(10, 10));
 }
 
 CAF_TEST(cell_function_view) {
   auto f = make_function_view(system.spawn(simple_cell));
-  CAF_CHECK_EQUAL(f(get_atom_v), 0);
+  CHECK_EQ(f(get_atom_v), 0);
   f(put_atom_v, 1024);
-  CAF_CHECK_EQUAL(f(get_atom_v), 1024);
+  CHECK_EQ(f(get_atom_v), 1024);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/fused_downstream_manager.cpp
+++ b/libcaf_core/test/fused_downstream_manager.cpp
@@ -32,7 +32,7 @@ using string_downstream_manager = broadcast_downstream_manager<string>;
 template <class T>
 void push(std::deque<T>& xs, downstream<T>& out, size_t num) {
   auto n = std::min(num, xs.size());
-  CAF_MESSAGE("push " << n << " messages downstream");
+  MESSAGE("push " << n << " messages downstream");
   for (size_t i = 0; i < n; ++i)
     out.push(xs[i]);
   xs.erase(xs.begin(), xs.begin() + static_cast<ptrdiff_t>(n));
@@ -42,7 +42,7 @@ VARARGS_TESTEE(int_file_reader, size_t buf_size) {
   using buf = std::deque<int32_t>;
   return {
     [=](string& fname) -> result<stream<int32_t>> {
-      CAF_CHECK_EQUAL(fname, "numbers.txt");
+      CHECK_EQ(fname, "numbers.txt");
       return attach_stream_source(
         self,
         // initialize state
@@ -64,7 +64,7 @@ VARARGS_TESTEE(string_file_reader, size_t buf_size) {
   using buf = std::deque<string>;
   return {
     [=](string& fname) -> result<stream<string>> {
-      CAF_CHECK_EQUAL(fname, "strings.txt");
+      CHECK_EQ(fname, "strings.txt");
       return attach_stream_source(
         self,
         // initialize state
@@ -99,12 +99,10 @@ TESTEE(sum_up) {
         // processing step
         [](intptr& x, int32_t y) { *x += y; },
         // cleanup and produce result message
-        [=](intptr&, const error&) {
-          CAF_MESSAGE(self->name() << " is done");
-        });
+        [=](intptr&, const error&) { MESSAGE(self->name() << " is done"); });
     },
     [=](join_atom, actor src) {
-      CAF_MESSAGE(self->name() << " joins a stream");
+      MESSAGE(self->name() << " joins a stream");
       self->send(self * src, join_atom_v, int32_t{0});
     },
   };
@@ -130,12 +128,10 @@ TESTEE(collect) {
           self->state.strings.emplace_back(std::move(y));
         },
         // cleanup and produce result message
-        [=](unit_t&, const error&) {
-          CAF_MESSAGE(self->name() << " is done");
-        });
+        [=](unit_t&, const error&) { MESSAGE(self->name() << " is done"); });
     },
     [=](join_atom, actor src) {
-      CAF_MESSAGE(self->name() << " joins a stream");
+      MESSAGE(self->name() << " joins a stream");
       self->send(self * src, join_atom_v, "dummy");
     },
   };
@@ -145,8 +141,8 @@ using int_downstream_manager = broadcast_downstream_manager<int>;
 
 using string_downstream_manager = broadcast_downstream_manager<string>;
 
-using fused_manager = fused_downstream_manager<int_downstream_manager,
-                                               string_downstream_manager>;
+using fused_manager
+  = fused_downstream_manager<int_downstream_manager, string_downstream_manager>;
 
 class fused_stage : public stream_manager {
 public:
@@ -170,14 +166,14 @@ public:
     using int_vec = std::vector<int>;
     using string_vec = std::vector<string>;
     if (batch.xs.types() == make_type_id_list<int_vec>()) {
-      CAF_MESSAGE("handle an integer batch");
+      MESSAGE("handle an integer batch");
       auto& xs = batch.xs.get_mutable_as<int_vec>(0);
       auto& buf = out_.get<int_downstream_manager>().buf();
       buf.insert(buf.end(), xs.begin(), xs.end());
       return;
     }
     if (batch.xs.types() == make_type_id_list<string_vec>()) {
-      CAF_MESSAGE("handle a string batch");
+      MESSAGE("handle a string batch");
       auto& xs = batch.xs.get_mutable_as<string_vec>(0);
       auto& buf = out_.get<string_downstream_manager>().buf();
       buf.insert(buf.end(), xs.begin(), xs.end());
@@ -203,25 +199,25 @@ TESTEE(stream_multiplexer) {
   return {
     [=](join_atom, int32_t) {
       auto& stg = self->state.stage;
-      CAF_MESSAGE("received 'join' request for integers");
+      MESSAGE("received 'join' request for integers");
       auto result = stg->add_unchecked_outbound_path<int>();
       stg->out().assign<int_downstream_manager>(result);
       return result;
     },
     [=](join_atom, std::string) {
       auto& stg = self->state.stage;
-      CAF_MESSAGE("received 'join' request for strings");
+      MESSAGE("received 'join' request for strings");
       auto result = stg->add_unchecked_outbound_path<string>();
       stg->out().assign<string_downstream_manager>(result);
       return result;
     },
     [=](stream<int32_t> in) {
-      CAF_MESSAGE("received handshake for integers");
-      CAF_MESSAGE(self->current_mailbox_element()->content());
+      MESSAGE("received handshake for integers");
+      MESSAGE(self->current_mailbox_element()->content());
       return self->state.stage->add_unchecked_inbound_path(in);
     },
     [=](stream<string> in) {
-      CAF_MESSAGE("received handshake for strings");
+      MESSAGE("received handshake for strings");
       return self->state.stage->add_unchecked_inbound_path(in);
     },
   };
@@ -233,7 +229,7 @@ using fixture = test_coordinator_fixture<>;
 
 // -- unit tests ---------------------------------------------------------------
 
-CAF_TEST_FIXTURE_SCOPE(fused_downstream_manager_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST_DISABLED(depth_3_pipeline_with_fork) {
   auto src1 = sys.spawn(int_file_reader, 50u);
@@ -242,26 +238,26 @@ CAF_TEST_DISABLED(depth_3_pipeline_with_fork) {
   auto snk1 = sys.spawn(sum_up);
   auto snk2 = sys.spawn(collect);
   auto& st = deref<stream_multiplexer_actor>(stg).state;
-  CAF_MESSAGE("connect sinks to the fused stage");
+  MESSAGE("connect sinks to the fused stage");
   self->send(snk1, join_atom_v, stg);
   self->send(snk2, join_atom_v, stg);
   sched.run();
-  CAF_CHECK_EQUAL(st.stage->out().num_paths(), 2u);
-  CAF_CHECK_EQUAL(st.stage->inbound_paths().size(), 0u);
-  CAF_MESSAGE("connect sources to the fused stage");
+  CHECK_EQ(st.stage->out().num_paths(), 2u);
+  CHECK_EQ(st.stage->inbound_paths().size(), 0u);
+  MESSAGE("connect sources to the fused stage");
   self->send(stg * src1, "numbers.txt");
   self->send(stg * src2, "strings.txt");
   sched.run();
-  CAF_CHECK_EQUAL(st.stage->out().num_paths(), 2u);
-  CAF_CHECK_EQUAL(st.stage->inbound_paths().size(), 2u);
+  CHECK_EQ(st.stage->out().num_paths(), 2u);
+  CHECK_EQ(st.stage->inbound_paths().size(), 2u);
   run_until([&] {
     return st.stage->inbound_paths().empty() && st.stage->out().clean();
   });
-  CAF_CHECK_EQUAL(st.stage->out().num_paths(), 2u);
-  CAF_CHECK_EQUAL(st.stage->inbound_paths().size(), 0u);
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk1).state.x, 1275);
-  CAF_CHECK_EQUAL(deref<collect_actor>(snk2).state.strings.size(), 50u);
+  CHECK_EQ(st.stage->out().num_paths(), 2u);
+  CHECK_EQ(st.stage->inbound_paths().size(), 0u);
+  CHECK_EQ(deref<sum_up_actor>(snk1).state.x, 1275);
+  CHECK_EQ(deref<collect_actor>(snk2).state.strings.size(), 50u);
   self->send_exit(stg, exit_reason::kill);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/handles.cpp
+++ b/libcaf_core/test/handles.cpp
@@ -22,20 +22,12 @@ using testee_actor = typed_actor<replies_to<int32_t>::with<int32_t>>;
 
 // Dynamically typed testee.
 behavior dt_testee() {
-  return {
-    [](int32_t x) {
-      return x * x;
-    }
-  };
+  return {[](int32_t x) { return x * x; }};
 }
 
 // Statically typed testee.
 testee_actor::behavior_type st_testee() {
-  return {
-    [](int32_t x) {
-      return x * x;
-    }
-  };
+  return {[](int32_t x) { return x * x; }};
 }
 
 // A simple wrapper for storing a handle in all representations.
@@ -51,19 +43,19 @@ struct handle_set {
 
   template <class T>
   handle_set(const T& hdl)
-      : wh(hdl.address()),
-        dt(actor_cast<actor>(hdl)),
-        st(actor_cast<testee_actor>(hdl)) {
+    : wh(hdl.address()),
+      dt(actor_cast<actor>(hdl)),
+      st(actor_cast<testee_actor>(hdl)) {
     // nop
   }
 };
 
 struct fixture {
   fixture()
-      : sys(cfg),
-        self(sys, true),
-        a1{sys.spawn(dt_testee)},
-        a2{sys.spawn(st_testee)} {
+    : sys(cfg),
+      self(sys, true),
+      a1{sys.spawn(dt_testee)},
+      a2{sys.spawn(st_testee)} {
     // nop
   }
 
@@ -77,96 +69,96 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(handle_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(identity) {
   // all handles in a0 are equal
-  CAF_CHECK_EQUAL(a0.wh, a0.wh);
-  CAF_CHECK_EQUAL(a0.wh, a0.dt);
-  CAF_CHECK_EQUAL(a0.wh, a0.st);
-  CAF_CHECK_EQUAL(a0.dt, a0.wh);
-  CAF_CHECK_EQUAL(a0.dt, a0.dt);
-  CAF_CHECK_EQUAL(a0.dt, a0.st);
-  CAF_CHECK_EQUAL(a0.st, a0.wh);
-  CAF_CHECK_EQUAL(a0.st, a0.dt);
-  CAF_CHECK_EQUAL(a0.st, a0.st);
+  CHECK_EQ(a0.wh, a0.wh);
+  CHECK_EQ(a0.wh, a0.dt);
+  CHECK_EQ(a0.wh, a0.st);
+  CHECK_EQ(a0.dt, a0.wh);
+  CHECK_EQ(a0.dt, a0.dt);
+  CHECK_EQ(a0.dt, a0.st);
+  CHECK_EQ(a0.st, a0.wh);
+  CHECK_EQ(a0.st, a0.dt);
+  CHECK_EQ(a0.st, a0.st);
   // all handles in a1 are equal
-  CAF_CHECK_EQUAL(a1.wh, a1.wh);
-  CAF_CHECK_EQUAL(a1.wh, a1.dt);
-  CAF_CHECK_EQUAL(a1.wh, a1.st);
-  CAF_CHECK_EQUAL(a1.dt, a1.wh);
-  CAF_CHECK_EQUAL(a1.dt, a1.dt);
-  CAF_CHECK_EQUAL(a1.dt, a1.st);
-  CAF_CHECK_EQUAL(a1.st, a1.wh);
-  CAF_CHECK_EQUAL(a1.st, a1.dt);
-  CAF_CHECK_EQUAL(a1.st, a1.st);
+  CHECK_EQ(a1.wh, a1.wh);
+  CHECK_EQ(a1.wh, a1.dt);
+  CHECK_EQ(a1.wh, a1.st);
+  CHECK_EQ(a1.dt, a1.wh);
+  CHECK_EQ(a1.dt, a1.dt);
+  CHECK_EQ(a1.dt, a1.st);
+  CHECK_EQ(a1.st, a1.wh);
+  CHECK_EQ(a1.st, a1.dt);
+  CHECK_EQ(a1.st, a1.st);
   // all handles in a2 are equal
-  CAF_CHECK_EQUAL(a2.wh, a2.wh);
-  CAF_CHECK_EQUAL(a2.wh, a2.dt);
-  CAF_CHECK_EQUAL(a2.wh, a2.st);
-  CAF_CHECK_EQUAL(a2.dt, a2.wh);
-  CAF_CHECK_EQUAL(a2.dt, a2.dt);
-  CAF_CHECK_EQUAL(a2.dt, a2.st);
-  CAF_CHECK_EQUAL(a2.st, a2.wh);
-  CAF_CHECK_EQUAL(a2.st, a2.dt);
-  CAF_CHECK_EQUAL(a2.st, a2.st);
+  CHECK_EQ(a2.wh, a2.wh);
+  CHECK_EQ(a2.wh, a2.dt);
+  CHECK_EQ(a2.wh, a2.st);
+  CHECK_EQ(a2.dt, a2.wh);
+  CHECK_EQ(a2.dt, a2.dt);
+  CHECK_EQ(a2.dt, a2.st);
+  CHECK_EQ(a2.st, a2.wh);
+  CHECK_EQ(a2.st, a2.dt);
+  CHECK_EQ(a2.st, a2.st);
   // all handles in a0 are *not* equal to any handle in a1 or a2
-  CAF_CHECK_NOT_EQUAL(a0.wh, a1.wh);
-  CAF_CHECK_NOT_EQUAL(a0.wh, a1.dt);
-  CAF_CHECK_NOT_EQUAL(a0.wh, a1.st);
-  CAF_CHECK_NOT_EQUAL(a0.dt, a1.wh);
-  CAF_CHECK_NOT_EQUAL(a0.dt, a1.dt);
-  CAF_CHECK_NOT_EQUAL(a0.dt, a1.st);
-  CAF_CHECK_NOT_EQUAL(a0.st, a1.wh);
-  CAF_CHECK_NOT_EQUAL(a0.st, a1.dt);
-  CAF_CHECK_NOT_EQUAL(a0.st, a1.st);
-  CAF_CHECK_NOT_EQUAL(a0.wh, a2.wh);
-  CAF_CHECK_NOT_EQUAL(a0.wh, a2.dt);
-  CAF_CHECK_NOT_EQUAL(a0.wh, a2.st);
-  CAF_CHECK_NOT_EQUAL(a0.dt, a2.wh);
-  CAF_CHECK_NOT_EQUAL(a0.dt, a2.dt);
-  CAF_CHECK_NOT_EQUAL(a0.dt, a2.st);
-  CAF_CHECK_NOT_EQUAL(a0.st, a2.wh);
-  CAF_CHECK_NOT_EQUAL(a0.st, a2.dt);
-  CAF_CHECK_NOT_EQUAL(a0.st, a2.st);
+  CHECK_NE(a0.wh, a1.wh);
+  CHECK_NE(a0.wh, a1.dt);
+  CHECK_NE(a0.wh, a1.st);
+  CHECK_NE(a0.dt, a1.wh);
+  CHECK_NE(a0.dt, a1.dt);
+  CHECK_NE(a0.dt, a1.st);
+  CHECK_NE(a0.st, a1.wh);
+  CHECK_NE(a0.st, a1.dt);
+  CHECK_NE(a0.st, a1.st);
+  CHECK_NE(a0.wh, a2.wh);
+  CHECK_NE(a0.wh, a2.dt);
+  CHECK_NE(a0.wh, a2.st);
+  CHECK_NE(a0.dt, a2.wh);
+  CHECK_NE(a0.dt, a2.dt);
+  CHECK_NE(a0.dt, a2.st);
+  CHECK_NE(a0.st, a2.wh);
+  CHECK_NE(a0.st, a2.dt);
+  CHECK_NE(a0.st, a2.st);
   // all handles in a1 are *not* equal to any handle in a0 or a2
-  CAF_CHECK_NOT_EQUAL(a1.wh, a0.wh);
-  CAF_CHECK_NOT_EQUAL(a1.wh, a0.dt);
-  CAF_CHECK_NOT_EQUAL(a1.wh, a0.st);
-  CAF_CHECK_NOT_EQUAL(a1.dt, a0.wh);
-  CAF_CHECK_NOT_EQUAL(a1.dt, a0.dt);
-  CAF_CHECK_NOT_EQUAL(a1.dt, a0.st);
-  CAF_CHECK_NOT_EQUAL(a1.st, a0.wh);
-  CAF_CHECK_NOT_EQUAL(a1.st, a0.dt);
-  CAF_CHECK_NOT_EQUAL(a1.st, a0.st);
-  CAF_CHECK_NOT_EQUAL(a1.wh, a2.wh);
-  CAF_CHECK_NOT_EQUAL(a1.wh, a2.dt);
-  CAF_CHECK_NOT_EQUAL(a1.wh, a2.st);
-  CAF_CHECK_NOT_EQUAL(a1.dt, a2.wh);
-  CAF_CHECK_NOT_EQUAL(a1.dt, a2.dt);
-  CAF_CHECK_NOT_EQUAL(a1.dt, a2.st);
-  CAF_CHECK_NOT_EQUAL(a1.st, a2.wh);
-  CAF_CHECK_NOT_EQUAL(a1.st, a2.dt);
-  CAF_CHECK_NOT_EQUAL(a1.st, a2.st);
+  CHECK_NE(a1.wh, a0.wh);
+  CHECK_NE(a1.wh, a0.dt);
+  CHECK_NE(a1.wh, a0.st);
+  CHECK_NE(a1.dt, a0.wh);
+  CHECK_NE(a1.dt, a0.dt);
+  CHECK_NE(a1.dt, a0.st);
+  CHECK_NE(a1.st, a0.wh);
+  CHECK_NE(a1.st, a0.dt);
+  CHECK_NE(a1.st, a0.st);
+  CHECK_NE(a1.wh, a2.wh);
+  CHECK_NE(a1.wh, a2.dt);
+  CHECK_NE(a1.wh, a2.st);
+  CHECK_NE(a1.dt, a2.wh);
+  CHECK_NE(a1.dt, a2.dt);
+  CHECK_NE(a1.dt, a2.st);
+  CHECK_NE(a1.st, a2.wh);
+  CHECK_NE(a1.st, a2.dt);
+  CHECK_NE(a1.st, a2.st);
   // all handles in a2 are *not* equal to any handle in a0 or a1
-  CAF_CHECK_NOT_EQUAL(a2.wh, a0.wh);
-  CAF_CHECK_NOT_EQUAL(a2.wh, a0.dt);
-  CAF_CHECK_NOT_EQUAL(a2.wh, a0.st);
-  CAF_CHECK_NOT_EQUAL(a2.dt, a0.wh);
-  CAF_CHECK_NOT_EQUAL(a2.dt, a0.dt);
-  CAF_CHECK_NOT_EQUAL(a2.dt, a0.st);
-  CAF_CHECK_NOT_EQUAL(a2.st, a0.wh);
-  CAF_CHECK_NOT_EQUAL(a2.st, a0.dt);
-  CAF_CHECK_NOT_EQUAL(a2.st, a0.st);
-  CAF_CHECK_NOT_EQUAL(a2.wh, a1.wh);
-  CAF_CHECK_NOT_EQUAL(a2.wh, a1.dt);
-  CAF_CHECK_NOT_EQUAL(a2.wh, a1.st);
-  CAF_CHECK_NOT_EQUAL(a2.dt, a1.wh);
-  CAF_CHECK_NOT_EQUAL(a2.dt, a1.dt);
-  CAF_CHECK_NOT_EQUAL(a2.dt, a1.st);
-  CAF_CHECK_NOT_EQUAL(a2.st, a1.wh);
-  CAF_CHECK_NOT_EQUAL(a2.st, a1.dt);
-  CAF_CHECK_NOT_EQUAL(a2.st, a1.st);
+  CHECK_NE(a2.wh, a0.wh);
+  CHECK_NE(a2.wh, a0.dt);
+  CHECK_NE(a2.wh, a0.st);
+  CHECK_NE(a2.dt, a0.wh);
+  CHECK_NE(a2.dt, a0.dt);
+  CHECK_NE(a2.dt, a0.st);
+  CHECK_NE(a2.st, a0.wh);
+  CHECK_NE(a2.st, a0.dt);
+  CHECK_NE(a2.st, a0.st);
+  CHECK_NE(a2.wh, a1.wh);
+  CHECK_NE(a2.wh, a1.dt);
+  CHECK_NE(a2.wh, a1.st);
+  CHECK_NE(a2.dt, a1.wh);
+  CHECK_NE(a2.dt, a1.dt);
+  CHECK_NE(a2.dt, a1.st);
+  CHECK_NE(a2.st, a1.wh);
+  CHECK_NE(a2.st, a1.dt);
+  CHECK_NE(a2.st, a1.st);
 }
 
 CAF_TEST(ordering) {
@@ -201,34 +193,34 @@ CAF_TEST(ordering) {
   CAF_CHECK_NOT_LESS(a2.st, a2.dt);
   CAF_CHECK_NOT_LESS(a2.st, a2.st);
   // all handles in a0 are less than handles in a1 or a2
-  CAF_CHECK_LESS(a0.wh, a1.wh);
-  CAF_CHECK_LESS(a0.wh, a1.dt);
-  CAF_CHECK_LESS(a0.wh, a1.st);
-  CAF_CHECK_LESS(a0.dt, a1.wh);
-  CAF_CHECK_LESS(a0.dt, a1.dt);
-  CAF_CHECK_LESS(a0.dt, a1.st);
-  CAF_CHECK_LESS(a0.st, a1.wh);
-  CAF_CHECK_LESS(a0.st, a1.dt);
-  CAF_CHECK_LESS(a0.st, a1.st);
-  CAF_CHECK_LESS(a0.wh, a2.wh);
-  CAF_CHECK_LESS(a0.wh, a2.dt);
-  CAF_CHECK_LESS(a0.wh, a2.st);
-  CAF_CHECK_LESS(a0.dt, a2.wh);
-  CAF_CHECK_LESS(a0.dt, a2.dt);
-  CAF_CHECK_LESS(a0.dt, a2.st);
-  CAF_CHECK_LESS(a0.st, a2.wh);
-  CAF_CHECK_LESS(a0.st, a2.dt);
-  CAF_CHECK_LESS(a0.st, a2.st);
+  CHECK_LT(a0.wh, a1.wh);
+  CHECK_LT(a0.wh, a1.dt);
+  CHECK_LT(a0.wh, a1.st);
+  CHECK_LT(a0.dt, a1.wh);
+  CHECK_LT(a0.dt, a1.dt);
+  CHECK_LT(a0.dt, a1.st);
+  CHECK_LT(a0.st, a1.wh);
+  CHECK_LT(a0.st, a1.dt);
+  CHECK_LT(a0.st, a1.st);
+  CHECK_LT(a0.wh, a2.wh);
+  CHECK_LT(a0.wh, a2.dt);
+  CHECK_LT(a0.wh, a2.st);
+  CHECK_LT(a0.dt, a2.wh);
+  CHECK_LT(a0.dt, a2.dt);
+  CHECK_LT(a0.dt, a2.st);
+  CHECK_LT(a0.st, a2.wh);
+  CHECK_LT(a0.st, a2.dt);
+  CHECK_LT(a0.st, a2.st);
   // all handles in a1 are less than handles in a2
-  CAF_CHECK_LESS(a1.wh, a2.wh);
-  CAF_CHECK_LESS(a1.wh, a2.dt);
-  CAF_CHECK_LESS(a1.wh, a2.st);
-  CAF_CHECK_LESS(a1.dt, a2.wh);
-  CAF_CHECK_LESS(a1.dt, a2.dt);
-  CAF_CHECK_LESS(a1.dt, a2.st);
-  CAF_CHECK_LESS(a1.st, a2.wh);
-  CAF_CHECK_LESS(a1.st, a2.dt);
-  CAF_CHECK_LESS(a1.st, a2.st);
+  CHECK_LT(a1.wh, a2.wh);
+  CHECK_LT(a1.wh, a2.dt);
+  CHECK_LT(a1.wh, a2.st);
+  CHECK_LT(a1.dt, a2.wh);
+  CHECK_LT(a1.dt, a2.dt);
+  CHECK_LT(a1.dt, a2.st);
+  CHECK_LT(a1.st, a2.wh);
+  CHECK_LT(a1.st, a2.dt);
+  CHECK_LT(a1.st, a2.st);
   // all handles in a1 are *not* less than handles in a0
   CAF_CHECK_NOT_LESS(a1.wh, a0.wh);
   CAF_CHECK_NOT_LESS(a1.wh, a0.dt);
@@ -264,16 +256,15 @@ CAF_TEST(string_representation) {
   auto s1 = a0.wh;
   auto s2 = a0.dt;
   auto s3 = a0.st;
-  CAF_CHECK_EQUAL(s1, s2);
-  CAF_CHECK_EQUAL(s2, s3);
+  CHECK_EQ(s1, s2);
+  CHECK_EQ(s2, s3);
 }
 
 CAF_TEST(mpi_string_representation) {
-  CAF_CHECK(sys.message_types(a0.dt).empty());
+  CHECK(sys.message_types(a0.dt).empty());
   std::set<std::string> st_expected{"(int32_t) -> (int32_t)"};
-  CAF_CHECK_EQUAL(st_expected, sys.message_types(a0.st));
-  CAF_CHECK_EQUAL(st_expected, sys.message_types<testee_actor>());
+  CHECK_EQ(st_expected, sys.message_types(a0.st));
+  CHECK_EQ(st_expected, sys.message_types<testee_actor>());
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
-
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/hash/fnv.cpp
+++ b/libcaf_core/test/hash/fnv.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/hash/fnv.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include <string>
 
@@ -26,25 +26,25 @@ auto fnv64_hash(Ts&&... xs) {
 
 CAF_TEST(FNV hashes build incrementally) {
   hash::fnv<uint32_t> f;
-  CAF_CHECK_EQUAL(f.result, 0x811C9DC5u);
+  CHECK_EQ(f.result, 0x811C9DC5u);
   f.value('a');
-  CAF_CHECK_EQUAL(f.result, 0xE40C292Cu);
+  CHECK_EQ(f.result, 0xE40C292Cu);
   f.value('b');
-  CAF_CHECK_EQUAL(f.result, 0x4D2505CAu);
+  CHECK_EQ(f.result, 0x4D2505CAu);
   f.value('c');
-  CAF_CHECK_EQUAL(f.result, 0x1A47E90Bu);
+  CHECK_EQ(f.result, 0x1A47E90Bu);
   f.value('d');
-  CAF_CHECK_EQUAL(f.result, 0xCE3479BDu);
+  CHECK_EQ(f.result, 0xCE3479BDu);
 }
 
 CAF_TEST(FNV supports uint32 hashing) {
-  CAF_CHECK_EQUAL(fnv32_hash(), 0x811C9DC5u);
-  CAF_CHECK_EQUAL(fnv32_hash("abcd"s), 0xCE3479BDu);
-  CAF_CHECK_EQUAL(fnv32_hash("C++ Actor Framework"s), 0x2FF91FE5u);
+  CHECK_EQ(fnv32_hash(), 0x811C9DC5u);
+  CHECK_EQ(fnv32_hash("abcd"s), 0xCE3479BDu);
+  CHECK_EQ(fnv32_hash("C++ Actor Framework"s), 0x2FF91FE5u);
 }
 
 CAF_TEST(FNV supports uint64 hashing) {
-  CAF_CHECK_EQUAL(fnv64_hash(), 0xCBF29CE484222325ull);
-  CAF_CHECK_EQUAL(fnv64_hash("abcd"s), 0xFC179F83EE0724DDull);
-  CAF_CHECK_EQUAL(fnv64_hash("C++ Actor Framework"s), 0xA229A760C3AF69C5ull);
+  CHECK_EQ(fnv64_hash(), 0xCBF29CE484222325ull);
+  CHECK_EQ(fnv64_hash("abcd"s), 0xFC179F83EE0724DDull);
+  CHECK_EQ(fnv64_hash("C++ Actor Framework"s), 0xA229A760C3AF69C5ull);
 }

--- a/libcaf_core/test/hash/sha1.cpp
+++ b/libcaf_core/test/hash/sha1.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/hash/sha1.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 using namespace caf;
 
@@ -21,7 +21,7 @@ auto make_hash(Ts... xs) {
 } // namespace
 
 #define CHECK_HASH_EQ(str, bytes)                                              \
-  CAF_CHECK_EQUAL(hash::sha1::compute(string_view{str}), bytes);
+  CHECK_EQ(hash::sha1::compute(string_view{str}), bytes);
 
 CAF_TEST(strings are hashed by their content only) {
   CHECK_HASH_EQ("dGhlIHNhbXBsZSBub25jZQ==258EAFA5-E914-47DA-95CA-C5AB0DC85B11",

--- a/libcaf_core/test/intrusive/drr_cached_queue.cpp
+++ b/libcaf_core/test/intrusive/drr_cached_queue.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/intrusive/drr_cached_queue.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include <memory>
 
@@ -68,7 +68,7 @@ auto make_new_round_result(size_t consumed_items, bool stop_all) {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(drr_cached_queue_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(default_constructed) {
   CAF_REQUIRE_EQUAL(queue.empty(), true);
@@ -97,14 +97,14 @@ CAF_TEST(new_round) {
   fill(queue, 1, 2, 3, 4, 5, 6, 7, 8, 9);
   // Allow f to consume 2, 4, and 6.
   auto round_result = queue.new_round(3, f);
-  CAF_CHECK_EQUAL(round_result, make_new_round_result(3, false));
-  CAF_CHECK_EQUAL(fseq, "246");
-  CAF_CHECK_EQUAL(queue.deficit(), 0);
+  CHECK_EQ(round_result, make_new_round_result(3, false));
+  CHECK_EQ(fseq, "246");
+  CHECK_EQ(queue.deficit(), 0);
   // Allow g to consume 1, 3, 5, and 7.
   round_result = queue.new_round(4, g);
-  CAF_CHECK_EQUAL(round_result, make_new_round_result(4, false));
-  CAF_CHECK_EQUAL(gseq, "1357");
-  CAF_CHECK_EQUAL(queue.deficit(), 0);
+  CHECK_EQ(round_result, make_new_round_result(4, false));
+  CHECK_EQ(gseq, "1357");
+  CHECK_EQ(queue.deficit(), 0);
 }
 
 CAF_TEST(skipping) {
@@ -116,23 +116,23 @@ CAF_TEST(skipping) {
     seq += to_string(x);
     return task_result::resume;
   };
-  CAF_MESSAGE("make a round on an empty queue");
-  CAF_CHECK_EQUAL(queue.new_round(10, f), make_new_round_result(0, false));
-  CAF_MESSAGE("make a round on a queue with only odd numbers (skip all)");
+  MESSAGE("make a round on an empty queue");
+  CHECK_EQ(queue.new_round(10, f), make_new_round_result(0, false));
+  MESSAGE("make a round on a queue with only odd numbers (skip all)");
   fill(queue, 1, 3, 5);
-  CAF_CHECK_EQUAL(queue.new_round(10, f), make_new_round_result(0, false));
-  CAF_MESSAGE("make a round on a queue with an even number at the front");
+  CHECK_EQ(queue.new_round(10, f), make_new_round_result(0, false));
+  MESSAGE("make a round on a queue with an even number at the front");
   fill(queue, 2);
-  CAF_CHECK_EQUAL(queue.new_round(10, f), make_new_round_result(1, false));
-  CAF_CHECK_EQUAL(seq, "2");
-  CAF_MESSAGE("make a round on a queue with an even number in between");
+  CHECK_EQ(queue.new_round(10, f), make_new_round_result(1, false));
+  CHECK_EQ(seq, "2");
+  MESSAGE("make a round on a queue with an even number in between");
   fill(queue, 7, 9, 4, 11, 13);
-  CAF_CHECK_EQUAL(queue.new_round(10, f), make_new_round_result(1, false));
-  CAF_CHECK_EQUAL(seq, "24");
-  CAF_MESSAGE("make a round on a queue with an even number at the back");
+  CHECK_EQ(queue.new_round(10, f), make_new_round_result(1, false));
+  CHECK_EQ(seq, "24");
+  MESSAGE("make a round on a queue with an even number at the back");
   fill(queue, 15, 17, 6);
-  CAF_CHECK_EQUAL(queue.new_round(10, f), make_new_round_result(1, false));
-  CAF_CHECK_EQUAL(seq, "246");
+  CHECK_EQ(queue.new_round(10, f), make_new_round_result(1, false));
+  CHECK_EQ(seq, "246");
 }
 
 CAF_TEST(take_front) {
@@ -142,19 +142,19 @@ CAF_TEST(take_front) {
     seq += to_string(x);
     return task_result::resume;
   };
-  CAF_CHECK_EQUAL(queue.deficit(), 0);
+  CHECK_EQ(queue.deficit(), 0);
   while (!queue.empty()) {
     auto ptr = queue.take_front();
     f(*ptr);
   }
-  CAF_CHECK_EQUAL(seq, "123456");
+  CHECK_EQ(seq, "123456");
   fill(queue, 5, 4, 3, 2, 1);
   while (!queue.empty()) {
     auto ptr = queue.take_front();
     f(*ptr);
   }
-  CAF_CHECK_EQUAL(seq, "12345654321");
-  CAF_CHECK_EQUAL(queue.deficit(), 0);
+  CHECK_EQ(seq, "12345654321");
+  CHECK_EQ(queue.deficit(), 0);
 }
 
 CAF_TEST(alternating_consumer) {
@@ -185,10 +185,10 @@ CAF_TEST(alternating_consumer) {
   // sequences and no odd value to read after 7 is available.
   fill(queue, 1, 2, 3, 4, 5, 6, 7, 8, 9);
   auto round_result = queue.new_round(1000, h);
-  CAF_CHECK_EQUAL(round_result, make_new_round_result(8, false));
-  CAF_CHECK_EQUAL(seq, "21436587");
-  CAF_CHECK_EQUAL(queue.deficit(), 0);
-  CAF_CHECK_EQUAL(deep_to_string(queue.cache()), "[9]");
+  CHECK_EQ(round_result, make_new_round_result(8, false));
+  CHECK_EQ(seq, "21436587");
+  CHECK_EQ(queue.deficit(), 0);
+  CHECK_EQ(deep_to_string(queue.cache()), "[9]");
 }
 
 CAF_TEST(peek_all) {
@@ -202,25 +202,25 @@ CAF_TEST(peek_all) {
     queue.peek_all(peek_fun);
     return str;
   };
-  CAF_CHECK_EQUAL(queue_to_string(), "");
+  CHECK_EQ(queue_to_string(), "");
   queue.emplace_back(2);
-  CAF_CHECK_EQUAL(queue_to_string(), "2");
+  CHECK_EQ(queue_to_string(), "2");
   queue.cache().emplace_back(1);
-  CAF_CHECK_EQUAL(queue_to_string(), "2");
+  CHECK_EQ(queue_to_string(), "2");
   queue.emplace_back(3);
-  CAF_CHECK_EQUAL(queue_to_string(), "2, 3");
+  CHECK_EQ(queue_to_string(), "2, 3");
   queue.flush_cache();
-  CAF_CHECK_EQUAL(queue_to_string(), "1, 2, 3");
+  CHECK_EQ(queue_to_string(), "1, 2, 3");
 }
 
 CAF_TEST(to_string) {
-  CAF_CHECK_EQUAL(deep_to_string(queue.items()), "[]");
+  CHECK_EQ(deep_to_string(queue.items()), "[]");
   fill(queue, 3, 4);
-  CAF_CHECK_EQUAL(deep_to_string(queue.items()), "[3, 4]");
+  CHECK_EQ(deep_to_string(queue.items()), "[3, 4]");
   fill(queue.cache(), 1, 2);
-  CAF_CHECK_EQUAL(deep_to_string(queue.items()), "[3, 4]");
+  CHECK_EQ(deep_to_string(queue.items()), "[3, 4]");
   queue.flush_cache();
-  CAF_CHECK_EQUAL(deep_to_string(queue.items()), "[1, 2, 3, 4]");
+  CHECK_EQ(deep_to_string(queue.items()), "[1, 2, 3, 4]");
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/intrusive/drr_queue.cpp
+++ b/libcaf_core/test/intrusive/drr_queue.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/intrusive/drr_queue.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include <memory>
 
@@ -67,7 +67,7 @@ auto make_new_round_result(size_t consumed_items, bool stop_all) {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(drr_queue_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(default_constructed) {
   CAF_REQUIRE_EQUAL(queue.empty(), true);
@@ -100,24 +100,24 @@ CAF_TEST(new_round) {
   };
   // Allow f to consume 1, 2, and 3 with a leftover deficit of 1.
   auto round_result = queue.new_round(7, f);
-  CAF_CHECK_EQUAL(round_result, make_new_round_result(3, false));
-  CAF_CHECK_EQUAL(seq, "123");
-  CAF_CHECK_EQUAL(queue.deficit(), 1);
+  CHECK_EQ(round_result, make_new_round_result(3, false));
+  CHECK_EQ(seq, "123");
+  CHECK_EQ(queue.deficit(), 1);
   // Allow f to consume 4 and 5 with a leftover deficit of 0.
   round_result = queue.new_round(8, f);
-  CAF_CHECK_EQUAL(round_result, make_new_round_result(2, false));
-  CAF_CHECK_EQUAL(seq, "12345");
-  CAF_CHECK_EQUAL(queue.deficit(), 0);
+  CHECK_EQ(round_result, make_new_round_result(2, false));
+  CHECK_EQ(seq, "12345");
+  CHECK_EQ(queue.deficit(), 0);
   // Allow f to consume 6 with a leftover deficit of 0 (queue is empty).
   round_result = queue.new_round(1000, f);
-  CAF_CHECK_EQUAL(round_result, make_new_round_result(1, false));
-  CAF_CHECK_EQUAL(seq, "123456");
-  CAF_CHECK_EQUAL(queue.deficit(), 0);
+  CHECK_EQ(round_result, make_new_round_result(1, false));
+  CHECK_EQ(seq, "123456");
+  CHECK_EQ(queue.deficit(), 0);
   // new_round on an empty queue does nothing.
   round_result = queue.new_round(1000, f);
-  CAF_CHECK_EQUAL(round_result, make_new_round_result(0, false));
-  CAF_CHECK_EQUAL(seq, "123456");
-  CAF_CHECK_EQUAL(queue.deficit(), 0);
+  CHECK_EQ(round_result, make_new_round_result(0, false));
+  CHECK_EQ(seq, "123456");
+  CHECK_EQ(queue.deficit(), 0);
 }
 
 CAF_TEST(next) {
@@ -136,14 +136,14 @@ CAF_TEST(next) {
     auto ptr = take();
     f(*ptr);
   }
-  CAF_CHECK_EQUAL(seq, "123456");
+  CHECK_EQ(seq, "123456");
   fill(queue, 5, 4, 3, 2, 1);
   while (!queue.empty()) {
     auto ptr = take();
     f(*ptr);
   }
-  CAF_CHECK_EQUAL(seq, "12345654321");
-  CAF_CHECK_EQUAL(queue.deficit(), 0);
+  CHECK_EQ(seq, "12345654321");
+  CHECK_EQ(queue.deficit(), 0);
 }
 
 CAF_TEST(peek_all) {
@@ -157,21 +157,21 @@ CAF_TEST(peek_all) {
     queue.peek_all(peek_fun);
     return str;
   };
-  CAF_CHECK_EQUAL(queue_to_string(), "");
+  CHECK_EQ(queue_to_string(), "");
   queue.emplace_back(1);
-  CAF_CHECK_EQUAL(queue_to_string(), "1");
+  CHECK_EQ(queue_to_string(), "1");
   queue.emplace_back(2);
-  CAF_CHECK_EQUAL(queue_to_string(), "1, 2");
+  CHECK_EQ(queue_to_string(), "1, 2");
   queue.emplace_back(3);
-  CAF_CHECK_EQUAL(queue_to_string(), "1, 2, 3");
+  CHECK_EQ(queue_to_string(), "1, 2, 3");
   queue.emplace_back(4);
-  CAF_CHECK_EQUAL(queue_to_string(), "1, 2, 3, 4");
+  CHECK_EQ(queue_to_string(), "1, 2, 3, 4");
 }
 
 CAF_TEST(to_string) {
-  CAF_CHECK_EQUAL(deep_to_string(queue), "[]");
+  CHECK_EQ(deep_to_string(queue), "[]");
   fill(queue, 1, 2, 3, 4);
-  CAF_CHECK_EQUAL(deep_to_string(queue), "[1, 2, 3, 4]");
+  CHECK_EQ(deep_to_string(queue), "[1, 2, 3, 4]");
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/intrusive/fifo_inbox.cpp
+++ b/libcaf_core/test/intrusive/fifo_inbox.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/intrusive/fifo_inbox.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include <memory>
 
@@ -87,7 +87,7 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(fifo_inbox_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(default_constructed) {
   CAF_REQUIRE_EQUAL(inbox.empty(), true);
@@ -133,7 +133,7 @@ CAF_TEST(timed_await) {
   fill(inbox, 1);
   res = inbox.synchronized_await(mx, cv, tout);
   CAF_REQUIRE_EQUAL(res, true);
-  CAF_CHECK_EQUAL(fetch(), "1");
+  CHECK_EQ(fetch(), "1");
   tout += std::chrono::hours(1000);
   std::thread t{[&] { inbox.synchronized_emplace_back(mx, cv, 2); }};
   res = inbox.synchronized_await(mx, cv, tout);
@@ -141,4 +141,4 @@ CAF_TEST(timed_await) {
   CAF_REQUIRE_EQUAL(close_and_fetch(), "2");
   t.join();
 }
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/intrusive/lifo_inbox.cpp
+++ b/libcaf_core/test/intrusive/lifo_inbox.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/intrusive/lifo_inbox.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include <memory>
 
@@ -80,7 +80,7 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(lifo_inbox_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(default_constructed) {
   CAF_REQUIRE_EQUAL(inbox.empty(), true);
@@ -126,7 +126,7 @@ CAF_TEST(timed_await) {
   fill(inbox, 1);
   res = inbox.synchronized_await(mx, cv, tout);
   CAF_REQUIRE_EQUAL(res, true);
-  CAF_CHECK_EQUAL(fetch(), "1");
+  CHECK_EQ(fetch(), "1");
   tout += std::chrono::hours(1000);
   std::thread t{[&] { inbox.synchronized_emplace_front(mx, cv, 2); }};
   res = inbox.synchronized_await(mx, cv, tout);
@@ -135,4 +135,4 @@ CAF_TEST(timed_await) {
   t.join();
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/intrusive/task_queue.cpp
+++ b/libcaf_core/test/intrusive/task_queue.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/intrusive/task_queue.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include <memory>
 
@@ -61,7 +61,7 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(task_queue_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(default_constructed) {
   CAF_REQUIRE_EQUAL(queue.empty(), true);
@@ -123,24 +123,24 @@ CAF_TEST(prepend) {
 }
 
 CAF_TEST(peek) {
-  CAF_CHECK_EQUAL(queue.peek(), nullptr);
+  CHECK_EQ(queue.peek(), nullptr);
   fill(queue, 1, 2, 3);
-  CAF_CHECK_EQUAL(queue.peek()->value, 1);
+  CHECK_EQ(queue.peek()->value, 1);
 }
 
 CAF_TEST(task_size) {
   fill(queue, 1, 2, 3);
-  CAF_CHECK_EQUAL(queue.total_task_size(), 6);
+  CHECK_EQ(queue.total_task_size(), 6);
   fill(queue, 4, 5);
-  CAF_CHECK_EQUAL(queue.total_task_size(), 15);
+  CHECK_EQ(queue.total_task_size(), 15);
   queue.clear();
-  CAF_CHECK_EQUAL(queue.total_task_size(), 0);
+  CHECK_EQ(queue.total_task_size(), 0);
 }
 
 CAF_TEST(to_string) {
-  CAF_CHECK_EQUAL(deep_to_string(queue), "[]");
+  CHECK_EQ(deep_to_string(queue), "[]");
   fill(queue, 1, 2, 3, 4);
-  CAF_CHECK_EQUAL(deep_to_string(queue), "[1, 2, 3, 4]");
+  CHECK_EQ(deep_to_string(queue), "[1, 2, 3, 4]");
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/intrusive/wdrr_dynamic_multiplexed_queue.cpp
+++ b/libcaf_core/test/intrusive/wdrr_dynamic_multiplexed_queue.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/intrusive/wdrr_dynamic_multiplexed_queue.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include <memory>
 
@@ -114,7 +114,7 @@ struct fixture {
   std::string fetch(int quantum) {
     std::string result;
     auto f = [&](int id, nested_queue_type& q, inode& x) {
-      CAF_CHECK_EQUAL(id, *q.policy().queue_id);
+      CHECK_EQ(id, *q.policy().queue_id);
       if (!result.empty())
         result += ',';
       result += to_string(id);
@@ -134,7 +134,7 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(wdrr_dynamic_multiplexed_queue_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(default_constructed) {
   CAF_REQUIRE_EQUAL(queue.empty(), true);
@@ -150,9 +150,9 @@ CAF_TEST(new_round) {
   make_queues();
   fill(queue, 1, 2, 3, 4, 5, 6, 7, 8, 9, 12);
   CAF_REQUIRE_EQUAL(queue.empty(), false);
-  CAF_CHECK_EQUAL(fetch(1), "0:3,1:1,2:2");
+  CHECK_EQ(fetch(1), "0:3,1:1,2:2");
   CAF_REQUIRE_EQUAL(queue.empty(), false);
-  CAF_CHECK_EQUAL(fetch(9), "0:6,0:9,0:12,1:4,1:7,2:5,2:8");
+  CHECK_EQ(fetch(9), "0:6,0:9,0:12,1:4,1:7,2:5,2:8");
   CAF_REQUIRE_EQUAL(queue.empty(), true);
 }
 
@@ -161,13 +161,13 @@ CAF_TEST(priorities) {
   queue.policy().enable_priorities = true;
   fill(queue, 1, 2, 3, 4, 5, 6, 7, 8, 9);
   // Allow f to consume 2 items from the high priority and 1 item otherwise.
-  CAF_CHECK_EQUAL(fetch(1), "0:3,0:6,1:1,2:2");
+  CHECK_EQ(fetch(1), "0:3,0:6,1:1,2:2");
   CAF_REQUIRE_EQUAL(queue.empty(), false);
   // Drain the high-priority queue with one item left per other queue.
-  CAF_CHECK_EQUAL(fetch(1), "0:9,1:4,2:5");
+  CHECK_EQ(fetch(1), "0:9,1:4,2:5");
   CAF_REQUIRE_EQUAL(queue.empty(), false);
   // Drain queue.
-  CAF_CHECK_EQUAL(fetch(1000), "1:7,2:8");
+  CHECK_EQ(fetch(1000), "1:7,2:8");
   CAF_REQUIRE_EQUAL(queue.empty(), true);
 }
 
@@ -183,17 +183,17 @@ CAF_TEST(peek_all) {
     return str;
   };
   make_queues();
-  CAF_CHECK_EQUAL(queue_to_string(), "");
+  CHECK_EQ(queue_to_string(), "");
   queue.emplace_back(1);
-  CAF_CHECK_EQUAL(queue_to_string(), "1");
+  CHECK_EQ(queue_to_string(), "1");
   queue.emplace_back(2);
-  CAF_CHECK_EQUAL(queue_to_string(), "1, 2");
+  CHECK_EQ(queue_to_string(), "1, 2");
   queue.emplace_back(3);
   // Lists are iterated in order and 3 is stored in the first queue for
   // `x mod 3 == 0` values.
-  CAF_CHECK_EQUAL(queue_to_string(), "3, 1, 2");
+  CHECK_EQ(queue_to_string(), "3, 1, 2");
   queue.emplace_back(4);
-  CAF_CHECK_EQUAL(queue_to_string(), "3, 1, 4, 2");
+  CHECK_EQ(queue_to_string(), "3, 1, 4, 2");
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/intrusive/wdrr_fixed_multiplexed_queue.cpp
+++ b/libcaf_core/test/intrusive/wdrr_fixed_multiplexed_queue.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/intrusive/wdrr_fixed_multiplexed_queue.hpp"
 
-#include "caf/test/unit_test.hpp"
+#include "core-test.hpp"
 
 #include <memory>
 
@@ -71,15 +71,16 @@ public:
 
 using nested_queue_type = drr_queue<inode_policy>;
 
-using queue_type = wdrr_fixed_multiplexed_queue<
-  inode_policy, high_prio_queue, nested_queue_type, nested_queue_type>;
+using queue_type
+  = wdrr_fixed_multiplexed_queue<inode_policy, high_prio_queue,
+                                 nested_queue_type, nested_queue_type>;
 
 struct fetch_helper {
   std::string result;
 
   template <size_t I, class Queue>
-  task_result operator()(std::integral_constant<size_t, I>, const Queue&,
-                         inode& x) {
+  task_result
+  operator()(std::integral_constant<size_t, I>, const Queue&, inode& x) {
     if (!result.empty())
       result += ',';
     result += std::to_string(I);
@@ -124,7 +125,7 @@ auto make_new_round_result(size_t consumed_items, bool stop_all) {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(wdrr_fixed_multiplexed_queue_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(default_constructed) {
   CAF_REQUIRE_EQUAL(queue.empty(), true);
@@ -135,20 +136,20 @@ CAF_TEST(new_round) {
   // Allow f to consume 2 items per nested queue.
   fetch_helper f;
   auto round_result = queue.new_round(2, f);
-  CAF_CHECK_EQUAL(round_result, make_new_round_result(6, false));
-  CAF_CHECK_EQUAL(f.result, "0:3,0:6,1:1,1:4,2:2,2:5");
+  CHECK_EQ(round_result, make_new_round_result(6, false));
+  CHECK_EQ(f.result, "0:3,0:6,1:1,1:4,2:2,2:5");
   CAF_REQUIRE_EQUAL(queue.empty(), false);
   // Allow f to consume one more item from each queue.
   f.result.clear();
   round_result = queue.new_round(1, f);
-  CAF_CHECK_EQUAL(round_result, make_new_round_result(3, false));
-  CAF_CHECK_EQUAL(f.result, "0:9,1:7,2:8");
+  CHECK_EQ(round_result, make_new_round_result(3, false));
+  CHECK_EQ(f.result, "0:9,1:7,2:8");
   CAF_REQUIRE_EQUAL(queue.empty(), false);
   // Allow f to consume the remainder, i.e., 12.
   f.result.clear();
   round_result = queue.new_round(1000, f);
-  CAF_CHECK_EQUAL(round_result, make_new_round_result(1, false));
-  CAF_CHECK_EQUAL(f.result, "0:12");
+  CHECK_EQ(round_result, make_new_round_result(1, false));
+  CHECK_EQ(f.result, "0:12");
   CAF_REQUIRE_EQUAL(queue.empty(), true);
 }
 
@@ -156,13 +157,13 @@ CAF_TEST(priorities) {
   queue.policy().enable_priorities = true;
   fill(queue, 1, 2, 3, 4, 5, 6, 7, 8, 9);
   // Allow f to consume 2 items from the high priority and 1 item otherwise.
-  CAF_CHECK_EQUAL(fetch(1), "0:3,0:6,1:1,2:2");
+  CHECK_EQ(fetch(1), "0:3,0:6,1:1,2:2");
   CAF_REQUIRE_EQUAL(queue.empty(), false);
   // Drain the high-priority queue with one item left per other queue.
-  CAF_CHECK_EQUAL(fetch(1), "0:9,1:4,2:5");
+  CHECK_EQ(fetch(1), "0:9,1:4,2:5");
   CAF_REQUIRE_EQUAL(queue.empty(), false);
   // Drain queue.
-  CAF_CHECK_EQUAL(fetch(1000), "1:7,2:8");
+  CHECK_EQ(fetch(1000), "1:7,2:8");
   CAF_REQUIRE_EQUAL(queue.empty(), true);
 }
 
@@ -177,17 +178,17 @@ CAF_TEST(peek_all) {
     queue.peek_all(peek_fun);
     return str;
   };
-  CAF_CHECK_EQUAL(queue_to_string(), "");
+  CHECK_EQ(queue_to_string(), "");
   queue.emplace_back(1);
-  CAF_CHECK_EQUAL(queue_to_string(), "1");
+  CHECK_EQ(queue_to_string(), "1");
   queue.emplace_back(2);
-  CAF_CHECK_EQUAL(queue_to_string(), "1, 2");
+  CHECK_EQ(queue_to_string(), "1, 2");
   queue.emplace_back(3);
   // Lists are iterated in order and 3 is stored in the first queue for
   // `x mod 3 == 0` values.
-  CAF_CHECK_EQUAL(queue_to_string(), "3, 1, 2");
+  CHECK_EQ(queue_to_string(), "3, 1, 2");
   queue.emplace_back(4);
-  CAF_CHECK_EQUAL(queue_to_string(), "3, 1, 4, 2");
+  CHECK_EQ(queue_to_string(), "3, 1, 4, 2");
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/intrusive_ptr.cpp
+++ b/libcaf_core/test/intrusive_ptr.cpp
@@ -11,11 +11,11 @@
 // this test doesn't verify thread-safety of intrusive_ptr
 // however, it is thread safe since it uses atomic operations only
 
-#include <vector>
 #include <cstddef>
+#include <vector>
 
-#include "caf/ref_counted.hpp"
 #include "caf/make_counted.hpp"
+#include "caf/ref_counted.hpp"
 
 using namespace caf;
 
@@ -81,34 +81,34 @@ class0ptr get_test_ptr() {
 
 struct fixture {
   ~fixture() {
-    CAF_CHECK_EQUAL(class0_instances, 0);
-    CAF_CHECK_EQUAL(class1_instances, 0);
+    CHECK_EQ(class0_instances, 0);
+    CHECK_EQ(class1_instances, 0);
   }
 };
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(atom_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(make_counted) {
   auto p = make_counted<class0>();
-  CAF_CHECK_EQUAL(class0_instances, 1);
-  CAF_CHECK(p->unique());
+  CHECK_EQ(class0_instances, 1);
+  CHECK(p->unique());
 }
 
 CAF_TEST(reset) {
   class0ptr p;
   p.reset(new class0, false);
-  CAF_CHECK_EQUAL(class0_instances, 1);
-  CAF_CHECK(p->unique());
+  CHECK_EQ(class0_instances, 1);
+  CHECK(p->unique());
 }
 
 CAF_TEST(get_test_rc) {
   class0ptr p1;
   p1 = get_test_rc();
   class0ptr p2 = p1;
-  CAF_CHECK_EQUAL(class0_instances, 1);
-  CAF_CHECK_EQUAL(p1->unique(), false);
+  CHECK_EQ(class0_instances, 1);
+  CHECK_EQ(p1->unique(), false);
 }
 
 CAF_TEST(list) {
@@ -116,27 +116,27 @@ CAF_TEST(list) {
   pl.push_back(get_test_ptr());
   pl.push_back(get_test_rc());
   pl.push_back(pl.front()->create());
-  CAF_CHECK(pl.front()->unique());
-  CAF_CHECK_EQUAL(class0_instances, 3);
+  CHECK(pl.front()->unique());
+  CHECK_EQ(class0_instances, 3);
 }
 
 CAF_TEST(full_test) {
   auto p1 = make_counted<class0>();
-  CAF_CHECK_EQUAL(p1->is_subtype(), false);
-  CAF_CHECK_EQUAL(p1->unique(), true);
-  CAF_CHECK_EQUAL(class0_instances, 1);
-  CAF_CHECK_EQUAL(class1_instances, 0);
+  CHECK_EQ(p1->is_subtype(), false);
+  CHECK_EQ(p1->unique(), true);
+  CHECK_EQ(class0_instances, 1);
+  CHECK_EQ(class1_instances, 0);
   p1.reset(new class1, false);
-  CAF_CHECK_EQUAL(p1->is_subtype(), true);
-  CAF_CHECK_EQUAL(p1->unique(), true);
-  CAF_CHECK_EQUAL(class0_instances, 0);
-  CAF_CHECK_EQUAL(class1_instances, 1);
+  CHECK_EQ(p1->is_subtype(), true);
+  CHECK_EQ(p1->unique(), true);
+  CHECK_EQ(class0_instances, 0);
+  CHECK_EQ(class1_instances, 1);
   auto p2 = make_counted<class1>();
   p1 = p2;
-  CAF_CHECK_EQUAL(p1->unique(), false);
-  CAF_CHECK_EQUAL(class0_instances, 0);
-  CAF_CHECK_EQUAL(class1_instances, 1);
-  CAF_CHECK_EQUAL(p1, static_cast<class0*>(p2.get()));
+  CHECK_EQ(p1->unique(), false);
+  CHECK_EQ(class0_instances, 0);
+  CHECK_EQ(class1_instances, 1);
+  CHECK_EQ(p1, static_cast<class0*>(p2.get()));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/ipv4_address.cpp
+++ b/libcaf_core/test/ipv4_address.cpp
@@ -22,13 +22,13 @@ const auto addr = make_ipv4_address;
 
 CAF_TEST(constructing) {
   auto localhost = addr(127, 0, 0, 1);
-  CAF_CHECK_EQUAL(localhost.bits(), to_network_order(0x7F000001u));
+  CHECK_EQ(localhost.bits(), to_network_order(0x7F000001u));
   ipv4_address zero;
-  CAF_CHECK_EQUAL(zero.bits(), 0u);
+  CHECK_EQ(zero.bits(), 0u);
 }
 
 CAF_TEST(to string) {
-  CAF_CHECK_EQUAL(to_string(addr(255, 255, 255, 255)), "255.255.255.255");
+  CHECK_EQ(to_string(addr(255, 255, 255, 255)), "255.255.255.255");
 }
 
 CAF_TEST(from string - valid inputs) {
@@ -38,8 +38,8 @@ CAF_TEST(from string - valid inputs) {
       return err;
     return result;
   };
-  CAF_CHECK_EQUAL(from_string("136.12.12.12"), addr(136, 12, 12, 12));
-  CAF_CHECK_EQUAL(from_string("255.255.255.255"), addr(255, 255, 255, 255));
+  CHECK_EQ(from_string("136.12.12.12"), addr(136, 12, 12, 12));
+  CHECK_EQ(from_string("255.255.255.255"), addr(255, 255, 255, 255));
 }
 
 CAF_TEST(from string - invalid inputs) {
@@ -58,69 +58,68 @@ CAF_TEST(from string - invalid inputs) {
 }
 
 CAF_TEST(properties) {
-  CAF_CHECK_EQUAL(addr(127, 0, 0, 1).is_loopback(), true);
-  CAF_CHECK_EQUAL(addr(127, 0, 0, 254).is_loopback(), true);
-  CAF_CHECK_EQUAL(addr(127, 0, 1, 1).is_loopback(), true);
-  CAF_CHECK_EQUAL(addr(128, 0, 0, 1).is_loopback(), false);
+  CHECK_EQ(addr(127, 0, 0, 1).is_loopback(), true);
+  CHECK_EQ(addr(127, 0, 0, 254).is_loopback(), true);
+  CHECK_EQ(addr(127, 0, 1, 1).is_loopback(), true);
+  CHECK_EQ(addr(128, 0, 0, 1).is_loopback(), false);
   // Checks multicast according to BCP 51, Section 3.
-  CAF_CHECK_EQUAL(addr(223, 255, 255, 255).is_multicast(), false);
+  CHECK_EQ(addr(223, 255, 255, 255).is_multicast(), false);
   // 224.0.0.0 - 224.0.0.255       (/24)      Local Network Control Block
-  CAF_CHECK_EQUAL(addr(224, 0, 0, 1).is_multicast(), true);
-  CAF_CHECK_EQUAL(addr(224, 0, 0, 255).is_multicast(), true);
+  CHECK_EQ(addr(224, 0, 0, 1).is_multicast(), true);
+  CHECK_EQ(addr(224, 0, 0, 255).is_multicast(), true);
   // 224.0.1.0 - 224.0.1.255       (/24)      Internetwork Control Block
-  CAF_CHECK_EQUAL(addr(224, 0, 1, 0).is_multicast(), true);
-  CAF_CHECK_EQUAL(addr(224, 0, 1, 255).is_multicast(), true);
+  CHECK_EQ(addr(224, 0, 1, 0).is_multicast(), true);
+  CHECK_EQ(addr(224, 0, 1, 255).is_multicast(), true);
   // 224.0.2.0 - 224.0.255.255     (65024)    AD-HOC Block I
-  CAF_CHECK_EQUAL(addr(224, 0, 2, 0).is_multicast(), true);
-  CAF_CHECK_EQUAL(addr(224, 0, 255, 255).is_multicast(), true);
+  CHECK_EQ(addr(224, 0, 2, 0).is_multicast(), true);
+  CHECK_EQ(addr(224, 0, 255, 255).is_multicast(), true);
   // 224.1.0.0 - 224.1.255.255     (/16)      RESERVED
-  CAF_CHECK_EQUAL(addr(224, 1, 0, 0).is_multicast(), true);
-  CAF_CHECK_EQUAL(addr(224, 1, 255, 255).is_multicast(), true);
+  CHECK_EQ(addr(224, 1, 0, 0).is_multicast(), true);
+  CHECK_EQ(addr(224, 1, 255, 255).is_multicast(), true);
   // 224.2.0.0 - 224.2.255.255     (/16)      SDP/SAP Block
-  CAF_CHECK_EQUAL(addr(224, 2, 0, 0).is_multicast(), true);
-  CAF_CHECK_EQUAL(addr(224, 2, 255, 255).is_multicast(), true);
+  CHECK_EQ(addr(224, 2, 0, 0).is_multicast(), true);
+  CHECK_EQ(addr(224, 2, 255, 255).is_multicast(), true);
   // 224.3.0.0 - 224.4.255.255     (2 /16s)   AD-HOC Block II
-  CAF_CHECK_EQUAL(addr(224, 3, 0, 0).is_multicast(), true);
-  CAF_CHECK_EQUAL(addr(224, 4, 255, 255).is_multicast(), true);
+  CHECK_EQ(addr(224, 3, 0, 0).is_multicast(), true);
+  CHECK_EQ(addr(224, 4, 255, 255).is_multicast(), true);
   // 224.5.0.0 - 224.255.255.255   (251 /16s) RESERVED
-  CAF_CHECK_EQUAL(addr(224, 5, 0, 0).is_multicast(), true);
-  CAF_CHECK_EQUAL(addr(224, 255, 255, 255).is_multicast(), true);
+  CHECK_EQ(addr(224, 5, 0, 0).is_multicast(), true);
+  CHECK_EQ(addr(224, 255, 255, 255).is_multicast(), true);
   // 225.0.0.0 - 231.255.255.255   (7 /8s)    RESERVED
-  CAF_CHECK_EQUAL(addr(225, 0, 0, 0).is_multicast(), true);
-  CAF_CHECK_EQUAL(addr(231, 255, 255, 255).is_multicast(), true);
+  CHECK_EQ(addr(225, 0, 0, 0).is_multicast(), true);
+  CHECK_EQ(addr(231, 255, 255, 255).is_multicast(), true);
   // 232.0.0.0 - 232.255.255.255   (/8)       Source-Specific Multicast Block
-  CAF_CHECK_EQUAL(addr(232, 0, 0, 0).is_multicast(), true);
-  CAF_CHECK_EQUAL(addr(232, 255, 255, 255).is_multicast(), true);
+  CHECK_EQ(addr(232, 0, 0, 0).is_multicast(), true);
+  CHECK_EQ(addr(232, 255, 255, 255).is_multicast(), true);
   // 233.0.0.0 - 233.251.255.255   (16515072) GLOP Block
-  CAF_CHECK_EQUAL(addr(233, 0, 0, 0).is_multicast(), true);
-  CAF_CHECK_EQUAL(addr(233, 251, 255, 255).is_multicast(), true);
+  CHECK_EQ(addr(233, 0, 0, 0).is_multicast(), true);
+  CHECK_EQ(addr(233, 251, 255, 255).is_multicast(), true);
   // 233.252.0.0 - 233.255.255.255 (/14)      AD-HOC Block III
-  CAF_CHECK_EQUAL(addr(233, 252, 0, 0).is_multicast(), true);
-  CAF_CHECK_EQUAL(addr(233, 255, 255, 255).is_multicast(), true);
+  CHECK_EQ(addr(233, 252, 0, 0).is_multicast(), true);
+  CHECK_EQ(addr(233, 255, 255, 255).is_multicast(), true);
   // 234.0.0.0 - 238.255.255.255   (5 /8s)    RESERVED
-  CAF_CHECK_EQUAL(addr(234, 0, 0, 0).is_multicast(), true);
-  CAF_CHECK_EQUAL(addr(238, 255, 255, 255).is_multicast(), true);
+  CHECK_EQ(addr(234, 0, 0, 0).is_multicast(), true);
+  CHECK_EQ(addr(238, 255, 255, 255).is_multicast(), true);
   // 239.0.0.0 - 239.255.255.255   (/8)       Administratively Scoped Block
-  CAF_CHECK_EQUAL(addr(239, 0, 0, 0).is_multicast(), true);
-  CAF_CHECK_EQUAL(addr(239, 255, 255, 255).is_multicast(), true);
+  CHECK_EQ(addr(239, 0, 0, 0).is_multicast(), true);
+  CHECK_EQ(addr(239, 255, 255, 255).is_multicast(), true);
   // One above.
-  CAF_CHECK_EQUAL(addr(240, 0, 0, 0).is_multicast(), false);
+  CHECK_EQ(addr(240, 0, 0, 0).is_multicast(), false);
 }
 
 CAF_TEST(network addresses) {
   auto all1 = addr(255, 255, 255, 255);
-  CAF_CHECK_EQUAL(all1.network_address(0), addr(0x00, 0x00, 0x00, 0x00));
-  CAF_CHECK_EQUAL(all1.network_address(7), addr(0xFE, 0x00, 0x00, 0x00));
-  CAF_CHECK_EQUAL(all1.network_address(8), addr(0xFF, 0x00, 0x00, 0x00));
-  CAF_CHECK_EQUAL(all1.network_address(9), addr(0xFF, 0x80, 0x00, 0x00));
-  CAF_CHECK_EQUAL(all1.network_address(31), addr(0xFF, 0xFF, 0xFF, 0xFE));
-  CAF_CHECK_EQUAL(all1.network_address(32), addr(0xFF, 0xFF, 0xFF, 0xFF));
-  CAF_CHECK_EQUAL(all1.network_address(33), addr(0xFF, 0xFF, 0xFF, 0xFF));
+  CHECK_EQ(all1.network_address(0), addr(0x00, 0x00, 0x00, 0x00));
+  CHECK_EQ(all1.network_address(7), addr(0xFE, 0x00, 0x00, 0x00));
+  CHECK_EQ(all1.network_address(8), addr(0xFF, 0x00, 0x00, 0x00));
+  CHECK_EQ(all1.network_address(9), addr(0xFF, 0x80, 0x00, 0x00));
+  CHECK_EQ(all1.network_address(31), addr(0xFF, 0xFF, 0xFF, 0xFE));
+  CHECK_EQ(all1.network_address(32), addr(0xFF, 0xFF, 0xFF, 0xFF));
+  CHECK_EQ(all1.network_address(33), addr(0xFF, 0xFF, 0xFF, 0xFF));
 }
 
 CAF_TEST(operators) {
-  CAF_CHECK_EQUAL(addr(16, 0, 0, 8) & addr(255, 2, 4, 6), addr(16, 0, 0, 0));
-  CAF_CHECK_EQUAL(addr(16, 0, 0, 8) | addr(255, 2, 4, 6), addr(255, 2, 4, 14));
-  CAF_CHECK_EQUAL(addr(16, 0, 0, 8) ^ addr(255, 2, 4, 6), addr(239, 2, 4, 14));
+  CHECK_EQ(addr(16, 0, 0, 8) & addr(255, 2, 4, 6), addr(16, 0, 0, 0));
+  CHECK_EQ(addr(16, 0, 0, 8) | addr(255, 2, 4, 6), addr(255, 2, 4, 14));
+  CHECK_EQ(addr(16, 0, 0, 8) ^ addr(255, 2, 4, 6), addr(239, 2, 4, 14));
 }
-

--- a/libcaf_core/test/ipv4_endpoint.cpp
+++ b/libcaf_core/test/ipv4_endpoint.cpp
@@ -50,41 +50,40 @@ struct fixture {
   }
 };
 
-#define CHECK_TO_STRING(addr) CAF_CHECK_EQUAL(addr, to_string(addr##_ep))
+#define CHECK_TO_STRING(addr) CHECK_EQ(addr, to_string(addr##_ep))
 
 #define CHECK_COMPARISON(addr1, addr2)                                         \
-  CAF_CHECK_GREATER(addr2##_ep, addr1##_ep);                                   \
-  CAF_CHECK_GREATER_OR_EQUAL(addr2##_ep, addr1##_ep);                          \
-  CAF_CHECK_GREATER_OR_EQUAL(addr1##_ep, addr1##_ep);                          \
-  CAF_CHECK_GREATER_OR_EQUAL(addr2##_ep, addr2##_ep);                          \
-  CAF_CHECK_EQUAL(addr1##_ep, addr1##_ep);                                     \
-  CAF_CHECK_EQUAL(addr2##_ep, addr2##_ep);                                     \
-  CAF_CHECK_LESS_OR_EQUAL(addr1##_ep, addr2##_ep);                             \
-  CAF_CHECK_LESS_OR_EQUAL(addr1##_ep, addr1##_ep);                             \
-  CAF_CHECK_LESS_OR_EQUAL(addr2##_ep, addr2##_ep);                             \
-  CAF_CHECK_NOT_EQUAL(addr1##_ep, addr2##_ep);                                 \
-  CAF_CHECK_NOT_EQUAL(addr2##_ep, addr1##_ep);
+  CHECK_GT(addr2##_ep, addr1##_ep);                                            \
+  CHECK_GE(addr2##_ep, addr1##_ep);                                            \
+  CHECK_GE(addr1##_ep, addr1##_ep);                                            \
+  CHECK_GE(addr2##_ep, addr2##_ep);                                            \
+  CHECK_EQ(addr1##_ep, addr1##_ep);                                            \
+  CHECK_EQ(addr2##_ep, addr2##_ep);                                            \
+  CHECK_LE(addr1##_ep, addr2##_ep);                                            \
+  CHECK_LE(addr1##_ep, addr1##_ep);                                            \
+  CHECK_LE(addr2##_ep, addr2##_ep);                                            \
+  CHECK_NE(addr1##_ep, addr2##_ep);                                            \
+  CHECK_NE(addr2##_ep, addr1##_ep);
 
-#define CHECK_SERIALIZATION(addr)                                              \
-  CAF_CHECK_EQUAL(addr##_ep, roundtrip(addr##_ep))
+#define CHECK_SERIALIZATION(addr) CHECK_EQ(addr##_ep, roundtrip(addr##_ep))
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(ipv4_endpoint_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(constructing assigning and hash_code) {
   const uint16_t port = 8888;
   auto addr = make_ipv4_address(127, 0, 0, 1);
   ipv4_endpoint ep1(addr, port);
-  CAF_CHECK_EQUAL(ep1.address(), addr);
-  CAF_CHECK_EQUAL(ep1.port(), port);
+  CHECK_EQ(ep1.address(), addr);
+  CHECK_EQ(ep1.port(), port);
   ipv4_endpoint ep2;
   ep2.address(addr);
   ep2.port(port);
-  CAF_CHECK_EQUAL(ep2.address(), addr);
-  CAF_CHECK_EQUAL(ep2.port(), port);
-  CAF_CHECK_EQUAL(ep1, ep2);
-  CAF_CHECK_EQUAL(ep1.hash_code(), ep2.hash_code());
+  CHECK_EQ(ep2.address(), addr);
+  CHECK_EQ(ep2.port(), port);
+  CHECK_EQ(ep1, ep2);
+  CHECK_EQ(ep1.hash_code(), ep2.hash_code());
 }
 
 CAF_TEST(to string) {
@@ -117,4 +116,4 @@ CAF_TEST(serialization) {
   CHECK_SERIALIZATION("127.0.0.1:8888");
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/ipv4_subnet.cpp
+++ b/libcaf_core/test/ipv4_subnet.cpp
@@ -22,35 +22,35 @@ ipv4_subnet operator/(ipv4_address addr, uint8_t prefix) {
 
 CAF_TEST(constructing) {
   ipv4_subnet zero{addr(0, 0, 0, 0), 32};
-  CAF_CHECK_EQUAL(zero.network_address(), addr(0, 0, 0, 0));
-  CAF_CHECK_EQUAL(zero.prefix_length(), 32u);
+  CHECK_EQ(zero.network_address(), addr(0, 0, 0, 0));
+  CHECK_EQ(zero.prefix_length(), 32u);
   ipv4_subnet local{addr(127, 0, 0, 0), 8};
-  CAF_CHECK_EQUAL(local.network_address(), addr(127, 0, 0, 0));
-  CAF_CHECK_EQUAL(local.prefix_length(), 8u);
+  CHECK_EQ(local.network_address(), addr(127, 0, 0, 0));
+  CHECK_EQ(local.prefix_length(), 8u);
 }
 
 CAF_TEST(equality) {
   auto a = addr(0xff, 0xff, 0xff, 0xff) / 19;
   auto b = addr(0xff, 0xff, 0xff, 0xab) / 19;
   auto net = addr(0xff, 0xff, 0xe0, 0x00);
-  CAF_CHECK_EQUAL(a.network_address(), net);
-  CAF_CHECK_EQUAL(a.network_address(), b.network_address());
-  CAF_CHECK_EQUAL(a.prefix_length(), b.prefix_length());
-  CAF_CHECK_EQUAL(a, b);
+  CHECK_EQ(a.network_address(), net);
+  CHECK_EQ(a.network_address(), b.network_address());
+  CHECK_EQ(a.prefix_length(), b.prefix_length());
+  CHECK_EQ(a, b);
 }
 
 CAF_TEST(contains) {
   ipv4_subnet local{addr(127, 0, 0, 0), 8};
-  CAF_CHECK(local.contains(addr(127, 0, 0, 1)));
-  CAF_CHECK(local.contains(addr(127, 1, 2, 3)));
-  CAF_CHECK(local.contains(addr(127, 128, 0, 0) / 9));
-  CAF_CHECK(local.contains(addr(127, 0, 0, 0) / 8));
-  CAF_CHECK(!local.contains(addr(127, 0, 0, 0) / 7));
+  CHECK(local.contains(addr(127, 0, 0, 1)));
+  CHECK(local.contains(addr(127, 1, 2, 3)));
+  CHECK(local.contains(addr(127, 128, 0, 0) / 9));
+  CHECK(local.contains(addr(127, 0, 0, 0) / 8));
+  CHECK(!local.contains(addr(127, 0, 0, 0) / 7));
 }
 
 CAF_TEST(ordering) {
-  CAF_CHECK_EQUAL(addr(192, 168, 168, 0) / 24, addr(192, 168, 168, 0) / 24);
-  CAF_CHECK_NOT_EQUAL(addr(192, 168, 168, 0) / 25, addr(192, 168, 168, 0) / 24);
-  CAF_CHECK_LESS(addr(192, 168, 167, 0) / 24, addr(192, 168, 168, 0) / 24);
-  CAF_CHECK_LESS(addr(192, 168, 168, 0) / 24, addr(192, 168, 168, 0) / 25);
+  CHECK_EQ(addr(192, 168, 168, 0) / 24, addr(192, 168, 168, 0) / 24);
+  CHECK_NE(addr(192, 168, 168, 0) / 25, addr(192, 168, 168, 0) / 24);
+  CHECK_LT(addr(192, 168, 167, 0) / 24, addr(192, 168, 168, 0) / 24);
+  CHECK_LT(addr(192, 168, 168, 0) / 24, addr(192, 168, 168, 0) / 25);
 }

--- a/libcaf_core/test/ipv6_address.cpp
+++ b/libcaf_core/test/ipv6_address.cpp
@@ -26,18 +26,17 @@ ipv6_address addr(std::initializer_list<uint16_t> prefix,
 } // namespace
 
 CAF_TEST(constructing) {
-  ipv6_address::array_type localhost_bytes{{0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 1}};
+  ipv6_address::array_type localhost_bytes{
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}};
   ipv6_address localhost{localhost_bytes};
-  CAF_CHECK_EQUAL(localhost.data(), localhost_bytes);
-  CAF_CHECK_EQUAL(localhost, addr({}, {0x01}));
+  CHECK_EQ(localhost.data(), localhost_bytes);
+  CHECK_EQ(localhost, addr({}, {0x01}));
 }
 
 CAF_TEST(comparison) {
-  CAF_CHECK_EQUAL(addr({1, 2, 3}), addr({1, 2, 3}));
-  CAF_CHECK_NOT_EQUAL(addr({3, 2, 1}), addr({1, 2, 3}));
-  CAF_CHECK_EQUAL(addr({}, {0xFFFF, 0x7F00, 0x0001}),
-                  make_ipv4_address(127, 0, 0, 1));
+  CHECK_EQ(addr({1, 2, 3}), addr({1, 2, 3}));
+  CHECK_NE(addr({3, 2, 1}), addr({1, 2, 3}));
+  CHECK_EQ(addr({}, {0xFFFF, 0x7F00, 0x0001}), make_ipv4_address(127, 0, 0, 1));
 }
 
 CAF_TEST(from string) {
@@ -48,36 +47,33 @@ CAF_TEST(from string) {
       CAF_FAIL("error while parsing " << str << ": " << to_string(err));
     return result;
   };
-  CAF_CHECK_EQUAL(from_string("::1"), addr({}, {0x01}));
-  CAF_CHECK_EQUAL(from_string("::11"), addr({}, {0x11}));
-  CAF_CHECK_EQUAL(from_string("::112"), addr({}, {0x0112}));
-  CAF_CHECK_EQUAL(from_string("::1122"), addr({}, {0x1122}));
-  CAF_CHECK_EQUAL(from_string("::1:2"), addr({}, {0x01, 0x02}));
-  CAF_CHECK_EQUAL(from_string("::1:2"), addr({}, {0x01, 0x02}));
-  CAF_CHECK_EQUAL(from_string("1::1"), addr({0x01}, {0x01}));
-  CAF_CHECK_EQUAL(from_string("2a00:bdc0:e003::"),
-                  addr({0x2a00, 0xbdc0, 0xe003}, {}));
-  CAF_CHECK_EQUAL(from_string("1::"), addr({0x01}, {}));
-  CAF_CHECK_EQUAL(from_string("0.1.0.1"), addr({}, {0xFFFF, 0x01, 0x01}));
-  CAF_CHECK_EQUAL(from_string("::ffff:127.0.0.1"),
-                  addr({}, {0xFFFF, 0x7F00, 0x0001}));
-  CAF_CHECK_EQUAL(from_string("1:2:3:4:5:6:7:8"), addr({1,2,3,4,5,6,7,8}));
-  CAF_CHECK_EQUAL(from_string("1:2:3:4::5:6:7:8"), addr({1,2,3,4,5,6,7,8}));
-  CAF_CHECK_EQUAL(from_string("1:2:3:4:5:6:0.7.0.8"), addr({1,2,3,4,5,6,7,8}));
+  CHECK_EQ(from_string("::1"), addr({}, {0x01}));
+  CHECK_EQ(from_string("::11"), addr({}, {0x11}));
+  CHECK_EQ(from_string("::112"), addr({}, {0x0112}));
+  CHECK_EQ(from_string("::1122"), addr({}, {0x1122}));
+  CHECK_EQ(from_string("::1:2"), addr({}, {0x01, 0x02}));
+  CHECK_EQ(from_string("::1:2"), addr({}, {0x01, 0x02}));
+  CHECK_EQ(from_string("1::1"), addr({0x01}, {0x01}));
+  CHECK_EQ(from_string("2a00:bdc0:e003::"), addr({0x2a00, 0xbdc0, 0xe003}, {}));
+  CHECK_EQ(from_string("1::"), addr({0x01}, {}));
+  CHECK_EQ(from_string("0.1.0.1"), addr({}, {0xFFFF, 0x01, 0x01}));
+  CHECK_EQ(from_string("::ffff:127.0.0.1"), addr({}, {0xFFFF, 0x7F00, 0x0001}));
+  CHECK_EQ(from_string("1:2:3:4:5:6:7:8"), addr({1, 2, 3, 4, 5, 6, 7, 8}));
+  CHECK_EQ(from_string("1:2:3:4::5:6:7:8"), addr({1, 2, 3, 4, 5, 6, 7, 8}));
+  CHECK_EQ(from_string("1:2:3:4:5:6:0.7.0.8"), addr({1, 2, 3, 4, 5, 6, 7, 8}));
   auto invalid = [](string_view str) {
     ipv6_address result;
     auto err = parse(str, result);
     return err != none;
   };
-  CAF_CHECK(invalid("1:2:3:4:5:6:7:8:9"));
-  CAF_CHECK(invalid("1:2:3:4::5:6:7:8:9"));
-  CAF_CHECK(invalid("1:2:3::4:5:6::7:8:9"));
+  CHECK(invalid("1:2:3:4:5:6:7:8:9"));
+  CHECK(invalid("1:2:3:4::5:6:7:8:9"));
+  CHECK(invalid("1:2:3::4:5:6::7:8:9"));
 }
 
 CAF_TEST(to string) {
-  CAF_CHECK_EQUAL(to_string(addr({}, {0x01})), "::1");
-  CAF_CHECK_EQUAL(to_string(addr({0x01}, {0x01})), "1::1");
-  CAF_CHECK_EQUAL(to_string(addr({0x01})), "1::");
-  CAF_CHECK_EQUAL(to_string(addr({}, {0xFFFF, 0x01, 0x01})), "0.1.0.1");
+  CHECK_EQ(to_string(addr({}, {0x01})), "::1");
+  CHECK_EQ(to_string(addr({0x01}, {0x01})), "1::1");
+  CHECK_EQ(to_string(addr({0x01})), "1::");
+  CHECK_EQ(to_string(addr({}, {0xFFFF, 0x01, 0x01})), "0.1.0.1");
 }
-

--- a/libcaf_core/test/ipv6_endpoint.cpp
+++ b/libcaf_core/test/ipv6_endpoint.cpp
@@ -50,27 +50,26 @@ struct fixture {
   }
 };
 
-#define CHECK_TO_STRING(addr) CAF_CHECK_EQUAL(addr, to_string(addr##_ep))
+#define CHECK_TO_STRING(addr) CHECK_EQ(addr, to_string(addr##_ep))
 
 #define CHECK_COMPARISON(addr1, addr2)                                         \
-  CAF_CHECK_GREATER(addr2##_ep, addr1##_ep);                                   \
-  CAF_CHECK_GREATER_OR_EQUAL(addr2##_ep, addr1##_ep);                          \
-  CAF_CHECK_GREATER_OR_EQUAL(addr1##_ep, addr1##_ep);                          \
-  CAF_CHECK_GREATER_OR_EQUAL(addr2##_ep, addr2##_ep);                          \
-  CAF_CHECK_EQUAL(addr1##_ep, addr1##_ep);                                     \
-  CAF_CHECK_EQUAL(addr2##_ep, addr2##_ep);                                     \
-  CAF_CHECK_LESS_OR_EQUAL(addr1##_ep, addr2##_ep);                             \
-  CAF_CHECK_LESS_OR_EQUAL(addr1##_ep, addr1##_ep);                             \
-  CAF_CHECK_LESS_OR_EQUAL(addr2##_ep, addr2##_ep);                             \
-  CAF_CHECK_NOT_EQUAL(addr1##_ep, addr2##_ep);                                 \
-  CAF_CHECK_NOT_EQUAL(addr2##_ep, addr1##_ep);
+  CHECK_GT(addr2##_ep, addr1##_ep);                                            \
+  CHECK_GE(addr2##_ep, addr1##_ep);                                            \
+  CHECK_GE(addr1##_ep, addr1##_ep);                                            \
+  CHECK_GE(addr2##_ep, addr2##_ep);                                            \
+  CHECK_EQ(addr1##_ep, addr1##_ep);                                            \
+  CHECK_EQ(addr2##_ep, addr2##_ep);                                            \
+  CHECK_LE(addr1##_ep, addr2##_ep);                                            \
+  CHECK_LE(addr1##_ep, addr1##_ep);                                            \
+  CHECK_LE(addr2##_ep, addr2##_ep);                                            \
+  CHECK_NE(addr1##_ep, addr2##_ep);                                            \
+  CHECK_NE(addr2##_ep, addr1##_ep);
 
-#define CHECK_SERIALIZATION(addr)                                              \
-  CAF_CHECK_EQUAL(addr##_ep, roundtrip(addr##_ep))
+#define CHECK_SERIALIZATION(addr) CHECK_EQ(addr##_ep, roundtrip(addr##_ep))
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(comparison_scope, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(constructing assigning and hash_code) {
   const uint16_t port = 8888;
@@ -78,22 +77,22 @@ CAF_TEST(constructing assigning and hash_code) {
                                  0, 0, 0, 0, 0, 0, 0, 1};
   auto addr = ipv6_address{bytes};
   ipv6_endpoint ep1(addr, port);
-  CAF_CHECK_EQUAL(ep1.address(), addr);
-  CAF_CHECK_EQUAL(ep1.port(), port);
+  CHECK_EQ(ep1.address(), addr);
+  CHECK_EQ(ep1.port(), port);
   ipv6_endpoint ep2;
   ep2.address(addr);
   ep2.port(port);
-  CAF_CHECK_EQUAL(ep2.address(), addr);
-  CAF_CHECK_EQUAL(ep2.port(), port);
-  CAF_CHECK_EQUAL(ep1, ep2);
-  CAF_CHECK_EQUAL(ep1.hash_code(), ep2.hash_code());
+  CHECK_EQ(ep2.address(), addr);
+  CHECK_EQ(ep2.port(), port);
+  CHECK_EQ(ep1, ep2);
+  CHECK_EQ(ep1.hash_code(), ep2.hash_code());
 }
 
 CAF_TEST(comparison to IPv4) {
   ipv4_endpoint v4{ipv4_address({127, 0, 0, 1}), 8080};
   ipv6_endpoint v6{v4.address(), v4.port()};
-  CAF_CHECK_EQUAL(v4, v6);
-  CAF_CHECK_EQUAL(v6, v4);
+  CHECK_EQ(v4, v6);
+  CHECK_EQ(v6, v4);
 }
 
 CAF_TEST(to_string) {
@@ -139,4 +138,4 @@ CAF_TEST(serialization) {
   CHECK_SERIALIZATION("[4432::33:1]:999");
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/ipv6_subnet.cpp
+++ b/libcaf_core/test/ipv6_subnet.cpp
@@ -20,30 +20,29 @@ ipv6_subnet operator/(ipv6_address addr, uint8_t prefix) {
 
 CAF_TEST(constructing) {
   auto zero = ipv6_address() / 128;
-  CAF_CHECK_EQUAL(zero.network_address(), ipv6_address());
-  CAF_CHECK_EQUAL(zero.prefix_length(), 128u);
+  CHECK_EQ(zero.network_address(), ipv6_address());
+  CHECK_EQ(zero.prefix_length(), 128u);
 }
 
 CAF_TEST(equality) {
   auto a = ipv6_address{{0xffff, 0xffff, 0xffff}, {}} / 27;
   auto b = ipv6_address{{0xffff, 0xffff, 0xabab}, {}} / 27;
   auto net = ipv6_address{{0xffff, 0xffe0}, {}};
-  CAF_CHECK_EQUAL(a.network_address(), net);
-  CAF_CHECK_EQUAL(a.network_address(), b.network_address());
-  CAF_CHECK_EQUAL(a.prefix_length(), b.prefix_length());
-  CAF_CHECK_EQUAL(a, b);
+  CHECK_EQ(a.network_address(), net);
+  CHECK_EQ(a.network_address(), b.network_address());
+  CHECK_EQ(a.prefix_length(), b.prefix_length());
+  CHECK_EQ(a, b);
 }
 
 CAF_TEST(contains) {
   auto local = ipv6_address{{0xbebe, 0xbebe}, {}} / 32;
-  CAF_CHECK(local.contains(ipv6_address({0xbebe, 0xbebe, 0xbebe}, {})));
-  CAF_CHECK(!local.contains(ipv6_address({0xbebe, 0xbebf}, {})));
+  CHECK(local.contains(ipv6_address({0xbebe, 0xbebe, 0xbebe}, {})));
+  CHECK(!local.contains(ipv6_address({0xbebe, 0xbebf}, {})));
 }
 
 CAF_TEST(embedding) {
   ipv4_subnet v4_local{make_ipv4_address(127, 0, 0, 1), 8};
   ipv6_subnet local{v4_local};
-  CAF_CHECK(local.embeds_v4());
-  CAF_CHECK_EQUAL(local.prefix_length(), 104u);
+  CHECK(local.embeds_v4());
+  CHECK_EQ(local.prefix_length(), 104u);
 }
-

--- a/libcaf_core/test/json_reader.cpp
+++ b/libcaf_core/test/json_reader.cpp
@@ -111,7 +111,7 @@ fixture::fixture() {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(json_reader_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(json baselines) {
   size_t baseline_index = 0;
@@ -124,4 +124,4 @@ CAF_TEST(json baselines) {
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/json_writer.cpp
+++ b/libcaf_core/test/json_writer.cpp
@@ -35,7 +35,7 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(json_writer_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 SCENARIO("the JSON writer converts builtin types to strings") {
   GIVEN("an integer") {
@@ -296,4 +296,4 @@ SCENARIO("the JSON writer annotates variant fields") {
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/load_inspector.cpp
+++ b/libcaf_core/test/load_inspector.cpp
@@ -265,15 +265,15 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(load_inspector_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(load inspectors can visit simple POD types) {
   point_3d p{1, 1, 1};
-  CAF_CHECK_EQUAL(inspect(f, p), true);
-  CAF_CHECK_EQUAL(p.x, 0);
-  CAF_CHECK_EQUAL(p.y, 0);
-  CAF_CHECK_EQUAL(p.z, 0);
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK_EQ(inspect(f, p), true);
+  CHECK_EQ(p.x, 0);
+  CHECK_EQ(p.y, 0);
+  CHECK_EQ(p.z, 0);
+  CHECK_EQ(f.log, R"_(
 begin object point_3d
   begin field x
     int32_t value
@@ -289,14 +289,14 @@ end object)_");
 
 CAF_TEST(load inspectors recurse into members) {
   line l{point_3d{1, 1, 1}, point_3d{1, 1, 1}};
-  CAF_CHECK_EQUAL(inspect(f, l), true);
-  CAF_CHECK_EQUAL(l.p1.x, 0);
-  CAF_CHECK_EQUAL(l.p1.y, 0);
-  CAF_CHECK_EQUAL(l.p1.z, 0);
-  CAF_CHECK_EQUAL(l.p2.x, 0);
-  CAF_CHECK_EQUAL(l.p2.y, 0);
-  CAF_CHECK_EQUAL(l.p2.z, 0);
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK_EQ(inspect(f, l), true);
+  CHECK_EQ(l.p1.x, 0);
+  CHECK_EQ(l.p1.y, 0);
+  CHECK_EQ(l.p1.z, 0);
+  CHECK_EQ(l.p2.x, 0);
+  CHECK_EQ(l.p2.y, 0);
+  CHECK_EQ(l.p2.z, 0);
+  CHECK_EQ(f.log, R"_(
 begin object line
   begin field p1
     begin object point_3d
@@ -329,8 +329,8 @@ end object)_");
 
 CAF_TEST(load inspectors support optional) {
   optional<int32_t> x;
-  CAF_CHECK_EQUAL(f.apply(x), true);
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK_EQ(f.apply(x), true);
+  CHECK_EQ(f.log, R"_(
 begin object anonymous
   begin optional field value
   end field
@@ -339,10 +339,10 @@ end object)_");
 
 CAF_TEST(load inspectors support fields with fallbacks and invariants) {
   duration d{"minutes", 42};
-  CAF_CHECK_EQUAL(inspect(f, d), true);
-  CAF_CHECK_EQUAL(d.unit, "seconds");
-  CAF_CHECK_EQUAL(d.count, 0.0);
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK_EQ(inspect(f, d), true);
+  CHECK_EQ(d.unit, "seconds");
+  CHECK_EQ(d.count, 0.0);
+  CHECK_EQ(f.log, R"_(
 begin object duration
   begin optional field unit
   end field
@@ -354,10 +354,10 @@ end object)_");
 
 CAF_TEST(load inspectors support fields with optional values) {
   person p{"Bruce Almighty", std::string{"776-2323"}};
-  CAF_CHECK_EQUAL(inspect(f, p), true);
-  CAF_CHECK_EQUAL(p.name, "");
-  CAF_CHECK_EQUAL(p.phone, none);
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK_EQ(inspect(f, p), true);
+  CHECK_EQ(p.name, "");
+  CHECK_EQ(p.phone, none);
+  CHECK_EQ(f.log, R"_(
 begin object person
   begin field name
     std::string value
@@ -371,10 +371,10 @@ CAF_TEST(load inspectors support fields with getters and setters) {
   foobar fb;
   fb.foo("hello");
   fb.bar("world");
-  CAF_CHECK_EQUAL(inspect(f, fb), true);
-  CAF_CHECK_EQUAL(fb.foo(), "");
-  CAF_CHECK_EQUAL(fb.bar(), "");
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK_EQ(inspect(f, fb), true);
+  CHECK_EQ(fb.foo(), "");
+  CHECK_EQ(fb.bar(), "");
+  CHECK_EQ(f.log, R"_(
 begin object foobar
   begin field foo
     std::string value
@@ -388,10 +388,10 @@ end object)_");
 CAF_TEST(load inspectors support variant fields) {
   dummy_message d;
   d.content = 42.0;
-  CAF_CHECK(inspect(f, d));
+  CHECK(inspect(f, d));
   // Our dummy inspector resets variants to their first type.
-  CAF_CHECK(holds_alternative<std::string>(d.content));
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK(holds_alternative<std::string>(d.content));
+  CHECK_EQ(f.log, R"_(
 begin object dummy_message
   begin variant field content
     std::string value
@@ -403,9 +403,9 @@ CAF_TEST(load inspectors support variant fields with fallbacks) {
   fallback_dummy_message d;
   using content_type = decltype(d.content);
   d.content = std::string{"hello world"};
-  CAF_CHECK(inspect(f, d));
-  CAF_CHECK_EQUAL(d.content, content_type{42.0});
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK(inspect(f, d));
+  CHECK_EQ(d.content, content_type{42.0});
+  CHECK_EQ(f.log, R"_(
 begin object fallback_dummy_message
   begin optional variant field content
   end field
@@ -414,8 +414,8 @@ end object)_");
 
 CAF_TEST(load inspectors support nasty data structures) {
   nasty x;
-  CAF_CHECK(inspect(f, x));
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK(inspect(f, x));
+  CHECK_EQ(f.log, R"_(
 begin object nasty
   begin field field_01
     int32_t value
@@ -510,8 +510,8 @@ end object)_");
 
 CAF_TEST(load inspectors support all basic STL types) {
   basics x;
-  CAF_CHECK(inspect(f, x));
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK(inspect(f, x));
+  CHECK_EQ(f.log, R"_(
 begin object basics
   begin field v1
     begin object anonymous
@@ -775,4 +775,4 @@ end object)_";
 
 #endif
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/logger.cpp
+++ b/libcaf_core/test/logger.cpp
@@ -29,7 +29,7 @@ using std::string;
                                            << prefix << " instead of "         \
                                            << PrefixName);                     \
     else                                                                       \
-      CAF_CHECK_EQUAL(prefix, PrefixName);                                     \
+      CHECK_EQ(prefix, PrefixName);                                            \
   } while (false)
 
 void global_fun() {
@@ -122,7 +122,7 @@ constexpr const char* file_format = "%r %c %p %a %t %C %M %F:%L %m%n";
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(logger_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 // copy construction, copy assign, move construction, move assign
 // and finally serialization round-trip
@@ -148,8 +148,8 @@ CAF_TEST(parse_default_format_strings) {
   add(logger::plain_text_field, " ");
   add(logger::message_field);
   add(logger::newline_field);
-  CAF_CHECK_EQUAL(logger::parse_format(file_format), lf);
-  CAF_CHECK_EQUAL(sys.logger().file_format(), lf);
+  CHECK_EQ(logger::parse_format(file_format), lf);
+  CHECK_EQ(sys.logger().file_format(), lf);
 }
 
 CAF_TEST(rendering) {
@@ -157,9 +157,9 @@ CAF_TEST(rendering) {
   timestamp t0;
   time_t t0_t = 0;
   char t0_buf[50];
-  CAF_REQUIRE(strftime(t0_buf, sizeof(t0_buf),
-                       "%Y-%m-%dT%H:%M:%S.000", localtime(&t0_t)));
-  CAF_CHECK_EQUAL(render(logger::render_date, t0), t0_buf);
+  CAF_REQUIRE(strftime(t0_buf, sizeof(t0_buf), "%Y-%m-%dT%H:%M:%S.000",
+                       localtime(&t0_t)));
+  CHECK_EQ(render(logger::render_date, t0), t0_buf);
   // Rendering of events.
   logger::event e{
     CAF_LOG_LEVEL_WARNING,
@@ -173,17 +173,16 @@ CAF_TEST(rendering) {
     0,
     t0,
   };
-  CAF_CHECK_EQUAL(render(logger::render_fun_name, e), string_view{"bar"});
-  CAF_CHECK_EQUAL(render(logger::render_fun_prefix, e),
-                  string_view{"ns.foo"});
+  CHECK_EQ(render(logger::render_fun_name, e), string_view{"bar"});
+  CHECK_EQ(render(logger::render_fun_prefix, e), string_view{"ns.foo"});
   // Exclude %r and %t from rendering test because they are nondeterministic.
   actor_system sys{cfg};
   auto lf = logger::parse_format("%c %p %a %C %M %F:%L %m");
   auto& lg = sys.logger();
   using namespace std::placeholders;
   auto render_event = bind(&logger::render, &lg, _1, _2, _3);
-  CAF_CHECK_EQUAL(render(render_event, lf, e),
-                  "unit_test WARN actor0 ns.foo bar foo.cpp:42 hello world");
+  CHECK_EQ(render(render_event, lf, e),
+           "unit_test WARN actor0 ns.foo bar foo.cpp:42 hello world");
 }
 
 CAF_TEST(render_fun_prefix) {
@@ -199,4 +198,4 @@ CAF_TEST(render_fun_prefix) {
   foo::tpl<T>::run();
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/mailbox_element.cpp
+++ b/libcaf_core/test/mailbox_element.cpp
@@ -38,62 +38,62 @@ optional<tuple<Ts...>> fetch(const mailbox_element& x) {
 } // namespace
 
 CAF_TEST(empty_message) {
-  auto m1 = make_mailbox_element(nullptr, make_message_id(),
-                                 no_stages, make_message());
-  CAF_CHECK(m1->mid.is_async());
-  CAF_CHECK(m1->mid.category() == message_id::normal_message_category);
-  CAF_CHECK(m1->content().empty());
+  auto m1 = make_mailbox_element(nullptr, make_message_id(), no_stages,
+                                 make_message());
+  CHECK(m1->mid.is_async());
+  CHECK(m1->mid.category() == message_id::normal_message_category);
+  CHECK(m1->content().empty());
 }
 
 CAF_TEST(non_empty_message) {
-  auto m1 = make_mailbox_element(nullptr, make_message_id(),
-                                 no_stages, make_message(1, 2, 3));
-  CAF_CHECK(m1->mid.is_async());
-  CAF_CHECK(m1->mid.category() == message_id::normal_message_category);
-  CAF_CHECK(!m1->content().empty());
-  CAF_CHECK_EQUAL((fetch<int, int>(*m1)), none);
-  CAF_CHECK_EQUAL((fetch<int, int, int>(*m1)), make_tuple(1, 2, 3));
+  auto m1 = make_mailbox_element(nullptr, make_message_id(), no_stages,
+                                 make_message(1, 2, 3));
+  CHECK(m1->mid.is_async());
+  CHECK(m1->mid.category() == message_id::normal_message_category);
+  CHECK(!m1->content().empty());
+  CHECK_EQ((fetch<int, int>(*m1)), none);
+  CHECK_EQ((fetch<int, int, int>(*m1)), make_tuple(1, 2, 3));
 }
 
 CAF_TEST(tuple) {
-  auto m1 = make_mailbox_element(nullptr, make_message_id(),
-                                 no_stages, 1, 2, 3);
-  CAF_CHECK(m1->mid.is_async());
-  CAF_CHECK(m1->mid.category() == message_id::normal_message_category);
-  CAF_CHECK(!m1->content().empty());
-  CAF_CHECK_EQUAL((fetch<int, int>(*m1)), none);
-  CAF_CHECK_EQUAL((fetch<int, int, int>(*m1)), make_tuple(1, 2, 3));
+  auto m1 = make_mailbox_element(nullptr, make_message_id(), no_stages, 1, 2,
+                                 3);
+  CHECK(m1->mid.is_async());
+  CHECK(m1->mid.category() == message_id::normal_message_category);
+  CHECK(!m1->content().empty());
+  CHECK_EQ((fetch<int, int>(*m1)), none);
+  CHECK_EQ((fetch<int, int, int>(*m1)), make_tuple(1, 2, 3));
 }
 
 CAF_TEST(high_priority) {
   auto m1 = make_mailbox_element(nullptr,
                                  make_message_id(message_priority::high),
                                  no_stages, 42);
-  CAF_CHECK(m1->mid.category() == message_id::urgent_message_category);
+  CHECK(m1->mid.category() == message_id::urgent_message_category);
 }
 
 CAF_TEST(upstream_msg_static) {
   auto m1 = make_mailbox_element(nullptr, make_message_id(), no_stages,
                                  make<upstream_msg::drop>({0, 0}, nullptr));
-  CAF_CHECK(m1->mid.category() == message_id::upstream_message_category);
+  CHECK(m1->mid.category() == message_id::upstream_message_category);
 }
 
 CAF_TEST(upstream_msg_dynamic) {
-  auto m1 = make_mailbox_element(
-    nullptr, make_message_id(), no_stages,
-    make_message(make<upstream_msg::drop>({0, 0}, nullptr)));
-  CAF_CHECK(m1->mid.category() == message_id::upstream_message_category);
+  auto m1 = make_mailbox_element(nullptr, make_message_id(), no_stages,
+                                 make_message(
+                                   make<upstream_msg::drop>({0, 0}, nullptr)));
+  CHECK(m1->mid.category() == message_id::upstream_message_category);
 }
 
 CAF_TEST(downstream_msg_static) {
   auto m1 = make_mailbox_element(nullptr, make_message_id(), no_stages,
                                  make<downstream_msg::close>({0, 0}, nullptr));
-  CAF_CHECK(m1->mid.category() == message_id::downstream_message_category);
+  CHECK(m1->mid.category() == message_id::downstream_message_category);
 }
 
 CAF_TEST(downstream_msg_dynamic) {
   auto m1 = make_mailbox_element(
     nullptr, make_message_id(), no_stages,
     make_message(make<downstream_msg::close>({0, 0}, nullptr)));
-  CAF_CHECK(m1->mid.category() == message_id::downstream_message_category);
+  CHECK(m1->mid.category() == message_id::downstream_message_category);
 }

--- a/libcaf_core/test/message.cpp
+++ b/libcaf_core/test/message.cpp
@@ -38,38 +38,36 @@ std::string msg_as_string(Ts&&... xs) {
 
 CAF_TEST(messages allow index - based access) {
   auto msg = make_message("abc", uint32_t{10}, 20.0);
-  CAF_CHECK_EQUAL(msg.size(), 3u);
-  CAF_CHECK_EQUAL(msg.types(),
-                  (make_type_id_list<std::string, uint32_t, double>()));
-  CAF_CHECK_EQUAL(msg.get_as<std::string>(0), "abc");
-  CAF_CHECK_EQUAL(msg.get_as<uint32_t>(1), 10u);
-  CAF_CHECK_EQUAL(msg.get_as<double>(2), 20.0);
-  CAF_CHECK_EQUAL(msg.cdata().get_reference_count(), 1u);
+  CHECK_EQ(msg.size(), 3u);
+  CHECK_EQ(msg.types(), (make_type_id_list<std::string, uint32_t, double>()));
+  CHECK_EQ(msg.get_as<std::string>(0), "abc");
+  CHECK_EQ(msg.get_as<uint32_t>(1), 10u);
+  CHECK_EQ(msg.get_as<double>(2), 20.0);
+  CHECK_EQ(msg.cdata().get_reference_count(), 1u);
 }
 
 CAF_TEST(message detach their content on mutating access) {
-  CAF_MESSAGE("Given to messages pointing to the same content.");
+  MESSAGE("Given to messages pointing to the same content.");
   auto msg1 = make_message("one", uint32_t{1});
   auto msg2 = msg1;
-  CAF_CHECK_EQUAL(msg1.cdata().get_reference_count(), 2u);
-  CAF_CHECK_EQUAL(msg1.cptr(), msg2.cptr());
-  CAF_MESSAGE("When calling a non-const member function of message.");
+  CHECK_EQ(msg1.cdata().get_reference_count(), 2u);
+  CHECK_EQ(msg1.cptr(), msg2.cptr());
+  MESSAGE("When calling a non-const member function of message.");
   msg1.ptr();
-  CAF_MESSAGE("Then the messages point to separate contents but remain equal.");
-  CAF_CHECK_NOT_EQUAL(msg1.cptr(), msg2.cptr());
-  CAF_CHECK_EQUAL(msg1.cdata().get_reference_count(), 1u);
-  CAF_CHECK_EQUAL(msg2.cdata().get_reference_count(), 1u);
-  CAF_CHECK(msg1.match_elements<std::string, uint32_t>());
-  CAF_CHECK(msg2.match_elements<std::string, uint32_t>());
-  CAF_CHECK_EQUAL(msg1.get_as<std::string>(0), msg2.get_as<std::string>(0));
-  CAF_CHECK_EQUAL(msg1.get_as<uint32_t>(1), msg2.get_as<uint32_t>(1));
+  MESSAGE("Then the messages point to separate contents but remain equal.");
+  CHECK_NE(msg1.cptr(), msg2.cptr());
+  CHECK_EQ(msg1.cdata().get_reference_count(), 1u);
+  CHECK_EQ(msg2.cdata().get_reference_count(), 1u);
+  CHECK((msg1.match_elements<std::string, uint32_t>()));
+  CHECK((msg2.match_elements<std::string, uint32_t>()));
+  CHECK_EQ(msg1.get_as<std::string>(0), msg2.get_as<std::string>(0));
+  CHECK_EQ(msg1.get_as<uint32_t>(1), msg2.get_as<uint32_t>(1));
 }
 
 CAF_TEST(compare_custom_types) {
   s2 tmp;
   tmp.value[0][1] = 100;
-  CAF_CHECK_NOT_EQUAL(to_string(make_message(s2{})),
-                      to_string(make_message(tmp)));
+  CHECK_NE(to_string(make_message(s2{})), to_string(make_message(tmp)));
 }
 
 CAF_TEST(integers_to_string) {
@@ -78,48 +76,47 @@ CAF_TEST(integers_to_string) {
   using sset = std::set<std::string>;
   using std::string;
   using itup = std::tuple<int, int, int>;
-  CAF_CHECK_EQUAL(make_message(ivec{}).types(), make_type_id_list<ivec>());
-  CAF_CHECK_EQUAL(make_type_id_list<ivec>()[0], type_id_v<ivec>);
-  CAF_CHECK_EQUAL(make_message(ivec{}).types()[0], type_id_v<ivec>);
-  CAF_CHECK_EQUAL(make_message(1.0).types()[0], type_id_v<double>);
-  CAF_CHECK_EQUAL(make_message(s1{}).types()[0], type_id_v<s1>);
-  CAF_CHECK_EQUAL(make_message(s2{}).types()[0], type_id_v<s2>);
-  CAF_CHECK_EQUAL(make_message(s3{}).types()[0], type_id_v<s3>);
-  CAF_CHECK_EQUAL(make_message(svec{}).types()[0], type_id_v<svec>);
-  CAF_CHECK_EQUAL(make_message(string{}).types()[0], type_id_v<string>);
-  CAF_CHECK_EQUAL(make_message(sset{}).types()[0], type_id_v<sset>);
-  CAF_CHECK_EQUAL(make_message(itup(1, 2, 3)).types()[0], type_id_v<itup>);
+  CHECK_EQ(make_message(ivec{}).types(), make_type_id_list<ivec>());
+  CHECK_EQ(make_type_id_list<ivec>()[0], type_id_v<ivec>);
+  CHECK_EQ(make_message(ivec{}).types()[0], type_id_v<ivec>);
+  CHECK_EQ(make_message(1.0).types()[0], type_id_v<double>);
+  CHECK_EQ(make_message(s1{}).types()[0], type_id_v<s1>);
+  CHECK_EQ(make_message(s2{}).types()[0], type_id_v<s2>);
+  CHECK_EQ(make_message(s3{}).types()[0], type_id_v<s3>);
+  CHECK_EQ(make_message(svec{}).types()[0], type_id_v<svec>);
+  CHECK_EQ(make_message(string{}).types()[0], type_id_v<string>);
+  CHECK_EQ(make_message(sset{}).types()[0], type_id_v<sset>);
+  CHECK_EQ(make_message(itup(1, 2, 3)).types()[0], type_id_v<itup>);
 }
 
 CAF_TEST(to_string converts messages to strings) {
   using svec = vector<string>;
-  CAF_CHECK_EQUAL(msg_as_string(), "message()");
-  CAF_CHECK_EQUAL(msg_as_string("hello", "world"),
-                  R"__(message("hello", "world"))__");
-  CAF_CHECK_EQUAL(msg_as_string(svec{"one", "two", "three"}),
-                  R"__(message(["one", "two", "three"]))__");
-  CAF_CHECK_EQUAL(msg_as_string(svec{"one", "two"}, "three", "four",
-                                svec{"five", "six", "seven"}),
-                  R"__(message(["one", "two"], "three", "four", )__"
-                  R"__(["five", "six", "seven"]))__");
+  CHECK_EQ(msg_as_string(), "message()");
+  CHECK_EQ(msg_as_string("hello", "world"), R"__(message("hello", "world"))__");
+  CHECK_EQ(msg_as_string(svec{"one", "two", "three"}),
+           R"__(message(["one", "two", "three"]))__");
+  CHECK_EQ(msg_as_string(svec{"one", "two"}, "three", "four",
+                         svec{"five", "six", "seven"}),
+           R"__(message(["one", "two"], "three", "four", )__"
+           R"__(["five", "six", "seven"]))__");
   auto teststr = R"__(message("this is a \"test\""))__"; // fails inline on MSVC
-  CAF_CHECK_EQUAL(msg_as_string(R"__(this is a "test")__"), teststr);
-  CAF_CHECK_EQUAL(msg_as_string(make_tuple(1, 2, 3), 4, 5),
-                  "message([1, 2, 3], 4, 5)");
-  CAF_CHECK_EQUAL(msg_as_string(s1{}), "message([10, 20, 30])");
+  CHECK_EQ(msg_as_string(R"__(this is a "test")__"), teststr);
+  CHECK_EQ(msg_as_string(make_tuple(1, 2, 3), 4, 5),
+           "message([1, 2, 3], 4, 5)");
+  CHECK_EQ(msg_as_string(s1{}), "message([10, 20, 30])");
   s2 tmp;
   tmp.value[0][1] = 100;
-  CAF_CHECK_EQUAL(msg_as_string(s2{}),
-                  "message([[1, 10], [2, 20], [3, 30], [4, 40]])");
-  CAF_CHECK_EQUAL(msg_as_string(s3{}), "message([1, 2, 3, 4])");
+  CHECK_EQ(msg_as_string(s2{}),
+           "message([[1, 10], [2, 20], [3, 30], [4, 40]])");
+  CHECK_EQ(msg_as_string(s3{}), "message([1, 2, 3, 4])");
 }
 
 CAF_TEST(match_elements exposes element types) {
   auto msg = make_message(put_atom_v, "foo", int64_t{123});
-  CAF_CHECK((msg.match_element<put_atom>(0)));
-  CAF_CHECK((msg.match_element<string>(1)));
-  CAF_CHECK((msg.match_element<int64_t>(2)));
-  CAF_CHECK((msg.match_elements<put_atom, string, int64_t>()));
+  CHECK((msg.match_element<put_atom>(0)));
+  CHECK((msg.match_element<string>(1)));
+  CHECK((msg.match_element<int64_t>(2)));
+  CHECK((msg.match_elements<put_atom, string, int64_t>()));
 }
 
 CAF_TEST(messages are concatenable) {

--- a/libcaf_core/test/message_builder.cpp
+++ b/libcaf_core/test/message_builder.cpp
@@ -19,37 +19,35 @@
 using namespace caf;
 
 #define STEP(message)                                                          \
-  CAF_MESSAGE(message);                                                        \
+  MESSAGE(message);                                                            \
   if (true)
 
 CAF_TEST(message builder can build messages incrermenetally) {
   message_builder builder;
-  CAF_CHECK(builder.empty());
-  CAF_CHECK(builder.to_message().empty());
-  CAF_CHECK_EQUAL(builder.size(), 0u);
+  CHECK(builder.empty());
+  CHECK(builder.to_message().empty());
+  CHECK_EQ(builder.size(), 0u);
   STEP("after adding 1, the message is (1)") {
     builder.append(int32_t{1});
     auto msg = builder.to_message();
-    CAF_CHECK_EQUAL(builder.size(), 1u);
-    CAF_CHECK_EQUAL(msg.types(), make_type_id_list<int32_t>());
-    CAF_CHECK_EQUAL(to_string(msg.types()), "[int32_t]");
-    CAF_CHECK_EQUAL(to_string(msg), "message(1)");
+    CHECK_EQ(builder.size(), 1u);
+    CHECK_EQ(msg.types(), make_type_id_list<int32_t>());
+    CHECK_EQ(to_string(msg.types()), "[int32_t]");
+    CHECK_EQ(to_string(msg), "message(1)");
   }
   STEP("after adding [2, 3], the message is (1, 2, 3)") {
     std::vector<int32_t> xs{2, 3};
     builder.append(xs.begin(), xs.end());
-    CAF_CHECK_EQUAL(builder.size(), 3u);
+    CHECK_EQ(builder.size(), 3u);
     auto msg = builder.to_message();
-    CAF_CHECK_EQUAL(msg.types(),
-                    (make_type_id_list<int32_t, int32_t, int32_t>()));
-    CAF_CHECK_EQUAL(to_string(msg.types()), "[int32_t, int32_t, int32_t]");
-    CAF_CHECK_EQUAL(to_string(msg), "message(1, 2, 3)");
+    CHECK_EQ(msg.types(), (make_type_id_list<int32_t, int32_t, int32_t>()));
+    CHECK_EQ(to_string(msg.types()), "[int32_t, int32_t, int32_t]");
+    CHECK_EQ(to_string(msg), "message(1, 2, 3)");
   }
   STEP("moving the content to a message produces the same message again") {
     auto msg = builder.move_to_message();
-    CAF_CHECK_EQUAL(msg.types(),
-                    (make_type_id_list<int32_t, int32_t, int32_t>()));
-    CAF_CHECK_EQUAL(to_string(msg.types()), "[int32_t, int32_t, int32_t]");
-    CAF_CHECK_EQUAL(to_string(msg), "message(1, 2, 3)");
+    CHECK_EQ(msg.types(), (make_type_id_list<int32_t, int32_t, int32_t>()));
+    CHECK_EQ(to_string(msg.types()), "[int32_t, int32_t, int32_t]");
+    CHECK_EQ(to_string(msg), "message(1, 2, 3)");
   }
 }

--- a/libcaf_core/test/message_id.cpp
+++ b/libcaf_core/test/message_id.cpp
@@ -12,84 +12,84 @@ using namespace caf;
 
 CAF_TEST(default construction) {
   message_id x;
-  CAF_CHECK_EQUAL(x.is_async(), true);
-  CAF_CHECK_EQUAL(x.is_request(), false);
-  CAF_CHECK_EQUAL(x.is_response(), false);
-  CAF_CHECK_EQUAL(x.is_answered(), false);
-  CAF_CHECK(x.category() == message_id::normal_message_category);
-  CAF_CHECK_EQUAL(x.is_urgent_message(), false);
-  CAF_CHECK_EQUAL(x.is_normal_message(), true);
-  CAF_CHECK_EQUAL(x.is_stream_message(), false);
-  CAF_CHECK_EQUAL(x.is_upstream_message(), false);
-  CAF_CHECK_EQUAL(x.is_downstream_message(), false);
-  CAF_CHECK_EQUAL(x, x.response_id());
-  CAF_CHECK_EQUAL(x.request_id().integer_value(), 0u);
-  CAF_CHECK(x.integer_value() == message_id::default_async_value);
+  CHECK_EQ(x.is_async(), true);
+  CHECK_EQ(x.is_request(), false);
+  CHECK_EQ(x.is_response(), false);
+  CHECK_EQ(x.is_answered(), false);
+  CHECK(x.category() == message_id::normal_message_category);
+  CHECK_EQ(x.is_urgent_message(), false);
+  CHECK_EQ(x.is_normal_message(), true);
+  CHECK_EQ(x.is_stream_message(), false);
+  CHECK_EQ(x.is_upstream_message(), false);
+  CHECK_EQ(x.is_downstream_message(), false);
+  CHECK_EQ(x, x.response_id());
+  CHECK_EQ(x.request_id().integer_value(), 0u);
+  CHECK(x.integer_value() == message_id::default_async_value);
 }
 
 CAF_TEST(make_message_id) {
   auto x = make_message_id();
   message_id y;
-  CAF_CHECK_EQUAL(x, y);
-  CAF_CHECK_EQUAL(x.integer_value(), y.integer_value());
+  CHECK_EQ(x, y);
+  CHECK_EQ(x.integer_value(), y.integer_value());
 }
 
 CAF_TEST(from integer value) {
   auto x = make_message_id(42);
-  CAF_CHECK_EQUAL(x.is_async(), false);
-  CAF_CHECK_EQUAL(x.is_request(), true);
-  CAF_CHECK_EQUAL(x.is_response(), false);
-  CAF_CHECK_EQUAL(x.is_answered(), false);
-  CAF_CHECK(x.category() == message_id::normal_message_category);
-  CAF_CHECK_EQUAL(x.is_urgent_message(), false);
-  CAF_CHECK_EQUAL(x.is_normal_message(), true);
-  CAF_CHECK_EQUAL(x.is_stream_message(), false);
-  CAF_CHECK_EQUAL(x.is_upstream_message(), false);
-  CAF_CHECK_EQUAL(x.is_downstream_message(), false);
-  CAF_CHECK_EQUAL(x.request_id().integer_value(), 42u);
+  CHECK_EQ(x.is_async(), false);
+  CHECK_EQ(x.is_request(), true);
+  CHECK_EQ(x.is_response(), false);
+  CHECK_EQ(x.is_answered(), false);
+  CHECK(x.category() == message_id::normal_message_category);
+  CHECK_EQ(x.is_urgent_message(), false);
+  CHECK_EQ(x.is_normal_message(), true);
+  CHECK_EQ(x.is_stream_message(), false);
+  CHECK_EQ(x.is_upstream_message(), false);
+  CHECK_EQ(x.is_downstream_message(), false);
+  CHECK_EQ(x.request_id().integer_value(), 42u);
 }
 
 CAF_TEST(response ID) {
   auto x = make_message_id(42).response_id();
-  CAF_CHECK_EQUAL(x.is_async(), false);
-  CAF_CHECK_EQUAL(x.is_request(), false);
-  CAF_CHECK_EQUAL(x.is_response(), true);
-  CAF_CHECK_EQUAL(x.is_answered(), false);
-  CAF_CHECK(x.category() == message_id::normal_message_category);
-  CAF_CHECK_EQUAL(x.is_urgent_message(), false);
-  CAF_CHECK_EQUAL(x.is_normal_message(), true);
-  CAF_CHECK_EQUAL(x.is_stream_message(), false);
-  CAF_CHECK_EQUAL(x.is_upstream_message(), false);
-  CAF_CHECK_EQUAL(x.is_downstream_message(), false);
-  CAF_CHECK_EQUAL(x.request_id().integer_value(), 42u);
+  CHECK_EQ(x.is_async(), false);
+  CHECK_EQ(x.is_request(), false);
+  CHECK_EQ(x.is_response(), true);
+  CHECK_EQ(x.is_answered(), false);
+  CHECK(x.category() == message_id::normal_message_category);
+  CHECK_EQ(x.is_urgent_message(), false);
+  CHECK_EQ(x.is_normal_message(), true);
+  CHECK_EQ(x.is_stream_message(), false);
+  CHECK_EQ(x.is_upstream_message(), false);
+  CHECK_EQ(x.is_downstream_message(), false);
+  CHECK_EQ(x.request_id().integer_value(), 42u);
 }
 
 CAF_TEST(request with high priority) {
   auto x = make_message_id(42).response_id();
-  CAF_CHECK_EQUAL(x.is_async(), false);
-  CAF_CHECK_EQUAL(x.is_request(), false);
-  CAF_CHECK_EQUAL(x.is_response(), true);
-  CAF_CHECK_EQUAL(x.is_answered(), false);
-  CAF_CHECK(x.category() == message_id::normal_message_category);
-  CAF_CHECK_EQUAL(x.is_urgent_message(), false);
-  CAF_CHECK_EQUAL(x.is_normal_message(), true);
-  CAF_CHECK_EQUAL(x.is_stream_message(), false);
-  CAF_CHECK_EQUAL(x.is_upstream_message(), false);
-  CAF_CHECK_EQUAL(x.is_downstream_message(), false);
-  CAF_CHECK_EQUAL(x.request_id().integer_value(), 42u);
+  CHECK_EQ(x.is_async(), false);
+  CHECK_EQ(x.is_request(), false);
+  CHECK_EQ(x.is_response(), true);
+  CHECK_EQ(x.is_answered(), false);
+  CHECK(x.category() == message_id::normal_message_category);
+  CHECK_EQ(x.is_urgent_message(), false);
+  CHECK_EQ(x.is_normal_message(), true);
+  CHECK_EQ(x.is_stream_message(), false);
+  CHECK_EQ(x.is_upstream_message(), false);
+  CHECK_EQ(x.is_downstream_message(), false);
+  CHECK_EQ(x.request_id().integer_value(), 42u);
 }
 
 CAF_TEST(with_category) {
   auto x = make_message_id();
-  CAF_CHECK(x.category() == message_id::normal_message_category);
+  CHECK(x.category() == message_id::normal_message_category);
   for (auto category : {message_id::urgent_message_category,
                         message_id::downstream_message_category,
                         message_id::upstream_message_category,
                         message_id::normal_message_category}) {
     x = x.with_category(category);
-    CAF_CHECK_EQUAL(x.category(), category);
-    CAF_CHECK_EQUAL(x.is_request(), false);
-    CAF_CHECK_EQUAL(x.is_response(), false);
-    CAF_CHECK_EQUAL(x.is_answered(), false);
+    CHECK_EQ(x.category(), category);
+    CHECK_EQ(x.is_request(), false);
+    CHECK_EQ(x.is_response(), false);
+    CHECK_EQ(x.is_answered(), false);
   }
 }

--- a/libcaf_core/test/metaprogramming.cpp
+++ b/libcaf_core/test/metaprogramming.cpp
@@ -6,10 +6,10 @@
 
 #include "core-test.hpp"
 
-#include <string>
 #include <cstdint>
-#include <typeinfo>
+#include <string>
 #include <type_traits>
+#include <typeinfo>
 
 #include "caf/all.hpp"
 
@@ -20,7 +20,6 @@ using namespace caf;
 using namespace caf::detail;
 
 namespace {
-
 
 // misc
 
@@ -36,35 +35,35 @@ CAF_TEST(metaprogramming) {
   using std::is_same;
   using l1 = type_list<int, float, std::string>;
   using r1 = tl_reverse<l1>::type;
-  CAF_CHECK((is_same<int, tl_at<l1, 0>::type>::value));
-  CAF_CHECK((is_same<float, tl_at<l1, 1>::type>::value));
-  CAF_CHECK((is_same<std::string, tl_at<l1, 2>::type>::value));
-  CAF_CHECK_EQUAL(3u, tl_size<l1>::value);
-  CAF_CHECK_EQUAL(tl_size<r1>::value, tl_size<l1>::value);
-  CAF_CHECK((is_same<tl_at<l1, 0>::type, tl_at<r1, 2>::type>::value));
-  CAF_CHECK((is_same<tl_at<l1, 1>::type, tl_at<r1, 1>::type>::value));
-  CAF_CHECK((is_same<tl_at<l1, 2>::type, tl_at<r1, 0>::type>::value));
+  CHECK((is_same<int, tl_at<l1, 0>::type>::value));
+  CHECK((is_same<float, tl_at<l1, 1>::type>::value));
+  CHECK((is_same<std::string, tl_at<l1, 2>::type>::value));
+  CHECK_EQ(3u, tl_size<l1>::value);
+  CHECK_EQ(tl_size<r1>::value, tl_size<l1>::value);
+  CHECK((is_same<tl_at<l1, 0>::type, tl_at<r1, 2>::type>::value));
+  CHECK((is_same<tl_at<l1, 1>::type, tl_at<r1, 1>::type>::value));
+  CHECK((is_same<tl_at<l1, 2>::type, tl_at<r1, 0>::type>::value));
   using l2 = tl_concat<type_list<int>, l1>::type;
-  CAF_CHECK((is_same<int, tl_head<l2>::type>::value));
-  CAF_CHECK((is_same<l1, tl_tail<l2>::type>::value));
-  CAF_CHECK_EQUAL((detail::tl_count<l1, is_int>::value), 1u);
-  CAF_CHECK_EQUAL((detail::tl_count<l2, is_int>::value), 2u);
+  CHECK((is_same<int, tl_head<l2>::type>::value));
+  CHECK((is_same<l1, tl_tail<l2>::type>::value));
+  CHECK_EQ((detail::tl_count<l1, is_int>::value), 1u);
+  CHECK_EQ((detail::tl_count<l2, is_int>::value), 2u);
   using il0 = int_list<0, 1, 2, 3, 4, 5>;
   using il1 = int_list<4, 5>;
   using il2 = il_right<il0, 2>::type;
-  CAF_CHECK((is_same<il2, il1>::value));
+  CHECK((is_same<il2, il1>::value));
   /* test tl_subset_of */ {
     using list_a = type_list<int, float, double>;
     using list_b = type_list<float, int, double, std::string>;
-    CAF_CHECK((tl_subset_of<list_a, list_b>::value));
-    CAF_CHECK(!(tl_subset_of<list_b, list_a>::value));
-    CAF_CHECK((tl_subset_of<list_a, list_a>::value));
-    CAF_CHECK((tl_subset_of<list_b, list_b>::value));
+    CHECK((tl_subset_of<list_a, list_b>::value));
+    CHECK(!(tl_subset_of<list_b, list_a>::value));
+    CHECK((tl_subset_of<list_a, list_a>::value));
+    CHECK((tl_subset_of<list_b, list_b>::value));
   }
 }
 
 template <class T>
-struct token { };
+struct token {};
 
 template <class T>
 std::ostream& operator<<(std::ostream& out, token<T>) {
@@ -96,7 +95,6 @@ constexpr token<composed_type_t<T, U>> dot_op(token<T>, token<U>) {
   return {};
 }
 
-
 // -- lift a list of callback types into a list of MPIs
 
 // -- typed behavior dummy class
@@ -109,8 +107,7 @@ struct typed_beh {
   }
 
   template <class... Ts>
-  typename std::enable_if<sizeof...(Ifs) == sizeof...(Ts)>::type
-  assign(Ts...) {
+  typename std::enable_if<sizeof...(Ifs) == sizeof...(Ts)>::type assign(Ts...) {
     using expected = type_list<Ifs...>;
     using found = type_list<deduce_mpi_t<Ts>...>;
     pos = interface_mismatch_t<found, expected>::value;
@@ -118,8 +115,7 @@ struct typed_beh {
   }
 
   template <class... Ts>
-  typename std::enable_if<sizeof...(Ifs) != sizeof...(Ts)>::type
-  assign(Ts...) {
+  typename std::enable_if<sizeof...(Ifs) != sizeof...(Ts)>::type assign(Ts...) {
     // too many or too few handlers present
     pos = -1;
     valid = false;
@@ -156,36 +152,33 @@ CAF_TEST(typed_behavior_assignment) {
   auto e1 = [=](int) { return 0.f; };
   auto e2 = [=](double, double) { return std::make_tuple(0.f, 0.f); };
   // omit one handler
-  CAF_CHECK_EQUAL(bi_pair(false, -1), tb_assign<bh1>(f1));
-  CAF_CHECK_EQUAL(bi_pair(false, -1), tb_assign<bh1>(f2));
-  CAF_CHECK_EQUAL(bi_pair(false, -1), tb_assign<bh1>(e1));
-  CAF_CHECK_EQUAL(bi_pair(false, -1), tb_assign<bh1>(e2));
+  CHECK_EQ(bi_pair(false, -1), tb_assign<bh1>(f1));
+  CHECK_EQ(bi_pair(false, -1), tb_assign<bh1>(f2));
+  CHECK_EQ(bi_pair(false, -1), tb_assign<bh1>(e1));
+  CHECK_EQ(bi_pair(false, -1), tb_assign<bh1>(e2));
   // any valid alteration of (f1, f2)
-  CAF_CHECK_EQUAL(bi_pair(true, 2), tb_assign<bh1>(f1, f2));
-  CAF_CHECK_EQUAL(bi_pair(true, 2), tb_assign<bh1>(f2, f1));
+  CHECK_EQ(bi_pair(true, 2), tb_assign<bh1>(f1, f2));
+  CHECK_EQ(bi_pair(true, 2), tb_assign<bh1>(f2, f1));
   // any invalid alteration of (f1, f2, e1, e2)
-  CAF_CHECK_EQUAL(bi_pair(false, 1), tb_assign<bh1>(f1, e1));
-  CAF_CHECK_EQUAL(bi_pair(false, 1), tb_assign<bh1>(f1, e2));
-  CAF_CHECK_EQUAL(bi_pair(false, 0), tb_assign<bh1>(e1, f1));
-  CAF_CHECK_EQUAL(bi_pair(false, 0), tb_assign<bh1>(e1, f2));
-  CAF_CHECK_EQUAL(bi_pair(false, 0), tb_assign<bh1>(e1, e2));
-  CAF_CHECK_EQUAL(bi_pair(false, 1), tb_assign<bh1>(f2, e1));
-  CAF_CHECK_EQUAL(bi_pair(false, 1), tb_assign<bh1>(f2, e2));
-  CAF_CHECK_EQUAL(bi_pair(false, 0), tb_assign<bh1>(e2, f1));
-  CAF_CHECK_EQUAL(bi_pair(false, 0), tb_assign<bh1>(e2, f2));
-  CAF_CHECK_EQUAL(bi_pair(false, 0), tb_assign<bh1>(e2, e1));
-  using bh2 = typed_beh<reacts_to<int>,
-                        reacts_to<int, int>,
-                        reacts_to<int, int, int>,
-                        reacts_to<int, int, int, int>,
-                        reacts_to<int, int, int, int, int>,
-                        reacts_to<int, int, int, int, int, int>,
-                        reacts_to<int, int, int, int, int, int, int>,
-                        reacts_to<int, int, int, int, int, int, int, int>,
-                        reacts_to<int, int, int, int, int,
-                                     int, int, int, int>,
-                        reacts_to<int, int, int, int, int,
-                                     int, int, int, int, int>>;
+  CHECK_EQ(bi_pair(false, 1), tb_assign<bh1>(f1, e1));
+  CHECK_EQ(bi_pair(false, 1), tb_assign<bh1>(f1, e2));
+  CHECK_EQ(bi_pair(false, 0), tb_assign<bh1>(e1, f1));
+  CHECK_EQ(bi_pair(false, 0), tb_assign<bh1>(e1, f2));
+  CHECK_EQ(bi_pair(false, 0), tb_assign<bh1>(e1, e2));
+  CHECK_EQ(bi_pair(false, 1), tb_assign<bh1>(f2, e1));
+  CHECK_EQ(bi_pair(false, 1), tb_assign<bh1>(f2, e2));
+  CHECK_EQ(bi_pair(false, 0), tb_assign<bh1>(e2, f1));
+  CHECK_EQ(bi_pair(false, 0), tb_assign<bh1>(e2, f2));
+  CHECK_EQ(bi_pair(false, 0), tb_assign<bh1>(e2, e1));
+  using bh2
+    = typed_beh<reacts_to<int>, reacts_to<int, int>, reacts_to<int, int, int>,
+                reacts_to<int, int, int, int>,
+                reacts_to<int, int, int, int, int>,
+                reacts_to<int, int, int, int, int, int>,
+                reacts_to<int, int, int, int, int, int, int>,
+                reacts_to<int, int, int, int, int, int, int, int>,
+                reacts_to<int, int, int, int, int, int, int, int, int>,
+                reacts_to<int, int, int, int, int, int, int, int, int, int>>;
   auto h0 = [](int) {};
   auto h1 = [](int, int) {};
   auto h2 = [](int, int, int) {};
@@ -196,30 +189,30 @@ CAF_TEST(typed_behavior_assignment) {
   auto h7 = [](int, int, int, int, int, int, int, int) {};
   auto h8 = [](int, int, int, int, int, int, int, int, int) {};
   auto h9 = [](int, int, int, int, int, int, int, int, int, int) {};
-  CAF_CHECK_EQUAL(bi_pair(true, 10), tb_assign<bh2>(h0, h1, h2, h3, h4,
-                                                    h5, h6, h7, h8, h9));
-  CAF_CHECK_EQUAL(bi_pair(false, 0), tb_assign<bh2>(e1, h1, h2, h3, h4,
-                                                    h5, h6, h7, h8, h9));
-  CAF_CHECK_EQUAL(bi_pair(false, 1), tb_assign<bh2>(h0, e1, h2, h3, h4,
-                                                    h5, h6, h7, h8, h9));
-  CAF_CHECK_EQUAL(bi_pair(false, 2), tb_assign<bh2>(h0, h1, e1, h3, h4,
-                                                    h5, h6, h7, h8, h9));
-  CAF_CHECK_EQUAL(bi_pair(false, 3), tb_assign<bh2>(h0, h1, h2, e1, h4,
-                                                    h5, h6, h7, h8, h9));
-  CAF_CHECK_EQUAL(bi_pair(false, 4), tb_assign<bh2>(h0, h1, h2, h3, e1,
-                                                    h5, h6, h7, h8, h9));
-  CAF_CHECK_EQUAL(bi_pair(false, 5), tb_assign<bh2>(h0, h1, h2, h3, h4,
-                                                    e1, h6, h7, h8, h9));
-  CAF_CHECK_EQUAL(bi_pair(false, 6), tb_assign<bh2>(h0, h1, h2, h3, h4,
-                                                    h5, e1, h7, h8, h9));
-  CAF_CHECK_EQUAL(bi_pair(false, 7), tb_assign<bh2>(h0, h1, h2, h3, h4,
-                                                    h5, h6, e1, h8, h9));
-  CAF_CHECK_EQUAL(bi_pair(false, 8), tb_assign<bh2>(h0, h1, h2, h3, h4,
-                                                    h5, h6, h7, e1, h9));
-  CAF_CHECK_EQUAL(bi_pair(false, 9), tb_assign<bh2>(h0, h1, h2, h3, h4,
-                                                    h5, h6, h7, h8, e1));
-  CAF_CHECK_EQUAL(bi_pair(false, -1), tb_assign<bh2>(h0, h1, h2, h3, h4,
-                                                     h5, h6, h7, h8));
+  CHECK_EQ(bi_pair(true, 10),
+           tb_assign<bh2>(h0, h1, h2, h3, h4, h5, h6, h7, h8, h9));
+  CHECK_EQ(bi_pair(false, 0),
+           tb_assign<bh2>(e1, h1, h2, h3, h4, h5, h6, h7, h8, h9));
+  CHECK_EQ(bi_pair(false, 1),
+           tb_assign<bh2>(h0, e1, h2, h3, h4, h5, h6, h7, h8, h9));
+  CHECK_EQ(bi_pair(false, 2),
+           tb_assign<bh2>(h0, h1, e1, h3, h4, h5, h6, h7, h8, h9));
+  CHECK_EQ(bi_pair(false, 3),
+           tb_assign<bh2>(h0, h1, h2, e1, h4, h5, h6, h7, h8, h9));
+  CHECK_EQ(bi_pair(false, 4),
+           tb_assign<bh2>(h0, h1, h2, h3, e1, h5, h6, h7, h8, h9));
+  CHECK_EQ(bi_pair(false, 5),
+           tb_assign<bh2>(h0, h1, h2, h3, h4, e1, h6, h7, h8, h9));
+  CHECK_EQ(bi_pair(false, 6),
+           tb_assign<bh2>(h0, h1, h2, h3, h4, h5, e1, h7, h8, h9));
+  CHECK_EQ(bi_pair(false, 7),
+           tb_assign<bh2>(h0, h1, h2, h3, h4, h5, h6, e1, h8, h9));
+  CHECK_EQ(bi_pair(false, 8),
+           tb_assign<bh2>(h0, h1, h2, h3, h4, h5, h6, h7, e1, h9));
+  CHECK_EQ(bi_pair(false, 9),
+           tb_assign<bh2>(h0, h1, h2, h3, h4, h5, h6, h7, h8, e1));
+  CHECK_EQ(bi_pair(false, -1),
+           tb_assign<bh2>(h0, h1, h2, h3, h4, h5, h6, h7, h8));
 }
 
 struct foo {};
@@ -238,14 +231,14 @@ private:
 };
 
 CAF_TEST(is_comparable) {
-  CAF_CHECK((is_comparable<double, std::string>::value) == false);
-  CAF_CHECK((is_comparable<foo, foo>::value) == false);
-  CAF_CHECK((is_comparable<bar, bar>::value) == true);
-  CAF_CHECK((is_comparable<double, bar>::value) == false);
-  CAF_CHECK((is_comparable<bar, double>::value) == false);
-  CAF_CHECK((is_comparable<baz, baz>::value) == true);
-  CAF_CHECK((is_comparable<double, baz>::value) == false);
-  CAF_CHECK((is_comparable<baz, double>::value) == false);
-  CAF_CHECK((is_comparable<std::string, baz>::value) == false);
-  CAF_CHECK((is_comparable<baz, std::string>::value) == false);
+  CHECK((is_comparable<double, std::string>::value) == false);
+  CHECK((is_comparable<foo, foo>::value) == false);
+  CHECK((is_comparable<bar, bar>::value) == true);
+  CHECK((is_comparable<double, bar>::value) == false);
+  CHECK((is_comparable<bar, double>::value) == false);
+  CHECK((is_comparable<baz, baz>::value) == true);
+  CHECK((is_comparable<double, baz>::value) == false);
+  CHECK((is_comparable<baz, double>::value) == false);
+  CHECK((is_comparable<std::string, baz>::value) == false);
+  CHECK((is_comparable<baz, std::string>::value) == false);
 }

--- a/libcaf_core/test/mixin/requester.cpp
+++ b/libcaf_core/test/mixin/requester.cpp
@@ -65,10 +65,10 @@ struct fixture : test_coordinator_fixture<> {
 #define SUBTEST(message)                                                       \
   *result = none;                                                              \
   run();                                                                       \
-  CAF_MESSAGE("subtest: " message);                                            \
+  MESSAGE("subtest: " message);                                                \
   for (int subtest_dummy = 0; subtest_dummy < 1; ++subtest_dummy)
 
-CAF_TEST_FIXTURE_SCOPE(requester_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(requests without result) {
   auto server = discarding_server;
@@ -79,7 +79,7 @@ CAF_TEST(requests without result) {
     run_once();
     expect((int, int), from(client).to(server).with(1, 2));
     expect((void), from(server).to(client));
-    CAF_CHECK_EQUAL(*result, result_type{unit});
+    CHECK_EQ(*result, result_type{unit});
   }
   SUBTEST("request.await") {
     auto client = sys.spawn([=](event_based_actor* self) {
@@ -88,13 +88,13 @@ CAF_TEST(requests without result) {
     run_once();
     expect((int, int), from(client).to(server).with(1, 2));
     expect((void), from(server).to(client));
-    CAF_CHECK_EQUAL(*result, result_type{unit});
+    CHECK_EQ(*result, result_type{unit});
   }
   SUBTEST("request.receive") {
     auto res_hdl = self->request(server, infinite, 1, 2);
     run();
     res_hdl.receive([&] { *result = unit; }, ERROR_HANDLER);
-    CAF_CHECK_EQUAL(*result, result_type{unit});
+    CHECK_EQ(*result, result_type{unit});
   }
 }
 
@@ -107,7 +107,7 @@ CAF_TEST(requests with integer result) {
     run_once();
     expect((int, int), from(client).to(server).with(1, 2));
     expect((int), from(server).to(client).with(3));
-    CAF_CHECK_EQUAL(*result, result_type{3});
+    CHECK_EQ(*result, result_type{3});
   }
   SUBTEST("request.await") {
     auto client = sys.spawn([=](event_based_actor* self) {
@@ -116,13 +116,13 @@ CAF_TEST(requests with integer result) {
     run_once();
     expect((int, int), from(client).to(server).with(1, 2));
     expect((int), from(server).to(client).with(3));
-    CAF_CHECK_EQUAL(*result, result_type{3});
+    CHECK_EQ(*result, result_type{3});
   }
   SUBTEST("request.receive") {
     auto res_hdl = self->request(server, infinite, 1, 2);
     run();
     res_hdl.receive([&](int x) { *result = x; }, ERROR_HANDLER);
-    CAF_CHECK_EQUAL(*result, result_type{3});
+    CHECK_EQ(*result, result_type{3});
   }
 }
 
@@ -136,7 +136,7 @@ CAF_TEST(delegated request with integer result) {
   expect((int, int), from(client).to(server).with(1, 2));
   expect((int, int), from(client).to(worker).with(1, 2));
   expect((int), from(worker).to(client).with(3));
-  CAF_CHECK_EQUAL(*result, result_type{3});
+  CHECK_EQ(*result, result_type{3});
 }
 
 CAF_TEST(requesters support fan_out_request) {
@@ -152,7 +152,7 @@ CAF_TEST(requesters support fan_out_request) {
     self->fan_out_request<select_all>(workers, infinite, 1, 2)
       .then([=](std::vector<int> results) {
         for (auto result : results)
-          CAF_CHECK_EQUAL(result, 3);
+          CHECK_EQ(result, 3);
         *sum = std::accumulate(results.begin(), results.end(), 0);
       });
   });
@@ -163,7 +163,7 @@ CAF_TEST(requesters support fan_out_request) {
   expect((int), from(workers[1]).to(client).with(3));
   expect((int, int), from(client).to(workers[2]).with(1, 2));
   expect((int), from(workers[2]).to(client).with(3));
-  CAF_CHECK_EQUAL(*sum, 9);
+  CHECK_EQ(*sum, 9);
 }
 
 #ifdef CAF_ENABLE_EXCEPTIONS
@@ -220,4 +220,4 @@ SCENARIO("request.await enforces a processing order") {
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/mixin/sender.cpp
+++ b/libcaf_core/test/mixin/sender.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/mixin/sender.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include <chrono>
 
@@ -43,7 +43,7 @@ struct fixture : test_coordinator_fixture<> {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(sender_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(delayed actor messages receive responses) {
   self->delayed_send(testee, seconds(1), hello);
@@ -89,4 +89,4 @@ CAF_TEST(anonymous messages receive no response) {
   disallow((std::string), from(testee).to(self).with(hello));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/mtl.cpp
+++ b/libcaf_core/test/mtl.cpp
@@ -181,7 +181,7 @@ SCENARIO("an MTL allows sending asynchronous messages") {
         inject((std::string, std::string),
                from(self).to(driver).with("try_send", get));
         expect((get_atom, std::string), from(driver).to(testee).with(_, "a"));
-        expect((int32_t), from(testee).to(driver).with(_, 1));
+        expect((int32_t), from(testee).to(driver).with(1));
         CHECK(!sched.has_job());
       }
     }
@@ -209,7 +209,7 @@ SCENARIO("an MTL allows sending requests") {
         inject((std::string, std::string),
                from(self).to(driver).with("try_request", get));
         expect((get_atom, std::string), from(driver).to(testee).with(_, "a"));
-        expect((int32_t), from(testee).to(driver).with(_, 1));
+        expect((int32_t), from(testee).to(driver).with(1));
         expect((std::string), from(driver).to(self).with("1"));
         CHECK(!sched.has_job());
       }

--- a/libcaf_core/test/native_streaming_classes.cpp
+++ b/libcaf_core/test/native_streaming_classes.cpp
@@ -71,7 +71,7 @@ namespace {
 struct print_with_comma_t {
   bool first = true;
   template <class T>
-  std::ostream&  operator()(std::ostream& out, const T& x) {
+  std::ostream& operator()(std::ostream& out, const T& x) {
     if (!first)
       out << ", ";
     else
@@ -90,8 +90,8 @@ std::string collapse_args(const T& x, const Ts&... xs) {
 }
 
 #define TRACE(name, type, ...)                                                 \
-  CAF_MESSAGE(name << " received a " << #type << ": "                          \
-                   << collapse_args(__VA_ARGS__));
+  MESSAGE(name << " received a " << #type << ": "                              \
+               << collapse_args(__VA_ARGS__));
 
 const char* name_of(const strong_actor_ptr& x) {
   CAF_ASSERT(x != nullptr);
@@ -108,7 +108,7 @@ const char* name_of(const actor_addr& x) {
 using mboxqueue = scheduled_actor::mailbox_policy::queue_type;
 
 template <size_t Value>
-using uint_constant =  std::integral_constant<size_t, Value>;
+using uint_constant = std::integral_constant<size_t, Value>;
 
 using urgent_async_id = uint_constant<scheduled_actor::urgent_queue_index>;
 
@@ -154,7 +154,7 @@ public:
 
   void enqueue(mailbox_element_ptr what, execution_unit*) override {
     auto push_back_result = mbox.push_back(std::move(what));
-    CAF_CHECK_EQUAL(push_back_result, true);
+    CHECK_EQ(push_back_result, true);
     CAF_ASSERT(push_back_result);
   }
 
@@ -212,14 +212,15 @@ public:
       bool done() const noexcept override {
         return x_ == sentinel_;
       }
+
     private:
       int32_t x_;
       int32_t sentinel_;
     };
     auto mgr = detail::make_stream_source<driver>(this, num_messages);
     auto res = mgr->add_outbound_path(ref.ctrl());
-    CAF_MESSAGE(name_ << " starts streaming to " << ref.name()
-                << " on slot " << res.value());
+    MESSAGE(name_ << " starts streaming to " << ref.name() << " on slot "
+                  << res.value());
   }
 
   void forward_to(entity& ref) {
@@ -234,7 +235,7 @@ public:
       }
 
       void process(downstream<int>& out, vector<int>& batch) override {
-        CAF_MESSAGE(name << " forwards " << batch.size() << " elements");
+        MESSAGE(name << " forwards " << batch.size() << " elements");
         log_->insert(log_->end(), batch.begin(), batch.end());
         out.append(batch.begin(), batch.end());
       }
@@ -249,8 +250,8 @@ public:
     };
     forwarder = detail::make_stream_stage<driver>(this, &data, name_);
     auto res = forwarder->add_outbound_path(ref.ctrl());
-    CAF_MESSAGE(name_ << " starts forwarding to " << ref.name()
-                << " on slot " << res.value());
+    MESSAGE(name_ << " starts forwarding to " << ref.name() << " on slot "
+                  << res.value());
   }
 
   void operator()(open_stream_msg& hs) {
@@ -269,6 +270,7 @@ public:
         void process(std::vector<int>& xs) override {
           log_->insert(log_->end(), xs.begin(), xs.end());
         }
+
       private:
         vector<int>* log_;
       };
@@ -289,8 +291,8 @@ public:
 
   void operator()(stream_slots slots, actor_addr& sender,
                   upstream_msg::ack_batch& x) {
-    TRACE(name_, ack_batch, CAF_ARG(slots),
-          CAF_ARG2("sender", name_of(sender)), CAF_ARG(x));
+    TRACE(name_, ack_batch, CAF_ARG(slots), CAF_ARG2("sender", name_of(sender)),
+          CAF_ARG(x));
     scheduled_actor::handle_upstream_msg(slots, sender, x);
   }
 
@@ -379,19 +381,14 @@ struct msg_visitor {
     self->current_mailbox_element(&x);
     auto& um = x.content().get_mutable_as<upstream_msg>(0);
     auto f = detail::make_overload(
-      [&](upstream_msg::ack_open& y) {
-        (*self)(um.slots, um.sender, y);
-      },
-      [&](upstream_msg::ack_batch& y) {
-        (*self)(um.slots, um.sender, y);
-      },
+      [&](upstream_msg::ack_open& y) { (*self)(um.slots, um.sender, y); },
+      [&](upstream_msg::ack_batch& y) { (*self)(um.slots, um.sender, y); },
       [](upstream_msg::drop&) {
         CAF_FAIL("did not expect upstream_msg::drop");
       },
       [](upstream_msg::forced_drop&) {
         CAF_FAIL("did not expect upstream_msg::forced_drop");
-      }
-    );
+      });
     visit(f, um.content);
     self->current_mailbox_element(nullptr);
     self->push();
@@ -412,8 +409,7 @@ struct msg_visitor {
         TRACE(self->name(), batch, CAF_ARG(dm.slots), CAF_ARG(y.xs_size));
         inptr->handle(y);
         if (inptr->mgr->done()) {
-          CAF_MESSAGE(self->name()
-                      << " is done receiving and closes its manager");
+          MESSAGE(self->name() << " is done receiving and closes its manager");
           inptr->mgr->stop();
         }
         return intrusive::task_result::resume;
@@ -506,9 +502,9 @@ struct fixture {
     // Check whether all actors cleaned up their state properly.
     entity* xs[] = {&alice, &bob, &carl};
     for (auto x : xs) {
-      CAF_CHECK(get<dmsg_id::value>(x->mbox.queues()).queues().empty());
-      CAF_CHECK(x->pending_stream_managers().empty());
-      CAF_CHECK(x->stream_managers().empty());
+      CHECK(get<dmsg_id::value>(x->mbox.queues()).queues().empty());
+      CHECK(x->pending_stream_managers().empty());
+      CHECK(x->stream_managers().empty());
     }
   }
 
@@ -524,7 +520,7 @@ struct fixture {
   template <class... Ts>
   void next_cycle(Ts&... xs) {
     entity* es[] = {&xs...};
-    CAF_MESSAGE("advance clock by " << max_batch_delay);
+    MESSAGE("advance clock by " << max_batch_delay);
     sched.clock().current_time += max_batch_delay;
     for (auto e : es)
       e->tick();
@@ -539,12 +535,11 @@ struct fixture {
       while (!std::all_of(std::begin(fs), std::end(fs), mailbox_empty))
         for (auto& f : fs)
           f.self->mbox.new_round(1, f);
-      CAF_MESSAGE("advance clock by " << max_batch_delay);
+      MESSAGE("advance clock by " << max_batch_delay);
       sched.clock().current_time += max_batch_delay;
       for (auto e : es)
         e->tick();
-    }
-    while (!pred());
+    } while (!pred());
   }
 
   bool done_streaming() {
@@ -566,46 +561,46 @@ vector<int> make_iota(int first, int last) {
 
 // -- unit tests ---------------------------------------------------------------
 
-CAF_TEST_FIXTURE_SCOPE(native_streaming_classes_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(depth_2_pipeline_30_items) {
   alice.start_streaming(bob, 30);
   loop_until([&] { return done_streaming(); }, alice, bob);
-  CAF_CHECK_EQUAL(bob.data, make_iota(0, 30));
+  CHECK_EQ(bob.data, make_iota(0, 30));
 }
 
 CAF_TEST(depth_2_pipeline_500_items) {
   constexpr size_t num_messages = 500;
   alice.start_streaming(bob, num_messages);
   loop_until([&] { return done_streaming(); }, alice, bob);
-  CAF_CHECK_EQUAL(bob.data, make_iota(0, num_messages));
+  CHECK_EQ(bob.data, make_iota(0, num_messages));
 }
 
 CAF_TEST(depth_3_pipeline_30_items) {
   bob.forward_to(carl);
   alice.start_streaming(bob, 30);
   loop_until([&] { return done_streaming(); }, alice, bob, carl);
-  CAF_CHECK_EQUAL(bob.data, make_iota(0, 30));
-  CAF_CHECK_EQUAL(carl.data, make_iota(0, 30));
+  CHECK_EQ(bob.data, make_iota(0, 30));
+  CHECK_EQ(carl.data, make_iota(0, 30));
 }
 
 CAF_TEST(depth_3_pipeline_500_items) {
   constexpr size_t num_messages = 500;
   bob.forward_to(carl);
   alice.start_streaming(bob, num_messages);
-  CAF_MESSAGE("loop over alice and bob until bob is congested");
+  MESSAGE("loop over alice and bob until bob is congested");
   loop(alice, bob);
-  CAF_CHECK_NOT_EQUAL(bob.data.size(), 0u);
-  CAF_CHECK_EQUAL(carl.data.size(), 0u);
-  CAF_MESSAGE("loop over bob and carl until bob finished sending");
+  CHECK_NE(bob.data.size(), 0u);
+  CHECK_EQ(carl.data.size(), 0u);
+  MESSAGE("loop over bob and carl until bob finished sending");
   // bob has one batch from alice in its mailbox that bob will read when
   // becoming uncongested again
   loop(bob, carl);
-  CAF_CHECK_EQUAL(bob.data.size(), carl.data.size());
-  CAF_MESSAGE("loop over all until done");
+  CHECK_EQ(bob.data.size(), carl.data.size());
+  MESSAGE("loop over all until done");
   loop_until([&] { return done_streaming(); }, alice, bob, carl);
-  CAF_CHECK_EQUAL(bob.data, make_iota(0, num_messages));
-  CAF_CHECK_EQUAL(carl.data, make_iota(0, num_messages));
+  CHECK_EQ(bob.data, make_iota(0, num_messages));
+  CHECK_EQ(carl.data, make_iota(0, num_messages));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/node_id.cpp
+++ b/libcaf_core/test/node_id.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/node_id.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include "caf/binary_deserializer.hpp"
 #include "caf/binary_serializer.hpp"
@@ -39,10 +39,10 @@ node_id roundtrip(node_id nid) {
 
 #define CHECK_PARSE_OK(str, ...)                                               \
   do {                                                                         \
-    CAF_CHECK(node_id::can_parse(str));                                        \
+    CHECK(node_id::can_parse(str));                                            \
     node_id nid;                                                               \
-    CAF_CHECK_EQUAL(parse(str, nid), none);                                    \
-    CAF_CHECK_EQUAL(nid, make_node_id(__VA_ARGS__));                           \
+    CHECK_EQ(parse(str, nid), none);                                           \
+    CHECK_EQ(nid, make_node_id(__VA_ARGS__));                                  \
   } while (false)
 
 CAF_TEST(node IDs are convertible from string) {
@@ -55,7 +55,7 @@ CAF_TEST(node IDs are convertible from string) {
   CHECK_PARSE_OK("ip://foo:8080", uri_id);
 }
 
-#define CHECK_PARSE_FAIL(str) CAF_CHECK(!node_id::can_parse(str))
+#define CHECK_PARSE_FAIL(str) CHECK(!node_id::can_parse(str))
 
 CAF_TEST(node IDs reject malformed strings) {
   // not URIs
@@ -66,20 +66,20 @@ CAF_TEST(node IDs reject malformed strings) {
 }
 
 CAF_TEST(node IDs are serializable) {
-  CAF_MESSAGE("empty node IDs remain empty");
+  MESSAGE("empty node IDs remain empty");
   {
     node_id nil_id;
-    CAF_CHECK_EQUAL(nil_id, roundtrip(nil_id));
+    CHECK_EQ(nil_id, roundtrip(nil_id));
   }
-  CAF_MESSAGE("hash-based node IDs remain intact");
+  MESSAGE("hash-based node IDs remain intact");
   {
     auto tmp = make_node_id(42, "0102030405060708090A0B0C0D0E0F1011121314");
     auto hash_based_id = unbox(tmp);
-    CAF_CHECK_EQUAL(hash_based_id, roundtrip(hash_based_id));
+    CHECK_EQ(hash_based_id, roundtrip(hash_based_id));
   }
-  CAF_MESSAGE("URI-based node IDs remain intact");
+  MESSAGE("URI-based node IDs remain intact");
   {
     auto uri_based_id = make_node_id(unbox(make_uri("foo:bar")));
-    CAF_CHECK_EQUAL(uri_based_id, roundtrip(uri_based_id));
+    CHECK_EQ(uri_based_id, roundtrip(uri_based_id));
   }
 }

--- a/libcaf_core/test/optional.cpp
+++ b/libcaf_core/test/optional.cpp
@@ -29,48 +29,48 @@ bool operator==(const qwertz& lhs, const qwertz& rhs) {
 CAF_TEST(empty) {
   optional<int> x;
   optional<int> y;
-  CAF_CHECK(x == y);
-  CAF_CHECK(!(x != y));
+  CHECK(x == y);
+  CHECK(!(x != y));
 }
 
 CAF_TEST(equality) {
   optional<int> x = 42;
   optional<int> y = 7;
-  CAF_CHECK(x != y);
-  CAF_CHECK(!(x == y));
+  CHECK(x != y);
+  CHECK(!(x == y));
 }
 
 CAF_TEST(ordering) {
   optional<int> x = 42;
   optional<int> y = 7;
-  CAF_CHECK(x > y);
-  CAF_CHECK(x >= y);
-  CAF_CHECK(y < x);
-  CAF_CHECK(y <= x);
-  CAF_CHECK(!(y > x));
-  CAF_CHECK(!(y >= x));
-  CAF_CHECK(!(x < y));
-  CAF_CHECK(!(x <= y));
-  CAF_CHECK(x < 4711);
-  CAF_CHECK(4711 > x);
-  CAF_CHECK(4711 >= x);
-  CAF_CHECK(!(x > 4711));
-  CAF_CHECK(!(x >= 4711));
-  CAF_CHECK(!(4211 < x));
-  CAF_CHECK(!(4211 <= x));
+  CHECK(x > y);
+  CHECK(x >= y);
+  CHECK(y < x);
+  CHECK(y <= x);
+  CHECK(!(y > x));
+  CHECK(!(y >= x));
+  CHECK(!(x < y));
+  CHECK(!(x <= y));
+  CHECK(x < 4711);
+  CHECK(4711 > x);
+  CHECK(4711 >= x);
+  CHECK(!(x > 4711));
+  CHECK(!(x >= 4711));
+  CHECK(!(4211 < x));
+  CHECK(!(4211 <= x));
 }
 
 CAF_TEST(custom_type_none) {
   optional<qwertz> x;
-  CAF_CHECK(x == none);
+  CHECK(x == none);
 }
 
 CAF_TEST(custom_type_engaged) {
   qwertz obj{1, 2};
   optional<qwertz> x = obj;
-  CAF_CHECK(x != none);
-  CAF_CHECK(obj == x);
-  CAF_CHECK(x == obj );
-  CAF_CHECK(obj == *x);
-  CAF_CHECK(*x == obj);
+  CHECK(x != none);
+  CHECK(obj == x);
+  CHECK(x == obj);
+  CHECK(obj == *x);
+  CHECK(*x == obj);
 }

--- a/libcaf_core/test/or_else.cpp
+++ b/libcaf_core/test/or_else.cpp
@@ -43,13 +43,13 @@ struct fixture {
   void run_testee(const actor& testee) {
     scoped_actor self{system};
     self->request(testee, infinite, int8_t{1})
-      .receive([](const std::string& str) { CAF_CHECK_EQUAL(str, "a"); },
+      .receive([](const std::string& str) { CHECK_EQ(str, "a"); },
                ERROR_HANDLER);
     self->request(testee, infinite, int16_t{1})
-      .receive([](const std::string& str) { CAF_CHECK_EQUAL(str, "b"); },
+      .receive([](const std::string& str) { CHECK_EQ(str, "b"); },
                ERROR_HANDLER);
     self->request(testee, infinite, int32_t{1})
-      .receive([](const std::string& str) { CAF_CHECK_EQUAL(str, "c"); },
+      .receive([](const std::string& str) { CHECK_EQ(str, "c"); },
                ERROR_HANDLER);
     self->send_exit(testee, exit_reason::user_shutdown);
   }
@@ -57,7 +57,7 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(atom_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(composition1) {
   run_testee(system.spawn(
@@ -78,4 +78,4 @@ CAF_TEST(composition3) {
   }));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/pipeline_streaming.cpp
+++ b/libcaf_core/test/pipeline_streaming.cpp
@@ -31,9 +31,9 @@ auto fin(Self* self) {
   return [=](T&, const error& err) {
     self->state.fin_called += 1;
     if (err == none) {
-      CAF_MESSAGE(self->name() << " is done");
+      MESSAGE(self->name() << " is done");
     } else {
-      CAF_MESSAGE(self->name() << " aborted with error");
+      MESSAGE(self->name() << " aborted with error");
     }
   };
 }
@@ -45,8 +45,8 @@ TESTEE_STATE(infinite_source) {
 TESTEE(infinite_source) {
   return {
     [=](string& fname) -> result<stream<int>> {
-      CAF_CHECK_EQUAL(fname, "numbers.txt");
-      CAF_CHECK_EQUAL(self->mailbox().empty(), true);
+      CHECK_EQ(fname, "numbers.txt");
+      CHECK_EQ(self->mailbox().empty(), true);
       return attach_stream_source(
         self, [](int& x) { x = 0; },
         [](int& x, downstream<int>& out, size_t num) {
@@ -70,7 +70,7 @@ VARARGS_TESTEE(file_reader, size_t buf_size) {
     };
   };
   auto push_from_buf = [](buf& xs, downstream<int>& out, size_t num) {
-    CAF_MESSAGE("push " << num << " messages downstream");
+    MESSAGE("push " << num << " messages downstream");
     auto n = std::min(num, xs.size());
     for (size_t i = 0; i < n; ++i)
       out.push(xs[i]);
@@ -78,21 +78,21 @@ VARARGS_TESTEE(file_reader, size_t buf_size) {
   };
   auto is_done = [self](const buf& xs) {
     if (xs.empty()) {
-      CAF_MESSAGE(self->name() << " exhausted its buffer");
+      MESSAGE(self->name() << " exhausted its buffer");
       return true;
     }
     return false;
   };
   return {
     [=](string& fname) -> result<stream<int>> {
-      CAF_CHECK_EQUAL(fname, "numbers.txt");
-      CAF_CHECK_EQUAL(self->mailbox().empty(), true);
+      CHECK_EQ(fname, "numbers.txt");
+      CHECK_EQ(self->mailbox().empty(), true);
       return attach_stream_source(self, init(buf_size), push_from_buf, is_done,
                                   fin<buf>(self));
     },
     [=](string& fname, actor next) {
-      CAF_CHECK_EQUAL(fname, "numbers.txt");
-      CAF_CHECK_EQUAL(self->mailbox().empty(), true);
+      CHECK_EQ(fname, "numbers.txt");
+      CHECK_EQ(self->mailbox().empty(), true);
       attach_stream_source(self, next, init(buf_size), push_from_buf, is_done,
                            fin<buf>(self));
     },
@@ -227,177 +227,177 @@ struct fixture : test_coordinator_fixture<> {
 
 // -- unit tests ---------------------------------------------------------------
 
-CAF_TEST_FIXTURE_SCOPE(local_streaming_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(depth_2_pipeline_50_items) {
   auto src = sys.spawn(file_reader, 50u);
   auto snk = sys.spawn(sum_up);
-  CAF_MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(snk));
-  CAF_MESSAGE("initiate stream handshake");
+  MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(snk));
+  MESSAGE("initiate stream handshake");
   self->send(snk * src, "numbers.txt");
   expect((string), from(self).to(src).with("numbers.txt"));
   expect((open_stream_msg), from(self).to(snk));
   expect((upstream_msg::ack_open), from(snk).to(src));
-  CAF_MESSAGE("start data transmission (a single batch)");
+  MESSAGE("start data transmission (a single batch)");
   expect((downstream_msg::batch), from(src).to(snk));
   expect((upstream_msg::ack_batch), from(snk).to(src));
   expect((downstream_msg::close), from(src).to(snk));
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk).state.x, 1275);
-  CAF_MESSAGE("verify that each actor called its finalizer once");
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk).state.fin_called, 1);
-  CAF_CHECK_EQUAL(deref<file_reader_actor>(src).state.fin_called, 1);
+  CHECK_EQ(deref<sum_up_actor>(snk).state.x, 1275);
+  MESSAGE("verify that each actor called its finalizer once");
+  CHECK_EQ(deref<sum_up_actor>(snk).state.fin_called, 1);
+  CHECK_EQ(deref<file_reader_actor>(src).state.fin_called, 1);
 }
 
 CAF_TEST(depth_2_pipeline_setup2_50_items) {
   auto src = sys.spawn(file_reader, 50u);
   auto snk = sys.spawn(sum_up);
-  CAF_MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(snk));
-  CAF_MESSAGE("initiate stream handshake");
+  MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(snk));
+  MESSAGE("initiate stream handshake");
   self->send(src, "numbers.txt", snk);
   expect((string, actor), from(self).to(src).with("numbers.txt", snk));
   expect((open_stream_msg), to(snk));
   expect((upstream_msg::ack_open), from(snk).to(src));
-  CAF_MESSAGE("start data transmission (a single batch)");
+  MESSAGE("start data transmission (a single batch)");
   expect((downstream_msg::batch), from(src).to(snk));
   expect((upstream_msg::ack_batch), from(snk).to(src));
   expect((downstream_msg::close), from(src).to(snk));
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk).state.x, 1275);
-  CAF_MESSAGE("verify that each actor called its finalizer once");
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk).state.fin_called, 1);
-  CAF_CHECK_EQUAL(deref<file_reader_actor>(src).state.fin_called, 1);
+  CHECK_EQ(deref<sum_up_actor>(snk).state.x, 1275);
+  MESSAGE("verify that each actor called its finalizer once");
+  CHECK_EQ(deref<sum_up_actor>(snk).state.fin_called, 1);
+  CHECK_EQ(deref<file_reader_actor>(src).state.fin_called, 1);
 }
 
 CAF_TEST(delayed_depth_2_pipeline_50_items) {
   auto src = sys.spawn(file_reader, 50u);
   auto snk = sys.spawn(delayed_sum_up);
-  CAF_MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(snk));
-  CAF_MESSAGE("initiate stream handshake");
+  MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(snk));
+  MESSAGE("initiate stream handshake");
   self->send(snk * src, "numbers.txt");
   expect((string), from(self).to(src).with("numbers.txt"));
   expect((open_stream_msg), from(self).to(snk));
   disallow((upstream_msg::ack_open), from(snk).to(src));
   disallow((upstream_msg::forced_drop), from(_).to(src));
-  CAF_MESSAGE("send 'ok' to trigger sink to handle open_stream_msg");
+  MESSAGE("send 'ok' to trigger sink to handle open_stream_msg");
   self->send(snk, ok_atom_v);
   expect((ok_atom), from(self).to(snk));
   expect((open_stream_msg), from(self).to(snk));
   expect((upstream_msg::ack_open), from(snk).to(src));
-  CAF_MESSAGE("start data transmission (a single batch)");
+  MESSAGE("start data transmission (a single batch)");
   expect((downstream_msg::batch), from(src).to(snk));
   expect((upstream_msg::ack_batch), from(snk).to(src));
-  CAF_MESSAGE("expect close message from src and then result from snk");
+  MESSAGE("expect close message from src and then result from snk");
   expect((downstream_msg::close), from(src).to(snk));
-  CAF_CHECK_EQUAL(deref<delayed_sum_up_actor>(snk).state.x, 1275);
-  CAF_MESSAGE("verify that each actor called its finalizer once");
-  CAF_CHECK_EQUAL(deref<delayed_sum_up_actor>(snk).state.fin_called, 1);
-  CAF_CHECK_EQUAL(deref<file_reader_actor>(src).state.fin_called, 1);
+  CHECK_EQ(deref<delayed_sum_up_actor>(snk).state.x, 1275);
+  MESSAGE("verify that each actor called its finalizer once");
+  CHECK_EQ(deref<delayed_sum_up_actor>(snk).state.fin_called, 1);
+  CHECK_EQ(deref<file_reader_actor>(src).state.fin_called, 1);
 }
 
 CAF_TEST(depth_2_pipeline_500_items) {
   auto src = sys.spawn(file_reader, 500u);
   auto snk = sys.spawn(sum_up);
-  CAF_MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(snk));
-  CAF_MESSAGE("initiate stream handshake");
+  MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(snk));
+  MESSAGE("initiate stream handshake");
   self->send(snk * src, "numbers.txt");
   expect((string), from(self).to(src).with("numbers.txt"));
   expect((open_stream_msg), from(self).to(snk));
   expect((upstream_msg::ack_open), from(snk).to(src));
-  CAF_MESSAGE("start data transmission (loop until src sends 'close')");
+  MESSAGE("start data transmission (loop until src sends 'close')");
   do {
-    CAF_MESSAGE("process all batches at the sink");
+    MESSAGE("process all batches at the sink");
     while (received<downstream_msg::batch>(snk)) {
       expect((downstream_msg::batch), from(src).to(snk));
     }
-    CAF_MESSAGE("trigger timeouts");
+    MESSAGE("trigger timeouts");
     tick();
     allow((timeout_msg), from(snk).to(snk));
     allow((timeout_msg), from(src).to(src));
-    CAF_MESSAGE("process ack_batch in source");
+    MESSAGE("process ack_batch in source");
     expect((upstream_msg::ack_batch), from(snk).to(src));
   } while (!received<downstream_msg::close>(snk));
-  CAF_MESSAGE("expect close message from src and then result from snk");
+  MESSAGE("expect close message from src and then result from snk");
   expect((downstream_msg::close), from(src).to(snk));
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk).state.x, 125250);
-  CAF_MESSAGE("verify that each actor called its finalizer once");
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk).state.fin_called, 1);
-  CAF_CHECK_EQUAL(deref<file_reader_actor>(src).state.fin_called, 1);
+  CHECK_EQ(deref<sum_up_actor>(snk).state.x, 125250);
+  MESSAGE("verify that each actor called its finalizer once");
+  CHECK_EQ(deref<sum_up_actor>(snk).state.fin_called, 1);
+  CHECK_EQ(deref<file_reader_actor>(src).state.fin_called, 1);
 }
 
 CAF_TEST(depth_2_pipeline_error_during_handshake) {
-  CAF_MESSAGE("streams must abort if a sink fails to initialize its state");
+  MESSAGE("streams must abort if a sink fails to initialize its state");
   auto src = sys.spawn(file_reader, 50u);
   auto snk = sys.spawn(broken_sink);
-  CAF_MESSAGE("initiate stream handshake");
+  MESSAGE("initiate stream handshake");
   self->send(snk * src, "numbers.txt");
   expect((std::string), from(self).to(src).with("numbers.txt"));
   expect((open_stream_msg), from(self).to(snk));
   expect((upstream_msg::forced_drop), from(_).to(src));
   expect((error), from(snk).to(self).with(sec::stream_init_failed));
   run();
-  CAF_MESSAGE("verify that the file reader called its finalizer once");
-  CAF_CHECK_EQUAL(deref<file_reader_actor>(src).state.fin_called, 1);
+  MESSAGE("verify that the file reader called its finalizer once");
+  CHECK_EQ(deref<file_reader_actor>(src).state.fin_called, 1);
 }
 
 CAF_TEST(depth_2_pipeline_error_at_source) {
-  CAF_MESSAGE("streams must abort if a source fails at runtime");
+  MESSAGE("streams must abort if a source fails at runtime");
   auto src = sys.spawn(file_reader, 500u);
   auto snk = sys.spawn(sum_up);
-  CAF_MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(snk));
-  CAF_MESSAGE("initiate stream handshake");
+  MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(snk));
+  MESSAGE("initiate stream handshake");
   self->send(snk * src, "numbers.txt");
   expect((string), from(self).to(src).with("numbers.txt"));
   expect((open_stream_msg), from(self).to(snk));
   expect((upstream_msg::ack_open), from(snk).to(src));
-  CAF_MESSAGE("start data transmission (and abort source)");
+  MESSAGE("start data transmission (and abort source)");
   hard_kill(src);
   expect((downstream_msg::batch), from(src).to(snk));
   expect((downstream_msg::batch), from(src).to(snk));
   expect((downstream_msg::batch), from(src).to(snk));
   expect((downstream_msg::batch), from(src).to(snk));
   expect((downstream_msg::forced_close), from(_).to(snk));
-  CAF_MESSAGE("verify that the sink called its finalizer once");
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk).state.fin_called, 1);
+  MESSAGE("verify that the sink called its finalizer once");
+  CHECK_EQ(deref<sum_up_actor>(snk).state.fin_called, 1);
 }
 
 CAF_TEST(depth_2_pipeline_error_at_sink) {
-  CAF_MESSAGE("streams must abort if a sink fails at runtime");
+  MESSAGE("streams must abort if a sink fails at runtime");
   auto src = sys.spawn(file_reader, 500u);
   auto snk = sys.spawn(sum_up);
-  CAF_MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(snk));
-  CAF_MESSAGE("initiate stream handshake");
+  MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(snk));
+  MESSAGE("initiate stream handshake");
   self->send(snk * src, "numbers.txt");
   expect((string), from(self).to(src).with("numbers.txt"));
   expect((open_stream_msg), from(self).to(snk));
-  CAF_MESSAGE("start data transmission (and abort sink)");
+  MESSAGE("start data transmission (and abort sink)");
   hard_kill(snk);
   expect((upstream_msg::ack_open), from(snk).to(src));
   expect((upstream_msg::forced_drop), from(_).to(src));
-  CAF_MESSAGE("verify that the source called its finalizer once");
-  CAF_CHECK_EQUAL(deref<file_reader_actor>(src).state.fin_called, 1);
+  MESSAGE("verify that the source called its finalizer once");
+  CHECK_EQ(deref<file_reader_actor>(src).state.fin_called, 1);
 }
 
 CAF_TEST(depth_3_pipeline_50_items) {
   auto src = sys.spawn(file_reader, 50u);
   auto stg = sys.spawn(filter);
   auto snk = sys.spawn(sum_up);
-  CAF_MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(stg) << CAF_ARG(snk));
-  CAF_MESSAGE("initiate stream handshake");
+  MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(stg) << CAF_ARG(snk));
+  MESSAGE("initiate stream handshake");
   self->send(snk * stg * src, "numbers.txt");
   expect((string), from(self).to(src).with("numbers.txt"));
   expect((open_stream_msg), from(self).to(stg));
   expect((open_stream_msg), from(self).to(snk));
   expect((upstream_msg::ack_open), from(snk).to(stg));
   expect((upstream_msg::ack_open), from(stg).to(src));
-  CAF_MESSAGE("start data transmission (a single batch)");
+  MESSAGE("start data transmission (a single batch)");
   expect((downstream_msg::batch), from(src).to(stg));
-  CAF_MESSAGE("the stage should delay its first batch since its underfull");
+  MESSAGE("the stage should delay its first batch since its underfull");
   disallow((downstream_msg::batch), from(stg).to(snk));
-  CAF_MESSAGE("after running the pipeline the sink received all batches");
+  MESSAGE("after running the pipeline the sink received all batches");
   run();
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk).state.x, 625);
-  CAF_CHECK_EQUAL(deref<file_reader_actor>(src).state.fin_called, 1);
-  CAF_CHECK_EQUAL(deref<filter_actor>(stg).state.fin_called, 1);
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk).state.fin_called, 1);
+  CHECK_EQ(deref<sum_up_actor>(snk).state.x, 625);
+  CHECK_EQ(deref<file_reader_actor>(src).state.fin_called, 1);
+  CHECK_EQ(deref<filter_actor>(stg).state.fin_called, 1);
+  CHECK_EQ(deref<sum_up_actor>(snk).state.fin_called, 1);
 }
 
 CAF_TEST(depth_4_pipeline_500_items) {
@@ -405,9 +405,9 @@ CAF_TEST(depth_4_pipeline_500_items) {
   auto stg1 = sys.spawn(filter);
   auto stg2 = sys.spawn(doubler);
   auto snk = sys.spawn(sum_up);
-  CAF_MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(stg1) << CAF_ARG(stg2)
-                            << CAF_ARG(snk));
-  CAF_MESSAGE("initiate stream handshake");
+  MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(stg1) << CAF_ARG(stg2)
+                        << CAF_ARG(snk));
+  MESSAGE("initiate stream handshake");
   self->send(snk * stg2 * stg1 * src, "numbers.txt");
   expect((string), from(self).to(src).with("numbers.txt"));
   expect((open_stream_msg), from(self).to(stg1));
@@ -416,59 +416,59 @@ CAF_TEST(depth_4_pipeline_500_items) {
   expect((upstream_msg::ack_open), from(snk).to(stg2));
   expect((upstream_msg::ack_open), from(stg2).to(stg1));
   expect((upstream_msg::ack_open), from(stg1).to(src));
-  CAF_MESSAGE("start data transmission");
+  MESSAGE("start data transmission");
   run();
-  CAF_MESSAGE("check sink result");
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk).state.x, 125000);
-  CAF_MESSAGE("verify that each actor called its finalizer once");
-  CAF_CHECK_EQUAL(deref<file_reader_actor>(src).state.fin_called, 1);
-  CAF_CHECK_EQUAL(deref<filter_actor>(stg1).state.fin_called, 1);
-  CAF_CHECK_EQUAL(deref<doubler_actor>(stg2).state.fin_called, 1);
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk).state.fin_called, 1);
+  MESSAGE("check sink result");
+  CHECK_EQ(deref<sum_up_actor>(snk).state.x, 125000);
+  MESSAGE("verify that each actor called its finalizer once");
+  CHECK_EQ(deref<file_reader_actor>(src).state.fin_called, 1);
+  CHECK_EQ(deref<filter_actor>(stg1).state.fin_called, 1);
+  CHECK_EQ(deref<doubler_actor>(stg2).state.fin_called, 1);
+  CHECK_EQ(deref<sum_up_actor>(snk).state.fin_called, 1);
 }
 
 CAF_TEST(depth_3_pipeline_graceful_shutdown) {
   auto src = sys.spawn(file_reader, 50u);
   auto stg = sys.spawn(filter);
   auto snk = sys.spawn(sum_up);
-  CAF_MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(stg) << CAF_ARG(snk));
-  CAF_MESSAGE("initiate stream handshake");
+  MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(stg) << CAF_ARG(snk));
+  MESSAGE("initiate stream handshake");
   self->send(snk * stg * src, "numbers.txt");
   expect((string), from(self).to(src).with("numbers.txt"));
   expect((open_stream_msg), from(self).to(stg));
   expect((open_stream_msg), from(self).to(snk));
   expect((upstream_msg::ack_open), from(snk).to(stg));
   expect((upstream_msg::ack_open), from(stg).to(src));
-  CAF_MESSAGE("start data transmission (a single batch) and stop the stage");
+  MESSAGE("start data transmission (a single batch) and stop the stage");
   anon_send_exit(stg, exit_reason::user_shutdown);
-  CAF_MESSAGE("expect the stage to still transfer pending items to the sink");
+  MESSAGE("expect the stage to still transfer pending items to the sink");
   run();
-  CAF_MESSAGE("check sink result");
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk).state.x, 625);
-  CAF_MESSAGE("verify that each actor called its finalizer once");
-  CAF_CHECK_EQUAL(deref<file_reader_actor>(src).state.fin_called, 1);
-  CAF_CHECK_EQUAL(deref<filter_actor>(stg).state.fin_called, 1);
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk).state.fin_called, 1);
+  MESSAGE("check sink result");
+  CHECK_EQ(deref<sum_up_actor>(snk).state.x, 625);
+  MESSAGE("verify that each actor called its finalizer once");
+  CHECK_EQ(deref<file_reader_actor>(src).state.fin_called, 1);
+  CHECK_EQ(deref<filter_actor>(stg).state.fin_called, 1);
+  CHECK_EQ(deref<sum_up_actor>(snk).state.fin_called, 1);
 }
 
 CAF_TEST(depth_3_pipeline_infinite_source) {
   auto src = sys.spawn(infinite_source);
   auto stg = sys.spawn(filter);
   auto snk = sys.spawn(sum_up);
-  CAF_MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(stg) << CAF_ARG(snk));
-  CAF_MESSAGE("initiate stream handshake");
+  MESSAGE(CAF_ARG(self) << CAF_ARG(src) << CAF_ARG(stg) << CAF_ARG(snk));
+  MESSAGE("initiate stream handshake");
   self->send(snk * stg * src, "numbers.txt");
   expect((string), from(self).to(src).with("numbers.txt"));
   expect((open_stream_msg), from(self).to(stg));
   expect((open_stream_msg), from(self).to(snk));
   expect((upstream_msg::ack_open), from(snk).to(stg));
   expect((upstream_msg::ack_open), from(stg).to(src));
-  CAF_MESSAGE("send exit to the source and expect the stream to terminate");
+  MESSAGE("send exit to the source and expect the stream to terminate");
   anon_send_exit(src, exit_reason::user_shutdown);
   run();
-  CAF_MESSAGE("verify that each actor called its finalizer once");
-  CAF_CHECK_EQUAL(deref<filter_actor>(stg).state.fin_called, 1);
-  CAF_CHECK_EQUAL(deref<sum_up_actor>(snk).state.fin_called, 1);
+  MESSAGE("verify that each actor called its finalizer once");
+  CHECK_EQ(deref<filter_actor>(stg).state.fin_called, 1);
+  CHECK_EQ(deref<sum_up_actor>(snk).state.fin_called, 1);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/policy/categorized.cpp
+++ b/libcaf_core/test/policy/categorized.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/policy/categorized.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include "caf/intrusive/drr_queue.hpp"
 #include "caf/intrusive/fifo_inbox.hpp"
@@ -28,8 +28,8 @@ using normal_queue = intrusive::drr_queue<policy::normal_messages>;
 
 using upstream_queue = intrusive::drr_queue<policy::upstream_messages>;
 
-using downstream_queue = intrusive::wdrr_dynamic_multiplexed_queue<
-  policy::downstream_messages>;
+using downstream_queue
+  = intrusive::wdrr_dynamic_multiplexed_queue<policy::downstream_messages>;
 
 struct mailbox_policy {
   using deficit_type = size_t;
@@ -38,9 +38,10 @@ struct mailbox_policy {
 
   using unique_pointer = mailbox_element_ptr;
 
-  using queue_type = intrusive::wdrr_fixed_multiplexed_queue<
-    policy::categorized, urgent_queue, normal_queue, upstream_queue,
-    downstream_queue>;
+  using queue_type
+    = intrusive::wdrr_fixed_multiplexed_queue<policy::categorized, urgent_queue,
+                                              normal_queue, upstream_queue,
+                                              downstream_queue>;
 };
 
 using mailbox_type = intrusive::fifo_inbox<mailbox_policy>;
@@ -51,8 +52,8 @@ struct consumer {
   std::vector<int> ints;
 
   template <class Key, class Queue>
-  intrusive::task_result operator()(const Key&, const Queue&,
-                                    const mailbox_element& x) {
+  intrusive::task_result
+  operator()(const Key&, const Queue&, const mailbox_element& x) {
     if (!x.content().match_elements<int>())
       CAF_FAIL("unexpected message: " << x.content());
     ints.emplace_back(x.content().get_as<int>(0));
@@ -68,17 +69,16 @@ struct consumer {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(categorized_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(priorities) {
   mailbox_type mbox{unit, unit, unit, unit, unit};
   mbox.push_back(make_mailbox_element(nullptr, make_message_id(), {}, 123));
-  mbox.push_back(make_mailbox_element(nullptr,
-                                      make_message_id(message_priority::high),
-                                      {}, 456));
+  mbox.push_back(make_mailbox_element(
+    nullptr, make_message_id(message_priority::high), {}, 456));
   consumer f;
   mbox.new_round(1000, f);
-  CAF_CHECK_EQUAL(f.ints, std::vector<int>({456, 123}));
+  CHECK_EQ(f.ints, std::vector<int>({456, 123}));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/policy/select_all.cpp
+++ b/libcaf_core/test/policy/select_all.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/policy/select_all.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include <tuple>
 
@@ -44,10 +44,10 @@ struct fixture : test_coordinator_fixture<> {
 
 #define SUBTEST(message)                                                       \
   run();                                                                       \
-  CAF_MESSAGE("subtest: " message);                                            \
+  MESSAGE("subtest: " message);                                                \
   for (int subtest_dummy = 0; subtest_dummy < 1; ++subtest_dummy)
 
-CAF_TEST_FIXTURE_SCOPE(select_all_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(select_all combines two integer results into one vector) {
   using int_list = std::vector<int>;
@@ -64,7 +64,7 @@ CAF_TEST(select_all combines two integer results into one vector) {
         self.ptr(),
         [](int_list results) {
           std::sort(results.begin(), results.end());
-          CAF_CHECK_EQUAL(results, int_list({3, 5}));
+          CHECK_EQ(results, int_list({3, 5}));
         },
         make_error_handler());
     }
@@ -79,8 +79,7 @@ CAF_TEST(select_all combines two integer results into one vector) {
         self.ptr(),
         [](results_vector results) {
           std::sort(results.begin(), results.end());
-          CAF_CHECK_EQUAL(results,
-                          results_vector({make_tuple(3), make_tuple(5)}));
+          CHECK_EQ(results, results_vector({make_tuple(3), make_tuple(5)}));
         },
         make_error_handler());
     }
@@ -100,8 +99,8 @@ CAF_TEST(select_all combines two integer results into one vector) {
     expect((int, int), from(client).to(server2).with(2, 3));
     expect((int), from(server1).to(client).with(3));
     expect((int), from(server2).to(client).with(5));
-    CAF_MESSAGE("request.then stores results in arrival order");
-    CAF_CHECK_EQUAL(results, int_list({3, 5}));
+    MESSAGE("request.then stores results in arrival order");
+    CHECK_EQ(results, int_list({3, 5}));
   }
   SUBTEST("request.await") {
     int_list results;
@@ -120,8 +119,8 @@ CAF_TEST(select_all combines two integer results into one vector) {
     // expect((int), from(server1).to(client).with(3));
     // expect((int), from(server2).to(client).with(5));
     run();
-    CAF_MESSAGE("request.await froces responses into reverse request order");
-    CAF_CHECK_EQUAL(results, int_list({5, 3}));
+    MESSAGE("request.await froces responses into reverse request order");
+    CHECK_EQ(results, int_list({5, 3}));
   }
 }
 
@@ -140,7 +139,7 @@ CAF_TEST(select_all calls the error handler at most once) {
       self.ptr(),
       [](int_list) { CAF_FAIL("fan-in policy called the result handler"); },
       make_counting_error_handler(&errors));
-    CAF_CHECK_EQUAL(errors, 1u);
+    CHECK_EQ(errors, 1u);
   }
   SUBTEST("request.then") {
     size_t errors = 0;
@@ -158,7 +157,7 @@ CAF_TEST(select_all calls the error handler at most once) {
     expect((int, int), from(client).to(server2).with(2, 3));
     expect((error), from(server1).to(client).with(sec::invalid_argument));
     expect((error), from(server2).to(client).with(sec::invalid_argument));
-    CAF_CHECK_EQUAL(errors, 1u);
+    CHECK_EQ(errors, 1u);
   }
   SUBTEST("request.await") {
     size_t errors = 0;
@@ -178,8 +177,8 @@ CAF_TEST(select_all calls the error handler at most once) {
     // expect((int), from(server1).to(client).with(3));
     // expect((int), from(server2).to(client).with(5));
     run();
-    CAF_CHECK_EQUAL(errors, 1u);
+    CHECK_EQ(errors, 1u);
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/policy/select_any.cpp
+++ b/libcaf_core/test/policy/select_any.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/policy/select_any.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include "caf/actor_system.hpp"
 #include "caf/event_based_actor.hpp"
@@ -42,10 +42,10 @@ struct fixture : test_coordinator_fixture<> {
 
 #define SUBTEST(message)                                                       \
   run();                                                                       \
-  CAF_MESSAGE("subtest: " message);                                            \
+  MESSAGE("subtest: " message);                                                \
   for (int subtest_dummy = 0; subtest_dummy < 1; ++subtest_dummy)
 
-CAF_TEST_FIXTURE_SCOPE(select_any_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(select_any picks the first arriving integer) {
   auto f = [](int x, int y) { return x + y; };
@@ -58,7 +58,7 @@ CAF_TEST(select_any picks the first arriving integer) {
       select_any<detail::type_list<int>> choose{{r1.id(), r2.id()}};
       run();
       choose.receive(
-        self.ptr(), [](int result) { CAF_CHECK_EQUAL(result, 3); },
+        self.ptr(), [](int result) { CHECK_EQ(result, 3); },
         make_error_handler());
     }
   }
@@ -76,8 +76,8 @@ CAF_TEST(select_any picks the first arriving integer) {
     expect((int, int), from(client).to(server2).with(2, 3));
     expect((int), from(server1).to(client).with(3));
     expect((int), from(server2).to(client).with(5));
-    CAF_MESSAGE("request.then picks the first arriving result");
-    CAF_CHECK_EQUAL(result, 3);
+    MESSAGE("request.then picks the first arriving result");
+    CHECK_EQ(result, 3);
   }
   SUBTEST("request.await") {
     int result = 0;
@@ -95,8 +95,8 @@ CAF_TEST(select_any picks the first arriving integer) {
     // expect((int), from(server1).to(client).with(3));
     // expect((int), from(server2).to(client).with(5));
     run();
-    CAF_MESSAGE("request.await froces responses into reverse request order");
-    CAF_CHECK_EQUAL(result, 5);
+    MESSAGE("request.await froces responses into reverse request order");
+    CHECK_EQ(result, 5);
   }
 }
 
@@ -114,7 +114,7 @@ CAF_TEST(select_any calls the error handler at most once) {
       self.ptr(),
       [](int) { CAF_FAIL("fan-in policy called the result handler"); },
       make_counting_error_handler(&errors));
-    CAF_CHECK_EQUAL(errors, 1u);
+    CHECK_EQ(errors, 1u);
   }
   SUBTEST("request.then") {
     size_t errors = 0;
@@ -132,7 +132,7 @@ CAF_TEST(select_any calls the error handler at most once) {
     expect((int, int), from(client).to(server2).with(2, 3));
     expect((error), from(server1).to(client).with(sec::invalid_argument));
     expect((error), from(server2).to(client).with(sec::invalid_argument));
-    CAF_CHECK_EQUAL(errors, 1u);
+    CHECK_EQ(errors, 1u);
   }
   SUBTEST("request.await") {
     size_t errors = 0;
@@ -152,8 +152,8 @@ CAF_TEST(select_any calls the error handler at most once) {
     // expect((int), from(server1).to(client).with(3));
     // expect((int), from(server2).to(client).with(5));
     run();
-    CAF_CHECK_EQUAL(errors, 1u);
+    CHECK_EQ(errors, 1u);
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/request_timeout.cpp
+++ b/libcaf_core/test/request_timeout.cpp
@@ -87,7 +87,7 @@ behavior ping_nested1(ping_actor* self, bool* had_timeout, const actor& buddy) {
     [=](timeout_atom) {
       self->state.had_first_timeout = true;
       self->become(after(milliseconds(100)) >> [=] {
-        CAF_CHECK(self->state.had_first_timeout);
+        CHECK(self->state.had_first_timeout);
         *had_timeout = true;
         self->quit();
       });
@@ -105,7 +105,7 @@ behavior ping_nested2(ping_actor* self, bool* had_timeout, const actor& buddy) {
       [=] {
         self->state.had_first_timeout = true;
         self->become(after(milliseconds(100)) >> [=] {
-          CAF_CHECK(self->state.had_first_timeout);
+          CHECK(self->state.had_first_timeout);
           *had_timeout = true;
           self->quit();
         });
@@ -129,7 +129,7 @@ behavior ping_nested3(ping_actor* self, bool* had_timeout, const actor& buddy) {
   return {
     after(milliseconds(100)) >>
       [=] {
-        CAF_CHECK(self->state.had_first_timeout);
+        CHECK(self->state.had_first_timeout);
         *had_timeout = true;
         self->quit();
       },
@@ -210,7 +210,7 @@ behavior ping_multiplexed3(ping_actor* self, bool* had_timeout,
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(request_timeout_tests, test_coordinator_fixture<>)
+BEGIN_FIXTURE_SCOPE(test_coordinator_fixture<>)
 
 CAF_TEST(single_timeout) {
   test_vec fs{{ping_single1, "ping_single1"},
@@ -218,7 +218,7 @@ CAF_TEST(single_timeout) {
               {ping_single3, "ping_single3"}};
   for (auto f : fs) {
     bool had_timeout = false;
-    CAF_MESSAGE("test implementation " << f.second);
+    MESSAGE("test implementation " << f.second);
     auto testee = sys.spawn(f.first, &had_timeout, sys.spawn<lazy_init>(pong));
     CAF_REQUIRE_EQUAL(sched.jobs.size(), 1u);
     CAF_REQUIRE_EQUAL(sched.next_job<local_actor>().name(), "ping"s);
@@ -229,8 +229,8 @@ CAF_TEST(single_timeout) {
     CAF_REQUIRE_EQUAL(sched.jobs.size(), 2u);
     // now, the timeout message is already dispatched, while pong did
     // not respond to the message yet, i.e., timeout arrives before response
-    CAF_CHECK_EQUAL(sched.run(), 2u);
-    CAF_CHECK(had_timeout);
+    CHECK_EQ(sched.run(), 2u);
+    CHECK(had_timeout);
   }
 }
 
@@ -240,7 +240,7 @@ CAF_TEST(nested_timeout) {
               {ping_nested3, "ping_nested3"}};
   for (auto f : fs) {
     bool had_timeout = false;
-    CAF_MESSAGE("test implementation " << f.second);
+    MESSAGE("test implementation " << f.second);
     auto testee = sys.spawn(f.first, &had_timeout, sys.spawn<lazy_init>(pong));
     CAF_REQUIRE_EQUAL(sched.jobs.size(), 1u);
     CAF_REQUIRE_EQUAL(sched.next_job<local_actor>().name(), "ping"s);
@@ -255,10 +255,10 @@ CAF_TEST(nested_timeout) {
     // dispatch second timeout
     CAF_REQUIRE_EQUAL(sched.trigger_timeout(), true);
     CAF_REQUIRE_EQUAL(sched.next_job<local_actor>().name(), "ping"s);
-    CAF_CHECK(!had_timeout);
-    CAF_CHECK(sched.next_job<ping_actor>().state.had_first_timeout);
+    CHECK(!had_timeout);
+    CHECK(sched.next_job<ping_actor>().state.had_first_timeout);
     sched.run();
-    CAF_CHECK(had_timeout);
+    CHECK(had_timeout);
   }
 }
 
@@ -268,7 +268,7 @@ CAF_TEST(multiplexed_timeout) {
               {ping_multiplexed3, "ping_multiplexed3"}};
   for (auto f : fs) {
     bool had_timeout = false;
-    CAF_MESSAGE("test implementation " << f.second);
+    MESSAGE("test implementation " << f.second);
     auto testee = sys.spawn(f.first, &had_timeout, sys.spawn<lazy_init>(pong));
     CAF_REQUIRE_EQUAL(sched.jobs.size(), 1u);
     CAF_REQUIRE_EQUAL(sched.next_job<local_actor>().name(), "ping"s);
@@ -280,8 +280,8 @@ CAF_TEST(multiplexed_timeout) {
     // now, the timeout message is already dispatched, while pong did
     // not respond to the message yet, i.e., timeout arrives before response
     sched.run();
-    CAF_CHECK(had_timeout);
+    CHECK(had_timeout);
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/response_promise.cpp
+++ b/libcaf_core/test/response_promise.cpp
@@ -94,7 +94,7 @@ behavior requester_v2(event_based_actor* self, actor worker) {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(response_promise_tests, test_coordinator_fixture<>)
+BEGIN_FIXTURE_SCOPE(test_coordinator_fixture<>)
 
 SCENARIO("response promises allow delaying of response messages") {
   auto adder_hdl = sys.spawn(adder);
@@ -169,4 +169,4 @@ SCENARIO("response promises allow delegation") {
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/result.cpp
+++ b/libcaf_core/test/result.cpp
@@ -6,27 +6,27 @@
 
 #include "core-test.hpp"
 
-#include "caf/sec.hpp"
 #include "caf/result.hpp"
+#include "caf/sec.hpp"
 
 using namespace std;
 using namespace caf;
 
 namespace {
 
-template<class T>
+template <class T>
 void test_unit_void() {
   auto x = result<T>{};
-  CAF_CHECK(holds_alternative<message>(x));
+  CHECK(holds_alternative<message>(x));
 }
 
-} // namespace anonymous
+} // namespace
 
 CAF_TEST(value) {
   auto x = result<int>{42};
   CAF_REQUIRE(holds_alternative<message>(x));
   if (auto view = make_typed_message_view<int>(get<message>(x)))
-    CAF_CHECK_EQUAL(get<0>(view), 42);
+    CHECK_EQ(get<0>(view), 42);
   else
     CAF_FAIL("unexpected types in result message");
 }
@@ -35,7 +35,7 @@ CAF_TEST(expected) {
   auto x = result<int>{expected<int>{42}};
   CAF_REQUIRE(holds_alternative<message>(x));
   if (auto view = make_typed_message_view<int>(get<message>(x)))
-    CAF_CHECK_EQUAL(get<0>(view), 42);
+    CHECK_EQ(get<0>(view), 42);
   else
     CAF_FAIL("unexpected types in result message");
 }

--- a/libcaf_core/test/save_inspector.cpp
+++ b/libcaf_core/test/save_inspector.cpp
@@ -270,12 +270,12 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(load_inspector_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(save inspectors can visit C arrays) {
   int32_t xs[] = {1, 2, 3};
-  CAF_CHECK_EQUAL(detail::save(f, xs), true);
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK_EQ(detail::save(f, xs), true);
+  CHECK_EQ(f.log, R"_(
 begin tuple of size 3
   int32_t value
   int32_t value
@@ -285,11 +285,11 @@ end tuple)_");
 
 CAF_TEST(save inspectors can visit simple POD types) {
   point_3d p{1, 1, 1};
-  CAF_CHECK_EQUAL(inspect(f, p), true);
-  CAF_CHECK_EQUAL(p.x, 1);
-  CAF_CHECK_EQUAL(p.y, 1);
-  CAF_CHECK_EQUAL(p.z, 1);
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK_EQ(inspect(f, p), true);
+  CHECK_EQ(p.x, 1);
+  CHECK_EQ(p.y, 1);
+  CHECK_EQ(p.z, 1);
+  CHECK_EQ(f.log, R"_(
 begin object point_3d
   begin field x
     int32_t value
@@ -306,8 +306,8 @@ end object)_");
 CAF_TEST(save inspectors can visit node IDs) {
   auto tmp = make_node_id(42, "0102030405060708090A0B0C0D0E0F1011121314");
   auto hash_based_id = unbox(tmp);
-  CAF_CHECK_EQUAL(inspect(f, hash_based_id), true);
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK_EQ(inspect(f, hash_based_id), true);
+  CHECK_EQ(f.log, R"_(
 begin object caf::node_id
   begin optional variant field data
     begin object caf::hashed_node_id
@@ -345,14 +345,14 @@ end object)_");
 
 CAF_TEST(save inspectors recurse into members) {
   line l{point_3d{1, 1, 1}, point_3d{1, 1, 1}};
-  CAF_CHECK_EQUAL(inspect(f, l), true);
-  CAF_CHECK_EQUAL(l.p1.x, 1);
-  CAF_CHECK_EQUAL(l.p1.y, 1);
-  CAF_CHECK_EQUAL(l.p1.z, 1);
-  CAF_CHECK_EQUAL(l.p2.x, 1);
-  CAF_CHECK_EQUAL(l.p2.y, 1);
-  CAF_CHECK_EQUAL(l.p2.z, 1);
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK_EQ(inspect(f, l), true);
+  CHECK_EQ(l.p1.x, 1);
+  CHECK_EQ(l.p1.y, 1);
+  CHECK_EQ(l.p1.z, 1);
+  CHECK_EQ(l.p2.x, 1);
+  CHECK_EQ(l.p2.y, 1);
+  CHECK_EQ(l.p2.z, 1);
+  CHECK_EQ(f.log, R"_(
 begin object line
   begin field p1
     begin object point_3d
@@ -384,13 +384,13 @@ end object)_");
 }
 
 CAF_TEST(save inspectors support fields with fallbacks and invariants) {
-  CAF_MESSAGE("save inspectors suppress fields with their default value");
+  MESSAGE("save inspectors suppress fields with their default value");
   {
     duration d{"seconds", 12.0};
-    CAF_CHECK_EQUAL(inspect(f, d), true);
-    CAF_CHECK_EQUAL(d.unit, "seconds");
-    CAF_CHECK_EQUAL(d.count, 12.0);
-    CAF_CHECK_EQUAL(f.log, R"_(
+    CHECK_EQ(inspect(f, d), true);
+    CHECK_EQ(d.unit, "seconds");
+    CHECK_EQ(d.count, 12.0);
+    CHECK_EQ(f.log, R"_(
 begin object duration
   begin optional field unit
   end field
@@ -400,13 +400,13 @@ begin object duration
 end object)_");
   }
   f.log.clear();
-  CAF_MESSAGE("save inspectors include fields with non-default value");
+  MESSAGE("save inspectors include fields with non-default value");
   {
     duration d{"minutes", 42.0};
-    CAF_CHECK_EQUAL(inspect(f, d), true);
-    CAF_CHECK_EQUAL(d.unit, "minutes");
-    CAF_CHECK_EQUAL(d.count, 42.0);
-    CAF_CHECK_EQUAL(f.log, R"_(
+    CHECK_EQ(inspect(f, d), true);
+    CHECK_EQ(d.unit, "minutes");
+    CHECK_EQ(d.count, 42.0);
+    CHECK_EQ(f.log, R"_(
 begin object duration
   begin optional field unit
     std::string value
@@ -420,8 +420,8 @@ end object)_");
 
 CAF_TEST(save inspectors support optional) {
   optional<int32_t> x;
-  CAF_CHECK_EQUAL(f.apply(x), true);
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK_EQ(f.apply(x), true);
+  CHECK_EQ(f.log, R"_(
 begin object anonymous
   begin optional field value
   end field
@@ -430,8 +430,8 @@ end object)_");
 
 CAF_TEST(save inspectors support fields with optional values) {
   person p1{"Eduard Example", none};
-  CAF_CHECK_EQUAL(inspect(f, p1), true);
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK_EQ(inspect(f, p1), true);
+  CHECK_EQ(f.log, R"_(
 begin object person
   begin field name
     std::string value
@@ -441,8 +441,8 @@ begin object person
 end object)_");
   f.log.clear();
   person p2{"Bruce Almighty", std::string{"776-2323"}};
-  CAF_CHECK_EQUAL(inspect(f, p2), true);
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK_EQ(inspect(f, p2), true);
+  CHECK_EQ(f.log, R"_(
 begin object person
   begin field name
     std::string value
@@ -457,10 +457,10 @@ CAF_TEST(save inspectors support fields with getters and setters) {
   foobar fb;
   fb.foo("hello");
   fb.bar("world");
-  CAF_CHECK(inspect(f, fb));
-  CAF_CHECK_EQUAL(fb.foo(), "hello");
-  CAF_CHECK_EQUAL(fb.bar(), "world");
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK(inspect(f, fb));
+  CHECK_EQ(fb.foo(), "hello");
+  CHECK_EQ(fb.bar(), "world");
+  CHECK_EQ(f.log, R"_(
 begin object foobar
   begin field foo
     std::string value
@@ -473,9 +473,9 @@ end object)_");
 
 CAF_TEST(save inspectors support nasty data structures) {
   nasty x;
-  CAF_CHECK(inspect(f, x));
-  CAF_CHECK_EQUAL(f.get_error(), error{});
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK(inspect(f, x));
+  CHECK_EQ(f.get_error(), error{});
+  CHECK_EQ(f.log, R"_(
 begin object nasty
   begin field field_01
     int32_t value
@@ -587,8 +587,8 @@ CAF_TEST(save inspectors support all basic STL types) {
   v8_2.emplace_back("foo", array_3i{{0, 0, 0}});
   x.v8.emplace_back(std::move(v8_1));
   x.v8.emplace_back(std::move(v8_2));
-  CAF_CHECK(inspect(f, x));
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK(inspect(f, x));
+  CHECK_EQ(f.log, R"_(
 begin object basics
   begin field v1
     begin object anonymous
@@ -688,9 +688,9 @@ end object)_");
 
 CAF_TEST(save inspectors support messages) {
   auto x = make_message(1, "two", 3.0);
-  CAF_MESSAGE("for machine-to-machine formats, messages prefix their types");
-  CAF_CHECK(inspect(f, x));
-  CAF_CHECK_EQUAL(f.log, R"_(
+  MESSAGE("for machine-to-machine formats, messages prefix their types");
+  CHECK(inspect(f, x));
+  CHECK_EQ(f.log, R"_(
 begin object message
   begin field types
     begin sequence of size 3
@@ -707,11 +707,11 @@ begin object message
     end tuple
   end field
 end object)_");
-  CAF_MESSAGE("for human-readable formats, messages inline type annotations");
+  MESSAGE("for human-readable formats, messages inline type annotations");
   f.log.clear();
   f.set_has_human_readable_format(true);
-  CAF_CHECK(inspect(f, x));
-  CAF_CHECK_EQUAL(f.log, R"_(
+  CHECK(inspect(f, x));
+  CHECK_EQ(f.log, R"_(
 begin sequence of size 3
   int32_t value
   std::string value
@@ -813,4 +813,4 @@ end object)_";
 
 #endif
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/scheduled_actor.cpp
+++ b/libcaf_core/test/scheduled_actor.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/scheduled_actor.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 using namespace caf;
 

--- a/libcaf_core/test/serial_reply.cpp
+++ b/libcaf_core/test/serial_reply.cpp
@@ -22,7 +22,7 @@ CAF_TEST(test_serial_reply) {
     };
   };
   auto master = system.spawn([=](event_based_actor* self) -> behavior {
-    CAF_MESSAGE("ID of master: " << self->id());
+    MESSAGE("ID of master: " << self->id());
     // spawn 5 mirror actors
     auto c0 = self->spawn<linked>(mirror_behavior);
     auto c1 = self->spawn<linked>(mirror_behavior);
@@ -32,20 +32,20 @@ CAF_TEST(test_serial_reply) {
     return {
       [=](hi_atom) mutable {
         auto rp = self->make_response_promise();
-        CAF_MESSAGE("received 'hi there'");
+        MESSAGE("received 'hi there'");
         self->request(c0, infinite, sub0_atom_v).then([=](sub0_atom) mutable {
-          CAF_MESSAGE("received 'sub0'");
+          MESSAGE("received 'sub0'");
           self->request(c1, infinite, sub1_atom_v).then([=](sub1_atom) mutable {
-            CAF_MESSAGE("received 'sub1'");
+            MESSAGE("received 'sub1'");
             self->request(c2, infinite, sub2_atom_v)
               .then([=](sub2_atom) mutable {
-                CAF_MESSAGE("received 'sub2'");
+                MESSAGE("received 'sub2'");
                 self->request(c3, infinite, sub3_atom_v)
                   .then([=](sub3_atom) mutable {
-                    CAF_MESSAGE("received 'sub3'");
+                    MESSAGE("received 'sub3'");
                     self->request(c4, infinite, sub4_atom_v)
                       .then([=](sub4_atom) mutable {
-                        CAF_MESSAGE("received 'sub4'");
+                        MESSAGE("received 'sub4'");
                         rp.deliver(ho_atom_v);
                       });
                   });
@@ -56,9 +56,9 @@ CAF_TEST(test_serial_reply) {
     };
   });
   scoped_actor self{system};
-  CAF_MESSAGE("ID of main: " << self->id());
+  MESSAGE("ID of main: " << self->id());
   self->request(master, infinite, hi_atom_v)
-    .receive([](ho_atom) { CAF_MESSAGE("received 'ho'"); },
+    .receive([](ho_atom) { MESSAGE("received 'ho'"); },
              [&](const error& err) { CAF_ERROR("Error: " << err); });
   CAF_REQUIRE(self->mailbox().empty());
 }

--- a/libcaf_core/test/serialization.cpp
+++ b/libcaf_core/test/serialization.cpp
@@ -196,8 +196,8 @@ struct fixture : test_coordinator_fixture<> {
     if (enable_json) {
       auto r2 = T{};
       deserialize_json(serialize_json(x), r2);
-      if (!CAF_CHECK_EQUAL(r1, r2))
-        CAF_MESSAGE("generated JSON: " << serialize_json(x));
+      if (!CHECK_EQ(r1, r2))
+        MESSAGE("generated JSON: " << serialize_json(x));
     }
     return r1;
   }
@@ -209,8 +209,8 @@ struct fixture : test_coordinator_fixture<> {
     message result;
     auto tmp = make_message(x);
     auto buf = serialize(tmp);
-    CAF_MESSAGE("serialized " << to_string(tmp) << " into " << buf.size()
-                              << " bytes");
+    MESSAGE("serialized " << to_string(tmp) << " into " << buf.size()
+                          << " bytes");
     deserialize(buf, result);
     if (!result.match_elements<T>())
       CAF_FAIL("expected: " << x << ", got: " << result);
@@ -252,27 +252,27 @@ struct is_message {
 
 #define CHECK_RT(val)                                                          \
   do {                                                                         \
-    CAF_MESSAGE(#val);                                                         \
-    CAF_CHECK_EQUAL(val, roundtrip(val));                                      \
+    MESSAGE(#val);                                                             \
+    CHECK_EQ(val, roundtrip(val));                                             \
   } while (false)
 
 #define CHECK_PRED_RT(pred, value)                                             \
   do {                                                                         \
-    CAF_MESSAGE(#pred "(" #value ")");                                         \
-    CAF_CHECK(pred(roundtrip(value, false)));                                  \
+    MESSAGE(#pred "(" #value ")");                                             \
+    CHECK(pred(roundtrip(value, false)));                                      \
   } while (false)
 
 #define CHECK_SIGN_RT(value)                                                   \
-  CAF_CHECK_EQUAL(std::signbit(roundtrip(value, false)), std::signbit(value))
+  CHECK_EQ(std::signbit(roundtrip(value, false)), std::signbit(value))
 
-#define CHECK_MSG_RT(val) CAF_CHECK_EQUAL(val, msg_roundtrip(val))
+#define CHECK_MSG_RT(val) CHECK_EQ(val, msg_roundtrip(val))
 
-#define CHECK_PRED_MSG_RT(pred, value) CAF_CHECK(pred(msg_roundtrip(value)))
+#define CHECK_PRED_MSG_RT(pred, value) CHECK(pred(msg_roundtrip(value)))
 
 #define CHECK_SIGN_MSG_RT(value)                                               \
-  CAF_CHECK_EQUAL(std::signbit(msg_roundtrip(value)), std::signbit(value))
+  CHECK_EQ(std::signbit(msg_roundtrip(value)), std::signbit(value))
 
-CAF_TEST_FIXTURE_SCOPE(serialization_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(serializing and then deserializing produces the same value) {
   CHECK_RT(i32);
@@ -321,7 +321,7 @@ CAF_TEST(raw_arrays) {
   int x[3];
   deserialize(buf, x);
   for (auto i = 0; i < 3; ++i)
-    CAF_CHECK_EQUAL(ra[i], x[i]);
+    CHECK_EQ(ra[i], x[i]);
 }
 
 CAF_TEST(arrays) {
@@ -329,10 +329,10 @@ CAF_TEST(arrays) {
   test_array x;
   deserialize(buf, x);
   for (auto i = 0; i < 4; ++i)
-    CAF_CHECK_EQUAL(ta.value[i], x.value[i]);
+    CHECK_EQ(ta.value[i], x.value[i]);
   for (auto i = 0; i < 2; ++i)
     for (auto j = 0; j < 4; ++j)
-      CAF_CHECK_EQUAL(ta.value2[i][j], x.value2[i][j]);
+      CHECK_EQ(ta.value2[i][j], x.value2[i][j]);
 }
 
 CAF_TEST(empty_non_pods) {
@@ -360,16 +360,16 @@ CAF_TEST(messages) {
   message x;
   auto buf1 = serialize(msg);
   deserialize(buf1, x);
-  CAF_CHECK_EQUAL(to_string(msg), to_string(x));
-  CAF_CHECK(is_message(x).equal(i32, i64, ts, te, str, rs));
+  CHECK_EQ(to_string(msg), to_string(x));
+  CHECK(is_message(x).equal(i32, i64, ts, te, str, rs));
   // serialize fully dynamic message again (do another roundtrip)
   message y;
   auto buf2 = serialize(x);
-  CAF_CHECK_EQUAL(buf1, buf2);
+  CHECK_EQ(buf1, buf2);
   deserialize(buf2, y);
-  CAF_CHECK_EQUAL(to_string(msg), to_string(y));
-  CAF_CHECK(is_message(y).equal(i32, i64, ts, te, str, rs));
-  CAF_CHECK_EQUAL(to_string(recursive), to_string(roundtrip(recursive, false)));
+  CHECK_EQ(to_string(msg), to_string(y));
+  CHECK(is_message(y).equal(i32, i64, ts, te, str, rs));
+  CHECK_EQ(to_string(recursive), to_string(roundtrip(recursive, false)));
 }
 
 CAF_TEST(multiple_messages) {
@@ -379,43 +379,43 @@ CAF_TEST(multiple_messages) {
   message m1;
   message m2;
   deserialize(buf, t, m1, m2);
-  CAF_CHECK_EQUAL(std::make_tuple(t, to_string(m1), to_string(m2)),
-                  std::make_tuple(te, to_string(m), to_string(msg)));
-  CAF_CHECK(is_message(m1).equal(rs, te));
-  CAF_CHECK(is_message(m2).equal(i32, i64, ts, te, str, rs));
+  CHECK_EQ(std::make_tuple(t, to_string(m1), to_string(m2)),
+           std::make_tuple(te, to_string(m), to_string(msg)));
+  CHECK(is_message(m1).equal(rs, te));
+  CHECK(is_message(m2).equal(i32, i64, ts, te, str, rs));
 }
 
 CAF_TEST(long_sequences) {
   byte_buffer data;
   binary_serializer sink{nullptr, data};
   size_t n = std::numeric_limits<uint32_t>::max();
-  CAF_CHECK(sink.begin_sequence(n));
-  CAF_CHECK(sink.end_sequence());
+  CHECK(sink.begin_sequence(n));
+  CHECK(sink.end_sequence());
   binary_deserializer source{nullptr, data};
   size_t m = 0;
-  CAF_CHECK(source.begin_sequence(m));
-  CAF_CHECK(source.end_sequence());
-  CAF_CHECK_EQUAL(n, m);
+  CHECK(source.begin_sequence(m));
+  CHECK(source.end_sequence());
+  CHECK_EQ(n, m);
 }
 
 CAF_TEST(non_empty_vector) {
-  CAF_MESSAGE("deserializing into a non-empty vector overrides any content");
+  MESSAGE("deserializing into a non-empty vector overrides any content");
   std::vector<int> foo{1, 2, 3};
   std::vector<int> bar{0};
   auto buf = serialize(foo);
   deserialize(buf, bar);
-  CAF_CHECK_EQUAL(foo, bar);
+  CHECK_EQ(foo, bar);
 }
 
 CAF_TEST(variant_with_tree_types) {
-  CAF_MESSAGE("deserializing into a non-empty vector overrides any content");
+  MESSAGE("deserializing into a non-empty vector overrides any content");
   using test_variant = variant<int, double, std::string>;
   test_variant x{42};
-  CAF_CHECK_EQUAL(x, roundtrip(x, false));
+  CHECK_EQ(x, roundtrip(x, false));
   x = 12.34;
-  CAF_CHECK_EQUAL(x, roundtrip(x, false));
+  CHECK_EQ(x, roundtrip(x, false));
   x = std::string{"foobar"};
-  CAF_CHECK_EQUAL(x, roundtrip(x, false));
+  CHECK_EQ(x, roundtrip(x, false));
 }
 
 // -- our vector<bool> serialization packs into an uint64_t. Hence, the
@@ -423,30 +423,30 @@ CAF_TEST(variant_with_tree_types) {
 
 CAF_TEST(bool_vector_size_0) {
   std::vector<bool> xs;
-  CAF_CHECK_EQUAL(deep_to_string(xs), "[]");
-  CAF_CHECK_EQUAL(xs, roundtrip(xs));
-  CAF_CHECK_EQUAL(xs, msg_roundtrip(xs));
+  CHECK_EQ(deep_to_string(xs), "[]");
+  CHECK_EQ(xs, roundtrip(xs));
+  CHECK_EQ(xs, msg_roundtrip(xs));
 }
 
 CAF_TEST(bool_vector_size_1) {
   std::vector<bool> xs{true};
-  CAF_CHECK_EQUAL(deep_to_string(xs), "[true]");
-  CAF_CHECK_EQUAL(xs, roundtrip(xs));
-  CAF_CHECK_EQUAL(xs, msg_roundtrip(xs));
+  CHECK_EQ(deep_to_string(xs), "[true]");
+  CHECK_EQ(xs, roundtrip(xs));
+  CHECK_EQ(xs, msg_roundtrip(xs));
 }
 
 CAF_TEST(bool_vector_size_2) {
   std::vector<bool> xs{true, true};
-  CAF_CHECK_EQUAL(deep_to_string(xs), "[true, true]");
-  CAF_CHECK_EQUAL(xs, roundtrip(xs));
-  CAF_CHECK_EQUAL(xs, msg_roundtrip(xs));
+  CHECK_EQ(deep_to_string(xs), "[true, true]");
+  CHECK_EQ(xs, roundtrip(xs));
+  CHECK_EQ(xs, msg_roundtrip(xs));
 }
 
 CAF_TEST(bool_vector_size_63) {
   std::vector<bool> xs;
   for (int i = 0; i < 63; ++i)
     xs.push_back(i % 3 == 0);
-  CAF_CHECK_EQUAL(
+  CHECK_EQ(
     deep_to_string(xs),
     "[true, false, false, true, false, false, true, false, false, true, false, "
     "false, true, false, false, true, false, false, true, false, false, true, "
@@ -454,32 +454,32 @@ CAF_TEST(bool_vector_size_63) {
     "true, false, false, true, false, false, true, false, false, true, false, "
     "false, true, false, false, true, false, false, true, false, false, true, "
     "false, false, true, false, false, true, false, false]");
-  CAF_CHECK_EQUAL(xs, roundtrip(xs));
-  CAF_CHECK_EQUAL(xs, msg_roundtrip(xs));
+  CHECK_EQ(xs, roundtrip(xs));
+  CHECK_EQ(xs, msg_roundtrip(xs));
 }
 
 CAF_TEST(bool_vector_size_64) {
   std::vector<bool> xs;
   for (int i = 0; i < 64; ++i)
     xs.push_back(i % 5 == 0);
-  CAF_CHECK_EQUAL(deep_to_string(xs),
-                  "[true, false, false, false, false, true, false, false, "
-                  "false, false, true, false, false, false, false, true, "
-                  "false, false, false, false, true, false, false, false, "
-                  "false, true, false, false, false, false, true, false, "
-                  "false, false, false, true, false, false, false, false, "
-                  "true, false, false, false, false, true, false, false, "
-                  "false, false, true, false, false, false, false, true, "
-                  "false, false, false, false, true, false, false, false]");
-  CAF_CHECK_EQUAL(xs, roundtrip(xs));
-  CAF_CHECK_EQUAL(xs, msg_roundtrip(xs));
+  CHECK_EQ(deep_to_string(xs),
+           "[true, false, false, false, false, true, false, false, "
+           "false, false, true, false, false, false, false, true, "
+           "false, false, false, false, true, false, false, false, "
+           "false, true, false, false, false, false, true, false, "
+           "false, false, false, true, false, false, false, false, "
+           "true, false, false, false, false, true, false, false, "
+           "false, false, true, false, false, false, false, true, "
+           "false, false, false, false, true, false, false, false]");
+  CHECK_EQ(xs, roundtrip(xs));
+  CHECK_EQ(xs, msg_roundtrip(xs));
 }
 
 CAF_TEST(bool_vector_size_65) {
   std::vector<bool> xs;
   for (int i = 0; i < 65; ++i)
     xs.push_back(!(i % 7 == 0));
-  CAF_CHECK_EQUAL(
+  CHECK_EQ(
     deep_to_string(xs),
     "[false, true, true, true, true, true, true, false, true, true, true, "
     "true, true, true, false, true, true, true, true, true, true, false, true, "
@@ -487,8 +487,8 @@ CAF_TEST(bool_vector_size_65) {
     "false, true, true, true, true, true, true, false, true, true, true, true, "
     "true, true, false, true, true, true, true, true, true, false, true, true, "
     "true, true, true, true, false, true]");
-  CAF_CHECK_EQUAL(xs, roundtrip(xs));
-  CAF_CHECK_EQUAL(xs, msg_roundtrip(xs));
+  CHECK_EQ(xs, roundtrip(xs));
+  CHECK_EQ(xs, msg_roundtrip(xs));
 }
 
 CAF_TEST(serializers handle actor handles) {
@@ -497,12 +497,12 @@ CAF_TEST(serializers handle actor handles) {
       [](int i) { return i; },
     };
   });
-  CAF_CHECK_EQUAL(dummy, roundtrip(dummy, false));
-  CAF_CHECK_EQUAL(dummy, msg_roundtrip(dummy));
+  CHECK_EQ(dummy, roundtrip(dummy, false));
+  CHECK_EQ(dummy, msg_roundtrip(dummy));
   std::vector<strong_actor_ptr> wrapped{actor_cast<strong_actor_ptr>(dummy)};
-  CAF_CHECK_EQUAL(wrapped, roundtrip(wrapped, false));
-  CAF_CHECK_EQUAL(wrapped, msg_roundtrip(wrapped));
+  CHECK_EQ(wrapped, roundtrip(wrapped, false));
+  CHECK_EQ(wrapped, msg_roundtrip(wrapped));
   anon_send_exit(dummy, exit_reason::user_shutdown);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/settings.cpp
+++ b/libcaf_core/test/settings.cpp
@@ -77,84 +77,83 @@ bool inspect(Inspector& f, foobar& x) {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(settings_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(put) {
   put(x, "foo", "bar");
   put(x, "logger.console", "none");
   put(x, "one.two.three", "four");
-  CAF_CHECK_EQUAL(x.size(), 3u);
-  CAF_CHECK(x.contains("foo"));
-  CAF_CHECK(x.contains("logger"));
-  CAF_CHECK(x.contains("one"));
-  CAF_CHECK_EQUAL(unpack(x, "foo"), config_value{"bar"s});
-  CAF_CHECK_EQUAL(unpack(x, "logger", "console"), config_value{"none"s});
-  CAF_CHECK_EQUAL(unpack(x, "one", "two", "three"), config_value{"four"s});
+  CHECK_EQ(x.size(), 3u);
+  CHECK(x.contains("foo"));
+  CHECK(x.contains("logger"));
+  CHECK(x.contains("one"));
+  CHECK_EQ(unpack(x, "foo"), config_value{"bar"s});
+  CHECK_EQ(unpack(x, "logger", "console"), config_value{"none"s});
+  CHECK_EQ(unpack(x, "one", "two", "three"), config_value{"four"s});
   put(x, "logger.console", "trace");
-  CAF_CHECK_EQUAL(unpack(x, "logger", "console"), config_value{"trace"s});
+  CHECK_EQ(unpack(x, "logger", "console"), config_value{"trace"s});
 }
 
 CAF_TEST(put missing) {
   put_missing(x, "foo", "bar");
   put_missing(x, "logger.console", "none");
   put_missing(x, "one.two.three", "four");
-  CAF_CHECK_EQUAL(x.size(), 3u);
-  CAF_CHECK(x.contains("foo"));
-  CAF_CHECK(x.contains("logger"));
-  CAF_CHECK(x.contains("one"));
-  CAF_CHECK_EQUAL(unpack(x, "foo"), config_value{"bar"s});
-  CAF_CHECK_EQUAL(unpack(x, "logger", "console"), config_value{"none"s});
-  CAF_CHECK_EQUAL(unpack(x, "one", "two", "three"), config_value{"four"s});
+  CHECK_EQ(x.size(), 3u);
+  CHECK(x.contains("foo"));
+  CHECK(x.contains("logger"));
+  CHECK(x.contains("one"));
+  CHECK_EQ(unpack(x, "foo"), config_value{"bar"s});
+  CHECK_EQ(unpack(x, "logger", "console"), config_value{"none"s});
+  CHECK_EQ(unpack(x, "one", "two", "three"), config_value{"four"s});
   put_missing(x, "logger.console", "trace");
-  CAF_CHECK_EQUAL(unpack(x, "logger", "console"), config_value{"none"s});
+  CHECK_EQ(unpack(x, "logger", "console"), config_value{"none"s});
 }
 
 CAF_TEST(put list) {
   put_list(x, "integers").emplace_back(42);
-  CAF_CHECK(x.contains("integers"));
-  CAF_CHECK_EQUAL(unpack(x, "integers"), make_config_value_list(42));
+  CHECK(x.contains("integers"));
+  CHECK_EQ(unpack(x, "integers"), make_config_value_list(42));
   put_list(x, "foo.bar").emplace_back("str");
-  CAF_CHECK_EQUAL(unpack(x, "foo", "bar"), make_config_value_list("str"));
+  CHECK_EQ(unpack(x, "foo", "bar"), make_config_value_list("str"));
   put_list(x, "one.two.three").emplace_back(4);
-  CAF_CHECK_EQUAL(unpack(x, "one", "two", "three"), make_config_value_list(4));
+  CHECK_EQ(unpack(x, "one", "two", "three"), make_config_value_list(4));
 }
 
 CAF_TEST(put dictionary) {
   put_dictionary(x, "logger").emplace("console", "none");
-  CAF_CHECK(x.contains("logger"));
-  CAF_CHECK_EQUAL(unpack(x, "logger", "console"), config_value{"none"s});
+  CHECK(x.contains("logger"));
+  CHECK_EQ(unpack(x, "logger", "console"), config_value{"none"s});
   put_dictionary(x, "foo.bar").emplace("value", 42);
-  CAF_CHECK_EQUAL(unpack(x, "foo", "bar", "value"), config_value{42});
+  CHECK_EQ(unpack(x, "foo", "bar", "value"), config_value{42});
   put_dictionary(x, "one.two.three").emplace("four", "five");
-  CAF_CHECK_EQUAL(unpack(x, "one", "two", "three", "four"),
-                  config_value{"five"s});
+  CHECK_EQ(unpack(x, "one", "two", "three", "four"), config_value{"five"s});
 }
 
 CAF_TEST(get and get_if) {
   fill();
-  CAF_CHECK(get_if(&x, "hello") != nullptr);
-  CAF_CHECK(get<std::string>(x, "hello") == "world"s);
-  CAF_CHECK(get_if(&x, "logger.console") != nullptr);
-  CAF_CHECK(get_if<std::string>(&x, "logger.console") != nullptr);
-  CAF_CHECK(get<std::string>(x, "logger.console") == "none"s);
-  CAF_CHECK(get_if(&x, "one.two.three") != nullptr);
-  CAF_CHECK(get_if<std::string>(&x, "one.two.three") == nullptr);
-  if (CAF_CHECK(get_if<int64_t>(&x, "one.two.three") != nullptr))
-    CAF_CHECK(get<int64_t>(x, "one.two.three") == 4);
+  CHECK(get_if(&x, "hello") != nullptr);
+  CHECK(get<std::string>(x, "hello") == "world"s);
+  CHECK(get_if(&x, "logger.console") != nullptr);
+  CHECK(get_if<std::string>(&x, "logger.console") != nullptr);
+  CHECK(get<std::string>(x, "logger.console") == "none"s);
+  CHECK(get_if(&x, "one.two.three") != nullptr);
+  CHECK(get_if<std::string>(&x, "one.two.three") == nullptr);
+  if (CHECK(get_if<int64_t>(&x, "one.two.three") != nullptr))
+    CHECK(get<int64_t>(x, "one.two.three") == 4);
 }
 
 CAF_TEST(get_or) {
   fill();
-  CAF_CHECK_EQUAL(get_or(x, "hello", "nobody"), "world"s);
-  CAF_CHECK_EQUAL(get_or(x, "goodbye", "nobody"), "nobody"s);
+  CHECK_EQ(get_or(x, "hello", "nobody"), "world"s);
+  CHECK_EQ(get_or(x, "goodbye", "nobody"), "nobody"s);
 }
 
 CAF_TEST(custom type) {
   put(x, "my-value.foo", 42);
   put(x, "my-value.bar", 24);
-  if (auto fb = get_as<foobar>(x, "my-value"); CAF_CHECK(fb)) {
-    CAF_CHECK_EQUAL(fb->foo, 42);
-    CAF_CHECK_EQUAL(fb->bar, 24);
+  if (auto fb = get_as<foobar>(x, "my-value"); CHECK(fb)) {
+    CHECK_EQ(fb->foo, 42);
+    CHECK_EQ(fb->bar, 24);
   }
 }
 
@@ -167,9 +166,9 @@ CAF_TEST(read_config accepts the to_string output of settings) {
   string_view str_view = str;
   string_parser_state res{str_view.begin(), str_view.end()};
   detail::parser::read_config(res, consumer);
-  CAF_CHECK(res.i == res.e);
-  CAF_CHECK_EQUAL(res.code, pec::success);
-  CAF_CHECK_EQUAL(x, y);
+  CHECK(res.i == res.e);
+  CHECK_EQ(res.code, pec::success);
+  CHECK_EQ(x, y);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/simple_timeout.cpp
+++ b/libcaf_core/test/simple_timeout.cpp
@@ -29,12 +29,12 @@ timer::behavior_type timer_impl(timer::stateful_pointer<timer_state> self) {
   self->delayed_send(self, ms(100), reset_atom_v);
   return {
     [=](reset_atom) {
-      CAF_MESSAGE("timer reset");
+      MESSAGE("timer reset");
       self->state.had_reset = true;
     },
     after(ms(600)) >>
       [=] {
-        CAF_MESSAGE("timer expired");
+        MESSAGE("timer expired");
         CAF_REQUIRE(self->state.had_reset);
         self->quit();
       },
@@ -46,12 +46,12 @@ timer::behavior_type timer_impl2(timer::pointer self) {
   delayed_anon_send(self, ms(100), reset_atom_v);
   return {
     [=](reset_atom) {
-      CAF_MESSAGE("timer reset");
+      MESSAGE("timer reset");
       *had_reset = true;
     },
     after(ms(600)) >>
       [=] {
-        CAF_MESSAGE("timer expired");
+        MESSAGE("timer expired");
         CAF_REQUIRE(*had_reset);
         self->quit();
       },
@@ -60,7 +60,7 @@ timer::behavior_type timer_impl2(timer::pointer self) {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(simple_timeout_tests, test_coordinator_fixture<>)
+BEGIN_FIXTURE_SCOPE(test_coordinator_fixture<>)
 
 CAF_TEST(single_timeout) {
   sys.spawn(timer_impl);
@@ -70,4 +70,4 @@ CAF_TEST(single_anon_timeout) {
   sys.spawn(timer_impl2);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/span.cpp
+++ b/libcaf_core/test/span.cpp
@@ -35,75 +35,75 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(span_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(default construction) {
   span<int> xs;
-  CAF_CHECK_EQUAL(xs.size(), 0u);
-  CAF_CHECK_EQUAL(xs.empty(), true);
-  CAF_CHECK_EQUAL(xs.data(), nullptr);
-  CAF_CHECK_EQUAL(xs.size_bytes(), 0u);
-  CAF_CHECK_EQUAL(xs.begin(), xs.end());
-  CAF_CHECK_EQUAL(xs.cbegin(), xs.cend());
-  CAF_CHECK_EQUAL(xs.rbegin(), xs.rend());
-  CAF_CHECK_EQUAL(xs.crbegin(), xs.crend());
-  CAF_CHECK_EQUAL(as_bytes(xs).size_bytes(), 0u);
-  CAF_CHECK_EQUAL(as_writable_bytes(xs).size_bytes(), 0u);
+  CHECK_EQ(xs.size(), 0u);
+  CHECK_EQ(xs.empty(), true);
+  CHECK_EQ(xs.data(), nullptr);
+  CHECK_EQ(xs.size_bytes(), 0u);
+  CHECK_EQ(xs.begin(), xs.end());
+  CHECK_EQ(xs.cbegin(), xs.cend());
+  CHECK_EQ(xs.rbegin(), xs.rend());
+  CHECK_EQ(xs.crbegin(), xs.crend());
+  CHECK_EQ(as_bytes(xs).size_bytes(), 0u);
+  CHECK_EQ(as_writable_bytes(xs).size_bytes(), 0u);
 }
 
 CAF_TEST(iterators) {
   auto xs = make_span(chars);
-  CAF_CHECK(std::equal(xs.begin(), xs.end(), chars.begin()));
-  CAF_CHECK(std::equal(xs.rbegin(), xs.rend(), rchars.begin()));
+  CHECK(std::equal(xs.begin(), xs.end(), chars.begin()));
+  CHECK(std::equal(xs.rbegin(), xs.rend(), rchars.begin()));
   auto ys = make_span(shorts);
-  CAF_CHECK(std::equal(ys.begin(), ys.end(), shorts.begin()));
-  CAF_CHECK(std::equal(ys.rbegin(), ys.rend(), rshorts.begin()));
+  CHECK(std::equal(ys.begin(), ys.end(), shorts.begin()));
+  CHECK(std::equal(ys.rbegin(), ys.rend(), rshorts.begin()));
 }
 
 CAF_TEST(subspans) {
   auto xs = make_span(chars);
-  CAF_CHECK(equal(xs.first(6), xs));
-  CAF_CHECK(equal(xs.last(6), xs));
-  CAF_CHECK(equal(xs.subspan(0, 6), xs));
-  CAF_CHECK(equal(xs.first(3), i8_list({'a', 'b', 'c'})));
-  CAF_CHECK(equal(xs.last(3), i8_list({'d', 'e', 'f'})));
-  CAF_CHECK(equal(xs.subspan(2, 2), i8_list({'c', 'd'})));
+  CHECK(equal(xs.first(6), xs));
+  CHECK(equal(xs.last(6), xs));
+  CHECK(equal(xs.subspan(0, 6), xs));
+  CHECK(equal(xs.first(3), i8_list({'a', 'b', 'c'})));
+  CHECK(equal(xs.last(3), i8_list({'d', 'e', 'f'})));
+  CHECK(equal(xs.subspan(2, 2), i8_list({'c', 'd'})));
 }
 
 CAF_TEST(free iterator functions) {
   auto xs = make_span(chars);
-  CAF_CHECK(xs.begin() == begin(xs));
-  CAF_CHECK(xs.cbegin() == cbegin(xs));
-  CAF_CHECK(xs.end() == end(xs));
-  CAF_CHECK(xs.cend() == cend(xs));
+  CHECK(xs.begin() == begin(xs));
+  CHECK(xs.cbegin() == cbegin(xs));
+  CHECK(xs.end() == end(xs));
+  CHECK(xs.cend() == cend(xs));
 }
 
 CAF_TEST(as bytes) {
   auto xs = make_span(chars);
   auto ys = make_span(shorts);
-  CAF_CHECK_EQUAL(as_bytes(xs).size(), chars.size());
-  CAF_CHECK_EQUAL(as_bytes(ys).size(), shorts.size() * 2);
-  CAF_CHECK_EQUAL(as_writable_bytes(xs).size(), chars.size());
-  CAF_CHECK_EQUAL(as_writable_bytes(ys).size(), shorts.size() * 2);
+  CHECK_EQ(as_bytes(xs).size(), chars.size());
+  CHECK_EQ(as_bytes(ys).size(), shorts.size() * 2);
+  CHECK_EQ(as_writable_bytes(xs).size(), chars.size());
+  CHECK_EQ(as_writable_bytes(ys).size(), shorts.size() * 2);
 }
 
 CAF_TEST(make_span) {
   auto xs = make_span(chars);
   auto ys = make_span(chars.data(), chars.size());
   auto zs = make_span(chars.data(), chars.data() + chars.size());
-  CAF_CHECK(std::equal(xs.begin(), xs.end(), chars.begin()));
-  CAF_CHECK(std::equal(ys.begin(), ys.end(), chars.begin()));
-  CAF_CHECK(std::equal(zs.begin(), zs.end(), chars.begin()));
-  CAF_CHECK(end(xs) == end(ys));
-  CAF_CHECK(end(ys) == end(zs));
-  CAF_CHECK(begin(xs) == begin(ys));
-  CAF_CHECK(begin(ys) == begin(zs));
+  CHECK(std::equal(xs.begin(), xs.end(), chars.begin()));
+  CHECK(std::equal(ys.begin(), ys.end(), chars.begin()));
+  CHECK(std::equal(zs.begin(), zs.end(), chars.begin()));
+  CHECK(end(xs) == end(ys));
+  CHECK(end(ys) == end(zs));
+  CHECK(begin(xs) == begin(ys));
+  CHECK(begin(ys) == begin(zs));
 }
 
 CAF_TEST(spans are convertible from compatible containers) {
   std::vector<int> xs{1, 2, 3};
   span<const int> ys{xs};
-  CAF_CHECK(std::equal(xs.begin(), xs.end(), ys.begin()));
+  CHECK(std::equal(xs.begin(), xs.end(), ys.begin()));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/stateful_actor.cpp
+++ b/libcaf_core/test/stateful_actor.cpp
@@ -93,7 +93,7 @@ struct fixture : test_coordinator_fixture<> {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(dynamic_stateful_actor_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(stateful actors can be dynamically typed) {
   test_adder(sys.spawn(adder));
@@ -154,13 +154,13 @@ CAF_TEST(states can accept constructor arguments and provide a behavior) {
   using actor_type = stateful_actor<state_type>;
   auto testee = sys.spawn<actor_type>(10, 20, add_operation);
   auto& state = deref<actor_type>(testee).state;
-  CAF_CHECK_EQUAL(state.x, 10);
-  CAF_CHECK_EQUAL(state.y, 20);
+  CHECK_EQ(state.x, 10);
+  CHECK_EQ(state.y, 20);
   inject((get_atom), from(self).to(testee).with(get_atom_v));
   expect((int32_t), from(testee).to(self).with(30));
   inject((int32_t, int32_t), to(testee).with(1, 2));
-  CAF_CHECK_EQUAL(state.x, 1);
-  CAF_CHECK_EQUAL(state.y, 2);
+  CHECK_EQ(state.x, 1);
+  CHECK_EQ(state.y, 2);
   inject((get_atom), from(self).to(testee).with(get_atom_v));
   expect((int32_t), from(testee).to(self).with(3));
 }
@@ -181,8 +181,8 @@ CAF_TEST(states optionally take the self pointer as first argument) {
   using actor_type = stateful_actor<state_type>;
   auto testee = sys.spawn<actor_type>(10);
   auto& state = deref<actor_type>(testee).state;
-  CAF_CHECK(state.self == &deref<actor_type>(testee));
-  CAF_CHECK_EQUAL(state.x, 10);
+  CHECK(state.self == &deref<actor_type>(testee));
+  CHECK_EQ(state.x, 10);
   inject((get_atom), from(self).to(testee).with(get_atom_v));
   expect((std::string), from(testee).to(self).with("testee"s));
 }
@@ -203,8 +203,8 @@ CAF_TEST(typed actors can use typed_actor_pointer as self pointer) {
   using actor_type = typed_adder_actor::stateful_impl<state_type>;
   auto testee = sys.spawn<actor_type>(10);
   auto& state = deref<actor_type>(testee).state;
-  CAF_CHECK(state.self == &deref<actor_type>(testee));
-  CAF_CHECK_EQUAL(state.value, 10);
+  CHECK(state.self == &deref<actor_type>(testee));
+  CHECK_EQ(state.value, 10);
   inject((add_atom, int), from(self).to(testee).with(add_atom_v, 1));
   inject((get_atom), from(self).to(testee).with(get_atom_v));
   expect((int), from(testee).to(self).with(11));
@@ -230,4 +230,4 @@ CAF_TEST(returned behaviors take precedence over make_behavior in the state) {
   expect((int32_t), from(testee).to(self).with(13));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/string_algorithms.cpp
+++ b/libcaf_core/test/string_algorithms.cpp
@@ -36,49 +36,49 @@ std::string join(str_list vec) {
 } // namespace
 
 CAF_TEST(splitting) {
-  CAF_CHECK_EQUAL(split(""), str_list({""}));
-  CAF_CHECK_EQUAL(split(","), str_list({"", ""}));
-  CAF_CHECK_EQUAL(split(",,"), str_list({"", "", ""}));
-  CAF_CHECK_EQUAL(split(",,,"), str_list({"", "", "", ""}));
-  CAF_CHECK_EQUAL(split("a,b,c"), str_list({"a", "b", "c"}));
-  CAF_CHECK_EQUAL(split("a,,b,c,"), str_list({"a", "", "b", "c", ""}));
+  CHECK_EQ(split(""), str_list({""}));
+  CHECK_EQ(split(","), str_list({"", ""}));
+  CHECK_EQ(split(",,"), str_list({"", "", ""}));
+  CHECK_EQ(split(",,,"), str_list({"", "", "", ""}));
+  CHECK_EQ(split("a,b,c"), str_list({"a", "b", "c"}));
+  CHECK_EQ(split("a,,b,c,"), str_list({"a", "", "b", "c", ""}));
 }
 
 CAF_TEST(compressed splitting) {
-  CAF_CHECK_EQUAL(compressed_split(""), str_list({}));
-  CAF_CHECK_EQUAL(compressed_split(","), str_list({}));
-  CAF_CHECK_EQUAL(compressed_split(",,"), str_list({}));
-  CAF_CHECK_EQUAL(compressed_split(",,,"), str_list({}));
-  CAF_CHECK_EQUAL(compressed_split("a,b,c"), str_list({"a", "b", "c"}));
-  CAF_CHECK_EQUAL(compressed_split("a,,b,c,"), str_list({"a", "b", "c"}));
+  CHECK_EQ(compressed_split(""), str_list({}));
+  CHECK_EQ(compressed_split(","), str_list({}));
+  CHECK_EQ(compressed_split(",,"), str_list({}));
+  CHECK_EQ(compressed_split(",,,"), str_list({}));
+  CHECK_EQ(compressed_split("a,b,c"), str_list({"a", "b", "c"}));
+  CHECK_EQ(compressed_split("a,,b,c,"), str_list({"a", "b", "c"}));
 }
 
 CAF_TEST(joining) {
-  CAF_CHECK_EQUAL(join({}), "");
-  CAF_CHECK_EQUAL(join({""}), "");
-  CAF_CHECK_EQUAL(join({"", ""}), ",");
-  CAF_CHECK_EQUAL(join({"", "", ""}), ",,");
-  CAF_CHECK_EQUAL(join({"a"}), "a");
-  CAF_CHECK_EQUAL(join({"a", "b"}), "a,b");
-  CAF_CHECK_EQUAL(join({"a", "b", "c"}), "a,b,c");
+  CHECK_EQ(join({}), "");
+  CHECK_EQ(join({""}), "");
+  CHECK_EQ(join({"", ""}), ",");
+  CHECK_EQ(join({"", "", ""}), ",,");
+  CHECK_EQ(join({"a"}), "a");
+  CHECK_EQ(join({"a", "b"}), "a,b");
+  CHECK_EQ(join({"a", "b", "c"}), "a,b,c");
 }
 
 CAF_TEST(starts with) {
-  CAF_CHECK(starts_with("foobar", "f"));
-  CAF_CHECK(starts_with("foobar", "foo"));
-  CAF_CHECK(starts_with("foobar", "fooba"));
-  CAF_CHECK(starts_with("foobar", "foobar"));
-  CAF_CHECK(!starts_with("foobar", "o"));
-  CAF_CHECK(!starts_with("foobar", "fa"));
-  CAF_CHECK(!starts_with("foobar", "foobaro"));
+  CHECK(starts_with("foobar", "f"));
+  CHECK(starts_with("foobar", "foo"));
+  CHECK(starts_with("foobar", "fooba"));
+  CHECK(starts_with("foobar", "foobar"));
+  CHECK(!starts_with("foobar", "o"));
+  CHECK(!starts_with("foobar", "fa"));
+  CHECK(!starts_with("foobar", "foobaro"));
 }
 
 CAF_TEST(ends with) {
-  CAF_CHECK(ends_with("foobar", "r"));
-  CAF_CHECK(ends_with("foobar", "ar"));
-  CAF_CHECK(ends_with("foobar", "oobar"));
-  CAF_CHECK(ends_with("foobar", "foobar"));
-  CAF_CHECK(!ends_with("foobar", "a"));
-  CAF_CHECK(!ends_with("foobar", "car"));
-  CAF_CHECK(!ends_with("foobar", "afoobar"));
+  CHECK(ends_with("foobar", "r"));
+  CHECK(ends_with("foobar", "ar"));
+  CHECK(ends_with("foobar", "oobar"));
+  CHECK(ends_with("foobar", "foobar"));
+  CHECK(!ends_with("foobar", "a"));
+  CHECK(!ends_with("foobar", "car"));
+  CHECK(!ends_with("foobar", "afoobar"));
 }

--- a/libcaf_core/test/string_view.cpp
+++ b/libcaf_core/test/string_view.cpp
@@ -14,30 +14,30 @@ using namespace caf::literals;
 CAF_TEST(default construction) {
   string_view x;
   string_view y;
-  CAF_CHECK(x.empty());
-  CAF_CHECK_EQUAL(x.size(), 0u);
-  CAF_CHECK_EQUAL(x.data(), nullptr);
-  CAF_CHECK_EQUAL(y, y);
+  CHECK(x.empty());
+  CHECK_EQ(x.size(), 0u);
+  CHECK_EQ(x.data(), nullptr);
+  CHECK_EQ(y, y);
 }
 
 CAF_TEST(cstring conversion) {
   auto x = "abc"_sv;
-  CAF_CHECK_EQUAL(x.size(), 3u);
-  CAF_CHECK_EQUAL(x[0], 'a');
-  CAF_CHECK_EQUAL(x[1], 'b');
-  CAF_CHECK_EQUAL(x[2], 'c');
-  CAF_CHECK_EQUAL(x, "abc");
+  CHECK_EQ(x.size(), 3u);
+  CHECK_EQ(x[0], 'a');
+  CHECK_EQ(x[1], 'b');
+  CHECK_EQ(x[2], 'c');
+  CHECK_EQ(x, "abc");
   x = "def";
-  CAF_CHECK_NOT_EQUAL(x, "abc");
-  CAF_CHECK_EQUAL(x, "def");
+  CHECK_NE(x, "abc");
+  CHECK_EQ(x, "def");
 }
 
 CAF_TEST(string conversion) {
   std::string x = "abc";
   string_view y;
   y = x;
-  CAF_CHECK_EQUAL(x, y);
-  auto f = [&](string_view z) { CAF_CHECK_EQUAL(x, z); };
+  CHECK_EQ(x, y);
+  auto f = [&](string_view z) { CHECK_EQ(x, z); };
   f(x);
 }
 
@@ -51,13 +51,13 @@ CAF_TEST(substrings) {
     return str;
   };
   auto x = "abcdefghi"_sv;
-  CAF_CHECK_EQUAL(without_prefix(x, 3), "defghi");
-  CAF_CHECK_EQUAL(without_suffix(x, 3), "abcdef");
-  CAF_CHECK_EQUAL(x.substr(3, 3), "def");
-  CAF_CHECK_EQUAL(without_prefix(x, 9), "");
-  CAF_CHECK_EQUAL(without_suffix(x, 9), "");
-  CAF_CHECK_EQUAL(x.substr(9), "");
-  CAF_CHECK_EQUAL(x.substr(0, 0), "");
+  CHECK_EQ(without_prefix(x, 3), "defghi");
+  CHECK_EQ(without_suffix(x, 3), "abcdef");
+  CHECK_EQ(x.substr(3, 3), "def");
+  CHECK_EQ(without_prefix(x, 9), "");
+  CHECK_EQ(without_suffix(x, 9), "");
+  CHECK_EQ(x.substr(9), "");
+  CHECK_EQ(x.substr(0, 0), "");
 }
 
 CAF_TEST(compare) {
@@ -66,145 +66,139 @@ CAF_TEST(compare) {
   auto y = "bcd"_sv;
   auto z = "cde"_sv;
   // x.compare full strings
-  CAF_CHECK(x.compare("abc") == 0);
-  CAF_CHECK(x.compare(y) < 0);
-  CAF_CHECK(x.compare(z) < 0);
+  CHECK(x.compare("abc") == 0);
+  CHECK(x.compare(y) < 0);
+  CHECK(x.compare(z) < 0);
   // y.compare full strings
-  CAF_CHECK(y.compare(x) > 0);
-  CAF_CHECK(y.compare("bcd") == 0);
-  CAF_CHECK(y.compare(z) < 0);
+  CHECK(y.compare(x) > 0);
+  CHECK(y.compare("bcd") == 0);
+  CHECK(y.compare(z) < 0);
   // z.compare full strings
-  CAF_CHECK(z.compare(x) > 0);
-  CAF_CHECK(z.compare(y) > 0);
-  CAF_CHECK(z.compare("cde") == 0);
+  CHECK(z.compare(x) > 0);
+  CHECK(z.compare(y) > 0);
+  CHECK(z.compare("cde") == 0);
   // x.compare substrings
-  CAF_CHECK(x.compare(0, 3, "abc") == 0);
-  CAF_CHECK(x.compare(1, 2, y, 0, 2) == 0);
-  CAF_CHECK(x.compare(2, 1, z, 0, 1) == 0);
+  CHECK(x.compare(0, 3, "abc") == 0);
+  CHECK(x.compare(1, 2, y, 0, 2) == 0);
+  CHECK(x.compare(2, 1, z, 0, 1) == 0);
   // make sure substrings aren't equal
-  CAF_CHECK("a/"_sv != "a/b"_sv);
-  CAF_CHECK(z.compare("cdef"_sv) < 0);
-  CAF_CHECK("cdef"_sv.compare(z) > 0);
+  CHECK("a/"_sv != "a/b"_sv);
+  CHECK(z.compare("cdef"_sv) < 0);
+  CHECK("cdef"_sv.compare(z) > 0);
 }
 
 CAF_TEST(copy) {
   char buf[10];
   auto str = "hello"_sv;
   auto n = str.copy(buf, str.size());
-  CAF_CHECK_EQUAL(n, 5u);
+  CHECK_EQ(n, 5u);
   buf[n] = '\0';
-  CAF_CHECK_EQUAL(str, string_view(buf, n));
-  CAF_CHECK(strcmp("hello", buf) == 0);
+  CHECK_EQ(str, string_view(buf, n));
+  CHECK(strcmp("hello", buf) == 0);
   n = str.copy(buf, 10, 3);
   buf[n] = '\0';
-  CAF_CHECK_EQUAL(string_view(buf, n), "lo");
-  CAF_CHECK(strcmp("lo", buf) == 0);
+  CHECK_EQ(string_view(buf, n), "lo");
+  CHECK(strcmp("lo", buf) == 0);
 }
 
 CAF_TEST(find) {
   // Check whether string_view behaves exactly like std::string.
   auto x = "abcdef"_sv;
   std::string y = "abcdef";
-  CAF_CHECK_EQUAL(x.find('a'), y.find('a'));
-  CAF_CHECK_EQUAL(x.find('b'), y.find('b'));
-  CAF_CHECK_EQUAL(x.find('g'), y.find('g'));
-  CAF_CHECK_EQUAL(x.find('a', 1), y.find('a', 1));
-  CAF_CHECK_EQUAL(x.find("a"), y.find("a"));
-  CAF_CHECK_EQUAL(x.find("bc"), y.find("bc"));
-  CAF_CHECK_EQUAL(x.find("ce"), y.find("ce"));
-  CAF_CHECK_EQUAL(x.find("bc", 1), y.find("bc", 1));
-  CAF_CHECK_EQUAL(x.find("bc", 1, 0), y.find("bc", 1, 0));
-  CAF_CHECK_EQUAL(x.find("bc", 0, 1), y.find("bc", 0, 1));
-  CAF_CHECK_EQUAL(x.find("bc", 2, 2), y.find("bc", 2, 2));
+  CHECK_EQ(x.find('a'), y.find('a'));
+  CHECK_EQ(x.find('b'), y.find('b'));
+  CHECK_EQ(x.find('g'), y.find('g'));
+  CHECK_EQ(x.find('a', 1), y.find('a', 1));
+  CHECK_EQ(x.find("a"), y.find("a"));
+  CHECK_EQ(x.find("bc"), y.find("bc"));
+  CHECK_EQ(x.find("ce"), y.find("ce"));
+  CHECK_EQ(x.find("bc", 1), y.find("bc", 1));
+  CHECK_EQ(x.find("bc", 1, 0), y.find("bc", 1, 0));
+  CHECK_EQ(x.find("bc", 0, 1), y.find("bc", 0, 1));
+  CHECK_EQ(x.find("bc", 2, 2), y.find("bc", 2, 2));
 }
 
 CAF_TEST(rfind) {
   // Check whether string_view behaves exactly like std::string.
   auto x = "abccba"_sv;
   std::string y = "abccba";
-  CAF_CHECK_EQUAL(x.rfind('a'), y.rfind('a'));
-  CAF_CHECK_EQUAL(x.rfind('b'), y.rfind('b'));
-  CAF_CHECK_EQUAL(x.rfind('g'), y.rfind('g'));
-  CAF_CHECK_EQUAL(x.rfind('a', 1), y.rfind('a', 1));
-  CAF_CHECK_EQUAL(x.rfind("a"), y.rfind("a"));
-  CAF_CHECK_EQUAL(x.rfind("bc"), y.rfind("bc"));
-  CAF_CHECK_EQUAL(x.rfind("ce"), y.rfind("ce"));
-  CAF_CHECK_EQUAL(x.rfind("bc", 1), y.rfind("bc", 1));
-  CAF_CHECK_EQUAL(x.rfind("bc", 1, 0), y.rfind("bc", 1, 0));
-  CAF_CHECK_EQUAL(x.rfind("bc", 0, 1), y.rfind("bc", 0, 1));
-  CAF_CHECK_EQUAL(x.rfind("bc", 2, 2), y.rfind("bc", 2, 2));
+  CHECK_EQ(x.rfind('a'), y.rfind('a'));
+  CHECK_EQ(x.rfind('b'), y.rfind('b'));
+  CHECK_EQ(x.rfind('g'), y.rfind('g'));
+  CHECK_EQ(x.rfind('a', 1), y.rfind('a', 1));
+  CHECK_EQ(x.rfind("a"), y.rfind("a"));
+  CHECK_EQ(x.rfind("bc"), y.rfind("bc"));
+  CHECK_EQ(x.rfind("ce"), y.rfind("ce"));
+  CHECK_EQ(x.rfind("bc", 1), y.rfind("bc", 1));
+  CHECK_EQ(x.rfind("bc", 1, 0), y.rfind("bc", 1, 0));
+  CHECK_EQ(x.rfind("bc", 0, 1), y.rfind("bc", 0, 1));
+  CHECK_EQ(x.rfind("bc", 2, 2), y.rfind("bc", 2, 2));
 }
 
 CAF_TEST(find_first_of) {
   // Check whether string_view behaves exactly like std::string.
   auto x = "abcdef"_sv;
   std::string y = "abcdef";
-  CAF_CHECK_EQUAL(x.find_first_of('a'), y.find_first_of('a'));
-  CAF_CHECK_EQUAL(x.find_first_of('b'), y.find_first_of('b'));
-  CAF_CHECK_EQUAL(x.find_first_of('g'), y.find_first_of('g'));
-  CAF_CHECK_EQUAL(x.find_first_of('a', 1), y.find_first_of('a', 1));
-  CAF_CHECK_EQUAL(x.find_first_of("a"), y.find_first_of("a"));
-  CAF_CHECK_EQUAL(x.find_first_of("bc"), y.find_first_of("bc"));
-  CAF_CHECK_EQUAL(x.find_first_of("ce"), y.find_first_of("ce"));
-  CAF_CHECK_EQUAL(x.find_first_of("bc", 1), y.find_first_of("bc", 1));
-  CAF_CHECK_EQUAL(x.find_first_of("bc", 1, 0), y.find_first_of("bc", 1, 0));
-  CAF_CHECK_EQUAL(x.find_first_of("bc", 0, 1), y.find_first_of("bc", 0, 1));
-  CAF_CHECK_EQUAL(x.find_first_of("bc", 2, 2), y.find_first_of("bc", 2, 2));
+  CHECK_EQ(x.find_first_of('a'), y.find_first_of('a'));
+  CHECK_EQ(x.find_first_of('b'), y.find_first_of('b'));
+  CHECK_EQ(x.find_first_of('g'), y.find_first_of('g'));
+  CHECK_EQ(x.find_first_of('a', 1), y.find_first_of('a', 1));
+  CHECK_EQ(x.find_first_of("a"), y.find_first_of("a"));
+  CHECK_EQ(x.find_first_of("bc"), y.find_first_of("bc"));
+  CHECK_EQ(x.find_first_of("ce"), y.find_first_of("ce"));
+  CHECK_EQ(x.find_first_of("bc", 1), y.find_first_of("bc", 1));
+  CHECK_EQ(x.find_first_of("bc", 1, 0), y.find_first_of("bc", 1, 0));
+  CHECK_EQ(x.find_first_of("bc", 0, 1), y.find_first_of("bc", 0, 1));
+  CHECK_EQ(x.find_first_of("bc", 2, 2), y.find_first_of("bc", 2, 2));
 }
 
 CAF_TEST(find_last_of) {
   // Check whether string_view behaves exactly like std::string.
   auto x = "abcdef"_sv;
   std::string y = "abcdef";
-  CAF_CHECK_EQUAL(x.find_last_of('a'), y.find_last_of('a'));
-  CAF_CHECK_EQUAL(x.find_last_of('b'), y.find_last_of('b'));
-  CAF_CHECK_EQUAL(x.find_last_of('g'), y.find_last_of('g'));
-  CAF_CHECK_EQUAL(x.find_last_of('a', 1), y.find_last_of('a', 1));
-  CAF_CHECK_EQUAL(x.find_last_of("a"), y.find_last_of("a"));
-  CAF_CHECK_EQUAL(x.find_last_of("bc"), y.find_last_of("bc"));
-  CAF_CHECK_EQUAL(x.find_last_of("ce"), y.find_last_of("ce"));
-  CAF_CHECK_EQUAL(x.find_last_of("bc", 1), y.find_last_of("bc", 1));
-  CAF_CHECK_EQUAL(x.find_last_of("bc", 1, 0), y.find_last_of("bc", 1, 0));
-  CAF_CHECK_EQUAL(x.find_last_of("bc", 0, 1), y.find_last_of("bc", 0, 1));
-  CAF_CHECK_EQUAL(x.find_last_of("bc", 2, 2), y.find_last_of("bc", 2, 2));
+  CHECK_EQ(x.find_last_of('a'), y.find_last_of('a'));
+  CHECK_EQ(x.find_last_of('b'), y.find_last_of('b'));
+  CHECK_EQ(x.find_last_of('g'), y.find_last_of('g'));
+  CHECK_EQ(x.find_last_of('a', 1), y.find_last_of('a', 1));
+  CHECK_EQ(x.find_last_of("a"), y.find_last_of("a"));
+  CHECK_EQ(x.find_last_of("bc"), y.find_last_of("bc"));
+  CHECK_EQ(x.find_last_of("ce"), y.find_last_of("ce"));
+  CHECK_EQ(x.find_last_of("bc", 1), y.find_last_of("bc", 1));
+  CHECK_EQ(x.find_last_of("bc", 1, 0), y.find_last_of("bc", 1, 0));
+  CHECK_EQ(x.find_last_of("bc", 0, 1), y.find_last_of("bc", 0, 1));
+  CHECK_EQ(x.find_last_of("bc", 2, 2), y.find_last_of("bc", 2, 2));
 }
 
 CAF_TEST(find_first_not_of) {
   // Check whether string_view behaves exactly like std::string.
   auto x = "abcdef"_sv;
   std::string y = "abcdef";
-  CAF_CHECK_EQUAL(x.find_first_not_of('a'), y.find_first_not_of('a'));
-  CAF_CHECK_EQUAL(x.find_first_not_of('b'), y.find_first_not_of('b'));
-  CAF_CHECK_EQUAL(x.find_first_not_of('g'), y.find_first_not_of('g'));
-  CAF_CHECK_EQUAL(x.find_first_not_of('a', 1), y.find_first_not_of('a', 1));
-  CAF_CHECK_EQUAL(x.find_first_not_of("a"), y.find_first_not_of("a"));
-  CAF_CHECK_EQUAL(x.find_first_not_of("bc"), y.find_first_not_of("bc"));
-  CAF_CHECK_EQUAL(x.find_first_not_of("ce"), y.find_first_not_of("ce"));
-  CAF_CHECK_EQUAL(x.find_first_not_of("bc", 1), y.find_first_not_of("bc", 1));
-  CAF_CHECK_EQUAL(x.find_first_not_of("bc", 1, 0),
-                  y.find_first_not_of("bc", 1, 0));
-  CAF_CHECK_EQUAL(x.find_first_not_of("bc", 0, 1),
-                  y.find_first_not_of("bc", 0, 1));
-  CAF_CHECK_EQUAL(x.find_first_not_of("bc", 2, 2),
-                  y.find_first_not_of("bc", 2, 2));
+  CHECK_EQ(x.find_first_not_of('a'), y.find_first_not_of('a'));
+  CHECK_EQ(x.find_first_not_of('b'), y.find_first_not_of('b'));
+  CHECK_EQ(x.find_first_not_of('g'), y.find_first_not_of('g'));
+  CHECK_EQ(x.find_first_not_of('a', 1), y.find_first_not_of('a', 1));
+  CHECK_EQ(x.find_first_not_of("a"), y.find_first_not_of("a"));
+  CHECK_EQ(x.find_first_not_of("bc"), y.find_first_not_of("bc"));
+  CHECK_EQ(x.find_first_not_of("ce"), y.find_first_not_of("ce"));
+  CHECK_EQ(x.find_first_not_of("bc", 1), y.find_first_not_of("bc", 1));
+  CHECK_EQ(x.find_first_not_of("bc", 1, 0), y.find_first_not_of("bc", 1, 0));
+  CHECK_EQ(x.find_first_not_of("bc", 0, 1), y.find_first_not_of("bc", 0, 1));
+  CHECK_EQ(x.find_first_not_of("bc", 2, 2), y.find_first_not_of("bc", 2, 2));
 }
 
 CAF_TEST(find_last_not_of) {
   // Check whether string_view behaves exactly like std::string.
   auto x = "abcdef"_sv;
   std::string y = "abcdef";
-  CAF_CHECK_EQUAL(x.find_last_not_of('a'), y.find_last_not_of('a'));
-  CAF_CHECK_EQUAL(x.find_last_not_of('b'), y.find_last_not_of('b'));
-  CAF_CHECK_EQUAL(x.find_last_not_of('g'), y.find_last_not_of('g'));
-  CAF_CHECK_EQUAL(x.find_last_not_of('a', 1), y.find_last_not_of('a', 1));
-  CAF_CHECK_EQUAL(x.find_last_not_of("a"), y.find_last_not_of("a"));
-  CAF_CHECK_EQUAL(x.find_last_not_of("bc"), y.find_last_not_of("bc"));
-  CAF_CHECK_EQUAL(x.find_last_not_of("ce"), y.find_last_not_of("ce"));
-  CAF_CHECK_EQUAL(x.find_last_not_of("bc", 1), y.find_last_not_of("bc", 1));
-  CAF_CHECK_EQUAL(x.find_last_not_of("bc", 1, 0),
-                  y.find_last_not_of("bc", 1, 0));
-  CAF_CHECK_EQUAL(x.find_last_not_of("bc", 0, 1),
-                  y.find_last_not_of("bc", 0, 1));
-  CAF_CHECK_EQUAL(x.find_last_not_of("bc", 2, 2),
-                  y.find_last_not_of("bc", 2, 2));
+  CHECK_EQ(x.find_last_not_of('a'), y.find_last_not_of('a'));
+  CHECK_EQ(x.find_last_not_of('b'), y.find_last_not_of('b'));
+  CHECK_EQ(x.find_last_not_of('g'), y.find_last_not_of('g'));
+  CHECK_EQ(x.find_last_not_of('a', 1), y.find_last_not_of('a', 1));
+  CHECK_EQ(x.find_last_not_of("a"), y.find_last_not_of("a"));
+  CHECK_EQ(x.find_last_not_of("bc"), y.find_last_not_of("bc"));
+  CHECK_EQ(x.find_last_not_of("ce"), y.find_last_not_of("ce"));
+  CHECK_EQ(x.find_last_not_of("bc", 1), y.find_last_not_of("bc", 1));
+  CHECK_EQ(x.find_last_not_of("bc", 1, 0), y.find_last_not_of("bc", 1, 0));
+  CHECK_EQ(x.find_last_not_of("bc", 0, 1), y.find_last_not_of("bc", 0, 1));
+  CHECK_EQ(x.find_last_not_of("bc", 2, 2), y.find_last_not_of("bc", 2, 2));
 }

--- a/libcaf_core/test/sum_type.cpp
+++ b/libcaf_core/test/sum_type.cpp
@@ -8,8 +8,8 @@
 
 #include "core-test.hpp"
 
-#include <new>
 #include <map>
+#include <new>
 #include <string>
 
 #include "caf/default_sum_type_access.hpp"
@@ -106,9 +106,12 @@ private:
   template <class Result, class Visitor, class... Ts>
   inline Result apply(Visitor&& f, Ts&&... xs) const {
     switch (index_) {
-      case 0: return f(std::forward<Ts>(xs)..., v0);
-      case 1: return f(std::forward<Ts>(xs)..., v1);
-      case 2: return f(std::forward<Ts>(xs)..., v2);
+      case 0:
+        return f(std::forward<Ts>(xs)..., v0);
+      case 1:
+        return f(std::forward<Ts>(xs)..., v1);
+      case 2:
+        return f(std::forward<Ts>(xs)..., v2);
     }
     CAF_RAISE_ERROR("invalid index in union_type");
   }
@@ -174,70 +177,70 @@ constexpr stringify_t stringify = stringify_t{};
 
 CAF_TEST(holds_alternative) {
   union_type x;
-  CAF_CHECK_EQUAL(holds_alternative<int>(x), true);
-  CAF_CHECK_EQUAL(holds_alternative<string>(x), false);
-  CAF_CHECK_EQUAL(holds_alternative<map_type>(x), false);
+  CHECK_EQ(holds_alternative<int>(x), true);
+  CHECK_EQ(holds_alternative<string>(x), false);
+  CHECK_EQ(holds_alternative<map_type>(x), false);
   x = string{"hello world"};
-  CAF_CHECK_EQUAL(holds_alternative<int>(x), false);
-  CAF_CHECK_EQUAL(holds_alternative<string>(x), true);
-  CAF_CHECK_EQUAL(holds_alternative<map_type>(x), false);
+  CHECK_EQ(holds_alternative<int>(x), false);
+  CHECK_EQ(holds_alternative<string>(x), true);
+  CHECK_EQ(holds_alternative<map_type>(x), false);
   x = map_type{{1, 1}, {2, 2}};
-  CAF_CHECK_EQUAL(holds_alternative<int>(x), false);
-  CAF_CHECK_EQUAL(holds_alternative<string>(x), false);
-  CAF_CHECK_EQUAL(holds_alternative<map_type>(x), true);
+  CHECK_EQ(holds_alternative<int>(x), false);
+  CHECK_EQ(holds_alternative<string>(x), false);
+  CHECK_EQ(holds_alternative<map_type>(x), true);
 }
 
 CAF_TEST(get) {
   union_type x;
-  CAF_CHECK_EQUAL(get<int>(x), 0);
+  CHECK_EQ(get<int>(x), 0);
   x = 42;
-  CAF_CHECK_EQUAL(get<int>(x), 42);
+  CHECK_EQ(get<int>(x), 42);
   x = string{"hello world"};
-  CAF_CHECK_EQUAL(get<string>(x), "hello world");
+  CHECK_EQ(get<string>(x), "hello world");
   x = map_type{{1, 1}, {2, 2}};
-  CAF_CHECK_EQUAL(get<map_type>(x), map_type({{1, 1}, {2, 2}}));
+  CHECK_EQ(get<map_type>(x), map_type({{1, 1}, {2, 2}}));
 }
 
 CAF_TEST(get_if) {
   union_type x;
-  CAF_CHECK_EQUAL(get_if<int>(&x), &get<int>(x));
-  CAF_CHECK_EQUAL(get_if<string>(&x), nullptr);
-  CAF_CHECK_EQUAL(get_if<map_type>(&x), nullptr);
+  CHECK_EQ(get_if<int>(&x), &get<int>(x));
+  CHECK_EQ(get_if<string>(&x), nullptr);
+  CHECK_EQ(get_if<map_type>(&x), nullptr);
   x = string{"hello world"};
-  CAF_CHECK_EQUAL(get_if<int>(&x), nullptr);
-  CAF_CHECK_EQUAL(get_if<string>(&x), &get<string>(x));
-  CAF_CHECK_EQUAL(get_if<map_type>(&x), nullptr);
+  CHECK_EQ(get_if<int>(&x), nullptr);
+  CHECK_EQ(get_if<string>(&x), &get<string>(x));
+  CHECK_EQ(get_if<map_type>(&x), nullptr);
   x = map_type{{1, 1}, {2, 2}};
-  CAF_CHECK_EQUAL(get_if<int>(&x), nullptr);
-  CAF_CHECK_EQUAL(get_if<string>(&x), nullptr);
-  CAF_CHECK_EQUAL(get_if<map_type>(&x), &get<map_type>(x));
+  CHECK_EQ(get_if<int>(&x), nullptr);
+  CHECK_EQ(get_if<string>(&x), nullptr);
+  CHECK_EQ(get_if<map_type>(&x), &get<map_type>(x));
 }
 
 CAF_TEST(unary visit) {
   union_type x;
-  CAF_CHECK_EQUAL(visit(stringify, x), "0");
+  CHECK_EQ(visit(stringify, x), "0");
   x = string{"hello world"};
-  CAF_CHECK_EQUAL(visit(stringify, x), "hello world");
+  CHECK_EQ(visit(stringify, x), "hello world");
   x = map_type{{1, 1}, {2, 2}};
-  CAF_CHECK_EQUAL(visit(stringify, x), "{1 = 1, 2 = 2}");
+  CHECK_EQ(visit(stringify, x), "{1 = 1, 2 = 2}");
 }
 
 CAF_TEST(binary visit) {
   union_type x;
   union_type y;
-  CAF_CHECK_EQUAL(visit(stringify, x, y), "0, 0");
+  CHECK_EQ(visit(stringify, x, y), "0, 0");
   x = 42;
   y = string{"hello world"};
-  CAF_CHECK_EQUAL(visit(stringify, x, y), "42, hello world");
+  CHECK_EQ(visit(stringify, x, y), "42, hello world");
 }
 
 CAF_TEST(ternary visit) {
   union_type x;
   union_type y;
   union_type z;
-  //CAF_CHECK_EQUAL(visit(stringify, x, y, z), "0, 0, 0");
+  // CHECK_EQ(visit(stringify, x, y, z), "0, 0, 0");
   x = 42;
   y = string{"foo"};
   z = map_type{{1, 1}, {2, 2}};
-  CAF_CHECK_EQUAL(visit(stringify, x, y, z), "42, foo, {1 = 1, 2 = 2}");
+  CHECK_EQ(visit(stringify, x, y, z), "42, foo, {1 = 1, 2 = 2}");
 }

--- a/libcaf_core/test/telemetry/collector/prometheus.cpp
+++ b/libcaf_core/test/telemetry/collector/prometheus.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/telemetry/collector/prometheus.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include "caf/telemetry/metric_registry.hpp"
 #include "caf/telemetry/metric_type.hpp"
@@ -26,7 +26,7 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(prometheus_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(the Prometheus collector generates text output) {
   auto fb = registry.gauge_family("foo", "bar", {},
@@ -46,8 +46,8 @@ CAF_TEST(the Prometheus collector generates text output) {
   h->observe(3);
   h->observe(4);
   h->observe(7);
-  CAF_CHECK_EQUAL(exporter.collect_from(registry, timestamp{42s}),
-                  R"(# HELP foo_bar_seconds Some value without labels.
+  CHECK_EQ(exporter.collect_from(registry, timestamp{42s}),
+           R"(# HELP foo_bar_seconds Some value without labels.
 # TYPE foo_bar_seconds gauge
 foo_bar_seconds 123 42000
 # HELP some_value_total Some (total) value with two labels.
@@ -65,14 +65,14 @@ some_request_duration_seconds_bucket{x="get",le="+Inf"} 3 42000
 some_request_duration_seconds_sum{x="get"} 14 42000
 some_request_duration_seconds_count{x="get"} 3 42000
 )"_sv);
-  CAF_MESSAGE("multiple runs with the same timestamp generate the same output");
+  MESSAGE("multiple runs with the same timestamp generate the same output");
   auto ts = make_timestamp();
   std::string res1;
   {
     auto buf = exporter.collect_from(registry, ts);
     res1.assign(buf.begin(), buf.end());
   }
-  CAF_CHECK_EQUAL(res1, exporter.collect_from(registry, ts));
+  CHECK_EQ(res1, exporter.collect_from(registry, ts));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/telemetry/counter.cpp
+++ b/libcaf_core/test/telemetry/counter.cpp
@@ -6,32 +6,32 @@
 
 #include "caf/telemetry/counter.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 using namespace caf;
 
 CAF_TEST(double counters can only increment) {
   telemetry::dbl_counter c;
-  CAF_MESSAGE("counters start at 0");
-  CAF_CHECK_EQUAL(c.value(), 0.0);
-  CAF_MESSAGE("counters are incrementable");
+  MESSAGE("counters start at 0");
+  CHECK_EQ(c.value(), 0.0);
+  MESSAGE("counters are incrementable");
   c.inc();
   c.inc(2.0);
-  CAF_CHECK_EQUAL(c.value(), 3.0);
-  CAF_MESSAGE("users can create counters with custom start values");
-  CAF_CHECK_EQUAL(telemetry::dbl_counter{42.0}.value(), 42.0);
+  CHECK_EQ(c.value(), 3.0);
+  MESSAGE("users can create counters with custom start values");
+  CHECK_EQ(telemetry::dbl_counter{42.0}.value(), 42.0);
 }
 
 CAF_TEST(integer counters can only increment) {
   telemetry::int_counter c;
-  CAF_MESSAGE("counters start at 0");
-  CAF_CHECK_EQUAL(c.value(), 0);
-  CAF_MESSAGE("counters are incrementable");
+  MESSAGE("counters start at 0");
+  CHECK_EQ(c.value(), 0);
+  MESSAGE("counters are incrementable");
   c.inc();
   c.inc(2);
-  CAF_CHECK_EQUAL(c.value(), 3);
-  CAF_MESSAGE("integer counters also support operator++");
-  CAF_CHECK_EQUAL(++c, 4);
-  CAF_MESSAGE("users can create counters with custom start values");
-  CAF_CHECK_EQUAL(telemetry::int_counter{42}.value(), 42);
+  CHECK_EQ(c.value(), 3);
+  MESSAGE("integer counters also support operator++");
+  CHECK_EQ(++c, 4);
+  MESSAGE("users can create counters with custom start values");
+  CHECK_EQ(telemetry::int_counter{42}.value(), 42);
 }

--- a/libcaf_core/test/telemetry/gauge.cpp
+++ b/libcaf_core/test/telemetry/gauge.cpp
@@ -6,45 +6,45 @@
 
 #include "caf/telemetry/gauge.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 using namespace caf;
 
 CAF_TEST(double gauges can increment and decrement) {
   telemetry::dbl_gauge g;
-  CAF_MESSAGE("gauges start at 0");
-  CAF_CHECK_EQUAL(g.value(), 0.0);
-  CAF_MESSAGE("gauges are incrementable");
+  MESSAGE("gauges start at 0");
+  CHECK_EQ(g.value(), 0.0);
+  MESSAGE("gauges are incrementable");
   g.inc();
   g.inc(2.0);
-  CAF_CHECK_EQUAL(g.value(), 3.0);
-  CAF_MESSAGE("gauges are decrementable");
+  CHECK_EQ(g.value(), 3.0);
+  MESSAGE("gauges are decrementable");
   g.dec();
   g.dec(5.0);
-  CAF_CHECK_EQUAL(g.value(), -3.0);
-  CAF_MESSAGE("gauges allow setting values");
+  CHECK_EQ(g.value(), -3.0);
+  MESSAGE("gauges allow setting values");
   g.value(42.0);
-  CAF_CHECK_EQUAL(g.value(), 42.0);
-  CAF_MESSAGE("users can create gauges with custom start values");
-  CAF_CHECK_EQUAL(telemetry::dbl_gauge{42.0}.value(), 42.0);
+  CHECK_EQ(g.value(), 42.0);
+  MESSAGE("users can create gauges with custom start values");
+  CHECK_EQ(telemetry::dbl_gauge{42.0}.value(), 42.0);
 }
 
 CAF_TEST(integer gauges can increment and decrement) {
   telemetry::int_gauge g;
-  CAF_MESSAGE("gauges start at 0");
-  CAF_CHECK_EQUAL(g.value(), 0);
-  CAF_MESSAGE("gauges are incrementable");
+  MESSAGE("gauges start at 0");
+  CHECK_EQ(g.value(), 0);
+  MESSAGE("gauges are incrementable");
   g.inc();
   g.inc(2);
-  CAF_CHECK_EQUAL(g.value(), 3);
-  CAF_MESSAGE("gauges are decrementable");
+  CHECK_EQ(g.value(), 3);
+  MESSAGE("gauges are decrementable");
   g.dec();
   g.dec(5);
-  CAF_CHECK_EQUAL(g.value(), -3);
-  CAF_MESSAGE("gauges allow setting values");
+  CHECK_EQ(g.value(), -3);
+  MESSAGE("gauges allow setting values");
   g.value(42);
-  CAF_MESSAGE("integer gauges also support operator++");
-  CAF_CHECK_EQUAL(++g, 43);
-  CAF_MESSAGE("users can create gauges with custom start values");
-  CAF_CHECK_EQUAL(telemetry::int_gauge{42}.value(), 42);
+  MESSAGE("integer gauges also support operator++");
+  CHECK_EQ(++g, 43);
+  MESSAGE("users can create gauges with custom start values");
+  CHECK_EQ(telemetry::int_gauge{42}.value(), 42);
 }

--- a/libcaf_core/test/telemetry/histogram.cpp
+++ b/libcaf_core/test/telemetry/histogram.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/telemetry/histogram.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include <cmath>
 #include <limits>
@@ -18,19 +18,19 @@ using namespace caf::telemetry;
 
 CAF_TEST(double histograms use infinity for the last bucket) {
   dbl_histogram h1{.1, .2, .4, .8};
-  CAF_CHECK_EQUAL(h1.buckets().size(), 5u);
-  CAF_CHECK_EQUAL(h1.buckets().front().upper_bound, .1);
-  CAF_CHECK(std::isinf(h1.buckets().back().upper_bound));
-  CAF_CHECK_EQUAL(h1.sum(), 0.0);
+  CHECK_EQ(h1.buckets().size(), 5u);
+  CHECK_EQ(h1.buckets().front().upper_bound, .1);
+  CHECK(std::isinf(h1.buckets().back().upper_bound));
+  CHECK_EQ(h1.sum(), 0.0);
 }
 
 CAF_TEST(integer histograms use int_max for the last bucket) {
   using limits = std::numeric_limits<int64_t>;
   int_histogram h1{1, 2, 4, 8};
-  CAF_CHECK_EQUAL(h1.buckets().size(), 5u);
-  CAF_CHECK_EQUAL(h1.buckets().front().upper_bound, 1);
-  CAF_CHECK_EQUAL(h1.buckets().back().upper_bound, limits::max());
-  CAF_CHECK_EQUAL(h1.sum(), 0);
+  CHECK_EQ(h1.buckets().size(), 5u);
+  CHECK_EQ(h1.buckets().front().upper_bound, 1);
+  CHECK_EQ(h1.buckets().back().upper_bound, limits::max());
+  CHECK_EQ(h1.sum(), 0);
 }
 
 CAF_TEST(histograms aggregate to buckets and keep a sum) {
@@ -39,9 +39,9 @@ CAF_TEST(histograms aggregate to buckets and keep a sum) {
     h1.observe(value);
   auto buckets = h1.buckets();
   CAF_REQUIRE_EQUAL(buckets.size(), 4u);
-  CAF_CHECK_EQUAL(buckets[0].count.value(), 2); // 1, 2
-  CAF_CHECK_EQUAL(buckets[1].count.value(), 2); // 3, 4
-  CAF_CHECK_EQUAL(buckets[2].count.value(), 4); // 5, 6, 7, 8
-  CAF_CHECK_EQUAL(buckets[3].count.value(), 2); // 9, 10
-  CAF_CHECK_EQUAL(h1.sum(), 55);
+  CHECK_EQ(buckets[0].count.value(), 2); // 1, 2
+  CHECK_EQ(buckets[1].count.value(), 2); // 3, 4
+  CHECK_EQ(buckets[2].count.value(), 4); // 5, 6, 7, 8
+  CHECK_EQ(buckets[3].count.value(), 2); // 9, 10
+  CHECK_EQ(h1.sum(), 55);
 }

--- a/libcaf_core/test/telemetry/label.cpp
+++ b/libcaf_core/test/telemetry/label.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/telemetry/label.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include "caf/telemetry/label_view.hpp"
 
@@ -24,24 +24,24 @@ size_t hash(const T& x) {
 } // namespace
 
 CAF_TEST(labels wrap name and value) {
-  CAF_CHECK_EQUAL(to_string(label{"foo", "bar"}), "foo=bar");
+  CHECK_EQ(to_string(label{"foo", "bar"}), "foo=bar");
   label foobar{"foo", "bar"};
-  CAF_CHECK_EQUAL(foobar.name(), "foo");
-  CAF_CHECK_EQUAL(foobar.value(), "bar");
-  CAF_CHECK_EQUAL(foobar.str(), "foo=bar");
-  CAF_CHECK_EQUAL(to_string(foobar), "foo=bar");
-  CAF_CHECK_EQUAL(foobar, label("foo", "bar"));
-  CAF_CHECK_EQUAL(hash(foobar), hash(label("foo", "bar")));
+  CHECK_EQ(foobar.name(), "foo");
+  CHECK_EQ(foobar.value(), "bar");
+  CHECK_EQ(foobar.str(), "foo=bar");
+  CHECK_EQ(to_string(foobar), "foo=bar");
+  CHECK_EQ(foobar, label("foo", "bar"));
+  CHECK_EQ(hash(foobar), hash(label("foo", "bar")));
 }
 
 CAF_TEST(labels are convertible from views) {
   label foobar{"foo", "bar"};
   label_view foobar_view{"foo", "bar"};
-  CAF_CHECK_EQUAL(foobar, foobar_view);
-  CAF_CHECK_EQUAL(foobar, label{foobar_view});
-  CAF_CHECK_EQUAL(foobar.name(), foobar_view.name());
-  CAF_CHECK_EQUAL(foobar.value(), foobar_view.value());
-  CAF_CHECK_EQUAL(to_string(foobar), to_string(foobar_view));
-  CAF_CHECK_EQUAL(hash(foobar), hash(foobar_view));
-  CAF_CHECK_EQUAL(hash(foobar), hash(label{foobar_view}));
+  CHECK_EQ(foobar, foobar_view);
+  CHECK_EQ(foobar, label{foobar_view});
+  CHECK_EQ(foobar.name(), foobar_view.name());
+  CHECK_EQ(foobar.value(), foobar_view.value());
+  CHECK_EQ(to_string(foobar), to_string(foobar_view));
+  CHECK_EQ(hash(foobar), hash(foobar_view));
+  CHECK_EQ(hash(foobar), hash(label{foobar_view}));
 }

--- a/libcaf_core/test/telemetry/timer.cpp
+++ b/libcaf_core/test/telemetry/timer.cpp
@@ -6,23 +6,23 @@
 
 #include "caf/telemetry/timer.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 using namespace caf;
 using namespace caf::telemetry;
 
 CAF_TEST(timers observe how much time passes in a scope) {
   dbl_histogram h1{1, 2, 4, 8};
-  CAF_MESSAGE("timers call observe() with the measured time");
+  MESSAGE("timers call observe() with the measured time");
   {
     timer t{&h1};
-    CAF_CHECK_EQUAL(t.histogram_ptr(), &h1);
-    CAF_CHECK_GREATER(t.started().time_since_epoch().count(), 0);
+    CHECK_EQ(t.histogram_ptr(), &h1);
+    CHECK_GT(t.started().time_since_epoch().count(), 0);
   }
-  CAF_CHECK_GREATER(h1.sum(), 0.0);
-  CAF_MESSAGE("timers constructed with a nullptr have no effect");
+  CHECK_GT(h1.sum(), 0.0);
+  MESSAGE("timers constructed with a nullptr have no effect");
   {
     timer t{nullptr};
-    CAF_CHECK_EQUAL(t.histogram_ptr(), nullptr);
+    CHECK_EQ(t.histogram_ptr(), nullptr);
   }
 }

--- a/libcaf_core/test/thread_hook.cpp
+++ b/libcaf_core/test/thread_hook.cpp
@@ -34,16 +34,14 @@ struct dummy_thread_hook : thread_hook {
 class counting_thread_hook : public thread_hook {
 public:
   counting_thread_hook()
-      : count_init_{0},
-        count_thread_started_{0},
-        count_thread_terminates_{0} {
+    : count_init_{0}, count_thread_started_{0}, count_thread_terminates_{0} {
     // nop
   }
 
   ~counting_thread_hook() override {
-    CAF_CHECK_EQUAL(count_init_, assumed_init_calls);
-    CAF_CHECK_EQUAL(count_thread_started_, assumed_thread_count);
-    CAF_CHECK_EQUAL(count_thread_terminates_, assumed_thread_count);
+    CHECK_EQ(count_init_, assumed_init_calls);
+    CHECK_EQ(count_thread_started_, assumed_thread_count);
+    CHECK_EQ(count_thread_terminates_, assumed_thread_count);
   }
 
   void init(actor_system&) override {
@@ -89,15 +87,15 @@ CAF_TEST(counting_no_system) {
   cfg.add_thread_hook<counting_thread_hook>();
 }
 
-CAF_TEST_FIXTURE_SCOPE(dummy_hook, fixture<dummy_thread_hook>)
+BEGIN_FIXTURE_SCOPE(fixture<dummy_thread_hook>)
 
 CAF_TEST(counting_no_args) {
   // nop
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()
 
-CAF_TEST_FIXTURE_SCOPE(counting_hook, fixture<counting_thread_hook>)
+BEGIN_FIXTURE_SCOPE(fixture<counting_thread_hook>)
 
 CAF_TEST(counting_system_without_actor) {
   assumed_init_calls = 1;
@@ -121,4 +119,4 @@ CAF_TEST(counting_system_with_actor) {
   sys.spawn([] {});
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/tracing_data.cpp
+++ b/libcaf_core/test/tracing_data.cpp
@@ -147,23 +147,23 @@ NAMED_ACTOR_STATE(carl);
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(actor_profiler_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(profilers inject tracing data into asynchronous messages) {
-  CAF_MESSAGE("spawn a foo and a bar");
+  MESSAGE("spawn a foo and a bar");
   auto carl_fun = [](stateful_actor<carl_state>* self) -> behavior {
     return {
       [=](const string& str) {
-        CAF_CHECK_EQUAL(str, "hello carl");
-        CAF_CHECK_EQUAL(tracing_id(self), "bob");
+        CHECK_EQ(str, "hello carl");
+        CHECK_EQ(tracing_id(self), "bob");
       },
     };
   };
   auto bob_fun = [](stateful_actor<bob_state>* self, actor carl) -> behavior {
     return {
       [=](const string& str) {
-        CAF_CHECK_EQUAL(str, "hello bob");
-        CAF_CHECK_EQUAL(tracing_id(self), "alice");
+        CHECK_EQ(str, "hello bob");
+        CHECK_EQ(tracing_id(self), "alice");
         self->send(carl, "hello carl");
       },
     };
@@ -179,14 +179,14 @@ CAF_TEST(tracing data is serializable) {
   byte_buffer buf;
   binary_serializer sink{sys, buf};
   tracing_data_ptr data{new dummy_tracing_data("iTrace")};
-  CAF_CHECK(sink.apply(data));
+  CHECK(sink.apply(data));
   binary_deserializer source{sys, buf};
   tracing_data_ptr copy;
-  CAF_CHECK(source.apply(copy));
+  CHECK(source.apply(copy));
   CAF_REQUIRE_NOT_EQUAL(copy.get(), nullptr);
-  CAF_CHECK_EQUAL(dynamic_cast<dummy_tracing_data&>(*copy).value, "iTrace");
+  CHECK_EQ(dynamic_cast<dummy_tracing_data&>(*copy).value, "iTrace");
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()
 
 #endif // CAF_ENABLE_ACTOR_PROFILER

--- a/libcaf_core/test/type_id_list.cpp
+++ b/libcaf_core/test/type_id_list.cpp
@@ -51,10 +51,10 @@ using namespace caf;
 CAF_TEST(lists store the size at index 0) {
   type_id_t data[] = {3, 1, 2, 4};
   type_id_list xs{data};
-  CAF_CHECK_EQUAL(xs.size(), 3u);
-  CAF_CHECK_EQUAL(xs[0], 1u);
-  CAF_CHECK_EQUAL(xs[1], 2u);
-  CAF_CHECK_EQUAL(xs[2], 4u);
+  CHECK_EQ(xs.size(), 3u);
+  CHECK_EQ(xs[0], 1u);
+  CHECK_EQ(xs[1], 2u);
+  CHECK_EQ(xs[2], 4u);
 }
 
 CAF_TEST(lists are comparable) {
@@ -62,26 +62,25 @@ CAF_TEST(lists are comparable) {
   type_id_list xs{data};
   type_id_t data_copy[] = {3, 1, 2, 4};
   type_id_list ys{data_copy};
-  CAF_CHECK_EQUAL(xs, ys);
+  CHECK_EQ(xs, ys);
   data_copy[1] = 10;
-  CAF_CHECK_NOT_EQUAL(xs, ys);
-  CAF_CHECK_LESS(xs, ys);
-  CAF_CHECK_EQUAL(make_type_id_list<add_atom>(), make_type_id_list<add_atom>());
-  CAF_CHECK_NOT_EQUAL(make_type_id_list<add_atom>(),
-                      make_type_id_list<ok_atom>());
+  CHECK_NE(xs, ys);
+  CHECK_LT(xs, ys);
+  CHECK_EQ(make_type_id_list<add_atom>(), make_type_id_list<add_atom>());
+  CHECK_NE(make_type_id_list<add_atom>(), make_type_id_list<ok_atom>());
 }
 
 CAF_TEST(make_type_id_list constructs a list from types) {
   auto xs = make_type_id_list<uint8_t, bool, float>();
-  CAF_CHECK_EQUAL(xs.size(), 3u);
-  CAF_CHECK_EQUAL(xs[0], type_id_v<uint8_t>);
-  CAF_CHECK_EQUAL(xs[1], type_id_v<bool>);
-  CAF_CHECK_EQUAL(xs[2], type_id_v<float>);
+  CHECK_EQ(xs.size(), 3u);
+  CHECK_EQ(xs[0], type_id_v<uint8_t>);
+  CHECK_EQ(xs[1], type_id_v<bool>);
+  CHECK_EQ(xs[2], type_id_v<float>);
 }
 
 CAF_TEST(type ID lists are convertible to strings) {
   auto xs = make_type_id_list<uint16_t, bool, float, long double>();
-  CAF_CHECK_EQUAL(to_string(xs), "[uint16_t, bool, float, ldouble]");
+  CHECK_EQ(to_string(xs), "[uint16_t, bool, float, ldouble]");
 }
 
 CAF_TEST(type ID lists are concatenable) {

--- a/libcaf_core/test/typed_behavior.cpp
+++ b/libcaf_core/test/typed_behavior.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/typed_behavior.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "core-test.hpp"
 
 #include <cstdint>
 #include <string>

--- a/libcaf_core/test/typed_message_view.cpp
+++ b/libcaf_core/test/typed_message_view.cpp
@@ -15,28 +15,28 @@ using namespace caf;
 CAF_TEST(message views detach their content) {
   auto msg1 = make_message(1, 2, 3, "four");
   auto msg2 = msg1;
-  CAF_REQUIRE(msg1.cptr() == msg2.cptr());
-  CAF_REQUIRE(msg1.match_elements<int, int, int, std::string>());
+  REQUIRE_EQ(msg1.cptr(), msg2.cptr());
+  REQUIRE((msg1.match_elements<int, int, int, std::string>()));
   typed_message_view<int, int, int, std::string> view{msg1};
-  CAF_REQUIRE(msg1.cptr() != msg2.cptr());
+  REQUIRE_NE(msg1.cptr(), msg2.cptr());
 }
 
 CAF_TEST(message views allow access via get) {
   auto msg = make_message(1, 2, 3, "four");
-  CAF_REQUIRE(msg.match_elements<int, int, int, std::string>());
+  REQUIRE((msg.match_elements<int, int, int, std::string>()));
   typed_message_view<int, int, int, std::string> view{msg};
-  CAF_CHECK_EQUAL(get<0>(view), 1);
-  CAF_CHECK_EQUAL(get<1>(view), 2);
-  CAF_CHECK_EQUAL(get<2>(view), 3);
-  CAF_CHECK_EQUAL(get<3>(view), "four");
+  CHECK_EQ(get<0>(view), 1);
+  CHECK_EQ(get<1>(view), 2);
+  CHECK_EQ(get<2>(view), 3);
+  CHECK_EQ(get<3>(view), "four");
 }
 
 CAF_TEST(message views allow mutating elements) {
   auto msg1 = make_message(1, 2, 3, "four");
   auto msg2 = msg1;
-  CAF_REQUIRE(msg1.match_elements<int, int, int, std::string>());
+  REQUIRE((msg1.match_elements<int, int, int, std::string>()));
   typed_message_view<int, int, int, std::string> view{msg1};
   get<0>(view) = 10;
-  CAF_CHECK_EQUAL(msg1.get_as<int>(0), 10);
-  CAF_CHECK_EQUAL(msg2.get_as<int>(0), 1);
+  CHECK_EQ(msg1.get_as<int>(0), 10);
+  CHECK_EQ(msg2.get_as<int>(0), 1);
 }

--- a/libcaf_core/test/typed_response_promise.cpp
+++ b/libcaf_core/test/typed_response_promise.cpp
@@ -99,7 +99,7 @@ testee_actor::behavior_type requester_v2(testee_actor::pointer self,
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(typed_response_promise_tests, test_coordinator_fixture<>)
+BEGIN_FIXTURE_SCOPE(test_coordinator_fixture<>)
 
 SCENARIO("response promises allow delaying of response messages") {
   auto adder_hdl = sys.spawn(adder);
@@ -174,4 +174,4 @@ SCENARIO("response promises allow delegation") {
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/unit.cpp
+++ b/libcaf_core/test/unit.cpp
@@ -43,7 +43,7 @@ CAF_TEST(unit_results) {
     self->request(aut, infinite, a)
       .receive(
         [&] {
-          CAF_MESSAGE("actor under test correctly replied to " << to_string(a));
+          MESSAGE("actor under test correctly replied to " << to_string(a));
         },
         [&](const error&) {
           CAF_FAIL("actor under test failed at input " << to_string(a));

--- a/libcaf_core/test/uri.cpp
+++ b/libcaf_core/test/uri.cpp
@@ -16,9 +16,11 @@ using namespace caf;
 
 namespace {
 
-struct authority_separator_t {} authority_separator;
+struct authority_separator_t {
+} authority_separator;
 
-struct path_separator_t {} path_separator;
+struct path_separator_t {
+} path_separator;
 
 struct uri_str_builder {
   std::string res;
@@ -60,7 +62,7 @@ struct uri_str_builder {
   }
 
   uri_str_builder& host(ip_address addr) {
-    return add(authority_separator, '[', to_string(addr),  ']');
+    return add(authority_separator, '[', to_string(addr), ']');
   }
 
   uri_str_builder& port(uint16_t value) {
@@ -133,42 +135,48 @@ struct fixture {
   }
 };
 
-struct me_t {} me;
+struct me_t {
+} me;
 
 template <class T>
 T& operator<<(T& builder, me_t) {
   return builder.userinfo("me");
 }
 
-struct node_t {} node;
+struct node_t {
+} node;
 
 template <class T>
 T& operator<<(T& builder, node_t) {
   return builder.host("node");
 }
 
-struct port80_t {} port80;
+struct port80_t {
+} port80;
 
 template <class T>
 T& operator<<(T& builder, port80_t) {
   return builder.port(80);
 }
 
-struct file_t {} file;
+struct file_t {
+} file;
 
 template <class T>
 T& operator<<(T& builder, file_t) {
   return builder.path("file");
 }
 
-struct frag_t {} frag;
+struct frag_t {
+} frag;
 
 template <class T>
 T& operator<<(T& builder, frag_t) {
   return builder.fragment("42");
 }
 
-struct kvp_t {} kvp;
+struct kvp_t {
+} kvp;
 
 template <class T>
 T& operator<<(T& builder, kvp_t) {
@@ -183,7 +191,7 @@ uri operator*(uri_builder& builder) {
   return result;
 }
 
-uri operator "" _u(const char* cstr, size_t cstr_len) {
+uri operator"" _u(const char* cstr, size_t cstr_len) {
   uri result;
   string_view str{cstr, cstr_len};
   auto err = parse(str, result);
@@ -192,40 +200,40 @@ uri operator "" _u(const char* cstr, size_t cstr_len) {
   return result;
 }
 
-bool operator "" _i(const char* cstr, size_t cstr_len) {
+bool operator"" _i(const char* cstr, size_t cstr_len) {
   uri result;
   string_view str{cstr, cstr_len};
-  CAF_CHECK(!uri::can_parse(str));
+  CHECK(!uri::can_parse(str));
   auto err = parse(str, result);
   return err != none;
 }
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(uri_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(default URIs are empty) {
   uri x;
-  CAF_CHECK_EQUAL(x.empty(), true);
-  CAF_CHECK_EQUAL(x.str(), "");
+  CHECK_EQ(x.empty(), true);
+  CHECK_EQ(x.str(), "");
 }
 
 CAF_TEST(URIs recognize IP addresses while parsing) {
   auto v6_localhost = "tcp://[::1]:8080"_u;
-  CAF_CHECK(holds_alternative<ip_address>(v6_localhost.authority().host));
+  CHECK(holds_alternative<ip_address>(v6_localhost.authority().host));
   auto v4_localhost = "tcp://127.0.0.1:8080"_u;
-  CAF_CHECK(holds_alternative<ip_address>(v4_localhost.authority().host));
+  CHECK(holds_alternative<ip_address>(v4_localhost.authority().host));
   auto str_localhost = "tcp://localhost:8080"_u;
-  CAF_CHECK(holds_alternative<std::string>(str_localhost.authority().host));
+  CHECK(holds_alternative<std::string>(str_localhost.authority().host));
 }
 
 #define BUILD(components)                                                      \
-  CAF_CHECK_EQUAL(*(http << components), *(http_str << components))
+  CHECK_EQ(*(http << components), *(http_str << components))
 
 CAF_TEST(builder construction) {
   auto minimal = *(http << file);
-  CAF_CHECK_EQUAL(minimal.empty(), false);
-  CAF_CHECK_EQUAL(minimal, "http:file");
+  CHECK_EQ(minimal.empty(), false);
+  CHECK_EQ(minimal, "http:file");
   // all combinations of components
   BUILD(file);
   BUILD(file << kvp);
@@ -271,13 +279,13 @@ CAF_TEST(builder construction) {
                    .path("file 1")
                    .fragment("[42]")
                    .make();
-  CAF_CHECK_EQUAL(escaped, "hi%20there://it%27s@me%2F/file%201#%5B42%5D");
+  CHECK_EQ(escaped, "hi%20there://it%27s@me%2F/file%201#%5B42%5D");
 }
 
 #define ROUNDTRIP(str)                                                         \
   do {                                                                         \
-    CAF_CHECK(uri::can_parse(str));                                            \
-    CAF_CHECK_EQUAL(str##_u, str);                                             \
+    CHECK(uri::can_parse(str));                                                \
+    CHECK_EQ(str##_u, str);                                                    \
   } while (false)
 
 CAF_TEST(from string) {
@@ -361,27 +369,27 @@ CAF_TEST(from string) {
 #undef ROUNDTRIP
 
 CAF_TEST(empty components) {
-  CAF_CHECK_EQUAL("foo:/"_u, "foo:/");
-  CAF_CHECK_EQUAL("foo:///"_u, "foo:/");
-  CAF_CHECK_EQUAL("foo:/#"_u, "foo:/");
-  CAF_CHECK_EQUAL("foo:/?"_u, "foo:/");
-  CAF_CHECK_EQUAL("foo:/?#"_u, "foo:/");
-  CAF_CHECK_EQUAL("foo:bar#"_u, "foo:bar");
-  CAF_CHECK_EQUAL("foo:bar?"_u, "foo:bar");
-  CAF_CHECK_EQUAL("foo:bar?#"_u, "foo:bar");
-  CAF_CHECK_EQUAL("foo://bar#"_u, "foo://bar");
-  CAF_CHECK_EQUAL("foo://bar?"_u, "foo://bar");
-  CAF_CHECK_EQUAL("foo://bar?#"_u, "foo://bar");
+  CHECK_EQ("foo:/"_u, "foo:/");
+  CHECK_EQ("foo:///"_u, "foo:/");
+  CHECK_EQ("foo:/#"_u, "foo:/");
+  CHECK_EQ("foo:/?"_u, "foo:/");
+  CHECK_EQ("foo:/?#"_u, "foo:/");
+  CHECK_EQ("foo:bar#"_u, "foo:bar");
+  CHECK_EQ("foo:bar?"_u, "foo:bar");
+  CHECK_EQ("foo:bar?#"_u, "foo:bar");
+  CHECK_EQ("foo://bar#"_u, "foo://bar");
+  CHECK_EQ("foo://bar?"_u, "foo://bar");
+  CHECK_EQ("foo://bar?#"_u, "foo://bar");
 }
 
 CAF_TEST(invalid uris) {
-  CAF_CHECK("http"_i);
-  CAF_CHECK("http://"_i);
-  CAF_CHECK("http://foo:66000"_i);
+  CHECK("http"_i);
+  CHECK("http://"_i);
+  CHECK("http://foo:66000"_i);
 }
 
 #define SERIALIZATION_ROUNDTRIP(str)                                           \
-  CAF_CHECK_EQUAL(deserialize(serialize(str##_u)), str)
+  CHECK_EQ(deserialize(serialize(str##_u)), str)
 
 CAF_TEST(serialization) {
   // all combinations of components
@@ -460,4 +468,4 @@ CAF_TEST(serialization) {
 
 #undef SERIALIZATION_ROUNDTRIP
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/uuid.cpp
+++ b/libcaf_core/test/uuid.cpp
@@ -53,78 +53,78 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(uuid_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(default generated UUIDs have all 128 bits set to zero) {
   uuid nil;
-  CAF_CHECK(!nil);
+  CHECK(!nil);
   auto zero = [](byte x) { return to_integer<int>(x) == 0; };
-  CAF_CHECK(std::all_of(nil.bytes().begin(), nil.bytes().end(), zero));
-  CAF_CHECK(nil == uuid::nil());
+  CHECK(std::all_of(nil.bytes().begin(), nil.bytes().end(), zero));
+  CHECK(nil == uuid::nil());
 }
 
 CAF_TEST(UUIDs print in 4 2 2 2 6 format) {
-  CAF_CHECK_EQUAL(to_string(nil), "00000000-0000-0000-0000-000000000000");
-  CAF_CHECK_EQUAL(to_string(v1[0]), "cbba341a-6ceb-11ea-bc55-0242ac130003");
-  CAF_CHECK_EQUAL(to_string(v1[1]), "cbba369a-6ceb-11ea-bc55-0242ac130003");
-  CAF_CHECK_EQUAL(to_string(v1[2]), "cbba38fc-6ceb-11ea-bc55-0242ac130003");
+  CHECK_EQ(to_string(nil), "00000000-0000-0000-0000-000000000000");
+  CHECK_EQ(to_string(v1[0]), "cbba341a-6ceb-11ea-bc55-0242ac130003");
+  CHECK_EQ(to_string(v1[1]), "cbba369a-6ceb-11ea-bc55-0242ac130003");
+  CHECK_EQ(to_string(v1[2]), "cbba38fc-6ceb-11ea-bc55-0242ac130003");
 }
 
 CAF_TEST(make_uuid parses strings in 4 2 2 2 6 format) {
-  CAF_CHECK_EQUAL(make_uuid("00000000-0000-0000-0000-000000000000"), nil);
-  CAF_CHECK_EQUAL(make_uuid("cbba341a-6ceb-11ea-bc55-0242ac130003"), v1[0]);
-  CAF_CHECK_EQUAL(make_uuid("cbba369a-6ceb-11ea-bc55-0242ac130003"), v1[1]);
-  CAF_CHECK_EQUAL(make_uuid("cbba38fc-6ceb-11ea-bc55-0242ac130003"), v1[2]);
+  CHECK_EQ(make_uuid("00000000-0000-0000-0000-000000000000"), nil);
+  CHECK_EQ(make_uuid("cbba341a-6ceb-11ea-bc55-0242ac130003"), v1[0]);
+  CHECK_EQ(make_uuid("cbba369a-6ceb-11ea-bc55-0242ac130003"), v1[1]);
+  CHECK_EQ(make_uuid("cbba38fc-6ceb-11ea-bc55-0242ac130003"), v1[2]);
 }
 
 CAF_TEST(make_uuid rejects strings with invalid variant or version values) {
-  CAF_CHECK(!uuid::can_parse("cbba341a-6ceb-81ea-bc55-0242ac130003"));
-  CAF_CHECK(!uuid::can_parse("cbba369a-6ceb-F1ea-bc55-0242ac130003"));
-  CAF_CHECK(!uuid::can_parse("cbba38fc-6ceb-01ea-bc55-0242ac130003"));
-  CAF_CHECK_EQUAL(make_uuid("cbba341a-6ceb-81ea-bc55-0242ac130003"),
-                  pec::invalid_argument);
-  CAF_CHECK_EQUAL(make_uuid("cbba369a-6ceb-F1ea-bc55-0242ac130003"),
-                  pec::invalid_argument);
-  CAF_CHECK_EQUAL(make_uuid("cbba38fc-6ceb-01ea-bc55-0242ac130003"),
-                  pec::invalid_argument);
+  CHECK(!uuid::can_parse("cbba341a-6ceb-81ea-bc55-0242ac130003"));
+  CHECK(!uuid::can_parse("cbba369a-6ceb-F1ea-bc55-0242ac130003"));
+  CHECK(!uuid::can_parse("cbba38fc-6ceb-01ea-bc55-0242ac130003"));
+  CHECK_EQ(make_uuid("cbba341a-6ceb-81ea-bc55-0242ac130003"),
+           pec::invalid_argument);
+  CHECK_EQ(make_uuid("cbba369a-6ceb-F1ea-bc55-0242ac130003"),
+           pec::invalid_argument);
+  CHECK_EQ(make_uuid("cbba38fc-6ceb-01ea-bc55-0242ac130003"),
+           pec::invalid_argument);
 }
 
 #define WITH(uuid_str) if (auto x = uuid_str##_uuid; true)
 
 CAF_TEST(version 1 defines UUIDs that are based on time) {
-  CAF_CHECK_EQUAL(v1[0].version(), uuid::time_based);
-  CAF_CHECK_EQUAL(v1[1].version(), uuid::time_based);
-  CAF_CHECK_EQUAL(v1[2].version(), uuid::time_based);
-  CAF_CHECK_NOT_EQUAL(v4[0].version(), uuid::time_based);
-  CAF_CHECK_NOT_EQUAL(v4[1].version(), uuid::time_based);
-  CAF_CHECK_NOT_EQUAL(v4[2].version(), uuid::time_based);
+  CHECK_EQ(v1[0].version(), uuid::time_based);
+  CHECK_EQ(v1[1].version(), uuid::time_based);
+  CHECK_EQ(v1[2].version(), uuid::time_based);
+  CHECK_NE(v4[0].version(), uuid::time_based);
+  CHECK_NE(v4[1].version(), uuid::time_based);
+  CHECK_NE(v4[2].version(), uuid::time_based);
   WITH("00000001-0000-1000-8122-334455667788") {
-    CAF_CHECK_EQUAL(x.variant(), uuid::rfc4122);
-    CAF_CHECK_EQUAL(x.version(), uuid::time_based);
-    CAF_CHECK_EQUAL(x.timestamp(), 0x0000000000000001ull);
-    CAF_CHECK_EQUAL(x.clock_sequence(), 0x0122u);
-    CAF_CHECK_EQUAL(x.node(), 0x334455667788ull);
+    CHECK_EQ(x.variant(), uuid::rfc4122);
+    CHECK_EQ(x.version(), uuid::time_based);
+    CHECK_EQ(x.timestamp(), 0x0000000000000001ull);
+    CHECK_EQ(x.clock_sequence(), 0x0122u);
+    CHECK_EQ(x.node(), 0x334455667788ull);
   }
   WITH("00000001-0001-1000-8122-334455667788") {
-    CAF_CHECK_EQUAL(x.variant(), uuid::rfc4122);
-    CAF_CHECK_EQUAL(x.version(), uuid::time_based);
-    CAF_CHECK_EQUAL(x.timestamp(), 0x0000000100000001ull);
-    CAF_CHECK_EQUAL(x.clock_sequence(), 0x0122u);
-    CAF_CHECK_EQUAL(x.node(), 0x334455667788ull);
+    CHECK_EQ(x.variant(), uuid::rfc4122);
+    CHECK_EQ(x.version(), uuid::time_based);
+    CHECK_EQ(x.timestamp(), 0x0000000100000001ull);
+    CHECK_EQ(x.clock_sequence(), 0x0122u);
+    CHECK_EQ(x.node(), 0x334455667788ull);
   }
   WITH("00000001-0001-1001-8122-334455667788") {
-    CAF_CHECK_EQUAL(x.variant(), uuid::rfc4122);
-    CAF_CHECK_EQUAL(x.version(), uuid::time_based);
-    CAF_CHECK_EQUAL(x.timestamp(), 0x0001000100000001ull);
-    CAF_CHECK_EQUAL(x.clock_sequence(), 0x0122u);
-    CAF_CHECK_EQUAL(x.node(), 0x334455667788ull);
+    CHECK_EQ(x.variant(), uuid::rfc4122);
+    CHECK_EQ(x.version(), uuid::time_based);
+    CHECK_EQ(x.timestamp(), 0x0001000100000001ull);
+    CHECK_EQ(x.clock_sequence(), 0x0122u);
+    CHECK_EQ(x.node(), 0x334455667788ull);
   }
   WITH("ffffffff-ffff-1fff-bfff-334455667788") {
-    CAF_CHECK_EQUAL(x.variant(), uuid::rfc4122);
-    CAF_CHECK_EQUAL(x.version(), uuid::time_based);
-    CAF_CHECK_EQUAL(x.timestamp(), 0x0FFFFFFFFFFFFFFFull);
-    CAF_CHECK_EQUAL(x.clock_sequence(), 0x3FFFu);
-    CAF_CHECK_EQUAL(x.node(), 0x334455667788ull);
+    CHECK_EQ(x.variant(), uuid::rfc4122);
+    CHECK_EQ(x.version(), uuid::time_based);
+    CHECK_EQ(x.timestamp(), 0x0FFFFFFFFFFFFFFFull);
+    CHECK_EQ(x.clock_sequence(), 0x3FFFu);
+    CHECK_EQ(x.node(), 0x334455667788ull);
   }
 }
 
@@ -176,4 +176,4 @@ SCENARIO("UUIDs are hashable") {
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_core/test/variant.cpp
+++ b/libcaf_core/test/variant.cpp
@@ -59,16 +59,16 @@ using namespace caf;
 
 macro_repeat20(i_n)
 
-// a variant with 20 element types
-using v20 = variant<i01, i02, i03, i04, i05, i06, i07, i08, i09, i10,
-                    i11, i12, i13, i14, i15, i16, i17, i18, i19, i20>;
+  // a variant with 20 element types
+  using v20 = variant<i01, i02, i03, i04, i05, i06, i07, i08, i09, i10, i11,
+                      i12, i13, i14, i15, i16, i17, i18, i19, i20>;
 
 #define VARIANT_EQ(x, y)                                                       \
   do {                                                                         \
     using type = std::decay_t<decltype(y)>;                                    \
     auto&& tmp = x;                                                            \
-    if (CAF_CHECK(holds_alternative<type>(tmp)))                               \
-      CAF_CHECK_EQUAL(get<type>(tmp), y);                                      \
+    if (CHECK(holds_alternative<type>(tmp)))                                   \
+      CHECK_EQ(get<type>(tmp), y);                                             \
   } while (false)
 
 #define v20_test(n)                                                            \
@@ -122,17 +122,17 @@ CAF_TEST(n_ary_visit) {
   variant<float, int, std::string> b{"bar"s};
   variant<int, std::string, double> c{123};
   test_visitor f;
-  CAF_CHECK_EQUAL(visit(f, a), R"__([42])__");
-  CAF_CHECK_EQUAL(visit(f, a, b), R"__([42, "bar"])__");
-  CAF_CHECK_EQUAL(visit(f, a, b, c), R"__([42, "bar", 123])__");
+  CHECK_EQ(visit(f, a), R"__([42])__");
+  CHECK_EQ(visit(f, a, b), R"__([42, "bar"])__");
+  CHECK_EQ(visit(f, a, b, c), R"__([42, "bar", 123])__");
 }
 
 CAF_TEST(get_if) {
   variant<int, std::string> b = "foo"s;
-  CAF_MESSAGE("test get_if directly");
-  CAF_CHECK_EQUAL(get_if<int>(&b), nullptr);
-  CAF_CHECK_NOT_EQUAL(get_if<std::string>(&b), nullptr);
-  CAF_MESSAGE("test get_if via unit test framework");
+  MESSAGE("test get_if directly");
+  CHECK_EQ(get_if<int>(&b), nullptr);
+  CHECK_NE(get_if<std::string>(&b), nullptr);
+  MESSAGE("test get_if via unit test framework");
   VARIANT_EQ(b, "foo"s);
 }
 
@@ -140,25 +140,25 @@ CAF_TEST(less_than) {
   using variant_type = variant<char, int>;
   auto a = variant_type{'x'};
   auto b = variant_type{'y'};
-  CAF_CHECK(a < b);
-  CAF_CHECK(!(a > b));
-  CAF_CHECK(a <= b);
-  CAF_CHECK(!(a >= b));
+  CHECK(a < b);
+  CHECK(!(a > b));
+  CHECK(a <= b);
+  CHECK(!(a >= b));
   b = 42;
-  CAF_CHECK(a < b);
-  CAF_CHECK(!(a > b));
-  CAF_CHECK(a <= b);
-  CAF_CHECK(!(a >= b));
+  CHECK(a < b);
+  CHECK(!(a > b));
+  CHECK(a <= b);
+  CHECK(!(a >= b));
   a = 42;
-  CAF_CHECK(!(a < b));
-  CAF_CHECK(!(a > b));
-  CAF_CHECK(a <= b);
-  CAF_CHECK(a >= b);
+  CHECK(!(a < b));
+  CHECK(!(a > b));
+  CHECK(a <= b);
+  CHECK(a >= b);
   b = 'x';
 }
 
 CAF_TEST(equality) {
   variant<uint16_t, int> x = 42;
   variant<uint16_t, int> y = uint16_t{42};
-  CAF_CHECK_NOT_EQUAL(x, y);
+  CHECK_NE(x, y);
 }

--- a/libcaf_io/test/detail/prometheus_broker.cpp
+++ b/libcaf_io/test/detail/prometheus_broker.cpp
@@ -60,7 +60,7 @@ constexpr string_view http_ok_header = "HTTP/1.1 200 OK\r\n"
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(prometheus_broker_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(the prometheus broker responds to HTTP get requests) {
   auto bytes = as_bytes(make_span(http_request));
@@ -69,16 +69,16 @@ CAF_TEST(the prometheus broker responds to HTTP get requests) {
   auto& response_buf = mpx.output_buffer(connection);
   string_view response{reinterpret_cast<char*>(response_buf.data()),
                        response_buf.size()};
-  CAF_CHECK(starts_with(response, http_ok_header));
-  CAF_CHECK(contains(response, "\ncaf_system_running_actors 2 "));
+  CHECK(starts_with(response, http_ok_header));
+  CHECK(contains(response, "\ncaf_system_running_actors 2 "));
   if (detail::prometheus_broker::has_process_metrics()) {
-    CAF_CHECK(contains(response, "\nprocess_cpu_seconds_total "));
-    CAF_CHECK(contains(response, "\nprocess_resident_memory_bytes "));
-    CAF_CHECK(contains(response, "\nprocess_virtual_memory_bytes "));
+    CHECK(contains(response, "\nprocess_cpu_seconds_total "));
+    CHECK(contains(response, "\nprocess_resident_memory_bytes "));
+    CHECK(contains(response, "\nprocess_virtual_memory_bytes "));
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()
 
 namespace {
 
@@ -131,12 +131,12 @@ SCENARIO("setting caf.middleman.prometheus-http.port exports metrics to HTTP") {
         auto response_buf = read_all(http_request, "localhost", scraping_port);
         string_view response{reinterpret_cast<char*>(response_buf.data()),
                              response_buf.size()};
-        CAF_CHECK(starts_with(response, http_ok_header));
-        CAF_CHECK(contains(response, "\ncaf_system_running_actors "));
+        CHECK(starts_with(response, http_ok_header));
+        CHECK(contains(response, "\ncaf_system_running_actors "));
         if (detail::prometheus_broker::has_process_metrics()) {
-          CAF_CHECK(contains(response, "\nprocess_cpu_seconds_total "));
-          CAF_CHECK(contains(response, "\nprocess_resident_memory_bytes "));
-          CAF_CHECK(contains(response, "\nprocess_virtual_memory_bytes "));
+          CHECK(contains(response, "\nprocess_cpu_seconds_total "));
+          CHECK(contains(response, "\nprocess_resident_memory_bytes "));
+          CHECK(contains(response, "\nprocess_virtual_memory_bytes "));
         }
       }
     }

--- a/libcaf_io/test/io/basp/message_queue.cpp
+++ b/libcaf_io/test/io/basp/message_queue.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/io/basp/message_queue.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "io-test.hpp"
 
 #include "caf/actor_cast.hpp"
 #include "caf/actor_system.hpp"
@@ -45,19 +45,19 @@ struct fixture : test_coordinator_fixture<> {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(message_queue_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(default construction) {
-  CAF_CHECK_EQUAL(queue.next_id, 0u);
-  CAF_CHECK_EQUAL(queue.next_undelivered, 0u);
-  CAF_CHECK_EQUAL(queue.pending.size(), 0u);
+  CHECK_EQ(queue.next_id, 0u);
+  CHECK_EQ(queue.next_undelivered, 0u);
+  CHECK_EQ(queue.pending.size(), 0u);
 }
 
 CAF_TEST(ascending IDs) {
-  CAF_CHECK_EQUAL(queue.new_id(), 0u);
-  CAF_CHECK_EQUAL(queue.new_id(), 1u);
-  CAF_CHECK_EQUAL(queue.new_id(), 2u);
-  CAF_CHECK_EQUAL(queue.next_undelivered, 0u);
+  CHECK_EQ(queue.new_id(), 0u);
+  CHECK_EQ(queue.new_id(), 1u);
+  CHECK_EQ(queue.new_id(), 2u);
+  CHECK_EQ(queue.next_undelivered, 0u);
 }
 
 CAF_TEST(push order 0 - 1 - 2) {
@@ -138,4 +138,4 @@ CAF_TEST(dropping) {
   expect((ok_atom, int), from(self).to(testee).with(_, 2));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_io/test/io/basp_broker.cpp
+++ b/libcaf_io/test/io/basp_broker.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/io/basp_broker.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "io-test.hpp"
 
 #include <array>
 #include <condition_variable>
@@ -132,9 +132,9 @@ public:
     nodes_[0].name = "Jupiter";
     nodes_[1].name = "Mars";
     CAF_REQUIRE_NOT_EQUAL(jupiter().connection, mars().connection);
-    CAF_MESSAGE("Earth:   " << to_string(this_node_));
-    CAF_MESSAGE("Jupiter: " << to_string(jupiter().id));
-    CAF_MESSAGE("Mars:    " << to_string(mars().id));
+    MESSAGE("Earth:   " << to_string(this_node_));
+    MESSAGE("Jupiter: " << to_string(jupiter().id));
+    MESSAGE("Mars:    " << to_string(mars().id));
     CAF_REQUIRE_NOT_EQUAL(this_node_, jupiter().id);
     CAF_REQUIRE_NOT_EQUAL(jupiter().id, mars().id);
   }
@@ -245,9 +245,9 @@ public:
                     actor_id published_actor_id = invalid_actor_id,
                     const std::set<std::string>& published_actor_ifs = {}) {
     auto src = ax ? *ax : ahdl_;
-    CAF_MESSAGE("connect remote node "
-                << n.name << ", connection ID = " << n.connection.id()
-                << ", acceptor ID = " << src.id());
+    MESSAGE("connect remote node " << n.name
+                                   << ", connection ID = " << n.connection.id()
+                                   << ", acceptor ID = " << src.id());
     auto hdl = n.connection;
     mpx_->add_pending_connect(src, hdl);
     mpx_->accept_connection(src);
@@ -271,12 +271,12 @@ public:
     // routing table upon receiving client handshakes
     auto path = tbl().lookup(n.id);
     CAF_REQUIRE(path);
-    CAF_CHECK_EQUAL(path->hdl, n.connection);
-    CAF_CHECK_EQUAL(path->next_hop, n.id);
+    CHECK_EQ(path->hdl, n.connection);
+    CHECK_EQ(path->next_hop, n.id);
   }
 
   auto read_from_out_buf(connection_handle hdl) {
-    CAF_MESSAGE("read from output buffer for connection " << hdl.id());
+    MESSAGE("read from output buffer for connection " << hdl.id());
     auto& buf = mpx_->output_buffer(hdl);
     while (buf.size() < basp::header_size)
       mpx()->exec_runnable();
@@ -290,7 +290,7 @@ public:
     basp::header hdr;
     byte_buffer buf;
     std::tie(hdr, buf) = read_from_out_buf(hdl);
-    CAF_MESSAGE("dispatch output buffer for connection " << hdl.id());
+    MESSAGE("dispatch output buffer for connection " << hdl.id());
     CAF_REQUIRE_EQUAL(hdr.operation, basp::message_type::direct_message);
     binary_deserializer source{mpx_, buf};
     std::vector<strong_actor_ptr> stages;
@@ -315,8 +315,8 @@ public:
 
     ~mock_t() {
       if (num > 1)
-        CAF_MESSAGE("implementation under test responded with "
-                    << (num - 1) << " BASP message" << (num > 2 ? "s" : ""));
+        MESSAGE("implementation under test responded with "
+                << (num - 1) << " BASP message" << (num > 2 ? "s" : ""));
     }
 
     template <class... Ts>
@@ -325,14 +325,14 @@ public:
                     maybe<uint64_t> operation_data,
                     maybe<actor_id> source_actor, maybe<actor_id> dest_actor,
                     const Ts&... xs) {
-      CAF_MESSAGE("expect #" << num);
+      MESSAGE("expect #" << num);
       byte_buffer buf;
       this_->to_payload(buf, xs...);
       auto& ob = this_->mpx()->output_buffer(hdl);
       while (this_->mpx()->try_exec_runnable()) {
         // repeat
       }
-      CAF_MESSAGE("output buffer has " << ob.size() << " bytes");
+      MESSAGE("output buffer has " << ob.size() << " bytes");
       basp::header hdr;
       { // lifetime scope of source
         binary_deserializer source{this_->mpx(), ob};
@@ -345,18 +345,18 @@ public:
         auto first = ob.begin() + basp::header_size;
         auto end = first + hdr.payload_len;
         payload.assign(first, end);
-        CAF_MESSAGE("erase " << std::distance(ob.begin(), end)
-                             << " bytes from output buffer");
+        MESSAGE("erase " << std::distance(ob.begin(), end)
+                         << " bytes from output buffer");
         ob.erase(ob.begin(), end);
       } else {
         ob.erase(ob.begin(), ob.begin() + basp::header_size);
       }
-      CAF_CHECK_EQUAL(operation, hdr.operation);
-      CAF_CHECK_EQUAL(flags, static_cast<uint8_t>(hdr.flags));
-      CAF_CHECK_EQUAL(payload_len, hdr.payload_len);
-      CAF_CHECK_EQUAL(operation_data, hdr.operation_data);
-      CAF_CHECK_EQUAL(source_actor, hdr.source_actor);
-      CAF_CHECK_EQUAL(dest_actor, hdr.dest_actor);
+      CHECK_EQ(operation, hdr.operation);
+      CHECK_EQ(flags, static_cast<uint8_t>(hdr.flags));
+      CHECK_EQ(payload_len, hdr.payload_len);
+      CHECK_EQ(operation_data, hdr.operation_data);
+      CHECK_EQ(source_actor, hdr.source_actor);
+      CHECK_EQ(dest_actor, hdr.dest_actor);
       CAF_REQUIRE_EQUAL(buf.size(), payload.size());
       CAF_REQUIRE_EQUAL(hexstr(buf), hexstr(payload));
       ++num;
@@ -372,9 +372,9 @@ public:
   mock_t mock(connection_handle hdl, basp::header hdr, const Ts&... xs) {
     byte_buffer buf;
     to_buf(buf, hdr, nullptr, xs...);
-    CAF_MESSAGE("virtually send " << to_string(hdr.operation) << " with "
-                                  << (buf.size() - basp::header_size)
-                                  << " bytes payload");
+    MESSAGE("virtually send " << to_string(hdr.operation) << " with "
+                              << (buf.size() - basp::header_size)
+                              << " bytes payload");
     mpx()->virtual_send(hdl, buf);
     return {this};
   }
@@ -430,7 +430,7 @@ public:
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(basp_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(empty_server_handshake) {
   // test whether basp instance correctly sends a
@@ -446,9 +446,9 @@ CAF_TEST(empty_server_handshake) {
                         basp::version,
                         invalid_actor_id,
                         invalid_actor_id};
-  CAF_CHECK(basp::valid(hdr));
-  CAF_CHECK(basp::is_handshake(hdr));
-  CAF_CHECK_EQUAL(deep_to_string(hdr), deep_to_string(expected));
+  CHECK(basp::valid(hdr));
+  CHECK(basp::is_handshake(hdr));
+  CHECK_EQ(deep_to_string(hdr), deep_to_string(expected));
 }
 
 CAF_TEST(non_empty_server_handshake) {
@@ -467,9 +467,9 @@ CAF_TEST(non_empty_server_handshake) {
                         basp::version,
                         invalid_actor_id,
                         invalid_actor_id};
-  CAF_CHECK(basp::valid(hdr));
-  CAF_CHECK(basp::is_handshake(hdr));
-  CAF_CHECK_EQUAL(deep_to_string(hdr), deep_to_string(expected));
+  CHECK(basp::valid(hdr));
+  CHECK(basp::is_handshake(hdr));
+  CHECK_EQ(deep_to_string(hdr), deep_to_string(expected));
   byte_buffer expected_payload;
   std::set<std::string> ifs{"caf::replies_to<@u16>::with<@u16>"};
   binary_serializer sink{nullptr, expected_payload};
@@ -479,30 +479,30 @@ CAF_TEST(non_empty_server_handshake) {
       || !sink.apply(id)                  //
       || !sink.apply(ifs))
     CAF_FAIL("serializing handshake failed: " << sink.get_error());
-  CAF_CHECK_EQUAL(hexstr(payload), hexstr(expected_payload));
+  CHECK_EQ(hexstr(payload), hexstr(expected_payload));
 }
 
 CAF_TEST(remote_address_and_port) {
-  CAF_MESSAGE("connect to Mars");
+  MESSAGE("connect to Mars");
   connect_node(mars());
   auto mm = sys.middleman().actor_handle();
-  CAF_MESSAGE("ask MM about node ID of Mars");
+  MESSAGE("ask MM about node ID of Mars");
   self()->send(mm, get_atom_v, mars().id);
   do {
     mpx()->exec_runnable();
   } while (self()->mailbox().empty());
-  CAF_MESSAGE("receive result of MM");
+  MESSAGE("receive result of MM");
   self()->receive(
     [&](const node_id& nid, const std::string& addr, uint16_t port) {
-      CAF_CHECK_EQUAL(nid, mars().id);
+      CHECK_EQ(nid, mars().id);
       // all test nodes have address "test" and connection handle ID as port
-      CAF_CHECK_EQUAL(addr, "test");
-      CAF_CHECK_EQUAL(port, mars().connection.id());
+      CHECK_EQ(addr, "test");
+      CHECK_EQ(port, mars().connection.id());
     });
 }
 
 CAF_TEST(client_handshake_and_dispatch) {
-  CAF_MESSAGE("connect to Jupiter");
+  MESSAGE("connect to Jupiter");
   connect_node(jupiter());
   // send a message via `dispatch` from node 0
   mock(jupiter().connection,
@@ -517,16 +517,16 @@ CAF_TEST(client_handshake_and_dispatch) {
   // must've send remote node a message that this proxy is monitored now
   // receive the message
   self()->receive([](int a, int b, int c) {
-    CAF_CHECK_EQUAL(a, 1);
-    CAF_CHECK_EQUAL(b, 2);
-    CAF_CHECK_EQUAL(c, 3);
+    CHECK_EQ(a, 1);
+    CHECK_EQ(b, 2);
+    CHECK_EQ(c, 3);
     return a + b + c;
   });
-  CAF_MESSAGE("exec message of forwarding proxy");
+  MESSAGE("exec message of forwarding proxy");
   mpx()->exec_runnable();
   // deserialize and send message from out buf
   dispatch_out_buf(jupiter().connection);
-  jupiter().dummy_actor->receive([](int i) { CAF_CHECK_EQUAL(i, 6); });
+  jupiter().dummy_actor->receive([](int i) { CHECK_EQ(i, 6); });
 }
 
 CAF_TEST(message_forwarding) {
@@ -556,7 +556,7 @@ CAF_TEST(publish_and_connect) {
 
 CAF_TEST(remote_actor_and_send) {
   constexpr const char* lo = "localhost";
-  CAF_MESSAGE("self: " << to_string(self()->address()));
+  MESSAGE("self: " << to_string(self()->address()));
   mpx()->provide_scribe(lo, 4242, jupiter().connection);
   CAF_REQUIRE(mpx()->has_pending_scribe(lo, 4242));
   auto mm1 = sys.middleman().actor_handle();
@@ -567,7 +567,7 @@ CAF_TEST(remote_actor_and_send) {
     mpx()->exec_runnable();
   CAF_REQUIRE(!mpx()->has_pending_scribe(lo, 4242));
   // build a fake server handshake containing the id of our first pseudo actor
-  CAF_MESSAGE("server handshake => client handshake + proxy announcement");
+  MESSAGE("server handshake => client handshake + proxy announcement");
   auto na = registry()->named_actors();
   mock(jupiter().connection,
        {basp::message_type::server_handshake, 0, 0, basp::version,
@@ -585,24 +585,24 @@ CAF_TEST(remote_actor_and_send) {
     .receive(jupiter().connection, basp::message_type::monitor_message,
              no_flags, any_vals, no_operation_data, invalid_actor_id,
              jupiter().dummy_actor->id(), this_node(), jupiter().id);
-  CAF_MESSAGE("BASP broker should've send the proxy");
+  MESSAGE("BASP broker should've send the proxy");
   f.receive(
     [&](node_id nid, strong_actor_ptr res, std::set<std::string> ifs) {
       CAF_REQUIRE(res);
       auto aptr = actor_cast<abstract_actor*>(res);
       CAF_REQUIRE(dynamic_cast<forwarding_actor_proxy*>(aptr) != nullptr);
-      CAF_CHECK_EQUAL(proxies().count_proxies(jupiter().id), 1u);
-      CAF_CHECK_EQUAL(nid, jupiter().id);
-      CAF_CHECK_EQUAL(res->node(), jupiter().id);
-      CAF_CHECK_EQUAL(res->id(), jupiter().dummy_actor->id());
-      CAF_CHECK(ifs.empty());
+      CHECK_EQ(proxies().count_proxies(jupiter().id), 1u);
+      CHECK_EQ(nid, jupiter().id);
+      CHECK_EQ(res->node(), jupiter().id);
+      CHECK_EQ(res->id(), jupiter().dummy_actor->id());
+      CHECK(ifs.empty());
       auto proxy = proxies().get(jupiter().id, jupiter().dummy_actor->id());
       CAF_REQUIRE(proxy != nullptr);
       CAF_REQUIRE(proxy == res);
       result = actor_cast<actor>(res);
     },
     [&](error& err) { CAF_FAIL("error: " << err); });
-  CAF_MESSAGE("send message to proxy");
+  MESSAGE("send message to proxy");
   anon_send(actor_cast<actor>(result), 42);
   mpx()->flush_runnables();
   //  mpx()->exec_runnable(); // process forwarded message in basp_broker
@@ -611,15 +611,15 @@ CAF_TEST(remote_actor_and_send) {
                  jupiter().dummy_actor->id(), std::vector<strong_actor_ptr>{},
                  make_message(42));
   auto msg = make_message("hi there!");
-  CAF_MESSAGE("send message via BASP (from proxy)");
+  MESSAGE("send message via BASP (from proxy)");
   mock(jupiter().connection,
        {basp::message_type::direct_message, 0, 0, 0,
         jupiter().dummy_actor->id(), self()->id()},
        std::vector<strong_actor_ptr>{}, make_message("hi there!"));
   self()->receive([&](const std::string& str) {
-    CAF_CHECK_EQUAL(to_string(self()->current_sender()), to_string(result));
-    CAF_CHECK_EQUAL(self()->current_sender(), result.address());
-    CAF_CHECK_EQUAL(str, "hi there!");
+    CHECK_EQ(to_string(self()->current_sender()), to_string(result));
+    CHECK_EQ(self()->current_sender(), result.address());
+    CHECK_EQ(str, "hi there!");
   });
 }
 
@@ -635,17 +635,17 @@ CAF_TEST(actor_serialize_and_deserialize) {
   mock().receive(jupiter().connection, basp::message_type::monitor_message,
                  no_flags, any_vals, no_operation_data, invalid_actor_id,
                  prx->id(), this_node(), prx->node());
-  CAF_CHECK_EQUAL(prx->node(), jupiter().id);
-  CAF_CHECK_EQUAL(prx->id(), jupiter().dummy_actor->id());
+  CHECK_EQ(prx->node(), jupiter().id);
+  CHECK_EQ(prx->id(), jupiter().dummy_actor->id());
   auto testee = sys.spawn(testee_impl);
   registry()->put(testee->id(), actor_cast<strong_actor_ptr>(testee));
-  CAF_MESSAGE("send message via BASP (from proxy)");
+  MESSAGE("send message via BASP (from proxy)");
   auto msg = make_message(actor_cast<actor_addr>(prx));
   mock(jupiter().connection,
        {basp::message_type::direct_message, 0, 0, 0, prx->id(), testee->id()},
        std::vector<strong_actor_ptr>{}, msg);
   // testee must've responded (process forwarded message in BASP broker)
-  CAF_MESSAGE("wait until BASP broker writes to its output buffer");
+  MESSAGE("wait until BASP broker writes to its output buffer");
   while (mpx()->output_buffer(jupiter().connection).empty())
     mpx()->exec_runnable(); // process forwarded message in basp_broker
   // output buffer must contain the reflected message
@@ -657,34 +657,34 @@ CAF_TEST(actor_serialize_and_deserialize) {
 CAF_TEST(indirect_connections) {
   // this node receives a message from jupiter via mars and responds via mars
   // and any ad-hoc automatic connection requests are ignored
-  CAF_MESSAGE("self: " << to_string(self()->address()));
-  CAF_MESSAGE("publish self at port 4242");
+  MESSAGE("self: " << to_string(self()->address()));
+  MESSAGE("publish self at port 4242");
   auto ax = accept_handle::from_int(4242);
   mpx()->provide_acceptor(4242, ax);
   sys.middleman().publish(self(), 4242);
   mpx()->flush_runnables(); // process publish message in basp_broker
-  CAF_MESSAGE("connect to Mars");
+  MESSAGE("connect to Mars");
   connect_node(mars(), ax, self()->id());
-  CAF_MESSAGE("actor from Jupiter sends a message to us via Mars");
+  MESSAGE("actor from Jupiter sends a message to us via Mars");
   auto mx = mock(mars().connection,
                  {basp::message_type::routed_message, 0, 0, 0,
                   jupiter().dummy_actor->id(), self()->id()},
                  jupiter().id, this_node(), std::vector<strong_actor_ptr>{},
                  make_message("hello from jupiter!"));
-  CAF_MESSAGE("expect ('sys', 'get', \"info\") from Earth to Jupiter at Mars");
+  MESSAGE("expect ('sys', 'get', \"info\") from Earth to Jupiter at Mars");
   // this asks Jupiter if it has a 'SpawnServ'
   mx.receive(mars().connection, basp::message_type::routed_message,
              basp::header::named_receiver_flag, any_vals,
              default_operation_data, any_vals, spawn_serv_id, this_node(),
              jupiter().id, std::vector<strong_actor_ptr>{},
              make_message(sys_atom_v, get_atom_v, "info"));
-  CAF_MESSAGE("expect announce_proxy message at Mars from Earth to Jupiter");
+  MESSAGE("expect announce_proxy message at Mars from Earth to Jupiter");
   mx.receive(mars().connection, basp::message_type::monitor_message, no_flags,
              any_vals, no_operation_data, invalid_actor_id,
              jupiter().dummy_actor->id(), this_node(), jupiter().id);
-  CAF_MESSAGE("receive message from jupiter");
+  MESSAGE("receive message from jupiter");
   self()->receive([](const std::string& str) -> std::string {
-    CAF_CHECK_EQUAL(str, "hello from jupiter!");
+    CHECK_EQ(str, "hello from jupiter!");
     return "hello from earth!";
   });
   mpx()->exec_runnable(); // process forwarded message in basp_broker
@@ -695,9 +695,9 @@ CAF_TEST(indirect_connections) {
                  make_message("hello from earth!"));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()
 
-CAF_TEST_FIXTURE_SCOPE(basp_tests_with_autoconn, autoconn_enabled_fixture)
+BEGIN_FIXTURE_SCOPE(autoconn_enabled_fixture)
 
 CAF_TEST(automatic_connection) {
   // Utility helper for verifying routing tables.
@@ -707,17 +707,17 @@ CAF_TEST(automatic_connection) {
   };
   // Setup.
   mpx()->provide_scribe("jupiter", 8080, jupiter().connection);
-  CAF_CHECK(mpx()->has_pending_scribe("jupiter", 8080));
-  CAF_MESSAGE("self: " << to_string(self()->address()));
+  CHECK(mpx()->has_pending_scribe("jupiter", 8080));
+  MESSAGE("self: " << to_string(self()->address()));
   auto ax = accept_handle::from_int(4242);
   mpx()->provide_acceptor(4242, ax);
   publish(self(), 4242);
   // Process publish message in basp_broker.
   mpx()->flush_runnables();
-  CAF_MESSAGE("connect to mars");
+  MESSAGE("connect to mars");
   connect_node(mars(), ax, self()->id());
   check_node_in_tbl(mars());
-  CAF_MESSAGE("simulate that a message from jupiter travels over mars");
+  MESSAGE("simulate that a message from jupiter travels over mars");
   mock(mars().connection,
        {basp::message_type::routed_message, 0, 0,
         make_message_id().integer_value(), jupiter().dummy_actor->id(),
@@ -739,13 +739,13 @@ CAF_TEST(automatic_connection) {
     .receive(mars().connection, basp::message_type::monitor_message, no_flags,
              any_vals, no_operation_data, invalid_actor_id,
              jupiter().dummy_actor->id(), this_node(), jupiter().id);
-  CAF_CHECK_EQUAL(mpx()->output_buffer(mars().connection).size(), 0u);
-  CAF_CHECK_EQUAL(tbl().lookup_indirect(jupiter().id), mars().id);
-  CAF_CHECK_EQUAL(tbl().lookup_indirect(mars().id), none);
+  CHECK_EQ(mpx()->output_buffer(mars().connection).size(), 0u);
+  CHECK_EQ(tbl().lookup_indirect(jupiter().id), mars().id);
+  CHECK_EQ(tbl().lookup_indirect(mars().id), none);
   auto connection_helper_actor = sys.latest_actor_id();
-  CAF_CHECK_EQUAL(mpx()->output_buffer(mars().connection).size(), 0u);
+  CHECK_EQ(mpx()->output_buffer(mars().connection).size(), 0u);
   // Create a dummy config server and respond to the name lookup.
-  CAF_MESSAGE("receive ConfigServ of jupiter");
+  MESSAGE("receive ConfigServ of jupiter");
   network::address_listing res;
   res[network::protocol::ipv4].emplace_back("jupiter");
   mock(mars().connection,
@@ -771,23 +771,23 @@ CAF_TEST(automatic_connection) {
     .receive(jupiter().connection, basp::message_type::client_handshake,
              no_flags, any_vals, no_operation_data, invalid_actor_id,
              invalid_actor_id, this_node());
-  CAF_CHECK_EQUAL(tbl().lookup_indirect(jupiter().id), none);
-  CAF_CHECK_EQUAL(tbl().lookup_indirect(mars().id), none);
+  CHECK_EQ(tbl().lookup_indirect(jupiter().id), none);
+  CHECK_EQ(tbl().lookup_indirect(mars().id), none);
   check_node_in_tbl(jupiter());
   check_node_in_tbl(mars());
-  CAF_MESSAGE("receive message from jupiter");
+  MESSAGE("receive message from jupiter");
   self()->receive([](const std::string& str) -> std::string {
-    CAF_CHECK_EQUAL(str, "hello from jupiter!");
+    CHECK_EQ(str, "hello from jupiter!");
     return "hello from earth!";
   });
   mpx()->exec_runnable(); // process forwarded message in basp_broker
-  CAF_MESSAGE("response message must take direct route now");
+  MESSAGE("response message must take direct route now");
   mock().receive(jupiter().connection, basp::message_type::direct_message,
                  no_flags, any_vals, make_message_id().integer_value(),
                  self()->id(), jupiter().dummy_actor->id(),
                  std::vector<strong_actor_ptr>{},
                  make_message("hello from earth!"));
-  CAF_CHECK_EQUAL(mpx()->output_buffer(mars().connection).size(), 0u);
+  CHECK_EQ(mpx()->output_buffer(mars().connection).size(), 0u);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_io/test/io/http_broker.cpp
+++ b/libcaf_io/test/io/http_broker.cpp
@@ -5,7 +5,7 @@
 #include "caf/config.hpp"
 
 #define CAF_SUITE io_http_broker
-#include "caf/test/unit_test.hpp"
+#include "io-test.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -151,10 +151,10 @@ behavior http_worker(http_broker* self, connection_handle hdl) {
 }
 
 behavior server(broker* self) {
-  CAF_MESSAGE("server up and running");
+  MESSAGE("server up and running");
   return {
     [=](const new_connection_msg& ncm) {
-      CAF_MESSAGE("fork on new connection");
+      MESSAGE("fork on new connection");
       self->fork(http_worker, ncm.handle);
     },
   };
@@ -185,7 +185,7 @@ public:
     mpx_->flush_runnables();
   }
 
-  // helper class for a nice-and-easy "mock(...).expect(...)" syntax
+  // helper class for a nice-and-easy "mock(...).check_response(...)" syntax
   class mock_t {
   public:
     mock_t(fixture* thisptr) : this_(thisptr) {
@@ -194,13 +194,13 @@ public:
 
     mock_t(const mock_t&) = default;
 
-    mock_t& expect(const std::string& x) {
+    mock_t& check_response(const std::string& x) {
       auto bytes = as_bytes(make_span(x));
       auto& buf = this_->mpx_->output_buffer(this_->connection_);
-      CAF_REQUIRE(buf.size() >= x.size());
-      CAF_REQUIRE(std::equal(buf.begin(),
-                             buf.begin() + static_cast<ptrdiff_t>(x.size()),
-                             bytes.begin()));
+      REQUIRE_GE(buf.size(), x.size());
+      REQUIRE(std::equal(buf.begin(),
+                         buf.begin() + static_cast<ptrdiff_t>(x.size()),
+                         bytes.begin()));
       buf.erase(buf.begin(), buf.begin() + static_cast<ptrdiff_t>(x.size()));
       return *this;
     }
@@ -228,16 +228,16 @@ public:
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(http_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(valid_response) {
-  // write a GET message and expect an OK message as result
-  mock(http_get).expect(http_ok);
+  // write a GET message and check_response an OK message as result
+  mock(http_get).check_response(http_ok);
 }
 
 CAF_TEST(invalid_response) {
-  // write a GET with invalid path and expect a 404 message as result
-  mock("GET /kitten.gif HTTP/1.1\r\n\r\n").expect(http_error);
+  // write a GET with invalid path and check_response a 404 message as result
+  mock("GET /kitten.gif HTTP/1.1\r\n\r\n").check_response(http_error);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_io/test/io/middleman.cpp
+++ b/libcaf_io/test/io/middleman.cpp
@@ -9,7 +9,7 @@
 
 #include "caf/io/middleman.hpp"
 
-#include "caf/test/io_dsl.hpp"
+#include "io-test.hpp"
 
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -80,7 +80,7 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(middleman_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(remote_lookup allows registry lookups on other nodes) {
   auto testee_impl = []() -> behavior {
@@ -92,13 +92,13 @@ CAF_TEST(remote_lookup allows registry lookups on other nodes) {
   earth.sys.registry().put("testee", testee);
   auto testee_proxy_ptr = mars.mm.remote_lookup("testee", earth.sys.node());
   auto testee_proxy = actor_cast<actor>(testee_proxy_ptr);
-  CAF_CHECK_EQUAL(testee->node(), testee_proxy.node());
-  CAF_CHECK_EQUAL(testee->id(), testee_proxy.id());
+  CHECK_EQ(testee->node(), testee_proxy.node());
+  CHECK_EQ(testee->id(), testee_proxy.id());
   mars.self
     ->request(testee_proxy, std::chrono::minutes(1), int32_t{7}, int32_t{8})
-    .receive([](int32_t result) { CAF_CHECK_EQUAL(result, 15); },
+    .receive([](int32_t result) { CHECK_EQ(result, 15); },
              [](caf::error& err) { CAF_FAIL("request failed: " << err); });
   anon_send_exit(testee, exit_reason::user_shutdown);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_io/test/io/network/default_multiplexer.cpp
+++ b/libcaf_io/test/io/network/default_multiplexer.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/io/network/default_multiplexer.hpp"
 
-#include "caf/test/io_dsl.hpp"
+#include "io-test.hpp"
 
 #include <algorithm>
 #include <vector>
@@ -49,20 +49,20 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(default_multiplexer_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(doorman io_failure) {
-  CAF_MESSAGE("add doorman to server");
+  MESSAGE("add doorman to server");
   // The multiplexer adds a pipe reader on startup.
-  CAF_CHECK_EQUAL(server.mpx.num_socket_handlers(), 1u);
+  CHECK_EQ(server.mpx.num_socket_handlers(), 1u);
   auto doorman = unbox(server.mpx.new_tcp_doorman(0, nullptr, false));
   doorman->add_to_loop();
   server.mpx.handle_internal_events();
-  CAF_CHECK_EQUAL(server.mpx.num_socket_handlers(), 2u);
-  CAF_MESSAGE("trigger I/O failure in doorman");
+  CHECK_EQ(server.mpx.num_socket_handlers(), 2u);
+  MESSAGE("trigger I/O failure in doorman");
   doorman->io_failure(&server.mpx, io::network::operation::propagate_error);
   server.mpx.handle_internal_events();
-  CAF_CHECK_EQUAL(server.mpx.num_socket_handlers(), 1u);
+  CHECK_EQ(server.mpx.num_socket_handlers(), 1u);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_io/test/io/network/ip_endpoint.cpp
+++ b/libcaf_io/test/io/network/ip_endpoint.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/io/network/ip_endpoint.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "io-test.hpp"
 
 #include <vector>
 
@@ -50,37 +50,37 @@ struct fixture : test_coordinator_fixture<> {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(ep_endpoint_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST_DISABLED(ip_endpoint) {
   // create an empty endpoint
   network::ip_endpoint ep;
   ep.clear();
-  CAF_CHECK_EQUAL("", network::host(ep));
-  CAF_CHECK_EQUAL(uint16_t{0}, network::port(ep));
-  CAF_CHECK_EQUAL(size_t{0}, *ep.length());
+  CHECK_EQ("", network::host(ep));
+  CHECK_EQ(uint16_t{0}, network::port(ep));
+  CHECK_EQ(size_t{0}, *ep.length());
   // fill it with data from a local endpoint
   network::interfaces::get_endpoint("localhost", 12345, ep);
   // save the data
   auto h = network::host(ep);
   auto p = network::port(ep);
   auto l = *ep.length();
-  CAF_CHECK("localhost" == h || "127.0.0.1" == h || "::1" == h);
-  CAF_CHECK_EQUAL(12345, p);
-  CAF_CHECK(0 < l);
+  CHECK("localhost" == h || "127.0.0.1" == h || "::1" == h);
+  CHECK_EQ(12345, p);
+  CHECK(0 < l);
   // serialize the endpoint and clear it
   auto buf = serialize(ep);
   auto save = ep;
   ep.clear();
-  CAF_CHECK_EQUAL("", network::host(ep));
-  CAF_CHECK_EQUAL(uint16_t{0}, network::port(ep));
-  CAF_CHECK_EQUAL(size_t{0}, *ep.length());
+  CHECK_EQ("", network::host(ep));
+  CHECK_EQ(uint16_t{0}, network::port(ep));
+  CHECK_EQ(size_t{0}, *ep.length());
   // deserialize the data and check if it was load successfully
   deserialize(buf, ep);
-  CAF_CHECK_EQUAL(h, network::host(ep));
-  CAF_CHECK_EQUAL(uint16_t{p}, network::port(ep));
-  CAF_CHECK_EQUAL(size_t{l}, *ep.length());
-  CAF_CHECK_EQUAL(save, ep);
+  CHECK_EQ(h, network::host(ep));
+  CHECK_EQ(uint16_t{p}, network::port(ep));
+  CHECK_EQ(size_t{l}, *ep.length());
+  CHECK_EQ(save, ep);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_io/test/io/receive_buffer.cpp
+++ b/libcaf_io/test/io/receive_buffer.cpp
@@ -5,7 +5,7 @@
 #include "caf/config.hpp"
 
 #define CAF_SUITE io_receive_buffer
-#include "caf/test/unit_test.hpp"
+#include "io-test.hpp"
 
 #include <algorithm>
 
@@ -35,130 +35,130 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(receive_buffer_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(constructors) {
-  CAF_CHECK_EQUAL(a.size(), 0ul);
-  CAF_CHECK_EQUAL(a.capacity(), 0ul);
-  CAF_CHECK(a.data() == nullptr);
-  CAF_CHECK(a.empty());
-  CAF_CHECK_EQUAL(b.size(), 1024ul);
-  CAF_CHECK_EQUAL(b.capacity(), 1024ul);
-  CAF_CHECK(b.data() != nullptr);
-  CAF_CHECK(!b.empty());
+  CHECK_EQ(a.size(), 0ul);
+  CHECK_EQ(a.capacity(), 0ul);
+  CHECK(a.data() == nullptr);
+  CHECK(a.empty());
+  CHECK_EQ(b.size(), 1024ul);
+  CHECK_EQ(b.capacity(), 1024ul);
+  CHECK(b.data() != nullptr);
+  CHECK(!b.empty());
   receive_buffer other{std::move(b)};
-  CAF_CHECK_EQUAL(other.size(), 1024ul);
-  CAF_CHECK_EQUAL(other.capacity(), 1024ul);
-  CAF_CHECK(other.data() != nullptr);
-  CAF_CHECK(!other.empty());
+  CHECK_EQ(other.size(), 1024ul);
+  CHECK_EQ(other.capacity(), 1024ul);
+  CHECK(other.data() != nullptr);
+  CHECK(!other.empty());
 }
 
 CAF_TEST(reserve) {
   a.reserve(0);
-  CAF_CHECK_EQUAL(a.size(), 0ul);
-  CAF_CHECK_EQUAL(a.capacity(), 0ul);
-  CAF_CHECK(a.data() == nullptr);
-  CAF_CHECK(a.empty());
+  CHECK_EQ(a.size(), 0ul);
+  CHECK_EQ(a.capacity(), 0ul);
+  CHECK(a.data() == nullptr);
+  CHECK(a.empty());
   a.reserve(1024);
-  CAF_CHECK_EQUAL(a.size(), 0ul);
-  CAF_CHECK_EQUAL(a.capacity(), 1024ul);
-  CAF_CHECK(a.data() != nullptr);
-  CAF_CHECK(a.begin() == a.end());
-  CAF_CHECK(a.empty());
+  CHECK_EQ(a.size(), 0ul);
+  CHECK_EQ(a.capacity(), 1024ul);
+  CHECK(a.data() != nullptr);
+  CHECK(a.begin() == a.end());
+  CHECK(a.empty());
   a.reserve(512);
-  CAF_CHECK_EQUAL(a.size(), 0ul);
-  CAF_CHECK_EQUAL(a.capacity(), 1024ul);
-  CAF_CHECK(a.data() != nullptr);
-  CAF_CHECK(a.begin() == a.end());
-  CAF_CHECK(a.empty());
+  CHECK_EQ(a.size(), 0ul);
+  CHECK_EQ(a.capacity(), 1024ul);
+  CHECK(a.data() != nullptr);
+  CHECK(a.begin() == a.end());
+  CHECK(a.empty());
 }
 
 CAF_TEST(resize) {
   a.resize(512);
-  CAF_CHECK_EQUAL(a.size(), 512ul);
-  CAF_CHECK_EQUAL(a.capacity(), 512ul);
-  CAF_CHECK(a.data() != nullptr);
-  CAF_CHECK(!a.empty());
+  CHECK_EQ(a.size(), 512ul);
+  CHECK_EQ(a.capacity(), 512ul);
+  CHECK(a.data() != nullptr);
+  CHECK(!a.empty());
   b.resize(512);
-  CAF_CHECK_EQUAL(b.size(), 512ul);
-  CAF_CHECK_EQUAL(b.capacity(), 1024ul);
-  CAF_CHECK(b.data() != nullptr);
-  CAF_CHECK(!b.empty());
+  CHECK_EQ(b.size(), 512ul);
+  CHECK_EQ(b.capacity(), 1024ul);
+  CHECK(b.data() != nullptr);
+  CHECK(!b.empty());
   a.resize(1024);
   std::fill(a.begin(), a.end(), 'a');
   auto cnt = 0;
-  CAF_CHECK(std::all_of(a.begin(), a.end(), [&](char c) {
+  CHECK(std::all_of(a.begin(), a.end(), [&](char c) {
     ++cnt;
     return c == 'a';
   }));
-  CAF_CHECK_EQUAL(cnt, 1024);
+  CHECK_EQ(cnt, 1024);
   a.resize(10);
   cnt = 0;
-  CAF_CHECK(std::all_of(a.begin(), a.end(), [&](char c) {
+  CHECK(std::all_of(a.begin(), a.end(), [&](char c) {
     ++cnt;
     return c == 'a';
   }));
-  CAF_CHECK_EQUAL(cnt, 10);
+  CHECK_EQ(cnt, 10);
   a.resize(1024);
   cnt = 0;
-  CAF_CHECK(std::all_of(a.begin(), a.end(), [&](char c) {
+  CHECK(std::all_of(a.begin(), a.end(), [&](char c) {
     ++cnt;
     return c == 'a';
   }));
-  CAF_CHECK_EQUAL(cnt, 1024);
+  CHECK_EQ(cnt, 1024);
 }
 
 CAF_TEST(push_back) {
   for (auto c : vec)
     a.push_back(c);
-  CAF_CHECK_EQUAL(vec.size(), a.size());
-  CAF_CHECK_EQUAL(a.capacity(), 8ul);
-  CAF_CHECK(a.data() != nullptr);
-  CAF_CHECK(!a.empty());
-  CAF_CHECK(std::equal(vec.begin(), vec.end(), a.begin()));
+  CHECK_EQ(vec.size(), a.size());
+  CHECK_EQ(a.capacity(), 8ul);
+  CHECK(a.data() != nullptr);
+  CHECK(!a.empty());
+  CHECK(std::equal(vec.begin(), vec.end(), a.begin()));
 }
 
 CAF_TEST(insert) {
   for (auto c : vec)
     a.insert(a.end(), c);
-  CAF_CHECK_EQUAL(as_string(a), "hallo");
+  CHECK_EQ(as_string(a), "hallo");
   a.insert(a.begin(), '!');
-  CAF_CHECK_EQUAL(as_string(a), "!hallo");
+  CHECK_EQ(as_string(a), "!hallo");
   a.insert(a.begin() + 4, '-');
-  CAF_CHECK_EQUAL(as_string(a), "!hal-lo");
+  CHECK_EQ(as_string(a), "!hal-lo");
   std::string foo = "foo:";
   a.insert(a.begin() + 1, foo.begin(), foo.end());
-  CAF_CHECK_EQUAL(as_string(a), "!foo:hal-lo");
+  CHECK_EQ(as_string(a), "!foo:hal-lo");
   std::string bar = ":bar";
   a.insert(a.end(), bar.begin(), bar.end());
-  CAF_CHECK_EQUAL(as_string(a), "!foo:hal-lo:bar");
+  CHECK_EQ(as_string(a), "!foo:hal-lo:bar");
 }
 
 CAF_TEST(shrink_to_fit) {
   a.shrink_to_fit();
-  CAF_CHECK_EQUAL(a.size(), 0ul);
-  CAF_CHECK_EQUAL(a.capacity(), 0ul);
-  CAF_CHECK(a.data() == nullptr);
-  CAF_CHECK(a.empty());
+  CHECK_EQ(a.size(), 0ul);
+  CHECK_EQ(a.capacity(), 0ul);
+  CHECK(a.data() == nullptr);
+  CHECK(a.empty());
 }
 
 CAF_TEST(swap) {
   for (auto c : vec)
     a.push_back(c);
   std::swap(a, b);
-  CAF_CHECK_EQUAL(a.size(), 1024ul);
-  CAF_CHECK_EQUAL(a.capacity(), 1024ul);
-  CAF_CHECK(a.data() != nullptr);
-  CAF_CHECK_EQUAL(b.size(), vec.size());
-  CAF_CHECK_EQUAL(std::distance(b.begin(), b.end()),
-                  static_cast<receive_buffer::difference_type>(vec.size()));
-  CAF_CHECK_EQUAL(b.capacity(), 8ul);
-  CAF_CHECK(b.data() != nullptr);
-  CAF_CHECK_EQUAL(*(b.data() + 0), 'h');
-  CAF_CHECK_EQUAL(*(b.data() + 1), 'a');
-  CAF_CHECK_EQUAL(*(b.data() + 2), 'l');
-  CAF_CHECK_EQUAL(*(b.data() + 3), 'l');
-  CAF_CHECK_EQUAL(*(b.data() + 4), 'o');
+  CHECK_EQ(a.size(), 1024ul);
+  CHECK_EQ(a.capacity(), 1024ul);
+  CHECK(a.data() != nullptr);
+  CHECK_EQ(b.size(), vec.size());
+  CHECK_EQ(std::distance(b.begin(), b.end()),
+           static_cast<receive_buffer::difference_type>(vec.size()));
+  CHECK_EQ(b.capacity(), 8ul);
+  CHECK(b.data() != nullptr);
+  CHECK_EQ(*(b.data() + 0), 'h');
+  CHECK_EQ(*(b.data() + 1), 'a');
+  CHECK_EQ(*(b.data() + 2), 'l');
+  CHECK_EQ(*(b.data() + 3), 'l');
+  CHECK_EQ(*(b.data() + 4), 'o');
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_io/test/io/remote_group.cpp
+++ b/libcaf_io/test/io/remote_group.cpp
@@ -61,51 +61,51 @@ struct fixture : point_to_point_fixture<test_coordinator_fixture<config>> {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(dynamic_remote_group_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(publish_local_groups) {
   loop_after_next_enqueue(mars);
-  CAF_CHECK_EQUAL(mars.sys.middleman().publish_local_groups(port), port);
+  CHECK_EQ(mars.sys.middleman().publish_local_groups(port), port);
 }
 
 CAF_TEST(connecting to remote group) {
-  CAF_MESSAGE("publish local groups on mars");
+  MESSAGE("publish local groups on mars");
   loop_after_next_enqueue(mars);
-  CAF_CHECK_EQUAL(mars.sys.middleman().publish_local_groups(port), port);
-  CAF_MESSAGE("call remote_group on earth");
+  CHECK_EQ(mars.sys.middleman().publish_local_groups(port), port);
+  MESSAGE("call remote_group on earth");
   loop_after_next_enqueue(earth);
   auto grp = unbox(earth.mm.remote_group(group_name, server, port));
   CAF_REQUIRE(grp != nullptr);
-  CAF_CHECK_EQUAL(grp->get()->identifier(), group_name);
+  CHECK_EQ(grp->get()->identifier(), group_name);
 }
 
 CAF_TEST(message transmission) {
-  CAF_MESSAGE("spawn 5 receivers on mars");
+  MESSAGE("spawn 5 receivers on mars");
   auto mars_grp = mars.sys.groups().get_local(group_name);
   spawn_receivers(mars, mars_grp, 5u);
-  CAF_MESSAGE("publish local groups on mars");
+  MESSAGE("publish local groups on mars");
   loop_after_next_enqueue(mars);
-  CAF_CHECK_EQUAL(mars.sys.middleman().publish_local_groups(port), port);
-  CAF_MESSAGE("call remote_group on earth");
+  CHECK_EQ(mars.sys.middleman().publish_local_groups(port), port);
+  MESSAGE("call remote_group on earth");
   loop_after_next_enqueue(earth);
   auto earth_grp = unbox(earth.mm.remote_group(group_name, server, port));
-  CAF_MESSAGE("spawn 5 more receivers on earth");
+  MESSAGE("spawn 5 more receivers on earth");
   spawn_receivers(earth, earth_grp, 5u);
   exec_all();
-  CAF_MESSAGE("send message on mars and expect 10 handled messages total");
+  MESSAGE("send message on mars and expect 10 handled messages total");
   {
     received_messages = 0u;
     mars.self->send(mars_grp, ok_atom_v);
     exec_all();
-    CAF_CHECK_EQUAL(received_messages, 10u);
+    CHECK_EQ(received_messages, 10u);
   }
-  CAF_MESSAGE("send message on earth and again expect 10 handled messages");
+  MESSAGE("send message on earth and again expect 10 handled messages");
   {
     received_messages = 0u;
     earth.self->send(earth_grp, ok_atom_v);
     exec_all();
-    CAF_CHECK_EQUAL(received_messages, 10u);
+    CHECK_EQ(received_messages, 10u);
   }
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_io/test/io/remote_spawn.cpp
+++ b/libcaf_io/test/io/remote_spawn.cpp
@@ -69,15 +69,15 @@ struct fixture : point_to_point_fixture<test_coordinator_fixture<config>> {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(dynamic_remote_actor_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(nodes can spawn actors remotely) {
   loop_after_next_enqueue(mars);
-  CAF_CHECK_EQUAL(unbox(mars.mm.open(8080)), 8080);
+  CHECK_EQ(unbox(mars.mm.open(8080)), 8080);
   loop_after_next_enqueue(earth);
   auto nid = unbox(earth.mm.connect("mars", 8080));
   CAF_REQUIRE_EQUAL(nid, mars.sys.node());
-  CAF_MESSAGE("remote_spawn perform type checks on the handle");
+  MESSAGE("remote_spawn perform type checks on the handle");
   loop_after_next_enqueue(earth);
   auto calc = earth.mm.remote_spawn<calculator>(nid, "calculator",
                                                 make_message());
@@ -85,7 +85,7 @@ CAF_TEST(nodes can spawn actors remotely) {
   loop_after_next_enqueue(earth);
   calc = earth.mm.remote_spawn<calculator>(nid, "typed_calculator",
                                            make_message());
-  CAF_MESSAGE("remotely spawned actors respond to messages");
+  MESSAGE("remotely spawned actors respond to messages");
   earth.self->send(*calc, add_atom_v, 10, 20);
   run();
   expect_on(earth, (int), from(*calc).to(earth.self).with(30));
@@ -93,7 +93,7 @@ CAF_TEST(nodes can spawn actors remotely) {
   run();
   expect_on(earth, (int), from(*calc).to(earth.self).with(-10));
   anon_send_exit(*calc, exit_reason::user_shutdown);
-  CAF_MESSAGE("remote_spawn works with class-based actors as well");
+  MESSAGE("remote_spawn works with class-based actors as well");
   loop_after_next_enqueue(earth);
   auto dyn_calc = earth.mm.remote_spawn<actor>(nid, "calculator-class",
                                                make_message());
@@ -104,4 +104,4 @@ CAF_TEST(nodes can spawn actors remotely) {
   anon_send_exit(*dyn_calc, exit_reason::user_shutdown);
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_io/test/io/unpublish.cpp
+++ b/libcaf_io/test/io/unpublish.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/config.hpp"
 
-#include "caf/test/io_dsl.hpp"
+#include "io-test.hpp"
 
 #include <atomic>
 #include <memory>
@@ -56,7 +56,7 @@ struct fixture : point_to_point_fixture<> {
 
   ~fixture() {
     run();
-    CAF_CHECK_EQUAL(ssp->dtors_called, 2);
+    CHECK_EQ(ssp->dtors_called, 2);
   }
 
   suite_state_ptr ssp;
@@ -64,7 +64,7 @@ struct fixture : point_to_point_fixture<> {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(unpublish_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(actors can become unpublished) {
   auto testee = mars.sys.spawn<dummy>(ssp);
@@ -76,21 +76,21 @@ CAF_TEST(actors can become unpublished) {
   loop_after_next_enqueue(mars);
   auto port = unbox(mars.mm.publish(testee, 8080));
   CAF_REQUIRE_EQUAL(port, 8080);
-  CAF_MESSAGE("the middleman ignores invalid unpublish() calls");
+  MESSAGE("the middleman ignores invalid unpublish() calls");
   auto testee2 = mars.sys.spawn<dummy>(ssp);
   loop_after_next_enqueue(mars);
   auto res = mars.mm.unpublish(testee2, 8080);
-  CAF_CHECK(!res && res.error() == sec::no_actor_published_at_port);
+  CHECK(!res && res.error() == sec::no_actor_published_at_port);
   anon_send_exit(testee2, exit_reason::user_shutdown);
-  CAF_MESSAGE("after unpublishing an actor, remotes can no longer connect");
+  MESSAGE("after unpublishing an actor, remotes can no longer connect");
   loop_after_next_enqueue(mars);
-  CAF_CHECK(mars.mm.unpublish(testee, 8080));
+  CHECK(mars.mm.unpublish(testee, 8080));
   // TODO: ideally, we'd check that remote actors in fact can no longer connect.
   //       However, the test multiplexer does not support "closing" connections
   //       and the remote_actor blocks forever.
   // run();
   // loop_after_next_enqueue(earth);
-  // CAF_CHECK(!earth.mm.remote_actor("mars", 8080));
+  // CHECK(!earth.mm.remote_actor("mars", 8080));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_io/test/io/worker.cpp
+++ b/libcaf_io/test/io/worker.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/io/basp/worker.hpp"
 
-#include "caf/test/dsl.hpp"
+#include "io-test.hpp"
 
 #include "caf/actor_cast.hpp"
 #include "caf/actor_control_block.hpp"
@@ -93,15 +93,15 @@ struct fixture : test_coordinator_fixture<config> {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(worker_tests, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(deliver serialized message) {
-  CAF_MESSAGE("create the BASP worker");
+  MESSAGE("create the BASP worker");
   CAF_REQUIRE_EQUAL(hub.peek(), nullptr);
   hub.add_new_worker(queue, proxies);
   CAF_REQUIRE_NOT_EQUAL(hub.peek(), nullptr);
   auto w = hub.pop();
-  CAF_MESSAGE("create a fake message + BASP header");
+  MESSAGE("create a fake message + BASP header");
   byte_buffer payload;
   std::vector<strong_actor_ptr> stages;
   binary_serializer sink{sys, payload};
@@ -114,10 +114,10 @@ CAF_TEST(deliver serialized message) {
                        make_message_id().integer_value(),
                        42,
                        testee.id()};
-  CAF_MESSAGE("launch worker");
+  MESSAGE("launch worker");
   w->launch(last_hop, hdr, payload);
   sched.run_once();
   expect((ok_atom), from(_).to(testee));
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_openssl/test/openssl-test.hpp
+++ b/libcaf_openssl/test/openssl-test.hpp
@@ -1,4 +1,4 @@
-#include "caf/test/dsl.hpp"
+#include "caf/test/bdd_dsl.hpp"
 
 #include <cstdint>
 

--- a/libcaf_openssl/test/openssl/authentication.cpp
+++ b/libcaf_openssl/test/openssl/authentication.cpp
@@ -66,18 +66,18 @@ public:
 behavior make_pong_behavior() {
   return {[](int val) -> int {
     ++val;
-    CAF_MESSAGE("pong " << val);
+    MESSAGE("pong " << val);
     return val;
   }};
 }
 
 behavior make_ping_behavior(event_based_actor* self, const actor& pong) {
-  CAF_MESSAGE("ping " << 0);
+  MESSAGE("ping " << 0);
   self->send(pong, 0);
   return {[=](int val) -> int {
-    CAF_MESSAGE("ping " << val);
+    MESSAGE("ping " << val);
     if (val >= 3) {
-      CAF_MESSAGE("terminate ping");
+      MESSAGE("terminate ping");
       self->quit();
     }
     return val;
@@ -116,26 +116,26 @@ struct fixture {
     server_side_config.openssl_passphrase = "12345";
     // check whether all files exist before setting config parameters
     std::string dummy;
-    std::pair<const char*, std::string*>
-      cfg[]{{"ca.pem", &server_side_config.openssl_cafile},
-            {"cert.1.pem", &server_side_config.openssl_certificate},
-            {"key.1.enc.pem", &server_side_config.openssl_key},
-            {"ca.pem",
-             skip_client_side_ca ? &dummy : &client_side_config.openssl_cafile},
-            {"cert.2.pem", &client_side_config.openssl_certificate},
-            {"key.2.pem", &client_side_config.openssl_key}};
+    std::pair<const char*, std::string*> cfg[]{
+      {"ca.pem", &server_side_config.openssl_cafile},
+      {"cert.1.pem", &server_side_config.openssl_certificate},
+      {"key.1.enc.pem", &server_side_config.openssl_key},
+      {"ca.pem",
+       skip_client_side_ca ? &dummy : &client_side_config.openssl_cafile},
+      {"cert.2.pem", &client_side_config.openssl_certificate},
+      {"key.2.pem", &client_side_config.openssl_key}};
     // return if any file is unreadable or non-existent
     for (auto& x : cfg) {
       auto path = cd + x.first;
       if (access(path.c_str(), F_OK) == -1) {
-        CAF_MESSAGE("pem files missing, skip test");
+        MESSAGE("pem files missing, skip test");
         return false;
       }
       *x.second = std::move(path);
     }
-    CAF_MESSAGE("initialize server side");
+    MESSAGE("initialize server side");
     new (&server_side) actor_system(server_side_config);
-    CAF_MESSAGE("initialize client side");
+    MESSAGE("initialize client side");
     new (&client_side) actor_system(client_side_config);
     ssched = &dynamic_cast<sched_t&>(server_side.scheduler());
     csched = &dynamic_cast<sched_t&>(client_side.scheduler());
@@ -176,7 +176,7 @@ struct fixture {
 
 } // namespace
 
-CAF_TEST_FIXTURE_SCOPE(authentication, fixture)
+BEGIN_FIXTURE_SCOPE(fixture)
 
 using openssl::publish;
 using openssl::remote_actor;
@@ -185,22 +185,22 @@ CAF_TEST(authentication_success) {
   if (!init(false))
     return;
   // server side
-  CAF_MESSAGE("spawn pong on server");
+  MESSAGE("spawn pong on server");
   auto spong = server_side.spawn(make_pong_behavior);
   exec_loop();
-  CAF_MESSAGE("publish pong");
+  MESSAGE("publish pong");
   loop_after_next_enqueue(server_side);
   auto port = unbox(publish(spong, 0, local_host));
   exec_loop();
   // client side
-  CAF_MESSAGE("connect to pong via port " << port);
+  MESSAGE("connect to pong via port " << port);
   loop_after_next_enqueue(client_side);
   auto pong = unbox(remote_actor(client_side, local_host, port));
-  CAF_MESSAGE("spawn ping and exchange messages");
+  MESSAGE("spawn ping and exchange messages");
   auto sping = client_side.spawn(make_ping_behavior, pong);
   while (!terminated(sping))
     exec_loop();
-  CAF_MESSAGE("terminate pong");
+  MESSAGE("terminate pong");
   anon_send_exit(spong, exit_reason::user_shutdown);
   exec_loop();
 }
@@ -209,21 +209,21 @@ CAF_TEST(authentication_failure) {
   if (!init(true))
     return;
   // server side
-  CAF_MESSAGE("spawn pong on server");
+  MESSAGE("spawn pong on server");
   auto spong = server_side.spawn(make_pong_behavior);
   exec_loop();
   loop_after_next_enqueue(server_side);
-  CAF_MESSAGE("publish pong");
+  MESSAGE("publish pong");
   auto port = unbox(publish(spong, 0, local_host));
   exec_loop();
   // client side
-  CAF_MESSAGE("connect to pong via port " << port);
+  MESSAGE("connect to pong via port " << port);
   loop_after_next_enqueue(client_side);
   auto remote_pong = remote_actor(client_side, local_host, port);
-  CAF_CHECK(!remote_pong);
-  CAF_MESSAGE("terminate pong");
+  CHECK(!remote_pong);
+  MESSAGE("terminate pong");
   anon_send_exit(spong, exit_reason::user_shutdown);
   exec_loop();
 }
 
-CAF_TEST_FIXTURE_SCOPE_END()
+END_FIXTURE_SCOPE()

--- a/libcaf_test/caf/test/bdd_dsl.hpp
+++ b/libcaf_test/caf/test/bdd_dsl.hpp
@@ -37,6 +37,16 @@
 #define CHECK_GT(lhs, rhs) CAF_CHECK_GREATER(lhs, rhs)
 #define CHECK_GE(lhs, rhs) CAF_CHECK_GREATER_OR_EQUAL(lhs, rhs)
 
+#ifdef CAF_ENABLE_EXCEPTIONS
+
+#  define CHECK_NOTHROW(expr) CAF_CHECK_NOTHROW(expr)
+#  define CHECK_THROWS_AS(expr, type) CAF_CHECK_THROWS_AS(expr, type)
+#  define CHECK_THROWS_WITH(expr, msg) CAF_CHECK_THROWS_WITH(expr, msg)
+#  define CHECK_THROWS_WITH_AS(expr, msg, type)                                \
+    CAF_CHECK_THROWS_WITH_AS(expr, msg, type)
+
+#endif // CAF_ENABLE_EXCEPTIONS
+
 #define REQUIRE(what) CAF_REQUIRE(what)
 #define REQUIRE_EQ(lhs, rhs) CAF_REQUIRE_EQUAL(lhs, rhs)
 #define REQUIRE_NE(lhs, rhs) CAF_REQUIRE_NOT_EQUAL(lhs, rhs)

--- a/libcaf_test/caf/test/dsl.hpp
+++ b/libcaf_test/caf/test/dsl.hpp
@@ -86,48 +86,42 @@ T get(const has_outer_type<U>&);
 template <class T, class U>
 bool is(const has_outer_type<U>&);
 
-template <class Tup>
+template <class Tuple>
 class elementwise_compare_inspector {
 public:
   using result_type = bool;
 
-  template <size_t X>
-  using pos = std::integral_constant<size_t, X>;
+  static constexpr size_t num_values = std::tuple_size_v<Tuple>;
 
-  explicit elementwise_compare_inspector(const Tup& xs) : xs_(xs) {
+  explicit elementwise_compare_inspector(const Tuple& xs) : xs_(xs) {
     // nop
   }
 
   template <class... Ts>
-  bool operator()(const Ts&... xs) {
-    return iterate(pos<0>{}, xs...);
+  bool operator()(const Ts&... xs) const {
+    static_assert(sizeof...(Ts) == num_values);
+    return apply(std::forward_as_tuple(xs...),
+                 std::index_sequence_for<Ts...>{});
   }
 
 private:
-  template <size_t X>
-  bool iterate(pos<X>) {
-    // end of recursion
-    return true;
-  }
-
-  template <size_t X, class T, class... Ts>
-  bool iterate(pos<X>, const T& y, const Ts&... ys) {
-    std::integral_constant<size_t, X + 1> next;
-    check(y, get<X>(xs_));
-    return iterate(next, ys...);
+  template <class OtherTuple, size_t... Is>
+  bool apply(OtherTuple values, std::index_sequence<Is...>) const {
+    using std::get;
+    return (check(get<Is>(values), get<Is>(xs_)) && ...);
   }
 
   template <class T, class U>
-  static void check(const T& x, const U& y) {
-    CAF_CHECK_EQUAL(x, y);
+  static bool check(const T& x, const U& y) {
+    return x == y;
   }
 
   template <class T>
-  static void check(const T&, const wildcard&) {
-    // nop
+  static bool check(const T&, const wildcard&) {
+    return true;
   }
 
-  const Tup& xs_;
+  const Tuple& xs_;
 };
 
 // -- unified access to all actor handles in CAF -------------------------------
@@ -257,16 +251,18 @@ caf::optional<std::tuple<T, Ts...>> try_extract(caf_handle x) {
 /// the mailbox. Fails on an empty mailbox or if the content of the next
 /// element does not match `<T, Ts...>`.
 template <class T, class... Ts>
-std::tuple<T, Ts...> extract(caf_handle x) {
-  auto result = try_extract<T, Ts...>(x);
-  if (result == caf::none) {
+std::tuple<T, Ts...> extract(caf_handle x, int src_line) {
+  if (auto result = try_extract<T, Ts...>(x); result != caf::none) {
+    return std::move(*result);
+  } else {
     auto ptr = x->peek_at_next_mailbox_element();
     if (ptr == nullptr)
-      CAF_FAIL("Mailbox is empty");
-    CAF_FAIL(
-      "Message does not match expected pattern: " << to_string(ptr->content()));
+      CAF_FAIL("cannot peek at the next message: mailbox is empty", src_line);
+    else
+      CAF_FAIL("message does not match expected types: "
+                 << to_string(ptr->content()),
+               src_line);
   }
-  return std::move(*result);
 }
 
 template <class T, class... Ts>
@@ -277,22 +273,25 @@ bool received(caf_handle x) {
 template <class... Ts>
 class expect_clause {
 public:
-  explicit expect_clause(caf::scheduler::test_coordinator& sched)
-    : sched_(sched), dest_(nullptr) {
-    peek_ = [=] {
+  explicit expect_clause(caf::scheduler::test_coordinator& sched, int src_line)
+    : sched_(sched), src_line_(src_line) {
+    peek_ = [this] {
       /// The extractor will call CAF_FAIL on a type mismatch, essentially
       /// performing a type check when ignoring the result.
-      extract<Ts...>(dest_);
+      extract<Ts...>(dest_, src_line_);
     };
   }
 
   expect_clause(expect_clause&& other) = default;
 
-  ~expect_clause() {
-    if (peek_ != nullptr) {
-      peek_();
-      run_once();
-    }
+  void eval(const char* type_str, const char* fields_str) {
+    using namespace caf;
+    test::logger::instance().verbose()
+      << term::yellow << "  -> " << term::reset
+      << test::logger::stream::reset_flags_t{} << "expect " << type_str << "."
+      << fields_str << " [line " << src_line_ << "]\n";
+    peek_();
+    run_once();
   }
 
   expect_clause& from(const wildcard&) {
@@ -307,12 +306,15 @@ public:
 
   template <class Handle>
   expect_clause& to(const Handle& whom) {
-    CAF_REQUIRE(sched_.prioritize(whom));
+    if (!sched_.prioritize(whom))
+      CAF_FAIL("there is no message for the designated receiver", src_line_);
     dest_ = &sched_.next_job<caf::abstract_actor>();
     auto ptr = dest_->peek_at_next_mailbox_element();
-    CAF_REQUIRE(ptr != nullptr);
-    if (src_)
-      CAF_REQUIRE_EQUAL(ptr->sender, src_);
+    if (ptr == nullptr)
+      CAF_FAIL("the designated receiver has no message in its mailbox",
+               src_line_);
+    if (src_ && ptr->sender != src_)
+      CAF_FAIL("the found message is not from the expected sender", src_line_);
     return *this;
   }
 
@@ -322,14 +324,17 @@ public:
   }
 
   template <class... Us>
-  void with(Us&&... xs) {
+  expect_clause& with(Us&&... xs) {
     peek_ = [this, tmp = std::make_tuple(std::forward<Us>(xs)...)] {
-      using namespace caf::detail;
-      elementwise_compare_inspector<decltype(tmp)> inspector{tmp};
-      auto ys = extract<Ts...>(dest_);
-      auto ys_indices = get_indices(ys);
-      CAF_REQUIRE(apply_args(inspector, ys_indices, ys));
+      auto inspector = elementwise_compare_inspector<decltype(tmp)>{tmp};
+      auto content = extract<Ts...>(dest_, src_line_);
+      if (!std::apply(inspector, content))
+        CAF_FAIL("message does not match expected content: "
+                   << caf::deep_to_string(tmp) << " vs "
+                   << caf::deep_to_string(content),
+                 src_line_);
     };
+    return *this;
   }
 
 protected:
@@ -343,26 +348,33 @@ protected:
 
   caf::scheduler::test_coordinator& sched_;
   caf::strong_actor_ptr src_;
-  caf::abstract_actor* dest_;
+  caf::abstract_actor* dest_ = nullptr;
   std::function<void()> peek_;
+  int src_line_;
 };
 
 template <>
 class expect_clause<void> {
 public:
-  explicit expect_clause(caf::scheduler::test_coordinator& sched)
-    : sched_(sched), dest_(nullptr) {
+  explicit expect_clause(caf::scheduler::test_coordinator& sched, int src_line)
+    : sched_(sched), src_line_(src_line) {
     // nop
   }
 
   expect_clause(expect_clause&& other) = default;
 
-  ~expect_clause() {
+  void eval(const char* type_str, const char* fields_str) {
+    using namespace caf;
+    test::logger::instance().verbose()
+      << term::yellow << "  -> " << term::reset
+      << test::logger::stream::reset_flags_t{} << "expect(void)." << fields_str
+      << " [line " << src_line_ << "]\n";
     auto ptr = dest_->peek_at_next_mailbox_element();
     if (ptr == nullptr)
-      CAF_FAIL("no message found");
+      CAF_FAIL("no message found", src_line_);
     if (!ptr->content().empty())
-      CAF_FAIL("non-empty message found: " << to_string(ptr->content()));
+      CAF_FAIL("non-empty message found: " << to_string(ptr->content()),
+               src_line_);
     run_once();
   }
 
@@ -403,14 +415,15 @@ protected:
 
   caf::scheduler::test_coordinator& sched_;
   caf::strong_actor_ptr src_;
-  caf::abstract_actor* dest_;
+  caf::abstract_actor* dest_ = nullptr;
+  int src_line_;
 };
 
 template <class... Ts>
 class inject_clause {
 public:
-  explicit inject_clause(caf::scheduler::test_coordinator& sched)
-    : sched_(sched), dest_(nullptr) {
+  explicit inject_clause(caf::scheduler::test_coordinator& sched, int src_line)
+    : sched_(sched), src_line_(src_line) {
     // nop
   }
 
@@ -428,27 +441,39 @@ public:
     return *this;
   }
 
-  void with(Ts... xs) {
+  inject_clause& with(Ts... xs) {
+    msg_ = caf::make_message(std::move(xs)...);
+    return *this;
+  }
+
+  void eval(const char* type_str, const char* fields_str) {
+    using namespace caf;
+    test::logger::instance().verbose()
+      << term::yellow << "  -> " << term::reset
+      << test::logger::stream::reset_flags_t{} << "inject" << type_str << "."
+      << fields_str << " [line " << src_line_ << "]\n";
     if (dest_ == nullptr)
-      CAF_FAIL("missing .to() in inject() statement");
-    auto msg = caf::make_message(std::move(xs)...);
-    if (src_ == nullptr)
-      caf::anon_send(caf::actor_cast<caf::actor>(dest_), msg);
+      CAF_FAIL("missing .to() in inject() statement", src_line_);
+    else if (src_ == nullptr)
+      caf::anon_send(caf::actor_cast<caf::actor>(dest_), msg_);
     else
       caf::send_as(caf::actor_cast<caf::actor>(src_),
-                   caf::actor_cast<caf::actor>(dest_), msg);
+                   caf::actor_cast<caf::actor>(dest_), msg_);
     if (!sched_.prioritize(dest_))
-      CAF_FAIL("inject: failed to schedule destination actor");
+      CAF_FAIL("inject: failed to schedule destination actor", src_line_);
     auto dest_ptr = &sched_.next_job<caf::abstract_actor>();
     auto ptr = dest_ptr->peek_at_next_mailbox_element();
     if (ptr == nullptr)
-      CAF_FAIL("inject: failed to get next message from destination actor");
+      CAF_FAIL("inject: failed to get next message from destination actor",
+               src_line_);
     if (ptr->sender != src_)
-      CAF_FAIL("inject: found unexpected sender for the next message");
-    if (ptr->payload.cptr() != msg.cptr())
+      CAF_FAIL("inject: found unexpected sender for the next message",
+               src_line_);
+    if (ptr->payload.cptr() != msg_.cptr())
       CAF_FAIL("inject: found unexpected message => " << ptr->payload << " !! "
-                                                      << msg);
-    msg.reset(); // drop local reference before running the actor
+                                                      << msg_,
+               src_line_);
+    msg_.reset(); // drop local reference before running the actor
     run_once();
   }
 
@@ -465,25 +490,24 @@ protected:
   caf::scheduler::test_coordinator& sched_;
   caf::strong_actor_ptr src_;
   caf::strong_actor_ptr dest_;
+  caf::message msg_;
+  int src_line_;
 };
 
 template <class... Ts>
 class allow_clause {
 public:
-  explicit allow_clause(caf::scheduler::test_coordinator& sched)
-    : sched_(sched), dest_(nullptr) {
-    peek_ = [=] {
+  explicit allow_clause(caf::scheduler::test_coordinator& sched, int src_line)
+    : sched_(sched), src_line_(src_line) {
+    peek_ = [this] {
       if (dest_ != nullptr)
         return try_extract<Ts...>(dest_) != caf::none;
-      return false;
+      else
+        return false;
     };
   }
 
   allow_clause(allow_clause&& other) = default;
-
-  ~allow_clause() {
-    eval();
-  }
 
   allow_clause& from(const wildcard&) {
     return *this;
@@ -499,31 +523,46 @@ public:
   allow_clause& to(const Handle& whom) {
     if (sched_.prioritize(whom))
       dest_ = &sched_.next_job<caf::abstract_actor>();
+    else if (auto ptr = caf::actor_cast<caf::abstract_actor*>(whom))
+      dest_ = dynamic_cast<caf::blocking_actor*>(ptr);
     return *this;
   }
 
   template <class... Us>
-  void with(Us&&... xs) {
+  allow_clause& with(Us&&... xs) {
     peek_ = [this, tmp = std::make_tuple(std::forward<Us>(xs)...)] {
       using namespace caf::detail;
-      elementwise_compare_inspector<decltype(tmp)> inspector{tmp};
-      auto ys = try_extract<Ts...>(dest_);
-      if (ys != caf::none) {
-        auto ys_indices = get_indices(*ys);
-        return apply_args(inspector, ys_indices, *ys);
+      if (dest_ != nullptr) {
+        if (auto ys = try_extract<Ts...>(dest_); ys != caf::none) {
+          elementwise_compare_inspector<decltype(tmp)> inspector{tmp};
+          auto ys_indices = get_indices(*ys);
+          return apply_args(inspector, ys_indices, *ys);
+        }
       }
       return false;
     };
+    return *this;
   }
 
-  bool eval() {
-    if (peek_ != nullptr) {
-      if (peek_()) {
-        run_once();
-        return true;
-      }
+  bool eval(const char* type_str, const char* fields_str) {
+    using namespace caf;
+    test::logger::instance().verbose()
+      << term::yellow << "  -> " << term::reset
+      << test::logger::stream::reset_flags_t{} << "allow" << type_str << "."
+      << fields_str << " [line " << src_line_ << "]\n";
+    if (!dest_) {
+      return false;
     }
-    return false;
+    if (auto msg_ptr = dest_->peek_at_next_mailbox_element(); !msg_ptr) {
+      return false;
+    } else if (src_ && msg_ptr->sender != src_) {
+      return false;
+    } else if (peek_()) {
+      run_once();
+      return true;
+    } else {
+      return false;
+    }
   }
 
 protected:
@@ -537,15 +576,16 @@ protected:
 
   caf::scheduler::test_coordinator& sched_;
   caf::strong_actor_ptr src_;
-  caf::abstract_actor* dest_;
+  caf::abstract_actor* dest_ = nullptr;
   std::function<bool()> peek_;
+  int src_line_;
 };
 
 template <class... Ts>
 class disallow_clause {
 public:
-  disallow_clause() {
-    check_ = [=] {
+  disallow_clause(int src_line) : src_line_(src_line) {
+    check_ = [this] {
       auto ptr = dest_->peek_at_next_mailbox_element();
       if (ptr == nullptr)
         return;
@@ -553,16 +593,12 @@ public:
         return;
       auto res = try_extract<Ts...>(dest_);
       if (res != caf::none)
-        CAF_FAIL("received disallowed message: " << caf::deep_to_string(*ptr));
+        CAF_FAIL("received disallowed message: " << caf::deep_to_string(*ptr),
+                 src_line_);
     };
   }
 
   disallow_clause(disallow_clause&& other) = default;
-
-  ~disallow_clause() {
-    if (check_ != nullptr)
-      check_();
-  }
 
   disallow_clause& from(const wildcard&) {
     return *this;
@@ -579,7 +615,7 @@ public:
   }
 
   template <class... Us>
-  void with(Us&&... xs) {
+  disallow_clause& with(Us&&... xs) {
     check_ = [this, tmp = std::make_tuple(std::forward<Us>(xs)...)] {
       auto ptr = dest_->peek_at_next_mailbox_element();
       if (ptr == nullptr)
@@ -593,15 +629,26 @@ public:
         auto& ys = *res;
         auto ys_indices = get_indices(ys);
         if (apply_args(inspector, ys_indices, ys))
-          CAF_FAIL("received disallowed message: " << CAF_ARG(*res));
+          CAF_FAIL("received disallowed message: " << CAF_ARG(*res), src_line_);
       }
     };
+    return *this;
+  }
+
+  void eval(const char* type_str, const char* fields_str) {
+    using namespace caf;
+    test::logger::instance().verbose()
+      << term::yellow << "  -> " << term::reset
+      << test::logger::stream::reset_flags_t{} << "disallow" << type_str << "."
+      << fields_str << " [line " << src_line_ << "]\n";
+    check_();
   }
 
 protected:
   caf_handle src_;
   caf_handle dest_;
   std::function<void()> check_;
+  int src_line_;
 };
 
 template <class... Ts>
@@ -747,6 +794,7 @@ public:
       size_t progress = 0;
       while (consume_message()) {
         ++progress;
+        ++events;
         if (predicate()) {
           CAF_LOG_DEBUG("stop due to predicate:" << CAF_ARG(events));
           return events;
@@ -754,18 +802,20 @@ public:
       }
       while (handle_io_event()) {
         ++progress;
+        ++events;
         if (predicate()) {
           CAF_LOG_DEBUG("stop due to predicate:" << CAF_ARG(events));
           return events;
         }
       }
-      if (trigger_timeout())
+      if (trigger_timeout()) {
         ++progress;
+        ++events;
+      }
       if (progress == 0) {
         CAF_LOG_DEBUG("no activity left:" << CAF_ARG(events));
         return events;
       }
-      events += progress;
     }
   }
 
@@ -875,32 +925,22 @@ T unbox(T* x) {
 
 /// Convenience macro for defining expect clauses.
 #define expect(types, fields)                                                  \
-  do {                                                                         \
-    CAF_MESSAGE("expect" << #types << "." << #fields);                         \
-    expect_clause<CAF_EXPAND(CAF_DSL_LIST types)>{sched}.fields;               \
-  } while (false)
+  (expect_clause<CAF_EXPAND(CAF_DSL_LIST types)>{sched, __LINE__}.fields.eval( \
+    #types, #fields))
 
 #define inject(types, fields)                                                  \
-  do {                                                                         \
-    CAF_MESSAGE("inject" << #types << "." << #fields);                         \
-    inject_clause<CAF_EXPAND(CAF_DSL_LIST types)>{sched}.fields;               \
-  } while (false)
+  (inject_clause<CAF_EXPAND(CAF_DSL_LIST types)>{sched, __LINE__}.fields.eval( \
+    #types, #fields))
 
 /// Convenience macro for defining allow clauses.
 #define allow(types, fields)                                                   \
-  ([&] {                                                                       \
-    CAF_MESSAGE("allow" << #types << "." << #fields);                          \
-    allow_clause<CAF_EXPAND(CAF_DSL_LIST types)> x{sched};                     \
-    x.fields;                                                                  \
-    return x.eval();                                                           \
-  })()
+  (allow_clause<CAF_EXPAND(CAF_DSL_LIST types)>{sched, __LINE__}.fields.eval(  \
+    #types, #fields))
 
 /// Convenience macro for defining disallow clauses.
 #define disallow(types, fields)                                                \
-  do {                                                                         \
-    CAF_MESSAGE("disallow" << #types << "." << #fields);                       \
-    disallow_clause<CAF_EXPAND(CAF_DSL_LIST types)>{}.fields;                  \
-  } while (false)
+  (disallow_clause<CAF_EXPAND(CAF_DSL_LIST types)>{__LINE__}.fields.eval(      \
+    #types, #fields))
 
 /// Defines the required base type for testee states in the current namespace.
 #define TESTEE_SETUP()                                                         \

--- a/libcaf_test/caf/test/io_dsl.hpp
+++ b/libcaf_test/caf/test/io_dsl.hpp
@@ -55,9 +55,9 @@ public:
 
   /// @param fun A function object for delegating to the parent's `exec_all`.
   test_node_fixture(run_all_nodes_fun fun)
-      : mm(this->sys.middleman()),
-        mpx(dynamic_cast<caf::io::network::test_multiplexer&>(mm.backend())),
-        run_all_nodes(std::move(fun)) {
+    : mm(this->sys.middleman()),
+      mpx(dynamic_cast<caf::io::network::test_multiplexer&>(mm.backend())),
+      run_all_nodes(std::move(fun)) {
     bb = mm.named_broker<caf::io::basp_broker>("BASP");
   }
 
@@ -124,9 +124,7 @@ void exec_all_fixtures(Iterator first, Iterator last) {
     return x->sched.try_run_once() || x->mpx.read_data()
            || x->mpx.try_exec_runnable() || x->mpx.try_accept_connection();
   };
-  auto trigger_timeouts = [](fixture_ptr x) {
-    x->sched.trigger_timeouts();
-  };
+  auto trigger_timeouts = [](fixture_ptr x) { x->sched.trigger_timeouts(); };
   for (;;) {
     // Exhaust all messages in the system.
     while (std::any_of(first, last, advance))
@@ -167,9 +165,8 @@ public:
   /// (calls `publish`).
   /// @returns randomly picked connection handles for the server and the client.
   std::pair<connection_handle, connection_handle>
-  prepare_connection(PlanetType& server, PlanetType& client,
-                     std::string host, uint16_t port,
-                     accept_handle server_accept_hdl) {
+  prepare_connection(PlanetType& server, PlanetType& client, std::string host,
+                     uint16_t port, accept_handle server_accept_hdl) {
     auto server_hdl = next_connection_handle();
     auto client_hdl = next_connection_handle();
     server.mpx.prepare_connection(server_accept_hdl, server_hdl, client.mpx,
@@ -181,8 +178,8 @@ public:
   /// (calls `publish`).
   /// @returns randomly picked connection handles for the server and the client.
   std::pair<connection_handle, connection_handle>
-  prepare_connection(PlanetType& server, PlanetType& client,
-                     std::string host, uint16_t port) {
+  prepare_connection(PlanetType& server, PlanetType& client, std::string host,
+                     uint16_t port) {
     return prepare_connection(server, client, std::move(host), port,
                               next_accept_handle());
   }
@@ -206,7 +203,7 @@ public:
   }
 
   /// Type-erased callback for calling `exec_all`.
-  std::function<void ()> exec_all_callback() {
+  std::function<void()> exec_all_callback() {
     return [&] { exec_all(); };
   }
 
@@ -273,13 +270,9 @@ public:
 };
 
 #define expect_on(where, types, fields)                                        \
-  do {                                                                         \
-    CAF_MESSAGE(#where << ": expect" << #types << "." << #fields);             \
-    expect_clause<CAF_EXPAND(CAF_DSL_LIST types)>{where.sched}.fields;         \
-  } while (false)
+  (expect_clause<CAF_EXPAND(CAF_DSL_LIST types)>{where.sched, __LINE__}        \
+     .fields.eval(#types, #fields))
 
 #define disallow_on(where, types, fields)                                      \
-  do {                                                                         \
-    CAF_MESSAGE(#where << ": disallow" << #types << "." << #fields);           \
-    disallow_clause<CAF_EXPAND(CAF_DSL_LIST types)>{where.sched}.fields;       \
-  } while (false)
+  (disallow_clause<CAF_EXPAND(CAF_DSL_LIST types)>{where.sched, __LINE__}      \
+     .fields.eval(#types, #fields))


### PR DESCRIPTION
### Added

- When adding CAF with exceptions enabled (default), the unit test framework now
  offers new check macros:
  - `CAF_CHECK_NOTHROW(expr)`
  - `CAF_CHECK_THROWS_AS(expr, type)`
  - `CAF_CHECK_THROWS_WITH(expr, str)`
  - `CAF_CHECK_THROWS_WITH_AS(expr, str, type)`

### Fixed

- The DSL function `run_until` miscounted the number executed events, also
  causing `run_once` to report a wrong value. Both functions now return the
  correct result.
- Using `allow(...).with(...)` in unit tests without a matching message crashed
  the program. By adding a missing NULL-check, `allow` is now always safe to
  use.

### Changed

- When compiling CAF with exceptions enabled (default), `REQUIRE*` macros,
  `expect` and `disallow` no longer call `abort()`. Instead, they throw an
  exception that only stops the current test instead of stopping the entire test
  program.
- Reporting of several unit test macros has been improved to show correct line
  numbers and provide better diagnostic of test errors.