### PR TITLE
Implement requirement_failed exception

### DIFF
--- a/libcaf_test/CMakeLists.txt
+++ b/libcaf_test/CMakeLists.txt
@@ -30,6 +30,7 @@ caf_add_component(
     caf/test/nesting_error.cpp
     caf/test/registry.cpp
     caf/test/reporter.cpp
+    caf/test/requirement_error.cpp
     caf/test/runnable.cpp
     caf/test/runner.cpp
     caf/test/scenario.cpp

--- a/libcaf_test/caf/test/requirement_error.cpp
+++ b/libcaf_test/caf/test/requirement_error.cpp
@@ -1,0 +1,31 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/test/requirement_error.hpp"
+
+#include "caf/detail/format.hpp"
+
+namespace caf::test {
+
+std::string requirement_error::message() const {
+  switch (code_) {
+    case code::failed:
+      return detail::format("requirement failed at {}:{}", loc_.file_name(),
+                            static_cast<int>(loc_.line()));
+  }
+}
+
+[[noreturn]] void
+requirement_error::raise_impl(requirement_error::code what,
+                              const detail::source_location& loc) {
+#ifdef CAF_ENABLE_EXCEPTIONS
+  throw requirement_error{what, loc};
+#else
+  auto msg = nesting_error{what, parent, child, loc}.message();
+  fprintf(stderr, "[FATAL] critical error: %s\n", msg.c_str());
+  abort();
+#endif
+}
+
+} // namespace caf::test

--- a/libcaf_test/caf/test/requirement_error.cpp
+++ b/libcaf_test/caf/test/requirement_error.cpp
@@ -10,7 +10,7 @@ namespace caf::test {
 
 std::string requirement_error::message() const {
   return detail::format("requirement failed at {}:{}", loc_.file_name(),
-                        static_cast<int>(loc_.line()));
+                        loc_.line());
 }
 
 [[noreturn]] void

--- a/libcaf_test/caf/test/requirement_error.cpp
+++ b/libcaf_test/caf/test/requirement_error.cpp
@@ -13,6 +13,9 @@ std::string requirement_error::message() const {
     case code::failed:
       return detail::format("requirement failed at {}:{}", loc_.file_name(),
                             static_cast<int>(loc_.line()));
+    default:
+      return detail::format("requirement error at {}:{}", loc_.file_name(),
+                            static_cast<int>(loc_.line()));
   }
 }
 
