### PR TITLE
Return the result from check functions

### DIFF
--- a/libcaf_test/caf/test/runnable.cpp
+++ b/libcaf_test/caf/test/runnable.cpp
@@ -39,12 +39,13 @@ void runnable::run() {
   }
 }
 
-void runnable::check(bool value, const detail::source_location& location) {
+bool runnable::check(bool value, const detail::source_location& location) {
   if (value) {
     reporter::instance->pass(location);
-    return;
+  } else {
+    reporter::instance->fail("should be true", location);
   }
-  reporter::instance->fail("should be true", location);
+  return value;
 }
 
 block& runnable::current_block() {

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -55,7 +55,7 @@ public:
 
   /// Checks whether `lhs` and `rhs` are equal.
   template <class T0, class T1>
-  void check_eq(const T0& lhs, const T1& rhs,
+  bool check_eq(const T0& lhs, const T1& rhs,
                 const detail::source_location& location
                 = detail::source_location::current()) {
     if (std::is_integral_v<T0> && std::is_integral_v<T1>) {
@@ -64,13 +64,14 @@ public:
     }
     if (lhs == rhs) {
       reporter::instance->pass(location);
-      return;
+      return true;
     }
     reporter::instance->fail(binary_predicate::eq, stringify(lhs),
                              stringify(rhs), location);
+    return false;
   }
 
-  void check(bool value, const detail::source_location& location
+  bool check(bool value, const detail::source_location& location
                          = detail::source_location::current());
 
   block& current_block();


### PR DESCRIPTION
I've forgot to add the return value when first implementing the functions. This is very useful in testing, e.g.:

```
  if (check_eq(uut.size(), 3u)) {
    check_eq(uut[0], "hello");
    ...
  }
```

@shariarriday please also add the return values for the new additions in #1503.