### PR TITLE
Fix regression in --dump-config output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - The class `caf::telemetry::label` now has a new `compare` overload that
   accepts a `caf::telemetry::label_view` to make the interface of the both
   classes symmetrical.
+- The template class `caf::dictionary` now has new member functions for erasing
+  elements.
 
 ### Changed
 
@@ -18,10 +20,15 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   user-defined options. Previously, only options in the global category or
   options with a short name were included. Only CAF options are now excluded
   from the output. They will still be included in the output of `--long-help`.
+- The output of `--dump-config` now only contains CAF options from loaded
+  modules. Previously, it also included options from modules that were not
+  loaded.
 
 ### Fixed
 
 - Fix build errors with exceptions disabled.
+- Fix a regression in `--dump-config` that caused CAF applications to emit
+  malformed output.
 
 ## [0.19.2] - 2023-06-13
 

--- a/libcaf_core/caf/dictionary.hpp
+++ b/libcaf_core/caf/dictionary.hpp
@@ -281,6 +281,24 @@ public:
     return std::upper_bound(begin(), end(), key, cmp);
   }
 
+  // -- removal ----------------------------------------------------------------
+
+  iterator erase(const_iterator i) {
+    return xs_.erase(i);
+  }
+
+  iterator erase(const_iterator first, const_iterator last) {
+    return xs_.erase(first, last);
+  }
+
+  size_type erase(std::string_view key) {
+    if (auto i = lower_bound(key); i != end() && i->first == key) {
+      erase(i);
+      return 1;
+    }
+    return 0;
+  }
+
   // -- element access ---------------------------------------------------------
 
   mapped_type& operator[](std::string_view key) {

--- a/libcaf_io/src/io/middleman.cpp
+++ b/libcaf_io/src/io/middleman.cpp
@@ -190,6 +190,7 @@ void middleman::init_global_meta_objects() {
 }
 
 void middleman::add_module_options(actor_system_config& cfg) {
+  // Add options to the CLI parser.
   config_option_adder{cfg.custom_options(), "caf.middleman"}
     .add<std::string>("network-backend",
                       "either 'default' or 'asio' (if available)")
@@ -211,6 +212,18 @@ void middleman::add_module_options(actor_system_config& cfg) {
   config_option_adder{cfg.custom_options(), "caf.middleman.prometheus-http"}
     .add<uint16_t>("port", "listening port for incoming scrapes")
     .add<std::string>("address", "bind address for the HTTP server socket");
+  // Add the defaults to the config so they show up in --dump-config.
+  auto& grp = put_dictionary(cfg.content, "caf.middleman");
+  auto default_id = std::string{defaults::middleman::app_identifier};
+  put_missing(grp, "app-identifiers",
+              std::vector<std::string>{std::move(default_id)});
+  put_missing(grp, "enable-automatic-connections", false);
+  put_missing(grp, "max-consecutive-reads",
+              defaults::middleman::max_consecutive_reads);
+  put_missing(grp, "heartbeat-interval",
+              defaults::middleman::heartbeat_interval);
+  put_missing(grp, "connection-timeout",
+              defaults::middleman::connection_timeout);
 }
 
 actor_system::module* middleman::make(actor_system& sys, detail::type_list<>) {

--- a/libcaf_net/src/net/middleman.cpp
+++ b/libcaf_net/src/net/middleman.cpp
@@ -98,16 +98,10 @@ void middleman::stop() {
     mpx_->run();
 }
 
-void middleman::init(actor_system_config& cfg) {
+void middleman::init(actor_system_config&) {
   if (auto err = mpx_->init()) {
     CAF_LOG_ERROR("mpx_->init() failed: " << err);
     CAF_RAISE_ERROR("mpx_->init() failed");
-  }
-  if (auto node_uri = get_if<uri>(&cfg, "caf.middleman.this-node")) {
-    auto this_node = make_node_id(std::move(*node_uri));
-    sys_.node_.swap(this_node);
-  } else {
-    // CAF_RAISE_ERROR("no valid entry for caf.middleman.this-node found");
   }
 }
 
@@ -124,20 +118,9 @@ actor_system::module* middleman::make(actor_system& sys, detail::type_list<>) {
 }
 
 void middleman::add_module_options(actor_system_config& cfg) {
-  config_option_adder{cfg.custom_options(), "caf.middleman"}
-    .add<std::vector<std::string>>("app-identifiers",
-                                   "valid application identifiers of this node")
-    .add<uri>("this-node", "locator of this CAF node")
-    .add<size_t>("max-consecutive-reads",
-                 "max. number of consecutive reads per broker")
+  config_option_adder{cfg.custom_options(), "caf.middleman"} //
     .add<bool>("manual-multiplexing",
-               "disables background activity of the multiplexer")
-    .add<size_t>("workers", "number of deserialization workers")
-    .add<timespan>("heartbeat-interval", "interval of heartbeat messages")
-    .add<timespan>("connection-timeout",
-                   "max. time between messages before declaring a node dead "
-                   "(disabled if 0, ignored if heartbeats are disabled)")
-    .add<std::string>("network-backend", "legacy option");
+               "disables background activity of the multiplexer");
   config_option_adder{cfg.custom_options(), "caf.middleman.prometheus-http"}
     .add<uint16_t>("port", "listening port for incoming scrapes")
     .add<std::string>("address", "bind address for the HTTP server socket");

--- a/libcaf_openssl/src/openssl/manager.cpp
+++ b/libcaf_openssl/src/openssl/manager.cpp
@@ -136,6 +136,7 @@ bool manager::authentication_enabled() {
 }
 
 void manager::add_module_options(actor_system_config& cfg) {
+  // Add options to the CLI parser.
   config_option_adder(cfg.custom_options(), "caf.openssl")
     .add<std::string>(cfg.openssl_certificate, "certificate",
                       "path to the PEM-formatted certificate file")
@@ -151,6 +152,13 @@ void manager::add_module_options(actor_system_config& cfg) {
       "path to a file of concatenated PEM-formatted certificates")
     .add<std::string>("cipher-list",
                       "colon-separated list of OpenSSL cipher strings to use");
+  // Add the defaults to the config so they show up in --dump-config.
+  auto& grp = put_dictionary(cfg.content, "caf.openssl");
+  put_missing(grp, "certificate", cfg.openssl_certificate);
+  put_missing(grp, "key", cfg.openssl_key);
+  put_missing(grp, "passphrase", cfg.openssl_passphrase);
+  put_missing(grp, "capath", cfg.openssl_capath);
+  put_missing(grp, "cafile", cfg.openssl_cafile);
 }
 
 actor_system::module* manager::make(actor_system& sys, detail::type_list<>) {

--- a/robot/CMakeLists.txt
+++ b/robot/CMakeLists.txt
@@ -1,6 +1,14 @@
 find_package(Python COMPONENTS Interpreter)
 
 add_test(
+  NAME "robot-config-dump-config"
+  COMMAND
+    ${Python_EXECUTABLE}
+      -m robot
+      --variable BINARY_PATH:$<TARGET_FILE:hello_world>
+      "${CMAKE_CURRENT_SOURCE_DIR}/config/dump-config.robot")
+
+add_test(
   NAME "robot-http-rest"
   COMMAND
     ${Python_EXECUTABLE}

--- a/robot/config/dump-config.robot
+++ b/robot/config/dump-config.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Documentation     A test suite for --dump-config.
+Library           OperatingSystem
+Library           Process
+
+*** Variables ***
+${BINARY_PATH}    /path/to/the/test/binary
+
+*** Test Cases ***
+The output of --dump-config should generate valid input for --config-file
+    [Tags]    Config
+    Run Process  ${BINARY_PATH}  --dump-config  stdout=out1.cfg
+    Run Process  ${BINARY_PATH}  --config-file\=out1.cfg  --dump-config  stdout=out2.cfg
+    ${out1}=     Get File    out1.cfg
+    ${out2}=     Get File    out2.cfg
+    Should Be Equal As Strings    ${out1}    ${out2}


### PR DESCRIPTION
- Make sure the output of `--dump-config` generates valid input for `--config-file`.
- Add a regression test with Robot that ensures this property by calling a CAF application with `--dump-config` and then have the same application parse the output via `--config-file`.
- Omit the options from CAF modules that aren't loaded.