### PR TITLE
Fix bookkeeping of the field name

### DIFF
--- a/libcaf_core/caf/json_reader.hpp
+++ b/libcaf_core/caf/json_reader.hpp
@@ -203,12 +203,13 @@ public:
 
   bool value(span<std::byte> x) override;
 
+  /// @private
+  std::string current_field_name();
+
 private:
   [[nodiscard]] position pos() const noexcept;
 
   void append_current_field_name(std::string& str);
-
-  std::string current_field_name();
 
   std::string mandatory_field_missing_str(std::string_view name);
 

--- a/libcaf_core/src/json_reader.cpp
+++ b/libcaf_core/src/json_reader.cpp
@@ -634,10 +634,15 @@ json_reader::position json_reader::pos() const noexcept {
 }
 
 void json_reader::append_current_field_name(std::string& result) {
-  result += "ROOT";
-  for (auto& key : field_) {
-    result += '.';
-    result.insert(result.end(), key.begin(), key.end());
+  if (field_.empty()) {
+    result += "null";
+  } else {
+    auto i = field_.begin();
+    result += *i++;
+    while (i != field_.end()) {
+      result += '.';
+      result += *i++;
+    }
   }
 }
 

--- a/libcaf_core/test/json_reader.cpp
+++ b/libcaf_core/test/json_reader.cpp
@@ -124,4 +124,64 @@ CAF_TEST(json baselines) {
   }
 }
 
+constexpr std::string_view foo_json = R"_({
+  "@first-type": "int32_t",
+  "first": 42,
+  "top": {
+    "mid": {
+      "bottom": null
+    }
+  }
+})_";
+
+SCENARIO("the json reader keeps track of the current field") {
+  GIVEN("a sequence of member functions calls for type inspection") {
+    WHEN("encountering new fields") {
+      THEN("the json reader updates the current field name") {
+        auto dummy = int32_t{0};
+        auto first_present = false;
+        auto types_vec = std::vector{type_id_v<int32_t>, type_id_v<double>};
+        auto types = make_span(types_vec);
+        auto first_index = size_t{0};
+        auto top_present = false;
+        auto bottom_present = false;
+        auto bottom_index = size_t{0};
+        json_reader uut;
+        CHECK(uut.load(foo_json));
+        CHECK_EQ(uut.current_field_name(), "null");
+        // clang-format off
+        uut.begin_object(invalid_type_id, "foo");
+          // begin_field overload #4
+          uut.begin_field("first", first_present, types, first_index);
+            CHECK_EQ(first_present, true);
+            CHECK_EQ(first_index, 0u);
+            CHECK_EQ(uut.current_field_name(), "first");
+            uut.value(dummy);
+            CHECK_EQ(dummy, 42);
+          uut.end_field();
+          // begin_field overload #2
+          uut.begin_field("top", top_present);
+            CHECK_EQ(top_present, true);
+            CHECK_EQ(uut.current_field_name(), "top");
+            uut.begin_object(invalid_type_id, "top");
+              // begin_field overload #1
+              uut.begin_field("mid");
+                CHECK_EQ(uut.current_field_name(), "top.mid");
+                uut.begin_object(invalid_type_id, "bottom");
+                  // begin_field overload #3
+                  uut.begin_field("bottom", bottom_present, types, bottom_index);
+                    CHECK_EQ(bottom_present, false);
+                    CHECK_EQ(uut.current_field_name(), "top.mid.bottom");
+                  uut.end_field();
+                uut.end_object();
+              uut.end_field();
+            uut.end_object();
+          uut.end_field();
+        uut.end_object();
+        // clang-format on
+      }
+    }
+  }
+}
+
 END_FIXTURE_SCOPE()


### PR DESCRIPTION
The `field_` of `json_reader` keeps track of the nested field name in the JSON object. This PR fixes a bug where the `field_.pop_back();` had no prior `field_.push_back(...)` in some cases.