### PR TITLE
Drop unnecessary arguments in octet_stream::policy

### DIFF
--- a/libcaf_net/caf/net/http/server_factory.hpp
+++ b/libcaf_net/caf/net/http/server_factory.hpp
@@ -82,10 +82,9 @@ public:
                                connection_handle conn) override {
     auto app = net::http::router::make(routes_);
     auto serv = net::http::server::make(std::move(app));
-    auto fd = conn.fd();
     auto transport = Transport::make(std::move(conn), std::move(serv));
     transport->max_consecutive_reads(max_consecutive_reads_);
-    transport->active_policy().accept(fd);
+    transport->active_policy().accept();
     auto res = net::socket_manager::make(mpx, std::move(transport));
     mpx->watch(res->as_disposable());
     return res;

--- a/libcaf_net/caf/net/lp/client_factory.hpp
+++ b/libcaf_net/caf/net/lp/client_factory.hpp
@@ -102,9 +102,8 @@ private:
     auto bridge = bridge_t::make(std::move(a2s_pull), std::move(s2a_push));
     auto bridge_ptr = bridge.get();
     auto impl = framing::make(std::move(bridge));
-    auto fd = conn.fd();
     auto transport = transport_t::make(std::move(conn), std::move(impl));
-    transport->active_policy().connect(fd);
+    transport->active_policy().connect();
     auto ptr = socket_manager::make(cfg.mpx, std::move(transport));
     bridge_ptr->self_ref(ptr->as_disposable());
     cfg.mpx->start(ptr);

--- a/libcaf_net/caf/net/lp/server_factory.hpp
+++ b/libcaf_net/caf/net/lp/server_factory.hpp
@@ -99,10 +99,9 @@ public:
     auto bridge = bridge_t::make(producer_);
     auto bridge_ptr = bridge.get();
     auto impl = net::lp::framing::make(std::move(bridge));
-    auto fd = conn.fd();
     auto transport = Transport::make(std::move(conn), std::move(impl));
     transport->max_consecutive_reads(max_consecutive_reads_);
-    transport->active_policy().accept(fd);
+    transport->active_policy().accept();
     auto mgr = net::socket_manager::make(mpx, std::move(transport));
     bridge_ptr->self_ref(mgr->as_disposable());
     return mgr;

--- a/libcaf_net/caf/net/octet_stream/policy.hpp
+++ b/libcaf_net/caf/net/octet_stream/policy.hpp
@@ -18,25 +18,28 @@ class CAF_NET_EXPORT policy {
 public:
   virtual ~policy();
 
+  /// Returns the handle for the managed socket.
+  virtual stream_socket handle() const = 0;
+
   /// Reads data from the socket into the buffer.
-  virtual ptrdiff_t read(stream_socket x, byte_span buf);
+  virtual ptrdiff_t read(byte_span buf) = 0;
 
   /// Writes data from the buffer to the socket.
-  virtual ptrdiff_t write(stream_socket x, const_byte_span buf);
+  virtual ptrdiff_t write(const_byte_span buf) = 0;
 
   /// Returns the last socket error on this thread.
-  virtual errc last_error(stream_socket, ptrdiff_t);
+  virtual errc last_error(ptrdiff_t) = 0;
 
   /// Checks whether connecting a non-blocking socket was successful.
-  virtual ptrdiff_t connect(stream_socket x);
+  virtual ptrdiff_t connect() = 0;
 
   /// Convenience function that always returns 1. Exists to make writing code
   /// against multiple policies easier by providing the same interface.
-  virtual ptrdiff_t accept(stream_socket);
+  virtual ptrdiff_t accept() = 0;
 
   /// Returns the number of bytes that are buffered internally and available
   /// for immediate read.
-  virtual size_t buffered() const noexcept;
+  virtual size_t buffered() const noexcept = 0;
 };
 
 } // namespace caf::net::octet_stream

