### PR TITLE
Remove hard-coded default cipher lists for OpenSSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 ### Changed
 
 - Install CAF tools to `${CMAKE_INSTALL_BINDIR}` to make packaging easier.
+- The OpenSSL module no longer hard-codes calls to `SSL_CTX_set_cipher_list` in
+  order to use the system settings by default. Users can provide a custom cipher
+  list by providing a value for the configuration option
+  `caf.openssl.cipher-list`. To restore the previous behavior, set this
+  parameter to `HIGH:!aNULL:!MD5` when running with a certificate and
+  `AECDH-AES256-SHA@SECLEVEL=0` otherwise (or without `@SECLEVEL=0` for older
+  versions of OpenSSL). Please note that these lists are *not* recommended as
+  safe defaults, which is why we are no longer setting these values.
 
 ## [0.19.1] - 2023-05-01
 

--- a/libcaf_openssl/src/openssl/manager.cpp
+++ b/libcaf_openssl/src/openssl/manager.cpp
@@ -148,7 +148,9 @@ void manager::add_module_options(actor_system_config& cfg) {
       "path to an OpenSSL-style directory of trusted certificates")
     .add<std::string>(
       cfg.openssl_cafile, "cafile",
-      "path to a file of concatenated PEM-formatted certificates");
+      "path to a file of concatenated PEM-formatted certificates")
+    .add<std::string>("cipher-list",
+                      "colon-separated list of OpenSSL cipher strings to use");
 }
 
 actor_system::module* manager::make(actor_system& sys, detail::type_list<>) {


### PR DESCRIPTION
@topazus with this change, CAF should be in line with https://docs.fedoraproject.org/en-US/packaging-guidelines/CryptoPolicies/#_cc_applications: don't call `SSL_CTX_set_cipher_list` unless the user explicitly asks for it.

Closes #1410.