### PR TITLE
Decode and validate WebSocket closing payload

### DIFF
--- a/libcaf_net/caf/net/web_socket/framing.cpp
+++ b/libcaf_net/caf/net/web_socket/framing.cpp
@@ -257,8 +257,7 @@ ptrdiff_t framing::handle(uint8_t opcode, byte_span payload,
     case detail::rfc6455::connection_close: {
       auto result = decode_closing_payload(payload);
       if (!result) {
-        abort(result.error());
-        shutdown(result.error());
+        abort_and_shutdown(result.error());
         return -1;
       }
       abort_and_shutdown(sec::connection_closed);

--- a/libcaf_net/caf/net/web_socket/framing.cpp
+++ b/libcaf_net/caf/net/web_socket/framing.cpp
@@ -12,45 +12,41 @@ namespace caf::net::web_socket {
 
 // -- static utility functions -------------------------------------------------
 
-expected<std::pair<uint16_t, const_byte_span>>
-framing::decode_closing_payload(const_byte_span payload) {
-  if (payload.size() == 0)
-    return std::make_pair(0, payload);
-  if (payload.size() < 2)
+error framing::validate_closing_payload(const_byte_span payload) {
+  if (payload.empty())
+    return error{};
+  if (payload.size() == 1)
     return make_error(caf::sec::protocol_error,
-                      "no status flag in closing payload");
-  auto status = (std::to_integer<uint_fast16_t>(payload[0]) << 8)
+                      "closing status code must have two bytes");
+  auto status = (std::to_integer<uint16_t>(payload[0]) << 8)
                 + std::to_integer<uint16_t>(payload[1]);
   if (!detail::rfc3629::valid(payload.subspan(2)))
     return make_error(sec::protocol_error,
-                      "malformed text message in closing payload");
-  if (status < 1000 || status >= 5000)
-    return make_error(sec::protocol_error,
-                      "invalid status code in closing payload");
+                      "malformed UTF-8 text message in closing payload");
   // statuses between 3000 and 4999 are allowed and application specific
   if (status >= 3000 && status < 5000)
-    return std::make_pair(status, payload.subspan(2));
-  // statuses between 1000 and 2999 are protocol defined
-  web_socket::status status_code;
-  auto success = from_integer(status, status_code);
-  if (!success)
-    return make_error(sec::protocol_error,
-                      "invalid status code in closing payload");
-  switch (status_code) {
-    case status::normal_close:
-    case status::going_away:
-    case status::protocol_error:
-    case status::invalid_data:
-    case status::inconsistent_data:
-    case status::policy_violation:
-    case status::message_too_big:
-    case status::missing_extensions:
-    case status::unexpected_condition:
-      return std::make_pair(status, payload.subspan(2));
-    default:
-      return make_error(sec::protocol_error,
-                        "invalid status code in closing payload");
+    return error{};
+  // statuses between 1000 and 2999 need to be protocol defined, and status
+  // codes lower then 1000 and greater or equal then 5000 are invalid.
+  auto status_code = web_socket::status{0};
+  if (from_integer(status, status_code)) {
+    switch (status_code) {
+      case status::normal_close:
+      case status::going_away:
+      case status::protocol_error:
+      case status::invalid_data:
+      case status::inconsistent_data:
+      case status::policy_violation:
+      case status::message_too_big:
+      case status::missing_extensions:
+      case status::unexpected_condition:
+        return error{};
+      default:
+        break;
+    }
   }
+  return make_error(sec::protocol_error,
+                    "invalid status code in closing payload");
 }
 
 // -- octet_stream::upper_layer implementation ---------------------------------
@@ -254,15 +250,13 @@ ptrdiff_t framing::handle(uint8_t opcode, byte_span payload,
                           size_t frame_size) {
   // opcodes are checked for validity when decoding the header
   switch (opcode) {
-    case detail::rfc6455::connection_close: {
-      auto result = decode_closing_payload(payload);
-      if (!result) {
-        abort_and_shutdown(result.error());
+    case detail::rfc6455::connection_close:
+      if (auto error = validate_closing_payload(payload); error) {
+        abort_and_shutdown(error);
         return -1;
       }
       abort_and_shutdown(sec::connection_closed);
       return -1;
-    }
     case detail::rfc6455::text_frame: {
       std::string_view text{reinterpret_cast<const char*>(payload.data()),
                             payload.size()};

--- a/libcaf_net/caf/net/web_socket/framing.hpp
+++ b/libcaf_net/caf/net/web_socket/framing.hpp
@@ -43,6 +43,11 @@ public:
   /// Stored as currently active opcode to mean "no opcode received yet".
   static constexpr size_t nil_code = 0xFF;
 
+  // -- static utility functions -----------------------------------------------
+
+  static expected<std::pair<uint16_t, const_byte_span>>
+  decode_closing_payload(const_byte_span payload);
+
   // -- constructors, destructors, and assignment operators --------------------
 
   /// Creates a new framing protocol for client mode.

--- a/libcaf_net/caf/net/web_socket/framing.hpp
+++ b/libcaf_net/caf/net/web_socket/framing.hpp
@@ -45,8 +45,11 @@ public:
 
   // -- static utility functions -----------------------------------------------
 
-  static expected<std::pair<uint16_t, const_byte_span>>
-  decode_closing_payload(const_byte_span payload);
+  /// Checks whether the payload of a closing frame contains a valid status
+  /// code and an UTF-8 formatted message.
+  /// @returns A default constructed `error` if the payload is valid, error kind
+  ///          otherwise.
+  static error validate_closing_payload(const_byte_span payload);
 
   // -- constructors, destructors, and assignment operators --------------------
 

--- a/libcaf_net/caf/net/web_socket/framing.hpp
+++ b/libcaf_net/caf/net/web_socket/framing.hpp
@@ -152,7 +152,10 @@ private:
   // with closing message
   template <class... Ts>
   void abort_and_shutdown(sec reason, Ts&&... xs) {
-    auto err = make_error(reason, std::forward<Ts>(xs)...);
+    abort_and_shutdown(make_error(reason, std::forward<Ts>(xs)...));
+  }
+
+  void abort_and_shutdown(const error& err) {
     up_->abort(err);
     shutdown(err);
   }

--- a/libcaf_net/test/net/web_socket/framing.cpp
+++ b/libcaf_net/test/net/web_socket/framing.cpp
@@ -199,7 +199,6 @@ SCENARIO("the client closes the connection with a closing handshake") {
       CHECK(hdr.fin);
       auto result = net::web_socket::framing::decode_closing_payload(
         make_span(transport->output_buffer()).subspan(hdr_length));
-      MESSAGE(reinterpret_cast<char*>(transport->output_buffer().data()));
       CHECK(result);
       CHECK_EQ(result->first,
                static_cast<int>(net::web_socket::status::protocol_error));

--- a/libcaf_net/test/net/web_socket/framing.cpp
+++ b/libcaf_net/test/net/web_socket/framing.cpp
@@ -644,3 +644,9 @@ TEST_CASE("fail on invalid utf8 closing message") {
   auto result = net::web_socket::framing::decode_closing_payload(payload);
   CHECK_EQ(result.error(), sec::protocol_error);
 }
+
+TEST_CASE("fail on single byte payload") {
+  auto payload = byte_buffer{std::byte{0}};
+  auto result = net::web_socket::framing::decode_closing_payload(payload);
+  CHECK_EQ(result.error(), sec::protocol_error);
+}

--- a/libcaf_net/test/net/web_socket/framing.cpp
+++ b/libcaf_net/test/net/web_socket/framing.cpp
@@ -50,6 +50,15 @@ int fetch_status(const_byte_span payload) {
          + std::to_integer<int>(payload[3]);
 }
 
+byte_buffer make_closing_payload(uint16_t code_val, std::string_view msg) {
+  byte_buffer payload;
+  payload.push_back(static_cast<std::byte>((code_val & 0xFF00) >> 8));
+  payload.push_back(static_cast<std::byte>(code_val & 0x00FF));
+  auto* first = reinterpret_cast<const std::byte*>(msg.data());
+  payload.insert(payload.end(), first, first + msg.size());
+  return payload;
+}
+
 } // namespace
 
 BEGIN_FIXTURE_SCOPE(fixture)
@@ -170,6 +179,30 @@ SCENARIO("the client closes the connection with a closing handshake") {
       CHECK(hdr.payload_len >= 2);
       CHECK_EQ(fetch_status(transport->output_buffer()),
                static_cast<int>(net::web_socket::status::normal_close));
+    }
+    WHEN("the client sends an invalid closing handshake") {
+      reset();
+      std::vector<std::byte> handshake;
+      // invalid status code
+      auto payload = make_closing_payload(1016, ""sv);
+      detail::rfc6455::assemble_frame(detail::rfc6455::connection_close, 0x0,
+                                      payload, handshake);
+      transport->push(handshake);
+    }
+    THEN("the server closes the connection with protocol error") {
+      CHECK_EQ(transport->handle_input(), 0l);
+      detail::rfc6455::header hdr;
+      auto hdr_length
+        = detail::rfc6455::decode_header(transport->output_buffer(), hdr);
+      CHECK_EQ(app->abort_reason, sec::protocol_error);
+      CHECK_EQ(hdr.opcode, detail::rfc6455::connection_close);
+      CHECK(hdr.fin);
+      auto result = net::web_socket::framing::decode_closing_payload(
+        make_span(transport->output_buffer()).subspan(hdr_length));
+      MESSAGE(reinterpret_cast<char*>(transport->output_buffer().data()));
+      CHECK(result);
+      CHECK_EQ(result->first,
+               static_cast<int>(net::web_socket::status::protocol_error));
     }
   }
 }
@@ -585,3 +618,30 @@ SCENARIO("the application shuts down on invalid frame fragments") {
 }
 
 END_FIXTURE_SCOPE();
+
+TEST_CASE("decode valid closing codes") {
+  auto valid_status_codes = std::array{1000, 1001, 1002, 1003, 1007, 1008, 1009,
+                                       1010, 1011, 3000, 3999, 4000, 4999};
+  for (auto status_code : valid_status_codes) {
+    auto payload = make_closing_payload(status_code, ""sv);
+    auto result = net::web_socket::framing::decode_closing_payload(payload);
+    CHECK(result);
+    CHECK_EQ(result->first, status_code);
+  }
+}
+
+TEST_CASE("fail on invalid closing codes") {
+  auto valid_status_codes = std::array{0,    999,  1004, 1005, 1006, 1016,
+                                       1100, 2000, 2999, 5000, 65535};
+  for (auto status_code : valid_status_codes) {
+    auto payload = make_closing_payload(status_code, ""sv);
+    auto result = net::web_socket::framing::decode_closing_payload(payload);
+    CHECK_EQ(result.error(), sec::protocol_error);
+  }
+}
+
+TEST_CASE("fail on invalid utf8 closing message") {
+  auto payload = make_closing_payload(1000, "\xf4\x80"sv);
+  auto result = net::web_socket::framing::decode_closing_payload(payload);
+  CHECK_EQ(result.error(), sec::protocol_error);
+}


### PR DESCRIPTION
Relates #1394 
With this and #1497 we have the majority of tests green and a small number of yellow tests, that are non-strict due to the nature of distributed systems.  