### PR TITLE
Fix OpenSSL 3.0 warning by switching to newer EC-curve API

### DIFF
--- a/libcaf_openssl/src/openssl/session.cpp
+++ b/libcaf_openssl/src/openssl/session.cpp
@@ -231,13 +231,7 @@ SSL_CTX* session::create_ssl_context() {
 #if defined(CAF_SSL_HAS_ECDH_AUTO) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
     SSL_CTX_set_ecdh_auto(ctx, 1);
 #else
-    auto ecdh = EC_KEY_new_by_curve_name(NID_secp384r1);
-    if (!ecdh)
-      CAF_RAISE_ERROR("cannot get ECDH curve");
-    CAF_PUSH_WARNINGS
-    SSL_CTX_set_tmp_ecdh(ctx, ecdh);
-    EC_KEY_free(ecdh);
-    CAF_POP_WARNINGS
+    SSL_CTX_set1_groups_list(ctx, "P-384");
 #endif
 #ifdef CAF_SSL_HAS_SECURITY_LEVEL
     const char* cipher = "AECDH-AES256-SHA@SECLEVEL=0";


### PR DESCRIPTION
This switches the way in which the curve for a CTX is selected to a newer API that should work (at least) with OpenSSL 1.0, 1.1 and 3.0.

I think the functionality is equivalent. The following is the deprecation warning that is currently output when compiling CAF with OpenSSL 3:

```
[386/437] Building CXX object libcaf_openssl/CMakeFiles/libcaf_openssl_obj.dir/src/openssl/session.cpp.o
/Users/johanna/zeek/actor-framework/libcaf_openssl/src/openssl/session.cpp:234:17: warning: 'EC_KEY_new_by_curve_name' is deprecated [-Wdeprecated-declarations]
    auto ecdh = EC_KEY_new_by_curve_name(NID_secp384r1);
                ^
/opt/local/libexec/openssl3/include/openssl/ec.h:996:1: note: 'EC_KEY_new_by_curve_name' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 EC_KEY *EC_KEY_new_by_curve_name(int nid);
^
/opt/local/libexec/openssl3/include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)
                                                ^
/opt/local/libexec/openssl3/include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))
                                                   ^
1 warning generated.
[437/437] Linking CXX executable tools/caf-vec
```