### PR TITLE
Relax codecov threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,3 +9,8 @@ ignore:
   - libcaf_openssl
   - libcaf_test
   - tools
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1% # we have some fluctuation from nondeterminism alone


### PR DESCRIPTION
We have some fluctuation in coverage simply by having tests that use the default scheduler. The nondeterminism from work stealing causes the coverage to go up or down by small amounts even when not changing any code.

See https://docs.codecov.com/docs/commit-status.