### PR TITLE
Refactor remaining calls to $pred<>::value

### DIFF
--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -261,7 +261,7 @@ public:
   using mpi = std::set<std::string>;
 
   template <class T,
-            class E = typename std::enable_if<!is_typed_actor<T>::value>::type>
+            class E = typename std::enable_if<!is_typed_actor_v<T>>::type>
   mpi message_types(detail::type_list<T>) const {
     return mpi{};
   }
@@ -274,8 +274,7 @@ public:
   }
 
   template <class T,
-            class E
-            = typename std::enable_if<!detail::is_type_list<T>::value>::type>
+            class E = typename std::enable_if<!detail::is_type_list_v<T>>::type>
   mpi message_types(const T&) const {
     detail::type_list<T> token;
     return message_types(token);

--- a/libcaf_core/caf/actor_traits.hpp
+++ b/libcaf_core/caf/actor_traits.hpp
@@ -14,6 +14,10 @@ namespace caf::mixin {
 template <class T>
 struct is_blocking_requester : std::false_type {};
 
+/// Convenience alias for `is_blocking_requester<T>::value`.
+template <class T>
+inline constexpr bool is_blocking_requester_v = is_blocking_requester<T>::value;
+
 } // namespace caf::mixin
 
 namespace caf {
@@ -68,7 +72,7 @@ struct default_actor_traits<T, true> {
 
   /// Denotes whether `T` is a blocking actor type.
   static constexpr bool is_blocking = std::is_base_of_v<blocking_actor_base, T>
-                                      || mixin::is_blocking_requester<T>::value;
+                                      || mixin::is_blocking_requester_v<T>;
 
   /// Denotes whether `T` is a non-blocking actor type.
   static constexpr bool is_non_blocking

--- a/libcaf_core/caf/config_value.cpp
+++ b/libcaf_core/caf/config_value.cpp
@@ -34,9 +34,9 @@ template <class To, class From>
 auto no_conversion() {
   return [](const From&) {
     std::string msg = "cannot convert ";
-    msg += type_names[detail::tl_index_of<config_value::types, From>::value];
+    msg += type_names[detail::tl_index_of_v<config_value::types, From>];
     msg += " to ";
-    msg += type_names[detail::tl_index_of<config_value::types, To>::value];
+    msg += type_names[detail::tl_index_of_v<config_value::types, To>];
     auto err = make_error(sec::conversion_failed, std::move(msg));
     return expected<To>{std::move(err)};
   };

--- a/libcaf_core/caf/config_value.hpp
+++ b/libcaf_core/caf/config_value.hpp
@@ -59,7 +59,7 @@ CAF_ADD_CONFIG_VALUE_TYPE(dictionary<config_value>);
 #undef CAF_ADD_CONFIG_VALUE_TYPE
 
 template <class T>
-constexpr bool is_config_value_type_v = is_config_value_type<T>::value;
+inline constexpr bool is_config_value_type_v = is_config_value_type<T>::value;
 
 } // namespace caf::detail
 
@@ -252,7 +252,7 @@ public:
   template <class T>
   static constexpr std::string_view mapped_type_name() {
     if constexpr (detail::is_complete<caf::type_name<T>>) {
-      return caf::type_name<T>::value;
+      return caf::type_name_v<T>;
     } else if constexpr (detail::is_list_like_v<T>) {
       return "list";
     } else {
@@ -295,7 +295,7 @@ private:
     } else if constexpr (std::is_convertible<T, const char*>::value) {
       data_ = std::string{x};
     } else {
-      static_assert(detail::is_iterable<T>::value);
+      static_assert(detail::is_iterable_v<T>);
       using value_type = typename T::value_type;
       detail::bool_token<detail::is_pair_v<value_type>> is_map_type;
       set_range(x, is_map_type);

--- a/libcaf_core/caf/config_value_reader.cpp
+++ b/libcaf_core/caf/config_value_reader.cpp
@@ -31,7 +31,7 @@ PRETTY_NAME(caf::config_value_reader::sequence, "sequence");
 PRETTY_NAME(caf::config_value_reader::associative_array, "associative array");
 
 template <class T>
-constexpr auto pretty_name_v = pretty_name<T>::value;
+inline constexpr auto pretty_name_v = pretty_name<T>::value;
 
 auto get_pretty_name(const caf::config_value_reader::value_type& x) {
   const char* pretty_names[] = {

--- a/libcaf_core/caf/detail/type_list.hpp
+++ b/libcaf_core/caf/detail/type_list.hpp
@@ -356,9 +356,9 @@ struct tl_exists<empty_type_list, Pred> {
   static constexpr bool value = false;
 };
 
-// Uncomment after having switched to C++14
-// template <class List, template <class> class Pred>
-// inline constexpr bool tl_exists_v = tl_exists<List, Pred>::value;
+/// Convenience alias for `tl_exists<List, Pred>::value`.
+template <class List, template <class> class Pred>
+inline constexpr bool tl_exists_v = tl_exists<List, Pred>::value;
 
 // size_t count(predicate)
 
@@ -925,9 +925,9 @@ template <class T, class... Ts, class X>
 struct tl_contains<type_list<T, Ts...>, X> : tl_contains<type_list<Ts...>, X> {
 };
 
-// Uncomment after having switched to C++14
-// template <class List, class X>
-// inline constexpr bool tl_contains_v = tl_contains<List, X>::value;
+/// Convenience alias for `tl_contains<List, X>::value`.
+template <class List, class X>
+inline constexpr bool tl_contains_v = tl_contains<List, X>::value;
 
 // subset_of(list, list)
 
@@ -944,17 +944,16 @@ template <class T, class... Ts, class List>
 struct tl_subset_of<type_list<T, Ts...>, List>
   : tl_subset_of<type_list<Ts...>, List, tl_contains<List, T>::value> {};
 
-// Uncomment after having switched to C++14
-// template <class ListA, class ListB, bool Fwd = true>
-// inline constexpr bool tl_subset_of_v = tl_subset_of<ListA, ListB,
-// Fwd>::value;
+/// Convenience alias for `tl_contains<List, X>::value`.
+template <class ListA, class ListB, bool Fwd = true>
+inline constexpr bool tl_subset_of_v = tl_subset_of<ListA, ListB, Fwd>::value;
 
 /// Tests whether ListA contains the same elements as ListB
 /// and vice versa. This comparison ignores element positions.
 template <class ListA, class ListB>
 struct tl_equal {
-  static constexpr bool value = tl_subset_of<ListA, ListB>::value
-                                && tl_subset_of<ListB, ListA>::value;
+  static constexpr bool value = tl_subset_of_v<ListA, ListB>
+                                && tl_subset_of_v<ListB, ListA>;
 };
 
 // Uncomment after having switched to C++14

--- a/libcaf_core/caf/detail/type_traits.hpp
+++ b/libcaf_core/caf/detail/type_traits.hpp
@@ -840,6 +840,11 @@ public:
   static constexpr bool value = sfinae_type::value;
 };
 
+/// Convenience alias for `has_convertible_data_member<T, To>::value`.
+template <class T, class To>
+inline constexpr bool has_convertible_data_member_v
+  = has_convertible_data_member<T, To>::value;
+
 template <class T, class Arg>
 struct can_apply {
   template <class U>
@@ -908,6 +913,11 @@ public:
   static constexpr bool value = result_type::value;
 };
 
+/// Convenience alias for `has_inspect_overload<Inspector, T>::value`.
+template <class Inspector, class T>
+inline constexpr bool has_inspect_overload_v
+  = has_inspect_overload<Inspector, T>::value;
+
 /// Checks whether the inspector has a `builtin_inspect` overload for `T`.
 template <class Inspector, class T>
 class has_builtin_inspect {
@@ -925,6 +935,11 @@ private:
 public:
   static constexpr bool value = sfinae_result::value;
 };
+
+/// Convenience alias for `has_builtin_inspect<Inspector, T>::value`.
+template <class Inspector, class T>
+inline constexpr bool has_builtin_inspect_v
+  = has_builtin_inspect<Inspector, T>::value;
 
 /// Checks whether inspectors are required to provide a `value` overload for T.
 template <bool IsLoading, class T>

--- a/libcaf_core/caf/inspector_access_type.hpp
+++ b/libcaf_core/caf/inspector_access_type.hpp
@@ -61,11 +61,11 @@ constexpr auto inspect_access_type() {
   else if constexpr (detail::is_builtin_inspector_type<
                        T, Inspector::is_loading>::value)
     return inspector_access_type::builtin{};
-  else if constexpr (has_builtin_inspect<Inspector, T>::value)
+  else if constexpr (has_builtin_inspect_v<Inspector, T>)
     return inspector_access_type::builtin_inspect{};
   else if constexpr (detail::is_complete<inspector_access<T>>)
     return inspector_access_type::specialization{};
-  else if constexpr (has_inspect_overload<Inspector, T>::value)
+  else if constexpr (has_inspect_overload_v<Inspector, T>)
     return inspector_access_type::inspect{};
   else if constexpr (std::is_empty<T>::value)
     return inspector_access_type::empty{};

--- a/libcaf_core/caf/is_typed_actor.hpp
+++ b/libcaf_core/caf/is_typed_actor.hpp
@@ -17,4 +17,8 @@ struct is_typed_actor : std::false_type {};
 template <class... Ts>
 struct is_typed_actor<typed_actor<Ts...>> : std::true_type {};
 
+/// Convenience alias for `is_typed_actor<T>::value`.
+template <class T>
+inline constexpr bool is_typed_actor_v = is_typed_actor<T>::value;
+
 } // namespace caf

--- a/libcaf_core/caf/response_promise.hpp
+++ b/libcaf_core/caf/response_promise.hpp
@@ -100,9 +100,9 @@ public:
   template <class... Ts>
   void deliver(Ts... xs) {
     using arg_types = detail::type_list<Ts...>;
-    static_assert(!detail::tl_exists<arg_types, detail::is_result>::value,
+    static_assert(!detail::tl_exists_v<arg_types, detail::is_result>,
                   "delivering a result<T> is not supported");
-    static_assert(!detail::tl_exists<arg_types, detail::is_expected>::value,
+    static_assert(!detail::tl_exists_v<arg_types, detail::is_expected>,
                   "mixing expected<T> with regular values is not supported");
     if (pending()) {
       state_->deliver_impl(make_message(std::move(xs)...));

--- a/libcaf_core/caf/span.hpp
+++ b/libcaf_core/caf/span.hpp
@@ -64,16 +64,14 @@ public:
     // nop
   }
 
-  template <class C,
-            class = std::enable_if_t<
-              detail::has_convertible_data_member<C, value_type>::value>>
+  template <class C, class = std::enable_if_t<
+                       detail::has_convertible_data_member_v<C, value_type>>>
   span(C& xs) noexcept : begin_(xs.data()), size_(xs.size()) {
     // nop
   }
 
-  template <class C,
-            class = std::enable_if_t<
-              detail::has_convertible_data_member<C, value_type>::value>>
+  template <class C, class = std::enable_if_t<
+                       detail::has_convertible_data_member_v<C, value_type>>>
   span(const C& xs) noexcept : begin_(xs.data()), size_(xs.size()) {
     // nop
   }

--- a/libcaf_core/caf/typed_behavior.hpp
+++ b/libcaf_core/caf/typed_behavior.hpp
@@ -103,12 +103,16 @@ struct valid_input {
                                      adjusted_slist>::template inner>::value;
 };
 
+/// Convenience alias for `valid_input<SList, IList>::value`.
+template <class SList, class IList>
+inline constexpr bool valid_input_v = valid_input<SList, IList>::value;
+
 // this function is called from typed_behavior<...>::set and its whole
 // purpose is to give users a nicer error message on a type mismatch
 // (this function only has the type information needed to understand the error)
 template <class SignatureList, class InputList>
 void static_check_typed_behavior_input() {
-  constexpr bool is_valid = valid_input<SignatureList, InputList>::value;
+  constexpr bool is_valid = valid_input_v<SignatureList, InputList>;
   // note: it might be worth considering to allow a wildcard in the
   //     InputList if its return type is identical to all "missing"
   //     input types ... however, it might lead to unexpected results

--- a/libcaf_core/tests/legacy/metaprogramming.cpp
+++ b/libcaf_core/tests/legacy/metaprogramming.cpp
@@ -54,10 +54,10 @@ CAF_TEST(metaprogramming) {
   /* test tl_subset_of */ {
     using list_a = type_list<int, float, double>;
     using list_b = type_list<float, int, double, std::string>;
-    CHECK((tl_subset_of<list_a, list_b>::value));
-    CHECK(!(tl_subset_of<list_b, list_a>::value));
-    CHECK((tl_subset_of<list_a, list_a>::value));
-    CHECK((tl_subset_of<list_b, list_b>::value));
+    CHECK((tl_subset_of_v<list_a, list_b>) );
+    CHECK(!(tl_subset_of_v<list_b, list_a>) );
+    CHECK((tl_subset_of_v<list_a, list_a>) );
+    CHECK((tl_subset_of_v<list_b, list_b>) );
   }
 }
 


### PR DESCRIPTION
Relates https://github.com/actor-framework/actor-framework/issues/1446

This PR should refactor all of the remaining calls to $pred<>::value and add necessary aliases for all of the class