### PR TITLE
Support string_view in make_message and make_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - The CLI argument parser now supports a space separator when using long
   argument names, e.g., `--foo bar`. This is in addition to the existing
   `--foo=bar` syntax.
+- The functions `make_message` and `make_error` now support `std::string_view`
+  as input and automatically convert it to `std::string`.
 
 ### Changed
 

--- a/libcaf_core/caf/detail/implicit_conversions.hpp
+++ b/libcaf_core/caf/detail/implicit_conversions.hpp
@@ -52,6 +52,11 @@ struct implicit_conversions<char*> {
   using type = std::string;
 };
 
+template <>
+struct implicit_conversions<std::string_view> {
+  using type = std::string;
+};
+
 template <size_t N>
 struct implicit_conversions<char[N]> : implicit_conversions<char*> {};
 

--- a/libcaf_core/test/error.cpp
+++ b/libcaf_core/test/error.cpp
@@ -9,27 +9,38 @@
 #include "core-test.hpp"
 
 using namespace caf;
+using namespace std::literals;
 
-CAF_TEST(default constructed errors evaluate to false) {
+TEST_CASE("default-constructed errors evaluate to false") {
   error err;
   CHECK(!err);
 }
 
-CAF_TEST(error code zero is not an error) {
+TEST_CASE("error code zero is not an error") {
   CHECK(!error(sec::none));
   CHECK(!make_error(sec::none));
   CHECK(!error{error_code<sec>(sec::none)});
 }
 
-CAF_TEST(error codes that are not zero are errors) {
+TEST_CASE("error codes that are not zero are errors") {
   CHECK(error(sec::unexpected_message));
   CHECK(make_error(sec::unexpected_message));
   CHECK(error{error_code<sec>(sec::unexpected_message)});
 }
 
-CAF_TEST(errors convert enums to their integer value) {
+TEST_CASE("errors convert enums to their integer value") {
   CHECK_EQ(make_error(sec::unexpected_message).code(), 1u);
   CHECK_EQ(error{error_code<sec>(sec::unexpected_message)}.code(), 1u);
+}
+
+TEST_CASE("make_error converts string-like arguments to strings") {
+  using std::string;
+  char foo1[] = "foo1";
+  auto err = make_error(sec::runtime_error, foo1, "foo2"sv, "foo3", "foo4"s);
+  if (CHECK(err)) {
+    CHECK_EQ(err.code(), static_cast<uint8_t>(sec::runtime_error));
+    CHECK((err.context().match_elements<string, string, string, string>()));
+  }
 }
 
 SCENARIO("errors provide human-readable to_string output") {


### PR DESCRIPTION
The lack of `string_view` support came up here: https://github.com/actor-framework/actor-framework/pull/1461#discussion_r1246231520.