### PR TITLE
Remove the logger.inline-output parameter

### DIFF
--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -273,6 +273,12 @@ private:
 
   logger(actor_system& sys);
 
+  // -- called by the actor_system when running with a test coordinator --------
+
+  void inline_output(bool value) noexcept {
+    cfg_.inline_output = value;
+  }
+
   // -- initialization ---------------------------------------------------------
 
   void init(actor_system_config& cfg);

--- a/libcaf_core/src/actor_system.cpp
+++ b/libcaf_core/src/actor_system.cpp
@@ -351,6 +351,9 @@ actor_system::actor_system(actor_system_config& cfg)
   // Initialize state for each module and give each module the opportunity to
   // adapt the system configuration.
   logger_->init(cfg);
+  // When running with the test coordinator, generate logs in the same thread.
+  if (!scheduler().detaches_utility_actors())
+    logger_->inline_output(true);
   CAF_SET_LOGGER_SYS(this);
   for (auto& mod : modules_)
     if (mod)

--- a/libcaf_core/src/actor_system_config.cpp
+++ b/libcaf_core/src/actor_system_config.cpp
@@ -71,8 +71,6 @@ actor_system_config::actor_system_config()
                  "frequency of relaxed steal attempts")
     .add<timespan>("relaxed-sleep-duration",
                    "sleep duration between relaxed steal attempts");
-  opt_group{custom_options_, "caf.logger"} //
-    .add<bool>("inline-output", "disable logger thread (for testing only!)");
   opt_group{custom_options_, "caf.logger.file"}
     .add<string>("path", "filesystem path for the log file")
     .add<string>("format", "format for individual log file entries")
@@ -121,7 +119,6 @@ settings actor_system_config::dump_content() const {
               defaults::work_stealing::relaxed_sleep_duration);
   // -- logger parameters
   auto& logger_group = caf_group["logger"].as_dictionary();
-  // Note: omit "inline-output" option since it should only be used for testing.
   auto& file_group = logger_group["file"].as_dictionary();
   put_missing(file_group, "path", defaults::logger::file::path);
   put_missing(file_group, "format", defaults::logger::file::format);

--- a/libcaf_core/src/logger.cpp
+++ b/libcaf_core/src/logger.cpp
@@ -308,9 +308,6 @@ void logger::init(actor_system_config& cfg) {
     = parse_format(get_or(cfg, "caf.logger.file.format", lg::file::format));
   console_format_ = parse_format(
     get_or(cfg, "caf.logger.console.format", lg::console::format));
-  // Set flags.
-  if (get_or(cfg, "caf.logger.inline-output", false))
-    cfg_.inline_output = true;
   // If not set to `false`, CAF enables colored output when writing to TTYs.
   cfg_.console_coloring = get_or(cfg, "caf.logger.console.colored", true);
 }

--- a/libcaf_core/test/settings.cpp
+++ b/libcaf_core/test/settings.cpp
@@ -32,7 +32,6 @@ struct fixture {
     logger["console-format"] = "%m";
     logger["console-verbosity"] = "trace";
     logger["file-format"] = "%r %c %p %a %t %C %M %F:%L %m%n";
-    logger["inline-output"] = false;
     auto& middleman = x["middleman"].as_dictionary();
     middleman["app-identifiers"] = make_config_value_list("generic-caf-app");
     middleman["enable-automatic-connections"] = false;

--- a/libcaf_test/caf/test/dsl.hpp
+++ b/libcaf_test/caf/test/dsl.hpp
@@ -700,7 +700,6 @@ public:
                              caf::test::engine::argv()))
       CAF_FAIL("failed to parse config: " << to_string(err));
     cfg.set("caf.scheduler.policy", "testing");
-    cfg.set("caf.logger.inline-output", true);
     if (cfg.custom_options().has_category("caf.middleman")) {
       cfg.set("caf.middleman.network-backend", "testing");
       cfg.set("caf.middleman.manual-multiplexing", true);


### PR DESCRIPTION
Relates #1450. Removing this flag was pretty easy, the others are more involved.