### PR TITLE
Add NetBSD support

### DIFF
--- a/libcaf_core/caf/config.hpp
+++ b/libcaf_core/caf/config.hpp
@@ -191,6 +191,8 @@
 #  endif
 #elif defined(__FreeBSD__)
 #  define CAF_BSD
+#elif defined(__NetBSD__)
+#  define CAF_NETBSD
 #elif defined(__OpenBSD__)
 #  define CAF_BSD
 #elif defined(__CYGWIN__)
@@ -201,7 +203,7 @@
 #  error Platform and/or compiler not supported
 #endif
 #if defined(CAF_MACOS) || defined(CAF_LINUX) || defined(CAF_BSD)               \
-  || defined(CAF_CYGWIN)
+  || defined(CAF_CYGWIN) || defined(CAF_NETBSD)
 #  define CAF_POSIX
 #endif
 

--- a/libcaf_core/src/detail/get_mac_addresses.cpp
+++ b/libcaf_core/src/detail/get_mac_addresses.cpp
@@ -7,7 +7,8 @@
 #include "caf/config.hpp"
 #include "caf/detail/scope_guard.hpp"
 
-#if defined(CAF_MACOS) || defined(CAF_BSD) || defined(CAF_IOS)
+#if defined(CAF_MACOS) || defined(CAF_BSD) || defined(CAF_IOS)                 \
+  || defined(CAF_NETBSD)
 
 #  include <arpa/inet.h>
 #  include <cerrno>

--- a/libcaf_core/src/detail/get_root_uuid.cpp
+++ b/libcaf_core/src/detail/get_root_uuid.cpp
@@ -192,7 +192,7 @@ std::string get_root_uuid() {
 } // namespace detail
 } // namespace caf
 
-#elif defined(CAF_IOS) || defined(CAF_ANDROID)
+#elif defined(CAF_IOS) || defined(CAF_ANDROID) || defined(CAF_NETBSD)
 
 // return a randomly-generated UUID on mobile devices
 

--- a/libcaf_core/src/detail/pretty_type_name.cpp
+++ b/libcaf_core/src/detail/pretty_type_name.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/config.hpp"
 
-#if defined(CAF_LINUX) || defined(CAF_MACOS)
+#if defined(CAF_LINUX) || defined(CAF_MACOS) || defined(CAF_NETBSD)
 #  include <cxxabi.h>
 #  include <sys/types.h>
 #  include <unistd.h>
@@ -43,7 +43,7 @@ void prettify_type_name(std::string& class_name) {
 }
 
 void prettify_type_name(std::string& class_name, const char* c_class_name) {
-#if defined(CAF_LINUX) || defined(CAF_MACOS)
+#if defined(CAF_LINUX) || defined(CAF_MACOS) || defined(CAF_NETBSD)
   int stat = 0;
   std::unique_ptr<char, decltype(free)*> real_class_name{nullptr, free};
   auto tmp = abi::__cxa_demangle(c_class_name, nullptr, nullptr, &stat);

--- a/libcaf_core/src/detail/set_thread_name.cpp
+++ b/libcaf_core/src/detail/set_thread_name.cpp
@@ -34,6 +34,8 @@ void set_thread_name(const char* name) {
   prctl(PR_SET_NAME, name, 0, 0, 0);
 #  elif defined(CAF_BSD)
   pthread_set_name_np(pthread_self(), name);
+#  elif defined(CAF_NETBSD)
+  pthread_setname_np(pthread_self(), name, NULL);
 #  endif // defined(...)
 #endif   // CAF_WINDOWS
 }


### PR DESCRIPTION
Add support for NetBSD.
In order to get uuid from root disk
gpt can be used but using it to get
this require root privileges so use
random uuid for now.
NetBSD has cxxabi.h with __cxa_demangle.
Add process metrics for NetBSD.