### PR TITLE
Stop handling continuation frames as control frames

### DIFF
--- a/libcaf_net/caf/detail/rfc6455.hpp
+++ b/libcaf_net/caf/detail/rfc6455.hpp
@@ -59,8 +59,7 @@ struct CAF_NET_EXPORT rfc6455 {
   static ptrdiff_t decode_header(const_byte_span data, header& hdr);
 
   static constexpr bool is_control_frame(uint8_t opcode) noexcept {
-    return opcode != text_frame && opcode != binary_frame
-           && opcode != continuation_frame;
+    return opcode > binary_frame;
   }
 };
 

--- a/libcaf_net/caf/detail/rfc6455.hpp
+++ b/libcaf_net/caf/detail/rfc6455.hpp
@@ -59,7 +59,8 @@ struct CAF_NET_EXPORT rfc6455 {
   static ptrdiff_t decode_header(const_byte_span data, header& hdr);
 
   static constexpr bool is_control_frame(uint8_t opcode) noexcept {
-    return opcode != text_frame && opcode != binary_frame;
+    return opcode != text_frame && opcode != binary_frame
+           && opcode != continuation_frame;
   }
 };
 

--- a/libcaf_net/caf/net/web_socket/framing.cpp
+++ b/libcaf_net/caf/net/web_socket/framing.cpp
@@ -77,8 +77,7 @@ ptrdiff_t framing::consume(byte_span buffer, byte_span) {
   }
   // Handle control frames first, since these may not me fragmented,
   // and can arrive between regular message fragments.
-  if (detail::rfc6455::is_control_frame(hdr.opcode)
-      && hdr.opcode != detail::rfc6455::continuation_frame) {
+  if (detail::rfc6455::is_control_frame(hdr.opcode)) {
     if (!hdr.fin) {
       abort_and_shutdown(sec::protocol_error,
                          "received a fragmented WebSocket control message");


### PR DESCRIPTION
Relates #1394 

This caused a bug when a continuation frame had more than 126 bytes of data. Fixes the tests that transfer 4MB payloads. 