### PR TITLE
Fail early on invalid UTF-8 WebSocket text frames

### DIFF
--- a/libcaf_net/caf/detail/rfc6455.cpp
+++ b/libcaf_net/caf/detail/rfc6455.cpp
@@ -27,15 +27,15 @@ void rfc6455::mask_data(uint32_t key, byte_span data, size_t offset) {
 
 void rfc6455::assemble_frame(uint32_t mask_key, span<const char> data,
                              byte_buffer& out) {
-  assemble_frame(opcode_type::text_frame, mask_key, as_bytes(data), out);
+  assemble_frame(text_frame, mask_key, as_bytes(data), out);
 }
 
 void rfc6455::assemble_frame(uint32_t mask_key, const_byte_span data,
                              byte_buffer& out) {
-  assemble_frame(opcode_type::binary_frame, mask_key, data, out);
+  assemble_frame(binary_frame, mask_key, data, out);
 }
 
-void rfc6455::assemble_frame(opcode_type opcode, uint32_t mask_key,
+void rfc6455::assemble_frame(uint8_t opcode, uint32_t mask_key,
                              const_byte_span data, byte_buffer& out,
                              uint8_t flags) {
   // First 8 bits: flags + opcode
@@ -75,18 +75,19 @@ void rfc6455::assemble_frame(opcode_type opcode, uint32_t mask_key,
 ptrdiff_t rfc6455::decode_header(const_byte_span data, header& hdr) {
   if (data.size() < 2)
     return 0;
+  header temp_hdr;
   auto byte1 = std::to_integer<uint8_t>(data[0]);
   auto byte2 = std::to_integer<uint8_t>(data[1]);
   // Fetch FIN flag and opcode.
-  hdr.fin = (byte1 & 0x80) != 0;
-  hdr.opcode = static_cast<opcode_type>(byte1 & 0x0F);
+  temp_hdr.fin = (byte1 & 0x80) != 0;
+  temp_hdr.opcode = byte1 & 0x0F;
   // Decode mask bit and payload length field.
   bool masked = (byte2 & 0x80) != 0;
   auto len_field = byte2 & 0x7F;
   size_t header_length;
   if (len_field < 126) {
     header_length = 2 + (masked ? 4 : 0);
-    hdr.payload_len = len_field;
+    temp_hdr.payload_len = len_field;
   } else if (len_field == 126) {
     header_length = 4 + (masked ? 4 : 0);
   } else {
@@ -101,34 +102,35 @@ ptrdiff_t rfc6455::decode_header(const_byte_span data, header& hdr) {
   if (len_field == 126) {
     uint16_t no_len;
     memcpy(&no_len, p, 2);
-    hdr.payload_len = from_network_order(no_len);
+    temp_hdr.payload_len = from_network_order(no_len);
     p += 2;
   } else if (len_field == 127) {
     uint64_t no_len;
     memcpy(&no_len, p, 8);
-    hdr.payload_len = from_network_order(no_len);
+    temp_hdr.payload_len = from_network_order(no_len);
     p += 8;
   }
   // Fetch mask key.
   if (masked) {
     uint32_t no_key;
     memcpy(&no_key, p, 4);
-    hdr.mask_key = from_network_order(no_key);
+    temp_hdr.mask_key = from_network_order(no_key);
     p += 4;
   } else {
-    hdr.mask_key = 0;
+    temp_hdr.mask_key = 0;
   }
   // No extension bits allowed.
   if (byte1 & 0x70)
     return -1;
   // Verify opcode and return number of consumed bytes.
-  switch (hdr.opcode) {
-    case opcode_type::continuation_frame:
-    case opcode_type::text_frame:
-    case opcode_type::binary_frame:
-    case opcode_type::connection_close:
-    case opcode_type::ping:
-    case opcode_type::pong:
+  switch (temp_hdr.opcode) {
+    case continuation_frame:
+    case text_frame:
+    case binary_frame:
+    case connection_close_frame:
+    case ping_frame:
+    case pong_frame:
+      hdr = temp_hdr;
       return static_cast<ptrdiff_t>(header_length);
     default:
       return -1;

--- a/libcaf_net/caf/detail/rfc6455.cpp
+++ b/libcaf_net/caf/detail/rfc6455.cpp
@@ -19,7 +19,7 @@ void rfc6455::mask_data(uint32_t key, byte_span data, size_t skip) {
   std::byte arr[4];
   memcpy(arr, &no_key, 4);
   data = data.subspan(skip);
-  size_t i = skip % 4;
+  auto i = skip % 4;
   for (auto& x : data) {
     x = x ^ arr[i];
     i = (i + 1) % 4;

--- a/libcaf_net/caf/detail/rfc6455.cpp
+++ b/libcaf_net/caf/detail/rfc6455.cpp
@@ -10,16 +10,16 @@
 
 namespace caf::detail {
 
-void rfc6455::mask_data(uint32_t key, span<char> data, size_t skip) {
-  mask_data(key, as_writable_bytes(data), skip);
+void rfc6455::mask_data(uint32_t key, span<char> data, size_t offset) {
+  mask_data(key, as_writable_bytes(data), offset);
 }
 
-void rfc6455::mask_data(uint32_t key, byte_span data, size_t skip) {
+void rfc6455::mask_data(uint32_t key, byte_span data, size_t offset) {
   auto no_key = to_network_order(key);
   std::byte arr[4];
   memcpy(arr, &no_key, 4);
-  data = data.subspan(skip);
-  auto i = skip % 4;
+  data = data.subspan(offset);
+  auto i = offset % 4;
   for (auto& x : data) {
     x = x ^ arr[i];
     i = (i + 1) % 4;

--- a/libcaf_net/caf/detail/rfc6455.cpp
+++ b/libcaf_net/caf/detail/rfc6455.cpp
@@ -10,15 +10,16 @@
 
 namespace caf::detail {
 
-void rfc6455::mask_data(uint32_t key, span<char> data) {
-  mask_data(key, as_writable_bytes(data));
+void rfc6455::mask_data(uint32_t key, span<char> data, size_t skip) {
+  mask_data(key, as_writable_bytes(data), skip);
 }
 
-void rfc6455::mask_data(uint32_t key, byte_span data) {
+void rfc6455::mask_data(uint32_t key, byte_span data, size_t skip) {
   auto no_key = to_network_order(key);
   std::byte arr[4];
   memcpy(arr, &no_key, 4);
-  size_t i = 0;
+  data = data.subspan(skip);
+  size_t i = skip % 4;
   for (auto& x : data) {
     x = x ^ arr[i];
     i = (i + 1) % 4;

--- a/libcaf_net/caf/detail/rfc6455.hpp
+++ b/libcaf_net/caf/detail/rfc6455.hpp
@@ -34,7 +34,7 @@ struct CAF_NET_EXPORT rfc6455 {
     uint32_t mask_key = 0;
     uint64_t payload_len = 0;
 
-    // utility funcitons
+    // utility functions.
     explicit operator bool() const noexcept {
       return opcode != opcode_type::nil_code;
     }

--- a/libcaf_net/caf/detail/rfc6455.hpp
+++ b/libcaf_net/caf/detail/rfc6455.hpp
@@ -42,9 +42,9 @@ struct CAF_NET_EXPORT rfc6455 {
 
   // -- utility functions ------------------------------------------------------
 
-  static void mask_data(uint32_t key, span<char> data, size_t skip = 0);
+  static void mask_data(uint32_t key, span<char> data, size_t offset = 0);
 
-  static void mask_data(uint32_t key, byte_span data, size_t skip = 0);
+  static void mask_data(uint32_t key, byte_span data, size_t offset = 0);
 
   static void assemble_frame(uint32_t mask_key, span<const char> data,
                              byte_buffer& out);

--- a/libcaf_net/caf/detail/rfc6455.hpp
+++ b/libcaf_net/caf/detail/rfc6455.hpp
@@ -17,7 +17,7 @@ namespace caf::detail {
 struct CAF_NET_EXPORT rfc6455 {
   // -- member types -----------------------------------------------------------
 
-  enum class opcode_type : uint8_t {
+  enum opcode_type : uint8_t {
     continuation_frame = 0x00,
     text_frame = 0x01,
     binary_frame = 0x02,
@@ -25,17 +25,17 @@ struct CAF_NET_EXPORT rfc6455 {
     ping_frame = 0x09,
     pong_frame = 0x0A,
     /// Invalid opcode to mean "no opcode received yet".
-    nil_code = 0xFF,
+    invalid_frame = 0xFF,
   };
 
   struct header {
     bool fin = false;
-    opcode_type opcode = opcode_type::nil_code;
+    uint8_t opcode = invalid_frame;
     uint32_t mask_key = 0;
     uint64_t payload_len = 0;
 
     constexpr bool valid() const noexcept {
-      return opcode != opcode_type::nil_code;
+      return opcode != invalid_frame;
     }
   };
 
@@ -55,14 +55,14 @@ struct CAF_NET_EXPORT rfc6455 {
   static void assemble_frame(uint32_t mask_key, const_byte_span data,
                              byte_buffer& out);
 
-  static void assemble_frame(opcode_type opcode, uint32_t mask_key,
+  static void assemble_frame(uint8_t opcode, uint32_t mask_key,
                              const_byte_span data, byte_buffer& out,
                              uint8_t flags = fin_flag);
 
   static ptrdiff_t decode_header(const_byte_span data, header& hdr);
 
-  static constexpr bool is_control_frame(opcode_type opcode) noexcept {
-    return opcode > opcode_type::binary_frame;
+  static constexpr bool is_control_frame(uint8_t opcode) noexcept {
+    return opcode > binary_frame;
   }
 };
 

--- a/libcaf_net/caf/detail/rfc6455.hpp
+++ b/libcaf_net/caf/detail/rfc6455.hpp
@@ -42,9 +42,9 @@ struct CAF_NET_EXPORT rfc6455 {
 
   // -- utility functions ------------------------------------------------------
 
-  static void mask_data(uint32_t key, span<char> data);
+  static void mask_data(uint32_t key, span<char> data, size_t skip = 0);
 
-  static void mask_data(uint32_t key, byte_span data);
+  static void mask_data(uint32_t key, byte_span data, size_t skip = 0);
 
   static void assemble_frame(uint32_t mask_key, span<const char> data,
                              byte_buffer& out);

--- a/libcaf_net/caf/detail/rfc6455.hpp
+++ b/libcaf_net/caf/detail/rfc6455.hpp
@@ -17,17 +17,6 @@ namespace caf::detail {
 struct CAF_NET_EXPORT rfc6455 {
   // -- member types -----------------------------------------------------------
 
-  enum opcode_type : uint8_t {
-    continuation_frame = 0x00,
-    text_frame = 0x01,
-    binary_frame = 0x02,
-    connection_close_frame = 0x08,
-    ping_frame = 0x09,
-    pong_frame = 0x0A,
-    /// Invalid opcode to mean "no opcode received yet".
-    invalid_frame = 0xFF,
-  };
-
   struct header {
     bool fin = false;
     uint8_t opcode = invalid_frame;
@@ -40,6 +29,21 @@ struct CAF_NET_EXPORT rfc6455 {
   };
 
   // -- constants --------------------------------------------------------------
+
+  static constexpr uint8_t continuation_frame = 0x00;
+
+  static constexpr uint8_t text_frame = 0x01;
+
+  static constexpr uint8_t binary_frame = 0x02;
+
+  static constexpr uint8_t connection_close_frame = 0x08;
+
+  static constexpr uint8_t ping_frame = 0x09;
+
+  static constexpr uint8_t pong_frame = 0x0A;
+
+  /// Invalid opcode to mean "no opcode received yet".
+  static constexpr uint8_t invalid_frame = 0xFF;
 
   static constexpr uint8_t fin_flag = 0x80;
 
@@ -59,7 +63,7 @@ struct CAF_NET_EXPORT rfc6455 {
                              const_byte_span data, byte_buffer& out,
                              uint8_t flags = fin_flag);
 
-  static ptrdiff_t decode_header(const_byte_span data, header& hdr);
+  static ptrdiff_t decode_header(const_byte_span data, header& result);
 
   static constexpr bool is_control_frame(uint8_t opcode) noexcept {
     return opcode > binary_frame;

--- a/libcaf_net/caf/detail/rfc6455.hpp
+++ b/libcaf_net/caf/detail/rfc6455.hpp
@@ -21,9 +21,9 @@ struct CAF_NET_EXPORT rfc6455 {
     continuation_frame = 0x00,
     text_frame = 0x01,
     binary_frame = 0x02,
-    connection_close = 0x08,
-    ping = 0x09,
-    pong = 0x0A,
+    connection_close_frame = 0x08,
+    ping_frame = 0x09,
+    pong_frame = 0x0A,
     /// Invalid opcode to mean "no opcode received yet".
     nil_code = 0xFF,
   };
@@ -34,13 +34,8 @@ struct CAF_NET_EXPORT rfc6455 {
     uint32_t mask_key = 0;
     uint64_t payload_len = 0;
 
-    // utility functions.
-    explicit operator bool() const noexcept {
+    constexpr bool valid() const noexcept {
       return opcode != opcode_type::nil_code;
-    }
-
-    bool operator!() const noexcept {
-      return !static_cast<bool>(*this);
     }
   };
 

--- a/libcaf_net/caf/detail/rfc6455.test.cpp
+++ b/libcaf_net/caf/detail/rfc6455.test.cpp
@@ -32,7 +32,7 @@ auto take(const T& xs, size_t num_bytes) {
   return std::vector<typename T::value_type>{xs.begin(), xs.begin() + n};
 }
 
-TEST("masking") {
+TEST("masking the full payload") {
   auto key = uint32_t{0xDEADC0DE};
   auto data = bytes({0x12, 0x34, 0x45, 0x67, 0x89, 0x9A});
   SECTION("masking XORs the repeated key to data") {
@@ -52,6 +52,22 @@ TEST("masking") {
     impl::mask_data(key, masked_data);
     impl::mask_data(key, masked_data);
     check_eq(masked_data, data);
+  }
+}
+
+TEST("partial making with offset") {
+  using namespace std::literals;
+  auto key = uint32_t{0xDEADC0DE};
+  auto original_data = std::string{"Hello, world!"};
+  auto masked_data = original_data;
+  impl::mask_data(key, make_span(masked_data));
+  for (auto i = 0ul; i < original_data.size(); i++) {
+    auto uut = original_data;
+    impl::mask_data(key, make_span(uut), i);
+    check_eq(std::string_view{uut}.substr(0, i),
+             std::string_view{original_data}.substr(0, i));
+    check_eq(std::string_view{uut}.substr(i),
+             std::string_view{masked_data}.substr(i));
   }
 }
 

--- a/libcaf_net/caf/detail/rfc6455.test.cpp
+++ b/libcaf_net/caf/detail/rfc6455.test.cpp
@@ -84,7 +84,8 @@ TEST("decoding a frame with RSV bits fails") {
 TEST("decode a header with no mask key and no data") {
   std::vector<uint8_t> data;
   byte_buffer out;
-  impl::assemble_frame(impl::binary_frame, 0, as_bytes(make_span(data)), out);
+  impl::assemble_frame(impl::opcode_type::binary_frame, 0,
+                       as_bytes(make_span(data)), out);
   check_eq(out, bytes({
                   0x82, // FIN + binary frame opcode
                   0x00, // data size = 0
@@ -93,14 +94,14 @@ TEST("decode a header with no mask key and no data") {
   check_eq(impl::decode_header(out, hdr), 2);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0u);
-  check_eq(hdr.opcode, impl::binary_frame);
+  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
 TEST("decode a header with valid mask key but no data") {
   std::vector<uint8_t> data;
   byte_buffer out;
-  impl::assemble_frame(impl::binary_frame, 0xDEADC0DE,
+  impl::assemble_frame(impl::opcode_type::binary_frame, 0xDEADC0DE,
                        as_bytes(make_span(data)), out);
   check_eq(out, bytes({
                   0x82,                   // FIN + binary frame opcode
@@ -111,14 +112,15 @@ TEST("decode a header with valid mask key but no data") {
   check_eq(impl::decode_header(out, hdr), 6);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0xDEADC0DE);
-  check_eq(hdr.opcode, impl::binary_frame);
+  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
 TEST("decode a header with no mask key plus small data") {
   std::vector<uint8_t> data{0x12, 0x34, 0x45, 0x67};
   byte_buffer out;
-  impl::assemble_frame(impl::binary_frame, 0, as_bytes(make_span(data)), out);
+  impl::assemble_frame(impl::opcode_type::binary_frame, 0,
+                       as_bytes(make_span(data)), out);
   check_eq(out, bytes({
                   0x82,                   // FIN + binary frame opcode
                   0x04,                   // data size = 4
@@ -128,14 +130,14 @@ TEST("decode a header with no mask key plus small data") {
   check_eq(impl::decode_header(out, hdr), 2);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0u);
-  check_eq(hdr.opcode, impl::binary_frame);
+  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
 TEST("decode a header with valid mask key plus small data") {
   std::vector<uint8_t> data{0x12, 0x34, 0x45, 0x67};
   byte_buffer out;
-  impl::assemble_frame(impl::binary_frame, 0xDEADC0DE,
+  impl::assemble_frame(impl::opcode_type::binary_frame, 0xDEADC0DE,
                        as_bytes(make_span(data)), out);
   check_eq(out, bytes({
                   0x82,                   // FIN + binary frame opcode
@@ -147,7 +149,7 @@ TEST("decode a header with valid mask key plus small data") {
   check_eq(impl::decode_header(out, hdr), 6);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0xDEADC0DE);
-  check_eq(hdr.opcode, impl::binary_frame);
+  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -155,7 +157,8 @@ TEST("decode a header with no mask key plus upper bound on small data") {
   std::vector<uint8_t> data;
   data.resize(125, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::binary_frame, 0, as_bytes(make_span(data)), out);
+  impl::assemble_frame(impl::opcode_type::binary_frame, 0,
+                       as_bytes(make_span(data)), out);
   check_eq(take(out, 6), bytes({
                            0x82,                   // FIN + binary frame opcode
                            0x7D,                   // data size = 125
@@ -165,7 +168,7 @@ TEST("decode a header with no mask key plus upper bound on small data") {
   check_eq(impl::decode_header(out, hdr), 2);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0u);
-  check_eq(hdr.opcode, impl::binary_frame);
+  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -173,7 +176,7 @@ TEST("decode a header with valid mask key plus upper bound on small data") {
   std::vector<uint8_t> data;
   data.resize(125, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::binary_frame, 0xDEADC0DE,
+  impl::assemble_frame(impl::opcode_type::binary_frame, 0xDEADC0DE,
                        as_bytes(make_span(data)), out);
   check_eq(take(out, 10), bytes({
                             0x82,                   // FIN + binary frame opcode
@@ -185,7 +188,7 @@ TEST("decode a header with valid mask key plus upper bound on small data") {
   check_eq(impl::decode_header(out, hdr), 6);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0xDEADC0DE);
-  check_eq(hdr.opcode, impl::binary_frame);
+  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -193,7 +196,8 @@ TEST("decode a header with no mask key plus medium data") {
   std::vector<uint8_t> data;
   data.resize(126, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::binary_frame, 0, as_bytes(make_span(data)), out);
+  impl::assemble_frame(impl::opcode_type::binary_frame, 0,
+                       as_bytes(make_span(data)), out);
   check_eq(take(out, 8),
            bytes({
              0x82,                   // FIN + binary frame opcode
@@ -205,7 +209,7 @@ TEST("decode a header with no mask key plus medium data") {
   check_eq(impl::decode_header(out, hdr), 4);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0u);
-  check_eq(hdr.opcode, impl::binary_frame);
+  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -213,7 +217,7 @@ TEST("decode a header with valid mask key plus medium data") {
   std::vector<uint8_t> data;
   data.resize(126, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::binary_frame, 0xDEADC0DE,
+  impl::assemble_frame(impl::opcode_type::binary_frame, 0xDEADC0DE,
                        as_bytes(make_span(data)), out);
   check_eq(take(out, 12),
            bytes({
@@ -227,7 +231,7 @@ TEST("decode a header with valid mask key plus medium data") {
   check_eq(impl::decode_header(out, hdr), 8);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0xDEADC0DE);
-  check_eq(hdr.opcode, impl::binary_frame);
+  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -235,7 +239,8 @@ TEST("decode a header with no mask key plus upper bound on medium data") {
   std::vector<uint8_t> data;
   data.resize(65535, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::binary_frame, 0, as_bytes(make_span(data)), out);
+  impl::assemble_frame(impl::opcode_type::binary_frame, 0,
+                       as_bytes(make_span(data)), out);
   check_eq(take(out, 8),
            bytes({
              0x82,                   // FIN + binary frame opcode
@@ -247,7 +252,7 @@ TEST("decode a header with no mask key plus upper bound on medium data") {
   check_eq(impl::decode_header(out, hdr), 4);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0u);
-  check_eq(hdr.opcode, impl::binary_frame);
+  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -255,7 +260,7 @@ TEST("decode a header with valid mask key plus upper bound on medium data") {
   std::vector<uint8_t> data;
   data.resize(65535, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::binary_frame, 0xDEADC0DE,
+  impl::assemble_frame(impl::opcode_type::binary_frame, 0xDEADC0DE,
                        as_bytes(make_span(data)), out);
   check_eq(take(out, 12),
            bytes({
@@ -269,7 +274,7 @@ TEST("decode a header with valid mask key plus upper bound on medium data") {
   check_eq(impl::decode_header(out, hdr), 8);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0xDEADC0DE);
-  check_eq(hdr.opcode, impl::binary_frame);
+  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -277,7 +282,8 @@ TEST("decode a header with no mask key plus large data") {
   std::vector<uint8_t> data;
   data.resize(65536, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::binary_frame, 0, as_bytes(make_span(data)), out);
+  impl::assemble_frame(impl::opcode_type::binary_frame, 0,
+                       as_bytes(make_span(data)), out);
   check_eq(take(out, 14),
            bytes({
              0x82, // FIN + binary frame opcode
@@ -289,7 +295,7 @@ TEST("decode a header with no mask key plus large data") {
   check_eq(impl::decode_header(out, hdr), 10);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0u);
-  check_eq(hdr.opcode, impl::binary_frame);
+  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -297,7 +303,7 @@ TEST("decode a header with valid mask key plus large data") {
   std::vector<uint8_t> data;
   data.resize(65536, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::binary_frame, 0xDEADC0DE,
+  impl::assemble_frame(impl::opcode_type::binary_frame, 0xDEADC0DE,
                        as_bytes(make_span(data)), out);
   check_eq(take(out, 18),
            bytes({
@@ -311,7 +317,7 @@ TEST("decode a header with valid mask key plus large data") {
   check_eq(impl::decode_header(out, hdr), 14);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0xDEADC0DE);
-  check_eq(hdr.opcode, impl::binary_frame);
+  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 

--- a/libcaf_net/caf/detail/rfc6455.test.cpp
+++ b/libcaf_net/caf/detail/rfc6455.test.cpp
@@ -55,7 +55,7 @@ TEST("masking the full payload") {
   }
 }
 
-TEST("partial making with offset") {
+TEST("partial masking with offset") {
   using namespace std::literals;
   auto key = uint32_t{0xDEADC0DE};
   auto original_data = "Hello, world!"s;
@@ -82,8 +82,7 @@ TEST("decoding a frame with RSV bits fails") {
 TEST("decode a header with no mask key and no data") {
   std::vector<uint8_t> data;
   byte_buffer out;
-  impl::assemble_frame(impl::opcode_type::binary_frame, 0,
-                       as_bytes(make_span(data)), out);
+  impl::assemble_frame(impl::binary_frame, 0, as_bytes(make_span(data)), out);
   check_eq(out, bytes({
                   0x82, // FIN + binary frame opcode
                   0x00, // data size = 0
@@ -92,14 +91,14 @@ TEST("decode a header with no mask key and no data") {
   check_eq(impl::decode_header(out, hdr), 2);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0u);
-  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
+  check_eq(hdr.opcode, impl::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
 TEST("decode a header with valid mask key but no data") {
   std::vector<uint8_t> data;
   byte_buffer out;
-  impl::assemble_frame(impl::opcode_type::binary_frame, 0xDEADC0DE,
+  impl::assemble_frame(impl::binary_frame, 0xDEADC0DE,
                        as_bytes(make_span(data)), out);
   check_eq(out, bytes({
                   0x82,                   // FIN + binary frame opcode
@@ -110,15 +109,14 @@ TEST("decode a header with valid mask key but no data") {
   check_eq(impl::decode_header(out, hdr), 6);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0xDEADC0DE);
-  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
+  check_eq(hdr.opcode, impl::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
 TEST("decode a header with no mask key plus small data") {
   std::vector<uint8_t> data{0x12, 0x34, 0x45, 0x67};
   byte_buffer out;
-  impl::assemble_frame(impl::opcode_type::binary_frame, 0,
-                       as_bytes(make_span(data)), out);
+  impl::assemble_frame(impl::binary_frame, 0, as_bytes(make_span(data)), out);
   check_eq(out, bytes({
                   0x82,                   // FIN + binary frame opcode
                   0x04,                   // data size = 4
@@ -128,14 +126,14 @@ TEST("decode a header with no mask key plus small data") {
   check_eq(impl::decode_header(out, hdr), 2);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0u);
-  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
+  check_eq(hdr.opcode, impl::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
 TEST("decode a header with valid mask key plus small data") {
   std::vector<uint8_t> data{0x12, 0x34, 0x45, 0x67};
   byte_buffer out;
-  impl::assemble_frame(impl::opcode_type::binary_frame, 0xDEADC0DE,
+  impl::assemble_frame(impl::binary_frame, 0xDEADC0DE,
                        as_bytes(make_span(data)), out);
   check_eq(out, bytes({
                   0x82,                   // FIN + binary frame opcode
@@ -147,7 +145,7 @@ TEST("decode a header with valid mask key plus small data") {
   check_eq(impl::decode_header(out, hdr), 6);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0xDEADC0DE);
-  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
+  check_eq(hdr.opcode, impl::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -155,8 +153,7 @@ TEST("decode a header with no mask key plus upper bound on small data") {
   std::vector<uint8_t> data;
   data.resize(125, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::opcode_type::binary_frame, 0,
-                       as_bytes(make_span(data)), out);
+  impl::assemble_frame(impl::binary_frame, 0, as_bytes(make_span(data)), out);
   check_eq(take(out, 6), bytes({
                            0x82,                   // FIN + binary frame opcode
                            0x7D,                   // data size = 125
@@ -166,7 +163,7 @@ TEST("decode a header with no mask key plus upper bound on small data") {
   check_eq(impl::decode_header(out, hdr), 2);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0u);
-  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
+  check_eq(hdr.opcode, impl::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -174,7 +171,7 @@ TEST("decode a header with valid mask key plus upper bound on small data") {
   std::vector<uint8_t> data;
   data.resize(125, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::opcode_type::binary_frame, 0xDEADC0DE,
+  impl::assemble_frame(impl::binary_frame, 0xDEADC0DE,
                        as_bytes(make_span(data)), out);
   check_eq(take(out, 10), bytes({
                             0x82,                   // FIN + binary frame opcode
@@ -186,7 +183,7 @@ TEST("decode a header with valid mask key plus upper bound on small data") {
   check_eq(impl::decode_header(out, hdr), 6);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0xDEADC0DE);
-  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
+  check_eq(hdr.opcode, impl::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -194,8 +191,7 @@ TEST("decode a header with no mask key plus medium data") {
   std::vector<uint8_t> data;
   data.resize(126, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::opcode_type::binary_frame, 0,
-                       as_bytes(make_span(data)), out);
+  impl::assemble_frame(impl::binary_frame, 0, as_bytes(make_span(data)), out);
   check_eq(take(out, 8),
            bytes({
              0x82,                   // FIN + binary frame opcode
@@ -207,7 +203,7 @@ TEST("decode a header with no mask key plus medium data") {
   check_eq(impl::decode_header(out, hdr), 4);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0u);
-  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
+  check_eq(hdr.opcode, impl::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -215,7 +211,7 @@ TEST("decode a header with valid mask key plus medium data") {
   std::vector<uint8_t> data;
   data.resize(126, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::opcode_type::binary_frame, 0xDEADC0DE,
+  impl::assemble_frame(impl::binary_frame, 0xDEADC0DE,
                        as_bytes(make_span(data)), out);
   check_eq(take(out, 12),
            bytes({
@@ -229,7 +225,7 @@ TEST("decode a header with valid mask key plus medium data") {
   check_eq(impl::decode_header(out, hdr), 8);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0xDEADC0DE);
-  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
+  check_eq(hdr.opcode, impl::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -237,8 +233,7 @@ TEST("decode a header with no mask key plus upper bound on medium data") {
   std::vector<uint8_t> data;
   data.resize(65535, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::opcode_type::binary_frame, 0,
-                       as_bytes(make_span(data)), out);
+  impl::assemble_frame(impl::binary_frame, 0, as_bytes(make_span(data)), out);
   check_eq(take(out, 8),
            bytes({
              0x82,                   // FIN + binary frame opcode
@@ -250,7 +245,7 @@ TEST("decode a header with no mask key plus upper bound on medium data") {
   check_eq(impl::decode_header(out, hdr), 4);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0u);
-  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
+  check_eq(hdr.opcode, impl::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -258,7 +253,7 @@ TEST("decode a header with valid mask key plus upper bound on medium data") {
   std::vector<uint8_t> data;
   data.resize(65535, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::opcode_type::binary_frame, 0xDEADC0DE,
+  impl::assemble_frame(impl::binary_frame, 0xDEADC0DE,
                        as_bytes(make_span(data)), out);
   check_eq(take(out, 12),
            bytes({
@@ -272,7 +267,7 @@ TEST("decode a header with valid mask key plus upper bound on medium data") {
   check_eq(impl::decode_header(out, hdr), 8);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0xDEADC0DE);
-  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
+  check_eq(hdr.opcode, impl::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -280,8 +275,7 @@ TEST("decode a header with no mask key plus large data") {
   std::vector<uint8_t> data;
   data.resize(65536, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::opcode_type::binary_frame, 0,
-                       as_bytes(make_span(data)), out);
+  impl::assemble_frame(impl::binary_frame, 0, as_bytes(make_span(data)), out);
   check_eq(take(out, 14),
            bytes({
              0x82, // FIN + binary frame opcode
@@ -293,7 +287,7 @@ TEST("decode a header with no mask key plus large data") {
   check_eq(impl::decode_header(out, hdr), 10);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0u);
-  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
+  check_eq(hdr.opcode, impl::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 
@@ -301,7 +295,7 @@ TEST("decode a header with valid mask key plus large data") {
   std::vector<uint8_t> data;
   data.resize(65536, 0xFF);
   byte_buffer out;
-  impl::assemble_frame(impl::opcode_type::binary_frame, 0xDEADC0DE,
+  impl::assemble_frame(impl::binary_frame, 0xDEADC0DE,
                        as_bytes(make_span(data)), out);
   check_eq(take(out, 18),
            bytes({
@@ -315,7 +309,7 @@ TEST("decode a header with valid mask key plus large data") {
   check_eq(impl::decode_header(out, hdr), 14);
   check_eq(hdr.fin, true);
   check_eq(hdr.mask_key, 0xDEADC0DE);
-  check_eq(hdr.opcode, impl::opcode_type::binary_frame);
+  check_eq(hdr.opcode, impl::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
 

--- a/libcaf_net/caf/detail/rfc6455.test.cpp
+++ b/libcaf_net/caf/detail/rfc6455.test.cpp
@@ -58,16 +58,14 @@ TEST("masking the full payload") {
 TEST("partial making with offset") {
   using namespace std::literals;
   auto key = uint32_t{0xDEADC0DE};
-  auto original_data = std::string{"Hello, world!"};
+  auto original_data = "Hello, world!"s;
   auto masked_data = original_data;
   impl::mask_data(key, make_span(masked_data));
   for (auto i = 0ul; i < original_data.size(); i++) {
     auto uut = original_data;
     impl::mask_data(key, make_span(uut), i);
-    check_eq(std::string_view{uut}.substr(0, i),
-             std::string_view{original_data}.substr(0, i));
-    check_eq(std::string_view{uut}.substr(i),
-             std::string_view{masked_data}.substr(i));
+    check_eq(uut.substr(0, i), original_data.substr(0, i));
+    check_eq(uut.substr(i), masked_data.substr(i));
   }
 }
 

--- a/libcaf_net/caf/net/web_socket/framing.cpp
+++ b/libcaf_net/caf/net/web_socket/framing.cpp
@@ -215,7 +215,7 @@ ptrdiff_t framing::consume_payload(byte_span buffer, byte_span delta) {
 ptrdiff_t framing::consume(byte_span buffer, byte_span delta) {
   // Make sure we're overriding any 'exactly' setting.
   down_->configure_read(receive_policy::up_to(2048));
-  if (!hdr_) {
+  if (!hdr_.valid()) {
     auto hdr_bytes = consume_header(buffer, delta);
     if (hdr_bytes <= 0) {
       hdr_.opcode = detail::rfc6455::opcode_type::nil_code;
@@ -225,9 +225,8 @@ ptrdiff_t framing::consume(byte_span buffer, byte_span delta) {
         && consume_payload(buffer.first(0), delta.first(0)) < 0)
       return -1;
     return hdr_bytes;
-  } else {
-    return consume_payload(buffer, delta);
   }
+  return consume_payload(buffer, delta);
 }
 
 void framing::prepare_send() {

--- a/libcaf_net/caf/net/web_socket/framing.cpp
+++ b/libcaf_net/caf/net/web_socket/framing.cpp
@@ -78,149 +78,11 @@ void framing::abort(const error& reason) {
   up_->abort(reason);
 }
 
-ptrdiff_t framing::consume_header(byte_span buffer, byte_span) {
-  // Parse header.
-  auto hdr_bytes = detail::rfc6455::decode_header(buffer, hdr_);
-  if (hdr_bytes < 0) {
-    CAF_LOG_DEBUG("decoded malformed data: hdr_bytes < 0");
-    abort_and_shutdown(sec::protocol_error,
-                       "negative header size on WebSocket connection");
-    return -1;
-  }
-  // Wait for more input.
-  if (hdr_bytes == 0)
-    return 0;
-  if (auto err = validate_header(hdr_bytes); err) {
-    abort_and_shutdown(err);
-    return -1;
-  }
-  return hdr_bytes;
-}
-
-error framing::validate_header(ptrdiff_t hdr_bytes) noexcept {
-  auto make_error_with_log = [](const sec& code, const char* message) {
-    CAF_LOG_DEBUG(message);
-    return make_error(code, message);
-  };
-  if (detail::rfc6455::is_control_frame(hdr_.opcode)) {
-    // Control frames can have a payload up to 125 bytes and can't be
-    // fragmented.
-    if (hdr_.payload_len > 125)
-      return make_error_with_log(
-        sec::protocol_error,
-        "WebSocket control frame payload exceeds allowed size");
-    if (!hdr_.fin)
-      return make_error_with_log(
-        sec::protocol_error, "Received a fragmented WebSocket control message");
-  } else {
-    // The opcode is either continuation, text of binary frame.
-    // Make sure the entire frame (including header) fits into max_frame_size.
-    if (hdr_.payload_len >= max_frame_size - static_cast<size_t>(hdr_bytes))
-      return make_error_with_log(sec::protocol_error,
-                                 "WebSocket frame too large");
-    // Reject any message whose assembled payload size exceeds max_frame_size.
-    if (payload_buf_.size() + hdr_.payload_len > max_frame_size)
-      return make_error_with_log(
-        sec::protocol_error,
-        "Fragmented WebSocket payload exceeds maximum size");
-    if (hdr_.opcode != detail::rfc6455::opcode_type::continuation_frame
-        && opcode_ != detail::rfc6455::opcode_type::nil_code)
-      return make_error_with_log(sec::protocol_error,
-                                 "Expected a WebSocket continuation_frame");
-    if (hdr_.opcode == detail::rfc6455::opcode_type::continuation_frame
-        && opcode_ == detail::rfc6455::opcode_type::nil_code)
-      return make_error_with_log(
-        sec::protocol_error,
-        "Received WebSocket continuation frame without prior opcode");
-  }
-  return none;
-}
-
-ptrdiff_t framing::consume_payload(byte_span buffer, byte_span delta) {
-  // Calculate at what point of the received buffer the delta payload begins.
-  auto offset = static_cast<ptrdiff_t>(buffer.size() - delta.size());
-  // We read frame_size at most. This can leave unprocessed input.
-  auto payload = buffer.first(std::min(buffer.size(), hdr_.payload_len));
-  // Unmask the arrived data.
-  if (hdr_.mask_key != 0)
-    detail::rfc6455::mask_data(hdr_.mask_key, payload, offset);
-  // In case of text message, we want to validate the UTF-8 encoding early.
-  if (hdr_.opcode == detail::rfc6455::opcode_type::text_frame
-      || (hdr_.opcode == detail::rfc6455::opcode_type::continuation_frame
-          && opcode_ == detail::rfc6455::opcode_type::text_frame)) {
-    if (hdr_.opcode == detail::rfc6455::opcode_type::text_frame && hdr_.fin) {
-      if (!payload_valid(payload, validation_offset_)) {
-        abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
-        return -1;
-      }
-    } else {
-      payload_buf_.insert(payload_buf_.end(), payload.begin() + offset,
-                          payload.end());
-      if (!payload_valid(payload_buf_, validation_offset_)) {
-        abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
-        return -1;
-      }
-    }
-    // Wait for more data if necessary.
-    if (buffer.size() < hdr_.payload_len) {
-      down_->configure_read(receive_policy::up_to(hdr_.payload_len));
-      return 0;
-    }
-  } else {
-    // Wait for more data if necessary.
-    if (buffer.size() < hdr_.payload_len) {
-      down_->configure_read(receive_policy::exactly(hdr_.payload_len));
-      return 0;
-    }
-  }
-  // At this point the frame is guaranteed to have arrived completely.
-  // Handle control frames first, since these may not me fragmented,
-  // and can arrive between regular message fragments.
-  if (detail::rfc6455::is_control_frame(hdr_.opcode))
-    return handle(hdr_.opcode, payload, hdr_.payload_len);
-  if (hdr_.fin) {
-    if (opcode_ == detail::rfc6455::opcode_type::nil_code) {
-      if (hdr_.opcode == detail::rfc6455::opcode_type::text_frame
-          && validation_offset_ != payload.size()) {
-        abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
-        return -1;
-      }
-      // Call upper layer.
-      validation_offset_ = 0;
-      return handle(hdr_.opcode, payload, hdr_.payload_len);
-    }
-    // End of fragmented input.
-    if (opcode_ != detail::rfc6455::opcode_type::text_frame) {
-      payload_buf_.insert(payload_buf_.end(), payload.begin(), payload.end());
-    } else if (validation_offset_ != payload_buf_.size()) {
-      abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
-      return -1;
-    }
-    auto result = handle(opcode_, payload_buf_, hdr_.payload_len);
-    opcode_ = detail::rfc6455::opcode_type::nil_code;
-    payload_buf_.clear();
-    validation_offset_ = 0;
-    return result;
-  }
-  if (opcode_ == detail::rfc6455::opcode_type::nil_code) {
-    opcode_ = hdr_.opcode;
-  }
-  if (opcode_ != detail::rfc6455::opcode_type::text_frame) {
-    payload_buf_.insert(payload_buf_.end(), payload.begin(), payload.end());
-  }
-  hdr_.opcode = detail::rfc6455::opcode_type::nil_code;
-  return static_cast<ptrdiff_t>(hdr_.payload_len);
-}
-
 ptrdiff_t framing::consume(byte_span buffer, byte_span delta) {
-  // Make sure we're overriding any 'exactly' setting.
-  down_->configure_read(receive_policy::up_to(2048));
   if (!hdr_.valid()) {
     auto hdr_bytes = consume_header(buffer, delta);
-    if (hdr_bytes <= 0) {
-      hdr_.opcode = detail::rfc6455::opcode_type::nil_code;
+    if (hdr_bytes <= 0)
       return hdr_bytes;
-    }
     if (hdr_.payload_len == 0
         && consume_payload(buffer.first(0), delta.first(0)) < 0)
       return -1;
@@ -297,36 +159,168 @@ bool framing::end_text_message() {
 
 // -- implementation details ---------------------------------------------------
 
-ptrdiff_t framing::handle(detail::rfc6455::opcode_type opcode,
-                          byte_span payload, size_t frame_size) {
+error framing::validate_header(ptrdiff_t hdr_bytes) const noexcept {
+  auto make_error_with_log = [](const char* message) {
+    CAF_LOG_DEBUG(message);
+    return make_error(sec::protocol_error, message);
+  };
+  if (detail::rfc6455::is_control_frame(hdr_.opcode)) {
+    // Control frames can have a payload up to 125 bytes and can't be
+    // fragmented.
+    if (hdr_.payload_len > 125)
+      return make_error_with_log(
+        "WebSocket control frame payload exceeds allowed size");
+    if (!hdr_.fin)
+      return make_error_with_log(
+        "Received a fragmented WebSocket control message");
+  } else {
+    // The opcode is either continuation, text of binary frame.
+    // Make sure the entire frame (including header) fits into max_frame_size.
+    if (hdr_.payload_len >= max_frame_size - static_cast<size_t>(hdr_bytes))
+      return make_error_with_log("WebSocket frame too large");
+    // Reject any message whose assembled payload size exceeds max_frame_size.
+    if (payload_buf_.size() + hdr_.payload_len > max_frame_size)
+      return make_error_with_log(
+        "Fragmented WebSocket payload exceeds maximum size");
+    if (hdr_.opcode != detail::rfc6455::continuation_frame
+        && opcode_ != detail::rfc6455::invalid_frame)
+      return make_error_with_log("Expected a WebSocket continuation_frame");
+    if (hdr_.opcode == detail::rfc6455::continuation_frame
+        && opcode_ == detail::rfc6455::invalid_frame)
+      return make_error_with_log(
+        "Received WebSocket continuation frame without prior opcode");
+  }
+  return none;
+}
+
+ptrdiff_t framing::consume_header(byte_span buffer, byte_span) {
+  // Parse header.
+  auto hdr_bytes = detail::rfc6455::decode_header(buffer, hdr_);
+  if (hdr_bytes < 0) {
+    CAF_LOG_DEBUG("decoded malformed data: hdr_bytes < 0");
+    abort_and_shutdown(sec::protocol_error,
+                       "negative header size on WebSocket connection");
+    return -1;
+  }
+  // Wait for more input.
+  if (hdr_bytes == 0)
+    return 0;
+  if (auto err = validate_header(hdr_bytes); err) {
+    abort_and_shutdown(err);
+    return -1;
+  }
+  // Configure the buffer for the next call to consume_payload. In case of text
+  // messages, we validate the UTF-8 encoding on the go, hence the use of up_to.
+  if (hdr_.opcode == detail::rfc6455::text_frame
+      || (hdr_.opcode == detail::rfc6455::continuation_frame
+          && opcode_ == detail::rfc6455::text_frame))
+    down_->configure_read(receive_policy::up_to(hdr_.payload_len));
+  else
+    down_->configure_read(receive_policy::exactly(hdr_.payload_len));
+  return hdr_bytes;
+}
+
+ptrdiff_t framing::consume_payload(byte_span buffer, byte_span delta) {
+  // Calculate at what point of the received buffer the delta payload begins.
+  auto offset = static_cast<ptrdiff_t>(buffer.size() - delta.size());
+  // Unmask the arrived data.
+  if (hdr_.mask_key != 0)
+    detail::rfc6455::mask_data(hdr_.mask_key, buffer, offset);
+
+  // Handle control frames first, since these may not me fragmented,
+  // and can arrive between regular message fragments.
+  if (detail::rfc6455::is_control_frame(hdr_.opcode)) {
+    return handle(hdr_.opcode, buffer, hdr_.payload_len);
+  }
+  // Handle the fragmentation logic of text and binary messages.
+  if (hdr_.opcode == detail::rfc6455::text_frame
+      || opcode_ == detail::rfc6455::text_frame) {
+    // For text messages we validate the UTF-8 encoding on the go. Only text
+    // messages can arrive with incomplete payload.
+    if (hdr_.opcode == detail::rfc6455::text_frame && hdr_.fin) {
+      if (!payload_valid(buffer, validation_offset_)) {
+        abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
+        return -1;
+      }
+    } else {
+      payload_buf_.insert(payload_buf_.end(), buffer.begin() + offset,
+                          buffer.end());
+      if (!payload_valid(payload_buf_, validation_offset_)) {
+        abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
+        return -1;
+      }
+    }
+    // Wait for more data if necessary.
+    if (buffer.size() < hdr_.payload_len)
+      return 0;
+  } else if ((hdr_.opcode == detail::rfc6455::binary_frame && !hdr_.fin)
+             || opcode_ == detail::rfc6455::binary_frame) {
+    payload_buf_.insert(payload_buf_.end(), buffer.begin(), buffer.end());
+  }
+  // Handle the completed frame.
+  if (hdr_.fin) {
+    if (opcode_ == detail::rfc6455::invalid_frame) {
+      if (hdr_.opcode == detail::rfc6455::text_frame
+          && validation_offset_ != buffer.size()) {
+        abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
+        return -1;
+      }
+      // Call upper layer.
+      validation_offset_ = 0;
+      return handle(hdr_.opcode, buffer, hdr_.payload_len);
+    }
+    // End of fragmented input.
+    if (opcode_ == detail::rfc6455::text_frame
+        && validation_offset_ != payload_buf_.size()) {
+      abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
+      return -1;
+    }
+    auto result = handle(opcode_, payload_buf_, hdr_.payload_len);
+    opcode_ = detail::rfc6455::invalid_frame;
+    payload_buf_.clear();
+    validation_offset_ = 0;
+    return result;
+  }
+  if (opcode_ == detail::rfc6455::invalid_frame)
+    opcode_ = hdr_.opcode;
+  // Clean up the state since we finished processing this frame
+  down_->configure_read(receive_policy::up_to(2048));
+  hdr_.opcode = detail::rfc6455::invalid_frame;
+  return static_cast<ptrdiff_t>(hdr_.payload_len);
+}
+
+ptrdiff_t framing::handle(uint8_t opcode, byte_span payload,
+                          size_t frame_size) {
   // opcodes are checked for validity when decoding the header
   switch (opcode) {
-    case detail::rfc6455::opcode_type::connection_close:
+    case detail::rfc6455::connection_close_frame:
       if (auto err = validate_closing_payload(payload); err) {
         abort_and_shutdown(err);
         return -1;
       }
       abort_and_shutdown(sec::connection_closed);
       return -1;
-    case detail::rfc6455::opcode_type::text_frame: {
+    case detail::rfc6455::text_frame: {
       std::string_view text{reinterpret_cast<const char*>(payload.data()),
                             payload.size()};
       if (up_->consume_text(text) < 0)
         return -1;
       break;
     }
-    case detail::rfc6455::opcode_type::binary_frame:
+    case detail::rfc6455::binary_frame:
       if (up_->consume_binary(payload) < 0)
         return -1;
       break;
-    case detail::rfc6455::opcode_type::ping:
+    case detail::rfc6455::ping_frame:
       ship_pong(payload);
       break;
     default: //  detail::rfc6455::pong
       // nop
       break;
   }
-  hdr_.opcode = detail::rfc6455::opcode_type::nil_code;
+  // Clean up the state since we finished processing this frame
+  down_->configure_read(receive_policy::up_to(2048));
+  hdr_.opcode = detail::rfc6455::invalid_frame;
   return static_cast<ptrdiff_t>(frame_size);
 }
 
@@ -337,7 +331,7 @@ void framing::ship_pong(byte_span payload) {
     detail::rfc6455::mask_data(mask_key, payload);
   }
   down_->begin_output();
-  detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::pong, mask_key,
+  detail::rfc6455::assemble_frame(detail::rfc6455::pong_frame, mask_key,
                                   payload, down_->output_buffer());
   down_->end_output();
 }
@@ -369,9 +363,8 @@ void framing::ship_closing_message(status code, std::string_view msg) {
     detail::rfc6455::mask_data(mask_key, payload);
   }
   down_->begin_output();
-  detail::rfc6455::assemble_frame(
-    detail::rfc6455::opcode_type::connection_close, mask_key, payload,
-    down_->output_buffer());
+  detail::rfc6455::assemble_frame(detail::rfc6455::connection_close_frame,
+                                  mask_key, payload, down_->output_buffer());
   down_->end_output();
 }
 

--- a/libcaf_net/caf/net/web_socket/framing.cpp
+++ b/libcaf_net/caf/net/web_socket/framing.cpp
@@ -16,14 +16,12 @@ namespace {
 /// Checks whether the current input is valid UTF-8. Stores the last position
 /// while scanning in order to avoid validating the same bytes again.
 bool payload_valid(const_byte_span payload, size_t& offset) noexcept {
-  // validate from the index where we left off last time
+  // Continue from the index where we left off last time.
   auto [index, incomplete] = detail::rfc3629::validate(payload.subspan(offset));
   offset += index;
-  if (offset == payload.size())
-    return true;
-  // incomplete will be true if the last code point is missing continuation
-  // bytes but might be valid
-  return incomplete;
+  // Incomplete will be true if the last code point is missing continuation
+  // bytes but might be valid.
+  return offset == payload.size() || incomplete;
 }
 
 } // namespace
@@ -121,7 +119,7 @@ ptrdiff_t framing::consume(byte_span buffer, byte_span delta) {
     }
   }
   // Calculate at what point of the received buffer the delta payload begins.
-  auto offset = static_cast<ptrdiff_t>((buffer.size() - delta.size()))
+  auto offset = static_cast<ptrdiff_t>(buffer.size() - delta.size())
                 - hdr_bytes;
   // Offset < zero  - the delta buffer contains header bytes.
   // Delta is empty - we didn't process the whole input last time we got called.

--- a/libcaf_net/caf/net/web_socket/framing.cpp
+++ b/libcaf_net/caf/net/web_socket/framing.cpp
@@ -192,9 +192,7 @@ ptrdiff_t framing::consume_payload(byte_span buffer, byte_span delta) {
     // End of fragmented input.
     if (opcode_ != detail::rfc6455::opcode_type::text_frame) {
       payload_buf_.insert(payload_buf_.end(), payload.begin(), payload.end());
-    }
-    if (opcode_ == detail::rfc6455::opcode_type::text_frame
-        && validation_offset_ != payload_buf_.size()) {
+    } else if (validation_offset_ != payload_buf_.size()) {
       abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
       return -1;
     }

--- a/libcaf_net/caf/net/web_socket/framing.cpp
+++ b/libcaf_net/caf/net/web_socket/framing.cpp
@@ -26,7 +26,7 @@ bool payload_valid(const_byte_span payload, size_t& offset) noexcept {
   return incomplete;
 }
 
-}
+} // namespace
 
 // -- static utility functions -------------------------------------------------
 

--- a/libcaf_net/caf/net/web_socket/framing.cpp
+++ b/libcaf_net/caf/net/web_socket/framing.cpp
@@ -226,9 +226,7 @@ ptrdiff_t framing::consume_payload(byte_span buffer, byte_span delta) {
   // Unmask the arrived data.
   if (hdr_.mask_key != 0)
     detail::rfc6455::mask_data(hdr_.mask_key, buffer, offset);
-
-  // Handle control frames first, since these may not me fragmented,
-  // and can arrive between regular message fragments.
+  // Control frames may not me fragmented and can arrive between regular message fragments.
   if (detail::rfc6455::is_control_frame(hdr_.opcode)) {
     return handle(hdr_.opcode, buffer, hdr_.payload_len);
   }

--- a/libcaf_net/caf/net/web_socket/framing.hpp
+++ b/libcaf_net/caf/net/web_socket/framing.hpp
@@ -41,6 +41,9 @@ public:
   /// Restricts the size of received frames (including header).
   static constexpr size_t max_frame_size = INT32_MAX;
 
+  /// Default receive policy for a new frame.
+  static constexpr auto default_receive_policy = receive_policy::up_to(2048);
+
   // -- static utility functions -----------------------------------------------
 
   /// Checks whether the payload of a closing frame contains a valid status

--- a/libcaf_net/caf/net/web_socket/framing.hpp
+++ b/libcaf_net/caf/net/web_socket/framing.hpp
@@ -164,10 +164,6 @@ private:
     shutdown(err);
   }
 
-  /// Checks whether the current input is valid UTF-8. Stores the last position
-  /// while scanning in order to avoid validating the same bytes again.
-  bool payload_valid() noexcept;
-
   // -- member variables -------------------------------------------------------
 
   /// Points to the transport layer below.

--- a/libcaf_net/caf/net/web_socket/framing.hpp
+++ b/libcaf_net/caf/net/web_socket/framing.hpp
@@ -138,6 +138,9 @@ private:
     // nop
   }
 
+  // Validate the protocol after consuming a header.
+  error validate_header(ptrdiff_t hdr_bytes) noexcept;
+
   // Consume the header for the currently parsing frame. Returns the number of
   // sonsumed bytes.
   ptrdiff_t consume_header(byte_span input, byte_span);

--- a/libcaf_net/caf/net/web_socket/framing.hpp
+++ b/libcaf_net/caf/net/web_socket/framing.hpp
@@ -139,7 +139,7 @@ private:
   }
 
   // Validate the protocol after consuming a header.
-  error validate_header(ptrdiff_t hdr_bytes) noexcept;
+  error validate_header(ptrdiff_t hdr_bytes) const noexcept;
 
   // Consume the header for the currently parsing frame. Returns the number of
   // sonsumed bytes.
@@ -150,8 +150,7 @@ private:
   ptrdiff_t consume_payload(byte_span buffer, byte_span delta);
 
   // Returns `frame_size` on success and -1 on error.
-  ptrdiff_t handle(detail::rfc6455::opcode_type opcode, byte_span payload,
-                   size_t frame_size);
+  ptrdiff_t handle(uint8_t opcode, byte_span payload, size_t frame_size);
 
   void ship_pong(byte_span payload);
 
@@ -191,7 +190,7 @@ private:
   detail::rfc6455::header hdr_;
 
   /// Caches the opcode while decoding.
-  detail::rfc6455::opcode_type opcode_ = detail::rfc6455::opcode_type::nil_code;
+  uint8_t opcode_ = detail::rfc6455::invalid_frame;
 
   /// Assembles fragmented payloads.
   binary_buffer payload_buf_;

--- a/libcaf_net/caf/net/web_socket/framing.hpp
+++ b/libcaf_net/caf/net/web_socket/framing.hpp
@@ -41,9 +41,6 @@ public:
   /// Restricts the size of received frames (including header).
   static constexpr size_t max_frame_size = INT32_MAX;
 
-  /// Stored as currently active opcode to mean "no opcode received yet".
-  static constexpr size_t nil_code = 0xFF;
-
   // -- static utility functions -----------------------------------------------
 
   /// Checks whether the payload of a closing frame contains a valid status
@@ -141,8 +138,17 @@ private:
     // nop
   }
 
+  // Consume the header for the currently parsing frame. Returns the number of
+  // sonsumed bytes.
+  ptrdiff_t consume_header(byte_span input, byte_span);
+
+  // Consume the payload for the currently parsing frame. Returns the number of
+  // consumed bytes.
+  ptrdiff_t consume_payload(byte_span buffer, byte_span delta);
+
   // Returns `frame_size` on success and -1 on error.
-  ptrdiff_t handle(uint8_t opcode, byte_span payload, size_t frame_size);
+  ptrdiff_t handle(detail::rfc6455::opcode_type opcode, byte_span payload,
+                   size_t frame_size);
 
   void ship_pong(byte_span payload);
 
@@ -178,8 +184,11 @@ private:
   /// A 32-bit random number generator.
   std::mt19937 rng_;
 
+  /// Header of the currently parsing frame.
+  detail::rfc6455::header hdr_;
+
   /// Caches the opcode while decoding.
-  uint8_t opcode_ = nil_code;
+  detail::rfc6455::opcode_type opcode_ = detail::rfc6455::opcode_type::nil_code;
 
   /// Assembles fragmented payloads.
   binary_buffer payload_buf_;

--- a/libcaf_net/tests/legacy/net/web_socket/framing.cpp
+++ b/libcaf_net/tests/legacy/net/web_socket/framing.cpp
@@ -215,7 +215,7 @@ SCENARIO("ping messages may not be fragmented") {
                                       data, ping_frame, 0);
       transport->push(ping_frame);
       THEN("the server aborts the application") {
-        CHECK_EQ(transport->handle_input(), 2);
+        CHECK_EQ(transport->handle_input(), 0);
         CHECK(app->has_aborted());
         CHECK_EQ(app->abort_reason, sec::protocol_error);
         MESSAGE("Aborted with: " << app->abort_reason);
@@ -689,7 +689,7 @@ SCENARIO("the application shuts down on invalid frame fragments") {
         detail::rfc6455::opcode_type::continuation_frame, 0x0, data, input);
       transport->push(input);
       THEN("the app closes the connection with a protocol error") {
-        CHECK_EQ(transport->handle_input(), 2);
+        CHECK_EQ(transport->handle_input(), 0);
         CHECK_EQ(app->abort_reason, sec::protocol_error);
       }
     }
@@ -701,7 +701,7 @@ SCENARIO("the application shuts down on invalid frame fragments") {
         detail::rfc6455::opcode_type::continuation_frame, 0x0, data, input, 0);
       transport->push(input);
       THEN("the app closes the connection with a protocol error") {
-        CHECK_EQ(transport->handle_input(), 2);
+        CHECK_EQ(transport->handle_input(), 0);
         CHECK_EQ(app->abort_reason, sec::protocol_error);
       }
     }
@@ -718,7 +718,7 @@ SCENARIO("the application shuts down on invalid frame fragments") {
       }
       AND("the app closes the connection after the second frame") {
         transport->push(input);
-        CHECK_EQ(transport->handle_input(), 2);
+        CHECK_EQ(transport->handle_input(), 0);
         CHECK_EQ(app->abort_reason, sec::protocol_error);
       }
     }
@@ -738,7 +738,7 @@ SCENARIO("the application shuts down on invalid frame fragments") {
         detail::rfc6455::assemble_frame(
           detail::rfc6455::opcode_type::binary_frame, 0x0, data, input);
         transport->push(input);
-        CHECK_EQ(transport->handle_input(), 2);
+        CHECK_EQ(transport->handle_input(), 0);
         CHECK_EQ(app->abort_reason, sec::protocol_error);
       }
     }

--- a/libcaf_net/tests/legacy/net/web_socket/framing.cpp
+++ b/libcaf_net/tests/legacy/net/web_socket/framing.cpp
@@ -71,14 +71,14 @@ SCENARIO("the client sends a ping and receives a pong response") {
     std::vector<std::byte> pong_frame;
     WHEN("the client sends a ping with no data") {
       auto data = make_test_data(0);
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::ping, 0x0,
-                                      data, ping_frame);
+      detail::rfc6455::assemble_frame(detail::rfc6455::ping_frame, 0x0, data,
+                                      ping_frame);
       transport->push(ping_frame);
       CHECK_EQ(transport->handle_input(),
                static_cast<ptrdiff_t>(ping_frame.size()));
       THEN("the server responds with an empty pong") {
-        detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::pong, 0x0,
-                                        data, pong_frame);
+        detail::rfc6455::assemble_frame(detail::rfc6455::pong_frame, 0x0, data,
+                                        pong_frame);
         CHECK_EQ(transport->output_buffer(), pong_frame);
       }
       AND("the client did not abort") {
@@ -88,14 +88,14 @@ SCENARIO("the client sends a ping and receives a pong response") {
     transport->output_buffer().clear();
     WHEN("the client sends a ping with some data") {
       auto data = make_test_data(40);
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::ping, 0x0,
-                                      data, ping_frame);
+      detail::rfc6455::assemble_frame(detail::rfc6455::ping_frame, 0x0, data,
+                                      ping_frame);
       transport->push(ping_frame);
       CHECK_EQ(transport->handle_input(),
                static_cast<ptrdiff_t>(ping_frame.size()));
       THEN("the server echoes the data back to the client") {
-        detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::pong, 0x0,
-                                        data, pong_frame);
+        detail::rfc6455::assemble_frame(detail::rfc6455::pong_frame, 0x0, data,
+                                        pong_frame);
         CHECK_EQ(transport->output_buffer(), pong_frame);
       }
       AND("the client did not abort") {
@@ -105,14 +105,14 @@ SCENARIO("the client sends a ping and receives a pong response") {
     transport->output_buffer().clear();
     WHEN("the client sends a ping with the maximum allowed 125 bytes") {
       auto data = make_test_data(125);
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::ping, 0x0,
-                                      data, ping_frame);
+      detail::rfc6455::assemble_frame(detail::rfc6455::ping_frame, 0x0, data,
+                                      ping_frame);
       transport->push(ping_frame);
       CHECK_EQ(transport->handle_input(),
                static_cast<ptrdiff_t>(ping_frame.size()));
       THEN("the server echoes the data back to the client") {
-        detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::pong, 0x0,
-                                        data, pong_frame);
+        detail::rfc6455::assemble_frame(detail::rfc6455::pong_frame, 0x0, data,
+                                        pong_frame);
         CHECK_EQ(transport->output_buffer(), pong_frame);
       }
       AND("the client did not abort") {
@@ -126,7 +126,7 @@ TEST_CASE("calling shutdown with protocol_error sets status in close header") {
   uut->shutdown(make_error(sec::protocol_error));
   detail::rfc6455::header hdr;
   detail::rfc6455::decode_header(transport->output_buffer(), hdr);
-  CHECK_EQ(hdr.opcode, detail::rfc6455::opcode_type::connection_close);
+  CHECK_EQ(hdr.opcode, detail::rfc6455::connection_close_frame);
   CHECK(hdr.payload_len >= 2);
   CHECK_EQ(fetch_status(transport->output_buffer()),
            static_cast<int>(net::web_socket::status::protocol_error));
@@ -138,8 +138,8 @@ SCENARIO("the client sends an invalid ping that closes the connection") {
     std::vector<std::byte> ping_frame;
     WHEN("the client sends a ping with more data than allowed") {
       auto data = make_test_data(126);
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::ping, 0x0,
-                                      data, ping_frame);
+      detail::rfc6455::assemble_frame(detail::rfc6455::ping_frame, 0x0, data,
+                                      ping_frame);
       transport->push(ping_frame);
       THEN("the server aborts the application") {
         CHECK_EQ(transport->handle_input(), 0);
@@ -151,7 +151,7 @@ SCENARIO("the client sends an invalid ping that closes the connection") {
         detail::rfc6455::header hdr;
         detail::rfc6455::decode_header(transport->output_buffer(), hdr);
         MESSAGE("Buffer: " << transport->output_buffer());
-        CHECK_EQ(hdr.opcode, detail::rfc6455::opcode_type::connection_close);
+        CHECK_EQ(hdr.opcode, detail::rfc6455::connection_close_frame);
         CHECK(hdr.payload_len >= 2);
         CHECK_EQ(fetch_status(transport->output_buffer()),
                  static_cast<int>(net::web_socket::status::protocol_error));
@@ -164,9 +164,8 @@ SCENARIO("the client closes the connection with a closing handshake") {
   GIVEN("a valid WebSocket connection") {
     WHEN("the client sends a closing handshake") {
       std::vector<std::byte> handshake;
-      detail::rfc6455::assemble_frame(
-        detail::rfc6455::opcode_type::connection_close, 0x0, make_test_data(0),
-        handshake);
+      detail::rfc6455::assemble_frame(detail::rfc6455::connection_close_frame,
+                                      0x0, make_test_data(0), handshake);
       transport->push(handshake);
     }
     THEN("the server closes the connection after sending a close frame") {
@@ -177,7 +176,7 @@ SCENARIO("the client closes the connection with a closing handshake") {
       CHECK(app->has_aborted());
       CHECK_EQ(app->abort_reason, sec::connection_closed);
       CHECK_EQ(hdr_length, 2);
-      CHECK_EQ(hdr.opcode, detail::rfc6455::opcode_type::connection_close);
+      CHECK_EQ(hdr.opcode, detail::rfc6455::connection_close_frame);
       CHECK(hdr.fin);
       CHECK(hdr.payload_len >= 2);
       CHECK_EQ(fetch_status(transport->output_buffer()),
@@ -188,9 +187,8 @@ SCENARIO("the client closes the connection with a closing handshake") {
       std::vector<std::byte> handshake;
       // invalid status code
       auto payload = make_closing_payload(1016, ""sv);
-      detail::rfc6455::assemble_frame(
-        detail::rfc6455::opcode_type::connection_close, 0x0, payload,
-        handshake);
+      detail::rfc6455::assemble_frame(detail::rfc6455::connection_close_frame,
+                                      0x0, payload, handshake);
       transport->push(handshake);
     }
     THEN("the server closes the connection with protocol error") {
@@ -198,7 +196,7 @@ SCENARIO("the client closes the connection with a closing handshake") {
       detail::rfc6455::header hdr;
       detail::rfc6455::decode_header(transport->output_buffer(), hdr);
       CHECK_EQ(app->abort_reason, sec::protocol_error);
-      CHECK_EQ(hdr.opcode, detail::rfc6455::opcode_type::connection_close);
+      CHECK_EQ(hdr.opcode, detail::rfc6455::connection_close_frame);
       CHECK(hdr.fin);
       CHECK_EQ(fetch_status(transport->output_buffer()),
                static_cast<int>(net::web_socket::status::protocol_error));
@@ -211,8 +209,8 @@ SCENARIO("ping messages may not be fragmented") {
     std::vector<std::byte> ping_frame;
     WHEN("the client sends the first frame of a fragmented ping message") {
       auto data = make_test_data(10);
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::ping, 0x0,
-                                      data, ping_frame, 0);
+      detail::rfc6455::assemble_frame(detail::rfc6455::ping_frame, 0x0, data,
+                                      ping_frame, 0);
       transport->push(ping_frame);
       THEN("the server aborts the application") {
         CHECK_EQ(transport->handle_input(), 0);
@@ -224,7 +222,7 @@ SCENARIO("ping messages may not be fragmented") {
         detail::rfc6455::header hdr;
         detail::rfc6455::decode_header(transport->output_buffer(), hdr);
         MESSAGE("Buffer: " << transport->output_buffer());
-        CHECK_EQ(hdr.opcode, detail::rfc6455::opcode_type::connection_close);
+        CHECK_EQ(hdr.opcode, detail::rfc6455::connection_close_frame);
         CHECK(hdr.payload_len >= 2);
         CHECK_EQ(fetch_status(transport->output_buffer()),
                  static_cast<int>(net::web_socket::status::protocol_error));
@@ -240,17 +238,17 @@ SCENARIO("ping messages may arrive between message fragments") {
       auto fragment1 = "Hello"sv;
       auto fragment2 = ", world!"sv;
       auto data = as_bytes(make_span(fragment1));
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::text_frame,
-                                      0x0, data, input, 0);
+      detail::rfc6455::assemble_frame(detail::rfc6455::text_frame, 0x0, data,
+                                      input, 0);
       transport->push(input);
       input.clear();
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::ping, 0x0,
-                                      data, input);
+      detail::rfc6455::assemble_frame(detail::rfc6455::ping_frame, 0x0, data,
+                                      input);
       transport->push(input);
       input.clear();
       data = as_bytes(make_span(fragment2));
-      detail::rfc6455::assemble_frame(
-        detail::rfc6455::opcode_type::continuation_frame, 0x0, data, input);
+      detail::rfc6455::assemble_frame(detail::rfc6455::continuation_frame, 0x0,
+                                      data, input);
       transport->push(input);
       transport->handle_input();
       THEN("the server responds with a pong") {
@@ -260,7 +258,7 @@ SCENARIO("ping messages may arrive between message fragments") {
         MESSAGE("Payload: " << transport->output_buffer());
         CHECK_EQ(hdr_len, 2u);
         CHECK(hdr.fin);
-        CHECK_EQ(hdr.opcode, detail::rfc6455::opcode_type::pong);
+        CHECK_EQ(hdr.opcode, detail::rfc6455::pong_frame);
         CHECK_EQ(hdr.payload_len, 5u);
         CHECK_EQ(hdr.mask_key, 0u);
       }
@@ -277,8 +275,8 @@ SCENARIO("ping messages may arrive between message fragments") {
       auto fragment2 = ", world!"sv;
       std::vector<std::byte> input;
       auto data = as_bytes(make_span(fragment1));
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::text_frame,
-                                      0x0, data, input, 0);
+      detail::rfc6455::assemble_frame(detail::rfc6455::text_frame, 0x0, data,
+                                      input, 0);
       transport->push(input);
       transport->handle_input();
       THEN("the server receives nothing") {
@@ -286,8 +284,8 @@ SCENARIO("ping messages may arrive between message fragments") {
         CHECK(app->binary_input.empty());
       }
       input.clear();
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::ping, 0x0,
-                                      data, input);
+      detail::rfc6455::assemble_frame(detail::rfc6455::ping_frame, 0x0, data,
+                                      input);
       transport->push(input);
       transport->handle_input();
       THEN("the server responds with a pong") {
@@ -296,14 +294,14 @@ SCENARIO("ping messages may arrive between message fragments") {
           = detail::rfc6455::decode_header(transport->output_buffer(), hdr);
         CHECK_EQ(hdr_len, 2u);
         CHECK(hdr.fin);
-        CHECK_EQ(hdr.opcode, detail::rfc6455::opcode_type::pong);
+        CHECK_EQ(hdr.opcode, detail::rfc6455::pong_frame);
         CHECK_EQ(hdr.payload_len, 5u);
         CHECK_EQ(hdr.mask_key, 0u);
       }
       input.clear();
       data = as_bytes(make_span(fragment2));
-      detail::rfc6455::assemble_frame(
-        detail::rfc6455::opcode_type::continuation_frame, 0x0, data, input);
+      detail::rfc6455::assemble_frame(detail::rfc6455::continuation_frame, 0x0,
+                                      data, input);
       transport->push(input);
       transport->handle_input();
       THEN("the server receives the full text message") {
@@ -328,8 +326,8 @@ SCENARIO("the application shuts down on invalid UTF-8 message") {
     WHEN("the client sends the whole message as a single frame") {
       reset();
       byte_buffer frame;
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::text_frame,
-                                      0x0, data_span, frame);
+      detail::rfc6455::assemble_frame(detail::rfc6455::text_frame, 0x0,
+                                      data_span, frame);
       transport->push(frame);
       THEN("the server aborts the application") {
         CHECK_EQ(transport->handle_input(), 2);
@@ -342,8 +340,8 @@ SCENARIO("the application shuts down on invalid UTF-8 message") {
     WHEN("the client sends a message ending with a incomplete codepoint") {
       reset();
       byte_buffer frame;
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::text_frame,
-                                      0x0, data_span.first(6), frame);
+      detail::rfc6455::assemble_frame(detail::rfc6455::text_frame, 0x0,
+                                      data_span.first(6), frame);
       transport->push(frame);
       THEN("the server aborts the application") {
         CHECK_EQ(transport->handle_input(), 2);
@@ -356,8 +354,8 @@ SCENARIO("the application shuts down on invalid UTF-8 message") {
     WHEN("the client sends the first part of the message") {
       reset();
       byte_buffer frame;
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::text_frame,
-                                      0x0, data_span.subspan(0, 11), frame, 0);
+      detail::rfc6455::assemble_frame(detail::rfc6455::text_frame, 0x0,
+                                      data_span.subspan(0, 11), frame, 0);
       transport->push(frame);
       THEN("the connection did not abort") {
         CHECK_EQ(transport->handle_input(),
@@ -367,9 +365,8 @@ SCENARIO("the application shuts down on invalid UTF-8 message") {
     }
     AND_WHEN("the client sends the second frame containing invalid data") {
       byte_buffer frame;
-      detail::rfc6455::assemble_frame(
-        detail::rfc6455::opcode_type::continuation_frame, 0x0,
-        data_span.subspan(11), frame);
+      detail::rfc6455::assemble_frame(detail::rfc6455::continuation_frame, 0x0,
+                                      data_span.subspan(11), frame);
       transport->push(frame);
       THEN("the server aborts the application") {
         CHECK_EQ(transport->handle_input(), 2);
@@ -382,15 +379,14 @@ SCENARIO("the application shuts down on invalid UTF-8 message") {
     WHEN("the client sends the invalid byte on a frame boundary") {
       reset();
       byte_buffer frame;
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::text_frame,
-                                      0x0, data_span.subspan(0, 12), frame, 0);
+      detail::rfc6455::assemble_frame(detail::rfc6455::text_frame, 0x0,
+                                      data_span.subspan(0, 12), frame, 0);
       transport->push(frame);
       CHECK_EQ(transport->handle_input(), static_cast<ptrdiff_t>(frame.size()));
       CHECK(!app->has_aborted());
       frame.clear();
-      detail::rfc6455::assemble_frame(
-        detail::rfc6455::opcode_type::continuation_frame, 0x0,
-        data_span.subspan(12, 1), frame, 0);
+      detail::rfc6455::assemble_frame(detail::rfc6455::continuation_frame, 0x0,
+                                      data_span.subspan(12, 1), frame, 0);
       transport->push(frame);
       THEN("the server aborts the application") {
         CHECK_EQ(transport->handle_input(), 2);
@@ -404,8 +400,8 @@ SCENARIO("the application shuts down on invalid UTF-8 message") {
       reset();
       byte_buffer frame;
       detail::rfc6455::mask_data(0xDEADC0DE, data);
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::text_frame,
-                                      0xDEADC0DE, data_span, frame, 0);
+      detail::rfc6455::assemble_frame(detail::rfc6455::text_frame, 0xDEADC0DE,
+                                      data_span, frame, 0);
       // Incomplete header bytes.
       for (auto i = 0; i < 5; i++) {
         transport->push(make_span(frame).subspan(i, 1));
@@ -434,9 +430,8 @@ SCENARIO("the application shuts down on invalid UTF-8 message") {
       WHEN("the client sends the first frame of a text messagee") {
         reset();
         byte_buffer frame;
-        detail::rfc6455::assemble_frame(
-          detail::rfc6455::opcode_type::text_frame, 0xDEADC0DE,
-          data_span.subspan(0, 8), frame, 0);
+        detail::rfc6455::assemble_frame(detail::rfc6455::text_frame, 0xDEADC0DE,
+                                        data_span.subspan(0, 8), frame, 0);
         transport->push(frame);
         CHECK_EQ(transport->handle_input(),
                  static_cast<ptrdiff_t>(frame.size()));
@@ -444,9 +439,9 @@ SCENARIO("the application shuts down on invalid UTF-8 message") {
       }
       AND_WHEN("sending the invalid continuation frame byte by byte") {
         byte_buffer frame;
-        detail::rfc6455::assemble_frame(
-          detail::rfc6455::opcode_type::continuation_frame, 0xDEADC0DE,
-          data_span.subspan(8), frame);
+        detail::rfc6455::assemble_frame(detail::rfc6455::continuation_frame,
+                                        0xDEADC0DE, data_span.subspan(8),
+                                        frame);
         // Incomplete header bytes.
         for (auto i = 0; i < 5; i++) {
           transport->push(make_span(frame).subspan(i, 1));
@@ -483,15 +478,15 @@ SCENARIO("Send a payload in chucks exceeding the default receive policy") {
       reset();
       byte_buffer frame;
       const auto data = make_test_data(4096);
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::text_frame,
-                                      0x0, data, frame, 0);
+      detail::rfc6455::assemble_frame(detail::rfc6455::text_frame, 0x0, data,
+                                      frame, 0);
       transport->push(frame);
       CHECK_EQ(transport->handle_input(), static_cast<ptrdiff_t>(frame.size()));
       CHECK(!app->abort_reason);
       CHECK(app->text_input.empty());
       frame.clear();
-      detail::rfc6455::assemble_frame(
-        detail::rfc6455::opcode_type::continuation_frame, 0x0, data, frame, 0);
+      detail::rfc6455::assemble_frame(detail::rfc6455::continuation_frame, 0x0,
+                                      data, frame, 0);
       transport->push(frame);
       CHECK_EQ(transport->handle_input(), static_cast<ptrdiff_t>(frame.size()));
       CHECK(!app->abort_reason);
@@ -501,8 +496,8 @@ SCENARIO("Send a payload in chucks exceeding the default receive policy") {
       CHECK(!app->abort_reason);
       CHECK(app->text_input.empty());
       frame.clear();
-      detail::rfc6455::assemble_frame(
-        detail::rfc6455::opcode_type::continuation_frame, 0x0, data, frame);
+      detail::rfc6455::assemble_frame(detail::rfc6455::continuation_frame, 0x0,
+                                      data, frame);
       transport->push(frame);
       CHECK_EQ(transport->handle_input(), static_cast<ptrdiff_t>(frame.size()));
       CHECK(!app->abort_reason);
@@ -570,11 +565,11 @@ SCENARIO("apps can return errors to shut down the framing layer") {
         byte_buffer frame1;
         byte_buffer frame2;
         const auto data = make_test_data(4);
-        detail::rfc6455::assemble_frame(
-          detail::rfc6455::opcode_type::binary_frame, 0x0, data, frame1, 0);
+        detail::rfc6455::assemble_frame(detail::rfc6455::binary_frame, 0x0,
+                                        data, frame1, 0);
         transport->push(frame1);
-        detail::rfc6455::assemble_frame(
-          detail::rfc6455::opcode_type::continuation_frame, 0x0, data, frame2);
+        detail::rfc6455::assemble_frame(detail::rfc6455::continuation_frame,
+                                        0x0, data, frame2);
         transport->push(frame2);
         // We only handle the first frame and the header of the second frame.
         // The protocol aborts on the second frame payload.
@@ -600,13 +595,11 @@ SCENARIO("apps can return errors to shut down the framing layer") {
         byte_buffer frame1;
         byte_buffer frame2;
         const auto msg = "Hello, world!"sv;
-        detail::rfc6455::assemble_frame(
-          detail::rfc6455::opcode_type::text_frame, 0x0,
-          as_bytes(make_span(msg)), frame1, 0);
+        detail::rfc6455::assemble_frame(detail::rfc6455::text_frame, 0x0,
+                                        as_bytes(make_span(msg)), frame1, 0);
         transport->push(frame1);
-        detail::rfc6455::assemble_frame(
-          detail::rfc6455::opcode_type::continuation_frame, 0x0,
-          as_bytes(make_span(msg)), frame2);
+        detail::rfc6455::assemble_frame(detail::rfc6455::continuation_frame,
+                                        0x0, as_bytes(make_span(msg)), frame2);
         transport->push(frame2);
         CHECK_EQ(transport->handle_input(),
                  static_cast<ptrdiff_t>(frame1.size() + 2));
@@ -622,8 +615,8 @@ SCENARIO("the application receives a pong") {
       reset();
       byte_buffer input;
       const auto data = make_test_data(10);
-      detail::rfc6455::assemble_frame(detail::rfc6455::opcode_type::pong, 0x0,
-                                      data, input);
+      detail::rfc6455::assemble_frame(detail::rfc6455::pong_frame, 0x0, data,
+                                      input);
       transport->push(input);
       THEN("the application handles the frame without actual input") {
         CHECK_EQ(transport->handle_input(),
@@ -659,8 +652,8 @@ SCENARIO("apps reject frames whose payload exceeds maximum allowed size") {
       reset();
       byte_buffer frame;
       auto data = make_test_data(256);
-      detail::rfc6455::assemble_frame(
-        detail::rfc6455::opcode_type::binary_frame, 0x0, data, frame, 0);
+      detail::rfc6455::assemble_frame(detail::rfc6455::binary_frame, 0x0, data,
+                                      frame, 0);
       transport->push(frame);
       CHECK_EQ(transport->handle_input(), static_cast<ptrdiff_t>(frame.size()));
       frame.clear();
@@ -685,8 +678,8 @@ SCENARIO("the application shuts down on invalid frame fragments") {
       reset();
       byte_buffer input;
       const auto data = make_test_data(10);
-      detail::rfc6455::assemble_frame(
-        detail::rfc6455::opcode_type::continuation_frame, 0x0, data, input);
+      detail::rfc6455::assemble_frame(detail::rfc6455::continuation_frame, 0x0,
+                                      data, input);
       transport->push(input);
       THEN("the app closes the connection with a protocol error") {
         CHECK_EQ(transport->handle_input(), 0);
@@ -697,8 +690,8 @@ SCENARIO("the application shuts down on invalid frame fragments") {
       reset();
       byte_buffer input;
       const auto data = make_test_data(10);
-      detail::rfc6455::assemble_frame(
-        detail::rfc6455::opcode_type::continuation_frame, 0x0, data, input, 0);
+      detail::rfc6455::assemble_frame(detail::rfc6455::continuation_frame, 0x0,
+                                      data, input, 0);
       transport->push(input);
       THEN("the app closes the connection with a protocol error") {
         CHECK_EQ(transport->handle_input(), 0);
@@ -709,8 +702,8 @@ SCENARIO("the application shuts down on invalid frame fragments") {
       reset();
       byte_buffer input;
       const auto data = make_test_data(10);
-      detail::rfc6455::assemble_frame(
-        detail::rfc6455::opcode_type::binary_frame, 0x0, data, input, 0);
+      detail::rfc6455::assemble_frame(detail::rfc6455::binary_frame, 0x0, data,
+                                      input, 0);
       THEN("the app accepts the first frame") {
         transport->push(input);
         CHECK_EQ(transport->handle_input(),
@@ -726,8 +719,8 @@ SCENARIO("the application shuts down on invalid frame fragments") {
       reset();
       byte_buffer input;
       const auto data = make_test_data(10);
-      detail::rfc6455::assemble_frame(
-        detail::rfc6455::opcode_type::binary_frame, 0x0, data, input, 0);
+      detail::rfc6455::assemble_frame(detail::rfc6455::binary_frame, 0x0, data,
+                                      input, 0);
       THEN("the app accepts the first frame") {
         transport->push(input);
         CHECK_EQ(transport->handle_input(),
@@ -735,8 +728,8 @@ SCENARIO("the application shuts down on invalid frame fragments") {
       }
       AND("the app closes the connection after the second frame") {
         input.clear();
-        detail::rfc6455::assemble_frame(
-          detail::rfc6455::opcode_type::binary_frame, 0x0, data, input);
+        detail::rfc6455::assemble_frame(detail::rfc6455::binary_frame, 0x0,
+                                        data, input);
         transport->push(input);
         CHECK_EQ(transport->handle_input(), 0);
         CHECK_EQ(app->abort_reason, sec::protocol_error);

--- a/libcaf_net/tests/legacy/net/web_socket/server.cpp
+++ b/libcaf_net/tests/legacy/net/web_socket/server.cpp
@@ -185,12 +185,7 @@ TEST_CASE("data may arrive fragmented") {
   rfc6455_append(detail::rfc6455::continuation_frame, "Socket!\n"sv, buf);
   transport->push(buf);
   CHECK_EQ(transport->handle_input(), static_cast<ptrdiff_t>(buf.size()));
-  auto expected = "Hello WebSocket!\nBye WebSocket!\n"sv;
-  CHECK_EQ(app->text_input.size(), expected.size());
-  for (auto i = 0ul; i < expected.size(); i++) {
-    CHECK_EQ(app->text_input.at(i), expected.at(i));
-  }
-  MESSAGE(app->text_input);
+  CHECK_EQ(app->text_input, "Hello WebSocket!\nBye WebSocket!\n");
   CHECK(!app->has_aborted());
 }
 

--- a/libcaf_net/tests/legacy/net/web_socket/server.cpp
+++ b/libcaf_net/tests/legacy/net/web_socket/server.cpp
@@ -185,7 +185,12 @@ TEST_CASE("data may arrive fragmented") {
   rfc6455_append(detail::rfc6455::continuation_frame, "Socket!\n"sv, buf);
   transport->push(buf);
   CHECK_EQ(transport->handle_input(), static_cast<ptrdiff_t>(buf.size()));
-  CHECK_EQ(app->text_input, "Hello WebSocket!\nBye WebSocket!\n");
+  auto expected = "Hello WebSocket!\nBye WebSocket!\n"sv;
+  CHECK_EQ(app->text_input.size(), expected.size());
+  for (auto i = 0ul; i < expected.size(); i++) {
+    CHECK_EQ(app->text_input.at(i), expected.at(i));
+  }
+  MESSAGE(app->text_input);
   CHECK(!app->has_aborted());
 }
 

--- a/libcaf_net/tests/legacy/net/web_socket/server.cpp
+++ b/libcaf_net/tests/legacy/net/web_socket/server.cpp
@@ -33,8 +33,7 @@ struct fixture {
     rng.seed(0xD3ADC0D3);
   }
 
-  void rfc6455_append(detail::rfc6455::opcode_type opcode,
-                      const_byte_span bytes, byte_buffer& out,
+  void rfc6455_append(uint8_t opcode, const_byte_span bytes, byte_buffer& out,
                       uint8_t flags = detail::rfc6455::fin_flag) {
     byte_buffer payload{bytes.begin(), bytes.end()};
     auto key = static_cast<uint32_t>(rng());
@@ -42,33 +41,31 @@ struct fixture {
     detail::rfc6455::assemble_frame(opcode, key, payload, out, flags);
   }
 
-  void rfc6455_append(detail::rfc6455::opcode_type opcode,
-                      std::string_view text, byte_buffer& out,
+  void rfc6455_append(uint8_t opcode, std::string_view text, byte_buffer& out,
                       uint8_t flags = detail::rfc6455::fin_flag) {
     rfc6455_append(opcode, as_bytes(make_span(text)), out, flags);
   }
 
   void rfc6455_append(const_byte_span bytes, byte_buffer& out) {
-    rfc6455_append(detail::rfc6455::opcode_type::binary_frame, bytes, out);
+    rfc6455_append(detail::rfc6455::binary_frame, bytes, out);
   }
 
   void rfc6455_append(std::string_view text, byte_buffer& out) {
-    rfc6455_append(detail::rfc6455::opcode_type::text_frame,
-                   as_bytes(make_span(text)), out);
+    rfc6455_append(detail::rfc6455::text_frame, as_bytes(make_span(text)), out);
   }
 
-  void push(detail::rfc6455::opcode_type opcode, const_byte_span bytes) {
+  void push(uint8_t opcode, const_byte_span bytes) {
     byte_buffer frame;
     rfc6455_append(opcode, bytes, frame);
     transport->push(frame);
   }
 
   void push(const_byte_span bytes) {
-    push(detail::rfc6455::opcode_type::binary_frame, bytes);
+    push(detail::rfc6455::binary_frame, bytes);
   }
 
   void push(std::string_view str) {
-    push(detail::rfc6455::opcode_type::text_frame, as_bytes(make_span(str)));
+    push(detail::rfc6455::text_frame, as_bytes(make_span(str)));
   }
 
   std::unique_ptr<mock_stream_transport> transport;
@@ -181,14 +178,11 @@ TEST_CASE("data may arrive fragmented") {
   CHECK_EQ(transport->handle_input(),
            static_cast<ptrdiff_t>(opening_handshake.size()));
   byte_buffer buf;
-  rfc6455_append(detail::rfc6455::opcode_type::text_frame, "Hello "sv, buf, 0);
-  rfc6455_append(detail::rfc6455::opcode_type::continuation_frame,
-                 "WebSocket!\n"sv, buf);
-  rfc6455_append(detail::rfc6455::opcode_type::text_frame, "Bye "sv, buf, 0);
-  rfc6455_append(detail::rfc6455::opcode_type::continuation_frame, "Web"sv, buf,
-                 0);
-  rfc6455_append(detail::rfc6455::opcode_type::continuation_frame,
-                 "Socket!\n"sv, buf);
+  rfc6455_append(detail::rfc6455::text_frame, "Hello "sv, buf, 0);
+  rfc6455_append(detail::rfc6455::continuation_frame, "WebSocket!\n"sv, buf);
+  rfc6455_append(detail::rfc6455::text_frame, "Bye "sv, buf, 0);
+  rfc6455_append(detail::rfc6455::continuation_frame, "Web"sv, buf, 0);
+  rfc6455_append(detail::rfc6455::continuation_frame, "Socket!\n"sv, buf);
   transport->push(buf);
   CHECK_EQ(transport->handle_input(), static_cast<ptrdiff_t>(buf.size()));
   CHECK_EQ(app->text_input, "Hello WebSocket!\nBye WebSocket!\n");


### PR DESCRIPTION
Relates #1394 
With this the last two tests pass (they where passing non strictly before).

Take into account that with this we get multiple calls from the transport layer to the web_socket layer, even when we can know that the whole frame didn't arrive. This means that for a text message, on every call we:
- decode the header, check for malformed header 
- unmask the data, make the data owned (we need to either own the data or to mask it back up), 
- combine it with existing unvalidated bytes in case of an continuation frame (in which case we do need to own our data), 
- validate the utf-8.
Not my proudest peace of work. The mentioned overhead could be avoided at the cost of introducing additional state and complicating to the framing layer.

@Neverlord It's your call. I might even suggest we leave the 2 tests as non-strictly passing and fail on the end of the frame. I can't think of any security risk if we wait a little longer to fail. However I do want to have a big green dot saying fully autobahn compliant :smile:  