--- a/libcaf_net/caf/net/ssl/transport.hpp
+++ b/libcaf_net/caf/net/ssl/transport.hpp
@@ -26,15 +26,17 @@ public:
   public:
     explicit policy_impl(connection conn);
 
-    ptrdiff_t read(stream_socket, byte_span) override;
+    stream_socket handle() const override;
 
-    ptrdiff_t write(stream_socket, const_byte_span) override;
+    ptrdiff_t read(byte_span) override;
 
-    octet_stream::errc last_error(stream_socket, ptrdiff_t) override;
+    ptrdiff_t write(const_byte_span) override;
 
-    ptrdiff_t connect(stream_socket) override;
+    octet_stream::errc last_error(ptrdiff_t) override;
 
-    ptrdiff_t accept(stream_socket) override;
+    ptrdiff_t connect() override;
+
+    ptrdiff_t accept() override;
 
     size_t buffered() const noexcept override;
 
@@ -66,7 +68,7 @@ public:
 private:
   // -- constructors, destructors, and assignment operators --------------------
 
-  transport(stream_socket fd, connection conn, upper_layer_ptr up);
+  transport(connection conn, upper_layer_ptr up);
 
   policy_impl policy_impl_;
 };

--- a/libcaf_net/caf/net/web_socket/client_factory.hpp
+++ b/libcaf_net/caf/net/web_socket/client_factory.hpp
@@ -98,9 +98,8 @@ private:
     auto bridge = bridge_t::make(std::move(a2s_pull), std::move(s2a_push));
     auto bridge_ptr = bridge.get();
     auto impl = client::make(std::move(cfg.hs), std::move(bridge));
-    auto fd = conn.fd();
     auto transport = transport_t::make(std::move(conn), std::move(impl));
-    transport->active_policy().connect(fd);
+    transport->active_policy().connect();
     auto ptr = socket_manager::make(cfg.mpx, std::move(transport));
     bridge_ptr->self_ref(ptr->as_disposable());
     cfg.mpx->start(ptr);

--- a/libcaf_net/caf/net/web_socket/server_factory.hpp
+++ b/libcaf_net/caf/net/web_socket/server_factory.hpp
@@ -129,10 +129,9 @@ public:
     auto app = bridge_t::make(on_request_, producer_);
     auto app_ptr = app.get();
     auto ws = net::web_socket::server::make(std::move(app));
-    auto fd = conn.fd();
     auto transport = Transport::make(std::move(conn), std::move(ws));
     transport->max_consecutive_reads(max_consecutive_reads_);
-    transport->active_policy().accept(fd);
+    transport->active_policy().accept();
     auto mgr = net::socket_manager::make(mpx, std::move(transport));
     app_ptr->self_ref(mgr->as_disposable());
     return mgr;

--- a/libcaf_net/src/net/octet_stream/policy.cpp
+++ b/libcaf_net/src/net/octet_stream/policy.cpp
@@ -9,30 +9,4 @@ policy::~policy() {
   // nop
 }
 
-ptrdiff_t policy::read(stream_socket x, byte_span buf) {
-  return net::read(x, buf);
-}
-
-ptrdiff_t policy::write(stream_socket x, const_byte_span buf) {
-  return net::write(x, buf);
-}
-
-errc policy::last_error(stream_socket, ptrdiff_t) {
-  return last_socket_error_is_temporary() ? errc::temporary : errc::permanent;
-}
-
-ptrdiff_t policy::connect(stream_socket x) {
-  // A connection is established if the OS reports a socket as ready for read
-  // or write and if there is no error on the socket.
-  return probe(x) ? 1 : -1;
-}
-
-ptrdiff_t policy::accept(stream_socket) {
-  return 1;
-}
-
-size_t policy::buffered() const noexcept {
-  return 0;
-}
-
 } // namespace caf::net::octet_stream


### PR DESCRIPTION
The interface of `octet_stream::policy` still asks for the socket - but the policy should know best which socket it manages. 🙂