### PR TITLE
Limit how many actions actors may run in one go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   operators that use the `ucast` operator internally.
 - The `mcast` and `ucast` operators now stop calling `on_next` immediately when
   disposed.
+- Actors reading from external sources such as SPSC buffers via a local flow
+  could end up in a long-running read loop. To avoid potentially starving other
+  actors or activities, scheduled actors now limit the amount of actions that
+  may run in one iteration (#1364).
 
 ## [0.19.0-rc.1] - 2022-10-31
 

--- a/libcaf_core/caf/defaults.hpp
+++ b/libcaf_core/caf/defaults.hpp
@@ -32,6 +32,11 @@ constexpr parameter<T> make_parameter(std::string_view name, T fallback) {
   return {name, fallback};
 }
 
+/// Configures how many actions scheduled_actor::delay may add to the internal
+/// queue for scheduled_actor::run_actions before being forced to push them to
+/// the mailbox instead.
+constexpr auto max_inline_actions_per_run = size_t{10};
+
 } // namespace caf::defaults
 
 namespace caf::defaults::stream {

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -829,6 +829,11 @@ private:
   /// message.
   std::vector<action> actions_;
 
+  /// Counter for scheduled_actor::delay to make sure
+  /// scheduled_actor::run_actions does not end up in a busy loop that might
+  /// starve other activities.
+  size_t delayed_actions_this_run_ = 0;
+
   /// Stores ongoing activities such as flows that block the actor from
   /// terminating.
   std::vector<disposable> watched_disposables_;

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -849,6 +849,12 @@ private:
   /// Maps the ID of incoming stream batches to local state that allows the
   /// actor to push received batches into the local flow.
   std::unordered_map<uint64_t, detail::stream_bridge_sub_ptr> stream_bridges_;
+
+  /// Special-purpose behavior for scheduled_actor::delay. When pushing an
+  /// action to the mailbox, we register this behavior as the response handler.
+  /// This is to make sure that actor does not terminate because it thinks it's
+  /// done before processing the delayed action.
+  behavior delay_bhvr_;
 };
 
 } // namespace caf


### PR DESCRIPTION
I ended up with a slightly different patch then the first one I've tried in #1364. Instead of using a flag, I'm using a counter now to allow some actions to go through immediately but then "interrupt" flows if they have cause a chain of >= 10 consecutive actions to trigger. The threshold basically balances between fairness and efficiency. 10 should be low enough to be on the "fair scheduling" side where actors can't hog the CPU for themselves for too long while not being too aggressive.

I think hard-coding this parameter should be fine. Maybe we can run some benchmarking at some point to see whether it sits in the right spot at 10. But that's a story for another day. 🙂

Close #1364.