### PR TITLE
Only exclude CAF options from --help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## [Unreleased]
 
+### Changed
+
+- When using CAF to parse CLI arguments, the output of `--help` now includes all
+  user-defined options. Previously, only options in the global category or
+  options with a short name were included. Only CAF options are now excluded
+  from the output. They will still be included in the output of `--long-help`.
+
 ### Fixed
 
 - Fix build errors with exceptions disabled.

--- a/libcaf_core/caf/config_option_set.hpp
+++ b/libcaf_core/caf/config_option_set.hpp
@@ -158,7 +158,7 @@ public:
   config_option_set& add(config_option opt);
 
   /// Generates human-readable help text for all options.
-  std::string help_text(bool global_only = true) const;
+  std::string help_text(bool hide_caf_options = true) const;
 
   /// Drops all options.
   void clear() {

--- a/libcaf_core/src/actor_system_config.cpp
+++ b/libcaf_core/src/actor_system_config.cpp
@@ -47,7 +47,8 @@ actor_system_config::actor_system_config()
   using string_list = std::vector<string>;
   opt_group{custom_options_, "global"}
     .add<bool>("help,h?", "print help text to STDERR and exit")
-    .add<bool>("long-help", "print long help text to STDERR and exit")
+    .add<bool>("long-help",
+               "same as --help but list options that are omitted by default")
     .add<bool>("dump-config", "print configuration to STDERR and exit")
     .add<string>("config-file", "sets a path to a configuration file");
   opt_group{custom_options_, "caf.scheduler"}


### PR DESCRIPTION
Tweak the behavior of `--help` and `--long-help`. I think the previous behavior to only print global options and options with a short name was quite unintuitive. It makes sense to not include the CAF options by default, since there are ~40 of them (depending on loaded modules) and most users would only care about the options that the application actually defines.