### PR TITLE
Provide `*_weak` variants of `scheduled_actor::run_{delayed,scheduled}`

### DIFF
--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -647,6 +647,32 @@ public:
     return run_scheduled(time_point_cast<duration_t>(when), make_action(what));
   }
 
+  /// Runs `what` asynchronously at some point after `when`, iff this actor is
+  /// alive.
+  /// @param when The local time until the actor waits before invoking the
+  ///             action. Due to scheduling delays, there will always be some
+  ///             additional wait time. Passing the current time or a past time
+  ///             immediately schedules the action for execution.
+  /// @param what The action to invoke after waiting on the timeout.
+  /// @returns A @ref disposable that allows the actor to cancel the action.
+  template <class Duration, class F>
+  disposable run_scheduled_weak(
+    std::chrono::time_point<std::chrono::system_clock, Duration> when, F what) {
+    using std::chrono::time_point_cast;
+    return run_scheduled_weak(time_point_cast<timespan>(when),
+                              make_action(what));
+  }
+
+  /// @copydoc run_scheduled_weak
+  template <class Duration, class F>
+  disposable run_scheduled_weak(
+    std::chrono::time_point<actor_clock::clock_type, Duration> when, F what) {
+    using std::chrono::time_point_cast;
+    using duration_t = actor_clock::duration_type;
+    return run_scheduled_weak(time_point_cast<duration_t>(when),
+                              make_action(what));
+  }
+
   /// Runs `what` asynchronously after the `delay`.
   /// @param delay Minimum amount of time that actor waits before invoking the
   ///              action. Due to scheduling delays, there will always be some
@@ -657,6 +683,18 @@ public:
   disposable run_delayed(std::chrono::duration<Rep, Period> delay, F what) {
     using std::chrono::duration_cast;
     return run_delayed(duration_cast<timespan>(delay), make_action(what));
+  }
+
+  /// Runs `what` asynchronously after the `delay`, iff this actor is alive.
+  /// @param delay Minimum amount of time that actor waits before invoking the
+  ///              action. Due to scheduling delays, there will always be some
+  ///              additional wait time.
+  /// @param what The action to invoke after the delay.
+  /// @returns A @ref disposable that allows the actor to cancel the action.
+  template <class Rep, class Period, class F>
+  disposable run_delayed_weak(std::chrono::duration<Rep, Period> delay, F what) {
+    using std::chrono::duration_cast;
+    return run_delayed_weak(duration_cast<timespan>(delay), make_action(what));
   }
 
   // -- properties -------------------------------------------------------------
@@ -744,7 +782,10 @@ private:
 
   disposable run_scheduled(timestamp when, action what);
   disposable run_scheduled(actor_clock::time_point when, action what);
+  disposable run_scheduled_weak(timestamp when, action what);
+  disposable run_scheduled_weak(actor_clock::time_point when, action what);
   disposable run_delayed(timespan delay, action what);
+  disposable run_delayed_weak(timespan delay, action what);
 
   // -- caf::flow bindings -----------------------------------------------------
 

--- a/libcaf_core/src/scheduled_actor.cpp
+++ b/libcaf_core/src/scheduled_actor.cpp
@@ -885,11 +885,28 @@ disposable scheduled_actor::run_scheduled(actor_clock::time_point when,
   return clock().schedule(when, std::move(what), strong_actor_ptr{ctrl()});
 }
 
-disposable scheduled_actor::run_delayed(timespan delay, action what) {
+disposable scheduled_actor::run_scheduled_weak(timestamp when, action what) {
   CAF_ASSERT(what.ptr() != nullptr);
+  CAF_LOG_TRACE(CAF_ARG(when));
+  auto delay = when - make_timestamp();
+  return run_scheduled_weak(clock().now() + delay, std::move(what));
+}
+
+disposable scheduled_actor::run_scheduled_weak(actor_clock::time_point when,
+                                               action what) {
+  CAF_ASSERT(what.ptr() != nullptr);
+  CAF_LOG_TRACE(CAF_ARG(when));
+  return clock().schedule(when, std::move(what), weak_actor_ptr{ctrl()});
+}
+
+disposable scheduled_actor::run_delayed(timespan delay, action what) {
   CAF_LOG_TRACE(CAF_ARG(delay));
-  return clock().schedule(clock().now() + delay, std::move(what),
-                          strong_actor_ptr{ctrl()});
+  return run_scheduled(clock().now() + delay, std::move(what));
+}
+
+disposable scheduled_actor::run_delayed_weak(timespan delay, action what) {
+  CAF_LOG_TRACE(CAF_ARG(delay));
+  return run_scheduled_weak(clock().now() + delay, std::move(what));
 }
 
 // -- caf::flow bindings -------------------------------------------------------


### PR DESCRIPTION
This adds variants to the very useful `run_delayed` and `run_scheduled` member functions of `scheduled_actor` that do not keep the actor alive until the action is triggered.

I chose the `_weak` suffix rather than a `weak_` prefix so they show up in auto-completion alongside their strong variants, which makes it easier for users to discover these functions and to think about which one they need to call.

As of opening the PR the new functions still lack test coverage, as I wasn't quite sure how to test them. Ideas are welcome, and the PR is configured to allow pushes from maintainers.

Fixes #1222 by allowing `self->run_delayed_weak(delay, [self] { self->send(...) }` as a weak version of `self->delayed_send(self, delay, ...)`.