### PR TITLE
Add missing compare overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## [Unreleased]
 
+### Added
+
+- The class `caf::telemetry::label` now has a new `compare` overload that
+  accepts a `caf::telemetry::label_view` to make the interface of the both
+  classes symmetrical.
+
 ### Changed
 
 - When using CAF to parse CLI arguments, the output of `--help` now includes all

--- a/libcaf_core/caf/telemetry/label.hpp
+++ b/libcaf_core/caf/telemetry/label.hpp
@@ -53,9 +53,15 @@ public:
 
   // -- comparison -------------------------------------------------------------
 
-  int compare(const label_view& x) const noexcept;
+  template <class T1, class T2>
+  static int compare(const T1& lhs, const T2& rhs) noexcept {
+    auto cmp1 = lhs.name().compare(rhs.name());
+    return cmp1 != 0 ? cmp1 : lhs.value().compare(rhs.value());
+  }
 
-  int compare(const label& x) const noexcept;
+  int compare(const label_view& other) const noexcept;
+
+  int compare(const label& other) const noexcept;
 
 private:
   size_t name_length_;

--- a/libcaf_core/caf/telemetry/label.hpp
+++ b/libcaf_core/caf/telemetry/label.hpp
@@ -53,6 +53,8 @@ public:
 
   // -- comparison -------------------------------------------------------------
 
+  int compare(const label_view& x) const noexcept;
+
   int compare(const label& x) const noexcept;
 
 private:

--- a/libcaf_core/caf/telemetry/label_view.hpp
+++ b/libcaf_core/caf/telemetry/label_view.hpp
@@ -42,9 +42,9 @@ public:
 
   // -- comparison -------------------------------------------------------------
 
-  int compare(const label& x) const noexcept;
+  int compare(const label& other) const noexcept;
 
-  int compare(const label_view& x) const noexcept;
+  int compare(const label_view& other) const noexcept;
 
 private:
   std::string_view name_;

--- a/libcaf_core/src/telemetry/label.cpp
+++ b/libcaf_core/src/telemetry/label.cpp
@@ -26,13 +26,11 @@ void label::value(std::string_view new_value) {
 }
 
 int label::compare(const label_view& x) const noexcept {
-  auto cmp1 = name().compare(x.name());
-  return cmp1 != 0 ? cmp1 : value().compare(x.value());
+  return compare(*this, x);
 }
 
 int label::compare(const label& x) const noexcept {
-  auto cmp1 = name().compare(x.name());
-  return cmp1 != 0 ? cmp1 : value().compare(x.value());
+  return compare(*this, x);
 }
 
 std::string to_string(const label& x) {

--- a/libcaf_core/src/telemetry/label.cpp
+++ b/libcaf_core/src/telemetry/label.cpp
@@ -25,8 +25,14 @@ void label::value(std::string_view new_value) {
   str_.insert(str_.end(), new_value.begin(), new_value.end());
 }
 
+int label::compare(const label_view& x) const noexcept {
+  auto cmp1 = name().compare(x.name());
+  return cmp1 != 0 ? cmp1 : value().compare(x.value());
+}
+
 int label::compare(const label& x) const noexcept {
-  return str_.compare(x.str());
+  auto cmp1 = name().compare(x.name());
+  return cmp1 != 0 ? cmp1 : value().compare(x.value());
 }
 
 std::string to_string(const label& x) {

--- a/libcaf_core/src/telemetry/label_view.cpp
+++ b/libcaf_core/src/telemetry/label_view.cpp
@@ -8,14 +8,12 @@
 
 namespace caf::telemetry {
 
-int label_view::compare(const label_view& x) const noexcept {
-  auto cmp1 = name().compare(x.name());
-  return cmp1 != 0 ? cmp1 : value().compare(x.value());
+int label_view::compare(const label_view& other) const noexcept {
+  return label::compare(*this, other);
 }
 
-int label_view::compare(const label& x) const noexcept {
-  auto cmp1 = name().compare(x.name());
-  return cmp1 != 0 ? cmp1 : value().compare(x.value());
+int label_view::compare(const label& other) const noexcept {
+  return label::compare(*this, other);
 }
 
 std::string to_string(const label_view& x) {


### PR DESCRIPTION
Just a small addition for consistency. Also, I've reimplemented `int label::compare(const label& x)` so that all four `compare` overloads (the two in `label` and the two in `label_view`) now do the exact same thing.