### PR TITLE
Separate WebSocket control frames

### DIFF
--- a/libcaf_net/caf/net/web_socket/framing.hpp
+++ b/libcaf_net/caf/net/web_socket/framing.hpp
@@ -132,7 +132,8 @@ private:
     // nop
   }
 
-  bool handle(uint8_t opcode, byte_span payload);
+  // Returns `frame_size` on success and -1 on error.
+  ptrdiff_t handle(uint8_t opcode, byte_span payload, size_t frame_size);
 
   void ship_pong(byte_span payload);
 

--- a/libcaf_net/src/detail/rfc6455.cpp
+++ b/libcaf_net/src/detail/rfc6455.cpp
@@ -84,9 +84,6 @@ ptrdiff_t rfc6455::decode_header(const_byte_span data, header& hdr) {
   bool masked = (byte2 & 0x80) != 0;
   auto len_field = byte2 & 0x7F;
   size_t header_length;
-  // control frames can only have payload up to 125 bytes
-  if (rfc6455::is_control_frame(hdr.opcode) && len_field > 125)
-    return -1;
   if (len_field < 126) {
     header_length = 2 + (masked ? 4 : 0);
     hdr.payload_len = len_field;

--- a/libcaf_net/src/net/web_socket/framing.cpp
+++ b/libcaf_net/src/net/web_socket/framing.cpp
@@ -65,63 +65,51 @@ ptrdiff_t framing::consume(byte_span buffer, byte_span) {
                          "received a fragmented WebSocket control message");
       return -1;
     }
-    if (hdr.opcode == detail::rfc6455::connection_close) {
-      abort_and_shutdown(sec::connection_closed);
-      return -1;
-    } else if (!handle(hdr.opcode, payload)) {
-      return -1;
-    }
-  } else if (hdr.fin) {
+    return handle(hdr.opcode, payload, frame_size);
+  }
+  // Reject any payload that exceed max_frame_size. This covers assembled
+  // payloads as well by including payload_buf_
+  if (payload_buf_.size() + payload_len > max_frame_size) {
+    CAF_LOG_DEBUG("fragmented WebSocket payload exceeds maximum size");
+    abort_and_shutdown(sec::protocol_error, "fragmented WebSocket payload "
+                                            "exceeds maximum size");
+    return -1;
+  }
+  if (hdr.fin) {
     if (opcode_ == nil_code) {
       // Call upper layer.
-      if (!handle(hdr.opcode, payload)) {
-        return -1;
-      }
-    } else if (hdr.opcode != detail::rfc6455::continuation_frame) {
+      return handle(hdr.opcode, payload, frame_size);
+    }
+    if (hdr.opcode != detail::rfc6455::continuation_frame) {
       CAF_LOG_DEBUG("expected a WebSocket continuation_frame");
       abort_and_shutdown(sec::protocol_error,
                          "expected a WebSocket continuation_frame");
       return -1;
-    } else if (payload_buf_.size() + payload_len > max_frame_size) {
-      CAF_LOG_DEBUG("fragmented WebSocket payload exceeds maximum size");
-      abort_and_shutdown(sec::protocol_error, "fragmented WebSocket payload "
-                                              "exceeds maximum size");
-      return -1;
-    } else {
-      // End of fragmented input.
-      payload_buf_.insert(payload_buf_.end(), payload.begin(), payload.end());
-      if (!handle(opcode_, payload_buf_)) {
-        return -1;
-      }
-      opcode_ = nil_code;
-      payload_buf_.clear();
     }
-  } else {
-    // The first frame must not be a continuation frame. Any frame that is not
-    // the first frame must be a continuation frame.
-    if (opcode_ == nil_code) {
-      if (hdr.opcode == detail::rfc6455::continuation_frame) {
-        CAF_LOG_DEBUG("received WebSocket continuation "
-                      "frame without prior opcode");
-        abort_and_shutdown(sec::protocol_error,
-                           "received WebSocket continuation "
-                           "frame without prior opcode");
-        return -1;
-      }
-      opcode_ = hdr.opcode;
-    } else if (hdr.opcode != detail::rfc6455::continuation_frame) {
-      CAF_LOG_DEBUG("expected a continuation frame");
-      abort_and_shutdown(sec::protocol_error, "expected a continuation frame");
-      return -1;
-    } else if (payload_buf_.size() + payload_len > max_frame_size) {
-      // Reject assembled payloads that exceed max_frame_size.
-      CAF_LOG_DEBUG("fragmented WebSocket payload exceeds maximum size");
-      abort_and_shutdown(sec::protocol_error, "fragmented WebSocket payload "
-                                              "exceeds maximum size");
-      return -1;
-    }
+    // End of fragmented input.
     payload_buf_.insert(payload_buf_.end(), payload.begin(), payload.end());
+    auto result = handle(opcode_, payload_buf_, frame_size);
+    opcode_ = nil_code;
+    payload_buf_.clear();
+    return result;
   }
