### PR TITLE
Fix fallback when inspecting optional types

### DIFF
--- a/libcaf_core/caf/inspector_access.hpp
+++ b/libcaf_core/caf/inspector_access.hpp
@@ -396,7 +396,10 @@ struct optional_inspector_access {
   template <class Inspector, class IsPresent, class Get>
   static bool save_field(Inspector& f, std::string_view field_name,
                          IsPresent& is_present, Get& get) {
-    return detail::save_field(f, field_name, is_present, get);
+    auto deref_get = [&get]() -> decltype(auto) {
+      return traits::deref_save(get());
+    };
+    return detail::save_field(f, field_name, is_present, deref_get);
   }
 
   template <class Inspector, class IsValid, class SyncValue>

--- a/libcaf_core/caf/save_inspector.hpp
+++ b/libcaf_core/caf/save_inspector.hpp
@@ -75,7 +75,7 @@ public:
     template <class Inspector>
     bool operator()(Inspector& f) {
       auto is_present = [this] { return *val != fallback; };
-      auto get = [this] { return *val; };
+      auto get = [this]() -> decltype(auto) { return *val; };
       return detail::save_field(f, field_name, is_present, get);
     }
 

--- a/libcaf_core/test/load_inspector.cpp
+++ b/libcaf_core/test/load_inspector.cpp
@@ -769,4 +769,19 @@ end object)_";
   }
 }
 
+TEST_CASE("GH-1427 regression") {
+  struct opt_test {
+    std::optional<int> val;
+  };
+  auto x = opt_test{};
+  CHECK(f.object(x).fields(f.field("val", x.val).fallback(std::nullopt)));
+  CHECK(!f.get_error());
+  std::string baseline = R"_(
+begin object anonymous
+  begin optional field val
+  end field
+end object)_";
+  CHECK_EQ(f.log, baseline);
+}
+
 END_FIXTURE_SCOPE()

--- a/libcaf_core/test/save_inspector.cpp
+++ b/libcaf_core/test/save_inspector.cpp
@@ -808,6 +808,7 @@ end object)_";
     }
   }
 }
+
 TEST_CASE("GH-1427 regression") {
   struct opt_test {
     std::optional<int> val;

--- a/libcaf_core/test/save_inspector.cpp
+++ b/libcaf_core/test/save_inspector.cpp
@@ -808,5 +808,19 @@ end object)_";
     }
   }
 }
+TEST_CASE("GH-1427 regression") {
+  struct opt_test {
+    std::optional<int> val;
+  };
+  auto x = opt_test{};
+  CHECK(f.object(x).fields(f.field("val", x.val).fallback(std::nullopt)));
+  CHECK(!f.get_error());
+  std::string baseline = R"_(
+begin object anonymous
+  begin optional field val
+  end field
+end object)_";
+  CHECK_EQ(f.log, baseline);
+}
 
 END_FIXTURE_SCOPE()


### PR DESCRIPTION
Closes #1427 

This one was sneaky, we had a recursive call between `impl::save_field` and `detail::save_field` when using optional-like types (`unique_ptr`, `intrusive_ptr`, etc). 