### PR TITLE
Drop Codedocs integration

### DIFF
--- a/.codedocs
+++ b/.codedocs
@@ -1,1 +1,0 @@
-DOXYFILE = Doxyfile

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ transparent messaging, and more.
 * __Developer Blog__: https://www.actor-framework.org/blog
 * __Guides and Tutorials__: https://www.cafcademy.com/articles
 * __Manual__: https://actor-framework.readthedocs.io
-* __Doxygen__: https://codedocs.xyz/actor-framework/actor-framework
+* __Doxygen__: https://www.actor-framework.org/doxygen/
 
 ## Report Bugs / Get Help
 


### PR DESCRIPTION
The workers of Codedocs don't have the `dot` tool available for `doxygen`. This means all inheritance graphs consist of broken images. Further, the installed `doxygen` version on the workers is very old and doesn't seem to get updated.

We host our Doxygen-generated API reference on our website now. This also allows us to have multiple versions online. Currently, we only have the latest version: 0.18.7.

Close #1360.