### PR TITLE
Isolate closing handshake

### DIFF
--- a/libcaf_net/caf/net/web_socket/framing.hpp
+++ b/libcaf_net/caf/net/web_socket/framing.hpp
@@ -144,7 +144,12 @@ private:
 
   // Signal abort to the upper layer and shutdown to the lower layer,
   // with closing message
-  void abort_and_close_connection(sec reason, std::string_view msg);
+  template <class... Ts>
+  void abort_and_shutdown(sec reason, Ts&&... xs) {
+    auto err = make_error(reason, std::forward<Ts>(xs)...);
+    up_->abort(err);
+    shutdown(err);
+  }
 
   // -- member variables -------------------------------------------------------
 

--- a/libcaf_net/caf/net/web_socket/framing.hpp
+++ b/libcaf_net/caf/net/web_socket/framing.hpp
@@ -139,6 +139,11 @@ private:
   template <class T>
   void ship_frame(std::vector<T>& buf);
 
+  void abort_and_shutdown(caf::error reason) {
+    abort(reason);
+    shutdown(reason);
+  }
+
   // -- member variables -------------------------------------------------------
 
   /// Points to the transport layer below.

--- a/libcaf_net/caf/net/web_socket/framing.hpp
+++ b/libcaf_net/caf/net/web_socket/framing.hpp
@@ -139,10 +139,12 @@ private:
   template <class T>
   void ship_frame(std::vector<T>& buf);
 
-  void abort_and_shutdown(caf::error reason) {
-    abort(reason);
-    shutdown(reason);
-  }
+  // Sends closing message, can be error status, or closing handshake
+  void ship_closing_message(status code, std::string_view desc);
+
+  // Signal abort to the upper layer and shutdown to the lower layer,
+  // with closing message
+  void abort_and_close_connection(sec reason, std::string_view msg);
 
   // -- member variables -------------------------------------------------------
 