+  // The first frame must not be a continuation frame. Any frame that is not
+  // the first frame must be a continuation frame.
+  if (opcode_ == nil_code) {
+    if (hdr.opcode == detail::rfc6455::continuation_frame) {
+      CAF_LOG_DEBUG("received WebSocket continuation "
+                    "frame without prior opcode");
+      abort_and_shutdown(sec::protocol_error, "received WebSocket continuation "
+                                              "frame without prior opcode");
+      return -1;
+    }
+    opcode_ = hdr.opcode;
+  } else if (hdr.opcode != detail::rfc6455::continuation_frame) {
+    CAF_LOG_DEBUG("expected a continuation frame");
+    abort_and_shutdown(sec::protocol_error, "expected a continuation frame");
+    return -1;
+  }
+  payload_buf_.insert(payload_buf_.end(), payload.begin(), payload.end());
   return static_cast<ptrdiff_t>(frame_size);
 }
 
@@ -193,27 +181,34 @@ bool framing::end_text_message() {
 
 // -- implementation details ---------------------------------------------------
 
-bool framing::handle(uint8_t opcode, byte_span payload) {
-  // Code rfc6455::connection_close must be treated separately.
-  CAF_ASSERT(opcode != detail::rfc6455::connection_close);
+ptrdiff_t framing::handle(uint8_t opcode, byte_span payload,
+                          size_t frame_size) {
   switch (opcode) {
+    case detail::rfc6455::connection_close:
+      abort_and_shutdown(sec::connection_closed);
+      return -1;
     case detail::rfc6455::text_frame: {
       std::string_view text{reinterpret_cast<const char*>(payload.data()),
                             payload.size()};
-      return up_->consume_text(text) >= 0;
+      if (up_->consume_text(text) < 0)
+        return -1;
+      break;
     }
     case detail::rfc6455::binary_frame:
-      return up_->consume_binary(payload) >= 0;
+      if (up_->consume_binary(payload) < 0)
+        return -1;
+      break;
     case detail::rfc6455::ping:
       ship_pong(payload);
-      return true;
+      break;
     case detail::rfc6455::pong:
       // nop
-      return true;
+      break;
     default:
       // error
-      return false;
+      return -1;
   }
+  return static_cast<ptrdiff_t>(frame_size);
 }
 
 void framing::ship_pong(byte_span payload) {

--- a/libcaf_net/src/net/web_socket/framing.cpp
+++ b/libcaf_net/src/net/web_socket/framing.cpp
@@ -57,7 +57,7 @@ ptrdiff_t framing::consume(byte_span buffer, byte_span) {
     detail::rfc6455::mask_data(hdr.mask_key, payload);
   }
   // Handle control frames first, since these may not me fragmented,
-  // and can come up in between regular message fragments
+  // and can arrive between regular message fragments.
   if (detail::rfc6455::is_control_frame(hdr.opcode)
       && hdr.opcode != detail::rfc6455::continuation_frame) {
     if (!hdr.fin) {
@@ -67,8 +67,8 @@ ptrdiff_t framing::consume(byte_span buffer, byte_span) {
     }
     return handle(hdr.opcode, payload, frame_size);
   }
-  // Reject any payload that exceed max_frame_size. This covers assembled
-  // payloads as well by including payload_buf_
+  // Reject any payload that exceeds max_frame_size. This covers assembled
+  // payloads as well by including payload_buf_.
   if (payload_buf_.size() + payload_len > max_frame_size) {
     CAF_LOG_DEBUG("fragmented WebSocket payload exceeds maximum size");
     abort_and_shutdown(sec::protocol_error, "fragmented WebSocket payload "

--- a/libcaf_net/test/detail/rfc6455.cpp
+++ b/libcaf_net/test/detail/rfc6455.cpp
@@ -60,6 +60,16 @@ TEST_CASE("masking") {
   CHECK_EQ(masked_data, data);
 }
 
+TEST_CASE("decoding a frame with RSV bits fails") {
+  std::vector<uint8_t> data;
+  byte_buffer out = bytes({
+    0xF2, // FIN + RSV + binary frame opcode
+    0x00, // data size = 0
+  });
+  impl::header hdr;
+  CHECK_EQ(impl::decode_header(out, hdr), -1);
+}
+
 TEST_CASE("no mask key and no data") {
   std::vector<uint8_t> data;
   byte_buffer out;

--- a/libcaf_net/test/net-test.cpp
+++ b/libcaf_net/test/net-test.cpp
@@ -160,7 +160,6 @@ mock_web_socket_app::accept(const caf::net::http::request_header& hdr) {
 
 void mock_web_socket_app::abort(const caf::error& reason) {
   abort_reason = reason;
-  down->shutdown(reason);
 }
 
 ptrdiff_t mock_web_socket_app::consume_text(std::string_view text) {


### PR DESCRIPTION
Relates #1394 

Control frames (all beside text and binary) may not be fragmented, and they may come in-between fragmented messages. 
Also added a test for decoding a message with RSV bits.

Fixes the fragmentation autobahn test suite (quite a few test cases).