### PR TITLE
All BSD:s have abi::__cxa_demangle in cxxabi.h

### DIFF
--- a/libcaf_core/src/detail/pretty_type_name.cpp
+++ b/libcaf_core/src/detail/pretty_type_name.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/config.hpp"
 
-#if defined(CAF_LINUX) || defined(CAF_MACOS) || defined(CAF_NET_BSD)
+#if defined(CAF_LINUX) || defined(CAF_MACOS) || defined(CAF_BSD)
 #  define CAF_HAS_CXX_ABI
 #endif
 


### PR DESCRIPTION
tested this in Free, and OpenBSD.