### PR TITLE
Some clang tidy fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '-*,bugprone-*'
+Checks:          '-*,bugprone-*,-bugprone-easily-swappable-parameters,-bugprone-macro-parentheses'
 WarningsAsErrors: ''
 HeaderFilterRegex: '/caf/'
 AnalyzeTemporaryDtors: false

--- a/libcaf_core/caf/config_value.hpp
+++ b/libcaf_core/caf/config_value.hpp
@@ -628,7 +628,7 @@ struct variant_inspector_traits<config_value> {
 
   template <class U>
   static void assign(value_type& x, U&& value) {
-    x = std::move(value);
+    x = std::forward<U>(value);
   }
 
   template <class F>

--- a/libcaf_core/caf/flow/op/concat.hpp
+++ b/libcaf_core/caf/flow/op/concat.hpp
@@ -232,7 +232,7 @@ private:
   void add(Input&& x) {
     using input_t = std::decay_t<Input>;
     static_assert(is_observable_v<input_t>);
-    inputs_.emplace_back(std::move(x).as_observable());
+    inputs_.emplace_back(std::forward<Input>(x).as_observable());
   }
 
   std::vector<input_type> inputs_;

--- a/libcaf_core/caf/policy/select_all.hpp
+++ b/libcaf_core/caf/policy/select_all.hpp
@@ -201,7 +201,7 @@ private:
   behavior make_behavior(F&& f, OnError&& g) {
     using namespace detail;
     using helper_type = select_all_helper_t<decay_t<F>>;
-    helper_type helper{ids_.size(), pending_timeouts_, std::move(f)};
+    helper_type helper{ids_.size(), pending_timeouts_, std::forward<F>(f)};
     auto pending = helper.pending;
     auto error_handler = [pending{std::move(pending)},
                           timeouts{pending_timeouts_},


### PR DESCRIPTION
Related #1435 

This clears 3 bugprone checks:
`-bugprone-move-forwarding-reference` - fixed,
`-bugprone-macro-parentheses` - tried putting parentheses, it broke our solution. Just ignoring it for now seems reasonable, 
`-bugprone-easily-swappable-parameters` - ignoring it as discussed, since we have multiple occurrences of this and sub-typing every time would complicate stuff. 