@@ -22,7 +25,7 @@ requirement_error::raise_impl(requirement_error::code what,
 #ifdef CAF_ENABLE_EXCEPTIONS
   throw requirement_error{what, loc};
 #else
-  auto msg = nesting_error{what, parent, child, loc}.message();
+  auto msg = requirement_error{what, loc}.message();
   fprintf(stderr, "[FATAL] critical error: %s\n", msg.c_str());
   abort();
 #endif

--- a/libcaf_test/caf/test/requirement_error.cpp
+++ b/libcaf_test/caf/test/requirement_error.cpp
@@ -9,23 +9,16 @@
 namespace caf::test {
 
 std::string requirement_error::message() const {
-  switch (code_) {
-    case code::failed:
-      return detail::format("requirement failed at {}:{}", loc_.file_name(),
-                            static_cast<int>(loc_.line()));
-    default:
-      return detail::format("requirement error at {}:{}", loc_.file_name(),
-                            static_cast<int>(loc_.line()));
-  }
+  return detail::format("requirement failed at {}:{}", loc_.file_name(),
+                        static_cast<int>(loc_.line()));
 }
 
 [[noreturn]] void
-requirement_error::raise_impl(requirement_error::code what,
-                              const detail::source_location& loc) {
+requirement_error::raise_impl(const detail::source_location& loc) {
 #ifdef CAF_ENABLE_EXCEPTIONS
-  throw requirement_error{what, loc};
+  throw requirement_error{loc};
 #else
-  auto msg = requirement_error{what, loc}.message();
+  auto msg = requirement_error{loc}.message();
   fprintf(stderr, "[FATAL] critical error: %s\n", msg.c_str());
   abort();
 #endif

--- a/libcaf_test/caf/test/requirement_error.hpp
+++ b/libcaf_test/caf/test/requirement_error.hpp
@@ -1,0 +1,55 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/detail/source_location.hpp"
+#include "caf/detail/test_export.hpp"
+
+#include <string>
+
+namespace caf::test {
+
+/// Thrown when a requirement check fails. When `CAF_ENABLE_EXCEPTIONS` is off,
+/// the `raise` functions terminate the program instead.
+class CAF_TEST_EXPORT requirement_error {
+public:
+  constexpr requirement_error(const requirement_error&) noexcept = default;
+
+  constexpr requirement_error& operator=(const requirement_error&) noexcept
+    = default;
+
+  /// Returns a human-readable error message.
+  std::string message() const;
+
+  /// Returns the source location of the error.
+  constexpr const detail::source_location& location() const noexcept {
+    return loc_;
+  }
+
+  /// Throws a `requirement_error` to indicate that requirement check failed.
+  [[noreturn]] static void raise_failed(const detail::source_location& loc
+                                        = detail::source_location::current()) {
+    raise_impl(code::failed, loc);
+  }
+
+private:
+  enum class code {
+    failed,
+  };
+
+  constexpr requirement_error(code what,
+                              const detail::source_location& loc) noexcept
+    : code_(what), loc_(loc) {
+    // nop
+  }
+
+  [[noreturn]] static void raise_impl(code what,
+                                      const detail::source_location& loc);
+
+  code code_;
+  detail::source_location loc_;
+};
+
+} // namespace caf::test

--- a/libcaf_test/caf/test/requirement_error.hpp
+++ b/libcaf_test/caf/test/requirement_error.hpp
@@ -35,7 +35,8 @@ public:
   }
 
 private:
-  constexpr requirement_error(const detail::source_location& loc) noexcept
+  constexpr explicit requirement_error(
+    const detail::source_location& loc) noexcept
     : loc_(loc) {
     // nop
   }

--- a/libcaf_test/caf/test/requirement_error.hpp
+++ b/libcaf_test/caf/test/requirement_error.hpp
@@ -29,26 +29,19 @@ public:
   }
 
   /// Throws a `requirement_error` to indicate that requirement check failed.
-  [[noreturn]] static void raise_failed(const detail::source_location& loc
-                                        = detail::source_location::current()) {
-    raise_impl(code::failed, loc);
+  [[noreturn]] static void raise(const detail::source_location& loc
+                                 = detail::source_location::current()) {
+    raise_impl(loc);
   }
 
 private:
-  enum class code {
-    failed,
-  };
-
-  constexpr requirement_error(code what,
-                              const detail::source_location& loc) noexcept
-    : code_(what), loc_(loc) {
+  constexpr requirement_error(const detail::source_location& loc) noexcept
+    : loc_(loc) {
     // nop
   }
 
-  [[noreturn]] static void raise_impl(code what,
-                                      const detail::source_location& loc);
+  [[noreturn]] static void raise_impl(const detail::source_location& loc);
 
-  code code_;
   detail::source_location loc_;
 };
 

--- a/libcaf_test/caf/test/runnable.cpp
+++ b/libcaf_test/caf/test/runnable.cpp
@@ -24,19 +24,6 @@ runnable::~runnable() {
   // nop
 }
 
-#ifdef CAF_ENABLE_EXCEPTIONS
-
-requirement_failed::requirement_failed(std::string msg)
-  : what_(std::move(msg)) {
-  // nop
-}
-
-const char* requirement_failed::what() const noexcept {
-  return what_.c_str();
-}
-
-#endif // CAF_ENABLE_EXCEPTIONS
-
 void runnable::run() {
   current_runnable = this;
   auto guard = detail::make_scope_guard([] { current_runnable = nullptr; });

--- a/libcaf_test/caf/test/runnable.cpp
+++ b/libcaf_test/caf/test/runnable.cpp
@@ -24,6 +24,19 @@ runnable::~runnable() {
   // nop
 }
 
+#ifdef CAF_ENABLE_EXCEPTIONS
+
+requirement_failed::requirement_failed(std::string msg)
+  : what_(std::move(msg)) {
+  // nop
+}
+
+const char* requirement_failed::what() const noexcept {
+  return what_.c_str();
+}
+
+#endif // CAF_ENABLE_EXCEPTIONS
+
 void runnable::run() {
   current_runnable = this;
   auto guard = detail::make_scope_guard([] { current_runnable = nullptr; });

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -54,7 +54,7 @@ public:
     } else {
       reporter::instance().fail(fwl.value, fwl.location);
     }
-    requirement_error::raise_failed(fwl.location);
+    requirement_error::raise(fwl.location);
   }
 
   /// Generates a message with the INFO severity level.

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -8,6 +8,7 @@
 #include "caf/test/block_type.hpp"
 #include "caf/test/fwd.hpp"
 #include "caf/test/reporter.hpp"
+#include "caf/test/requirement_error.hpp"
 
 #include "caf/config.hpp"
 #include "caf/deep_to_string.hpp"
@@ -20,20 +21,6 @@
 #include <string_view>
 
 namespace caf::test {
-
-#ifdef CAF_ENABLE_EXCEPTIONS
-
-class requirement_failed : public std::exception {
-public:
-  requirement_failed(std::string msg);
-
-  const char* what() const noexcept override;
-
-private:
-  std::string what_;
-};
-
-#endif // CAF_ENABLE_EXCEPTIONS
 
 /// A runnable definition of a test case or scenario.
 class CAF_TEST_EXPORT runnable {
@@ -67,7 +54,7 @@ public:
     } else {
       reporter::instance().fail(fwl.value, fwl.location);
     }
-    CAF_RAISE_ERROR(requirement_failed, "requirement failed: abort test");
+    requirement_error::raise_failed(fwl.location);
   }
 
   /// Generates a message with the INFO severity level.

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -21,6 +21,20 @@
 
 namespace caf::test {
 
+#ifdef CAF_ENABLE_EXCEPTIONS
+
+class requirement_failed : public std::exception {
+public:
+  requirement_failed(std::string msg);
+
+  const char* what() const noexcept override;
+
+private:
+  std::string what_;
+};
+
+#endif // CAF_ENABLE_EXCEPTIONS
+
 /// A runnable definition of a test case or scenario.
 class CAF_TEST_EXPORT runnable {
 public:
@@ -53,7 +67,7 @@ public:
     } else {
       reporter::instance().fail(fwl.value, fwl.location);
     }
-    CAF_RAISE_ERROR(std::logic_error, "requirement failed: abort test");
+    CAF_RAISE_ERROR(requirement_failed, "requirement failed: abort test");
   }
 
   /// Generates a message with the INFO severity level.

--- a/libcaf_test/caf/test/runner.cpp
+++ b/libcaf_test/caf/test/runner.cpp
@@ -170,6 +170,8 @@ int runner::run(int argc, char** argv) {
       } catch (const nesting_error& ex) {
         default_reporter->unhandled_exception(ex.message(), ex.location());
         default_reporter->end_test();
+      } catch (const requirement_error& ex) {
+        default_reporter->end_test();
       } catch (const std::exception& ex) {
         default_reporter->unhandled_exception(ex.what());
         default_reporter->end_test();


### PR DESCRIPTION
Relates https://github.com/actor-framework/actor-framework/issues/1479

The fail function has been implemented in https://github.com/actor-framework/actor-framework/pull/1518 but the proper `requirement_failed` error was not raised. Proper error has been added here.

@Neverlord I think that the error can be added in a different file `libcaf_test/caf/test/errors.hpp`. I would like your opinion on this. Furthermore, I have not called fail() from the tests as I think the tests will be covered in the next PR when requirement_predicates are implemented.