--- a/libcaf_net/src/net/web_socket/framing.cpp
+++ b/libcaf_net/src/net/web_socket/framing.cpp
@@ -30,8 +30,8 @@ ptrdiff_t framing::consume(byte_span buffer, byte_span) {
   auto hdr_bytes = detail::rfc6455::decode_header(buffer, hdr);
   if (hdr_bytes < 0) {
     CAF_LOG_DEBUG("decoded malformed data: hdr_bytes < 0");
-    abort_and_shutdown(make_error(
-      sec::protocol_error, "negative header size on WebSocket connection"));
+    abort_and_close_connection(sec::protocol_error,
+                               "negative header size on WebSocket connection");
     return -1;
   }
   if (hdr_bytes == 0) {
@@ -41,8 +41,8 @@ ptrdiff_t framing::consume(byte_span buffer, byte_span) {
   // Make sure the entire frame (including header) fits into max_frame_size.
   if (hdr.payload_len >= (max_frame_size - static_cast<size_t>(hdr_bytes))) {
     CAF_LOG_DEBUG("WebSocket frame too large");
-    abort_and_shutdown(
-      make_error(sec::protocol_error, "WebSocket frame too large"));
+    abort_and_close_connection(sec::protocol_error,
+                               "WebSocket frame too large");
     return -1;
   }
   // Wait for more data if necessary.
@@ -61,25 +61,27 @@ ptrdiff_t framing::consume(byte_span buffer, byte_span) {
     if (opcode_ == nil_code) {
       // Call upper layer.
       if (hdr.opcode == detail::rfc6455::connection_close) {
-        abort_and_shutdown(make_error(sec::connection_closed));
+        // TODO
+        abort_and_close_connection(sec::connection_closed, "");
         return -1;
       } else if (!handle(hdr.opcode, payload)) {
         return -1;
       }
     } else if (hdr.opcode != detail::rfc6455::continuation_frame) {
       CAF_LOG_DEBUG("expected a WebSocket continuation_frame");
-      abort_and_shutdown(make_error(sec::protocol_error,
-                                    "expected a WebSocket continuation_frame"));
+      abort_and_close_connection(sec::protocol_error,
+                                 "expected a WebSocket continuation_frame");
       return -1;
     } else if (payload_buf_.size() + payload_len > max_frame_size) {
       CAF_LOG_DEBUG("fragmented WebSocket payload exceeds maximum size");
-      abort_and_shutdown(make_error(sec::protocol_error,
-                                    "fragmented WebSocket payload "
-                                    "exceeds maximum size"));
+      abort_and_close_connection(sec::protocol_error,
+                                 "fragmented WebSocket payload "
+                                 "exceeds maximum size");
       return -1;
     } else {
       if (hdr.opcode == detail::rfc6455::connection_close) {
-        abort_and_shutdown(make_error(sec::connection_closed));
+        // TODO
+        abort_and_close_connection(sec::connection_closed, "");
         return -1;
       } else {
         // End of fragmented input.
@@ -98,23 +100,23 @@ ptrdiff_t framing::consume(byte_span buffer, byte_span) {
       if (hdr.opcode == detail::rfc6455::continuation_frame) {
         CAF_LOG_DEBUG("received WebSocket continuation "
                       "frame without prior opcode");
-        abort_and_shutdown(make_error(sec::protocol_error,
-                                      "received WebSocket continuation "
-                                      "frame without prior opcode"));
+        abort_and_close_connection(sec::protocol_error,
+                                   "received WebSocket continuation "
+                                   "frame without prior opcode");
         return -1;
       }
       opcode_ = hdr.opcode;
     } else if (hdr.opcode != detail::rfc6455::continuation_frame) {
       CAF_LOG_DEBUG("expected a continuation frame");
-      abort_and_shutdown(make_error(sec::protocol_error, //
-                                    "expected a continuation frame"));
+      abort_and_close_connection(sec::protocol_error,
+                                 "expected a continuation frame");
       return -1;
     } else if (payload_buf_.size() + payload_len > max_frame_size) {
       // Reject assembled payloads that exceed max_frame_size.
       CAF_LOG_DEBUG("fragmented WebSocket payload exceeds maximum size");
-      abort_and_shutdown(make_error(sec::protocol_error,
-                                    "fragmented WebSocket payload "
-                                    "exceeds maximum size"));
+      abort_and_close_connection(sec::protocol_error,
+                                 "fragmented WebSocket payload "
+                                 "exceeds maximum size");
       return -1;
     }
     payload_buf_.insert(payload_buf_.end(), payload.begin(), payload.end());
@@ -153,22 +155,7 @@ void framing::write_later() {
 }
 
 void framing::shutdown(status code, std::string_view msg) {
-  auto code_val = static_cast<uint16_t>(code);
-  uint32_t mask_key = 0;
-  byte_buffer payload;
-  payload.reserve(msg.size() + 2);
-  payload.push_back(static_cast<std::byte>((code_val & 0xFF00) >> 8));
-  payload.push_back(static_cast<std::byte>(code_val & 0x00FF));
-  for (auto c : msg)
-    payload.push_back(static_cast<std::byte>(c));
-  if (mask_outgoing_frames) {
-    mask_key = static_cast<uint32_t>(rng_());
-    detail::rfc6455::mask_data(mask_key, payload);
-  }
-  down_->begin_output();
-  detail::rfc6455::assemble_frame(detail::rfc6455::connection_close, mask_key,
-                                  payload, down_->output_buffer());
-  down_->end_output();
+  ship_closing_message(code, msg);
   down_->shutdown();
 }
 
@@ -251,6 +238,39 @@ void framing::ship_frame(std::vector<T>& buf) {
   detail::rfc6455::assemble_frame(mask_key, buf, down_->output_buffer());
   down_->end_output();
   buf.clear();
+}
+
+void framing::ship_closing_message(status code, std::string_view msg) {
+  auto code_val = static_cast<uint16_t>(code);
+  uint32_t mask_key = 0;
+  byte_buffer payload;
+  payload.reserve(msg.size() + 2);
+  payload.push_back(static_cast<std::byte>((code_val & 0xFF00) >> 8));
+  payload.push_back(static_cast<std::byte>(code_val & 0x00FF));
+  for (auto c : msg)
+    payload.push_back(static_cast<std::byte>(c));
+  if (mask_outgoing_frames) {
+    mask_key = static_cast<uint32_t>(rng_());
+    detail::rfc6455::mask_data(mask_key, payload);
+  }
+  down_->begin_output();
+  detail::rfc6455::assemble_frame(detail::rfc6455::connection_close, mask_key,
+                                  payload, down_->output_buffer());
+  down_->end_output();
+}
+
+void framing::abort_and_close_connection(sec reason, std::string_view msg) {
+  if (msg.empty())
+    up_->abort(make_error(reason));
+  else
+    up_->abort(make_error(reason, std::string(msg)));
+  status code = status::unexpected_condition;
+  if (reason == sec::connection_closed)
+    code = status::normal_close;
+  else if (reason == sec::protocol_error)
+    code = status::protocol_error;
+  ship_closing_message(code, to_string(reason));
+  down_->shutdown();
 }
 
 } // namespace caf::net::web_socket

--- a/libcaf_net/src/net/web_socket/lower_layer.cpp
+++ b/libcaf_net/src/net/web_socket/lower_layer.cpp
@@ -20,7 +20,9 @@ void lower_layer::shutdown() {
 }
 
 void lower_layer::shutdown(const error& reason) {
-  if (reason.code() == static_cast<uint8_t>(sec::protocol_error)) {
+  if (reason.code() == static_cast<uint8_t>(sec::connection_closed)) {
+    shutdown(status::normal_close, to_string(reason));
+  } else if (reason.code() == static_cast<uint8_t>(sec::protocol_error)) {
     shutdown(status::protocol_error, to_string(reason));
   } else {
     shutdown(status::unexpected_condition, to_string(reason));

--- a/libcaf_net/test/net/web_socket/framing.cpp
+++ b/libcaf_net/test/net/web_socket/framing.cpp
@@ -144,7 +144,7 @@ SCENARIO("the client closes the connection with a closing handshake") {
                                       make_test_data(0), handshake);
       transport->push(handshake);
     }
-    THEN("the server closes the connection with a closing handshake") {
+    THEN("the server closes the connection after sending a close frame") {
       transport->handle_input();
       detail::rfc6455::header hdr;
       auto hdr_length


### PR DESCRIPTION
Isolate the closing handshake (or closing error status) to a separate method. Integrate into framing consume, and framing shutdown.
This is a draft, until we merge #1459 so we can rebase on these changes.