### PR TITLE
Add `[[nodiscard]]` to `expected`

### DIFF
--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -27,7 +27,7 @@ template <class> class behavior_type_of;
 template <class> class callback;
 template <class> class cow_vector;
 template <class> class dictionary;
-template <class> class expected;
+template <class> class [[nodiscard]] expected;
 template <class> class intrusive_cow_ptr;
 template <class> class intrusive_ptr;
 template <class> class param;

--- a/libcaf_io/test/io/basp_broker.cpp
+++ b/libcaf_io/test/io/basp_broker.cpp
@@ -661,7 +661,7 @@ CAF_TEST(indirect_connections) {
   MESSAGE("publish self at port 4242");
   auto ax = accept_handle::from_int(4242);
   mpx()->provide_acceptor(4242, ax);
-  sys.middleman().publish(self(), 4242);
+  CAF_REQUIRE(sys.middleman().publish(self(), 4242));
   mpx()->flush_runnables(); // process publish message in basp_broker
   MESSAGE("connect to Mars");
   connect_node(mars(), ax, self()->id());

--- a/libcaf_net/test/net/length_prefix_framing.cpp
+++ b/libcaf_net/test/net/length_prefix_framing.cpp
@@ -272,7 +272,8 @@ SCENARIO("lp::with(...).connect(...) translates between flows and socket I/O") {
                     .subscribe(push);
                 });
               });
-        conn.or_else([](const error& err) { FAIL("connect failed:" << err); });
+        (void) conn.or_else(
+          [](const error& err) { FAIL("connect failed:" << err); });
         scoped_actor self{sys};
         self->wait_for(hdl);
         if (CHECK_EQ(buf->size(), 5u)) {


### PR DESCRIPTION
Discarding a `caf::expected` is almost always an error. I would find it very useful to have this attribute on the declaration of the class itself. This small PR does exactly that. Feel free to close this if the absence of this attribute is intentional.