### PR TITLE
Add require function for all predicates

### DIFF
--- a/libcaf_test/CMakeLists.txt
+++ b/libcaf_test/CMakeLists.txt
@@ -30,7 +30,7 @@ caf_add_component(
     caf/test/nesting_error.cpp
     caf/test/registry.cpp
     caf/test/reporter.cpp
-    caf/test/requirement_error.cpp
+    caf/test/requirement_failed.cpp
     caf/test/runnable.cpp
     caf/test/runner.cpp
     caf/test/scenario.cpp

--- a/libcaf_test/caf/test/reporter.cpp
+++ b/libcaf_test/caf/test/reporter.cpp
@@ -386,6 +386,21 @@ public:
               ' ', indent_, location.file_name(), location.line(), msg);
   }
 
+  void info(binary_predicate type, std::string_view lhs, std::string_view rhs,
+            const detail::source_location& location) override {
+    using detail::format_to;
+    if (level_ < CAF_LOG_LEVEL_ERROR)
+      return;
+    set_live();
+    format_to(colored(),
+              "{0:{1}}$R(error): lhs {2} rhs\n"
+              "{0:{1}}  loc: $C({3}):$Y({4})$0\n"
+              "{0:{1}}  lhs: {5}\n"
+              "{0:{1}}  rhs: {6}\n",
+              ' ', indent_, str(negate(type)), location.file_name(),
+              location.line(), lhs, rhs);
+  }
+
   unsigned verbosity(unsigned level) override {
     auto result = level_;
     level_ = level;

--- a/libcaf_test/caf/test/reporter.cpp
+++ b/libcaf_test/caf/test/reporter.cpp
@@ -386,19 +386,17 @@ public:
               ' ', indent_, location.file_name(), location.line(), msg);
   }
 
-  void info(binary_predicate type, std::string_view lhs, std::string_view rhs,
-            const detail::source_location& location) override {
+  void print_error(std::string_view msg,
+                   const detail::source_location& location) override {
     using detail::format_to;
     if (level_ < CAF_LOG_LEVEL_ERROR)
       return;
     set_live();
     format_to(colored(),
-              "{0:{1}}$R(error): lhs {2} rhs\n"
-              "{0:{1}}  loc: $C({3}):$Y({4})$0\n"
-              "{0:{1}}  lhs: {5}\n"
-              "{0:{1}}  rhs: {6}\n",
-              ' ', indent_, str(negate(type)), location.file_name(),
-              location.line(), lhs, rhs);
+              "{0:{1}}$R(error):\n"
+              "{0:{1}}  loc: $C({2}):$Y({3})$0\n"
+              "{0:{1}}  msg: {4}\n",
+              ' ', indent_, location.file_name(), location.line(), msg);
   }
 
   unsigned verbosity(unsigned level) override {

--- a/libcaf_test/caf/test/reporter.hpp
+++ b/libcaf_test/caf/test/reporter.hpp
@@ -75,6 +75,11 @@ public:
   info(std::string_view msg, const detail::source_location& location)
     = 0;
 
+  virtual void info(binary_predicate type, std::string_view lhs,
+                    std::string_view rhs,
+                    const detail::source_location& location)
+    = 0;
+
   /// Sets the verbosity level of the reporter and returns the previous value.
   virtual unsigned verbosity(unsigned level) = 0;
 

--- a/libcaf_test/caf/test/reporter.hpp
+++ b/libcaf_test/caf/test/reporter.hpp
@@ -75,9 +75,8 @@ public:
   info(std::string_view msg, const detail::source_location& location)
     = 0;
 
-  virtual void info(binary_predicate type, std::string_view lhs,
-                    std::string_view rhs,
-                    const detail::source_location& location)
+  virtual void
+  print_error(std::string_view msg, const detail::source_location& location)
     = 0;
 
   /// Sets the verbosity level of the reporter and returns the previous value.

--- a/libcaf_test/caf/test/requirement_failed.cpp
+++ b/libcaf_test/caf/test/requirement_failed.cpp
@@ -2,23 +2,23 @@
 // the main distribution directory for license terms and copyright or visit
 // https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
 
-#include "caf/test/requirement_error.hpp"
+#include "caf/test/requirement_failed.hpp"
 
 #include "caf/detail/format.hpp"
 
 namespace caf::test {
 
-std::string requirement_error::message() const {
+std::string requirement_failed::message() const {
   return detail::format("requirement failed at {}:{}", loc_.file_name(),
                         loc_.line());
 }
 
 [[noreturn]] void
-requirement_error::raise_impl(const detail::source_location& loc) {
+requirement_failed::raise_impl(const detail::source_location& loc) {
 #ifdef CAF_ENABLE_EXCEPTIONS
-  throw requirement_error{loc};
+  throw requirement_failed{loc};
 #else
-  auto msg = requirement_error{loc}.message();
+  auto msg = requirement_failed{loc}.message();
   fprintf(stderr, "[FATAL] critical error: %s\n", msg.c_str());
   abort();
 #endif

--- a/libcaf_test/caf/test/requirement_failed.cpp
+++ b/libcaf_test/caf/test/requirement_failed.cpp
@@ -9,8 +9,7 @@
 namespace caf::test {
 
 std::string requirement_failed::message() const {
-  return detail::format("requirement failed at {}:{}", loc_.file_name(),
-                        loc_.line());
+  return detail::format("requirement failed\n");
 }
 
 [[noreturn]] void

--- a/libcaf_test/caf/test/requirement_failed.hpp
+++ b/libcaf_test/caf/test/requirement_failed.hpp
@@ -13,11 +13,11 @@ namespace caf::test {
 
 /// Thrown when a requirement check fails. When `CAF_ENABLE_EXCEPTIONS` is off,
 /// the `raise` functions terminate the program instead.
-class CAF_TEST_EXPORT requirement_error {
+class CAF_TEST_EXPORT requirement_failed {
 public:
-  constexpr requirement_error(const requirement_error&) noexcept = default;
+  constexpr requirement_failed(const requirement_failed&) noexcept = default;
 
-  constexpr requirement_error& operator=(const requirement_error&) noexcept
+  constexpr requirement_failed& operator=(const requirement_failed&) noexcept
     = default;
 
   /// Returns a human-readable error message.
@@ -28,14 +28,14 @@ public:
     return loc_;
   }
 
-  /// Throws a `requirement_error` to indicate that requirement check failed.
+  /// Throws a `requirement_failed` to indicate that requirement check failed.
   [[noreturn]] static void raise(const detail::source_location& loc
                                  = detail::source_location::current()) {
     raise_impl(loc);
   }
 
 private:
-  constexpr explicit requirement_error(
+  constexpr explicit requirement_failed(
     const detail::source_location& loc) noexcept
     : loc_(loc) {
     // nop

--- a/libcaf_test/caf/test/runnable.cpp
+++ b/libcaf_test/caf/test/runnable.cpp
@@ -59,12 +59,8 @@ bool runnable::check(bool value, const detail::source_location& location) {
 }
 
 void runnable::require(bool value, const detail::source_location& location) {
-  if (value) {
-    reporter::instance().pass(location);
-  } else {
-    reporter::instance().info("should be true", location);
-    fail({"requirement failed", location});
-  }
+  if (!check(value, location))
+    requirement_failed::raise(location);
 }
 
 runnable& runnable::current() {

--- a/libcaf_test/caf/test/runnable.cpp
+++ b/libcaf_test/caf/test/runnable.cpp
@@ -58,6 +58,15 @@ bool runnable::check(bool value, const detail::source_location& location) {
   return value;
 }
 
+void runnable::require(bool value, const detail::source_location& location) {
+  if (value) {
+    reporter::instance().pass(location);
+  } else {
+    reporter::instance().info("should be true", location);
+    fail({"requirement failed", location});
+  }
+}
+
 runnable& runnable::current() {
   auto ptr = current_runnable;
   if (!ptr)

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -8,7 +8,7 @@
 #include "caf/test/block_type.hpp"
 #include "caf/test/fwd.hpp"
 #include "caf/test/reporter.hpp"
-#include "caf/test/requirement_error.hpp"
+#include "caf/test/requirement_failed.hpp"
 
 #include "caf/config.hpp"
 #include "caf/deep_to_string.hpp"
@@ -54,7 +54,7 @@ public:
     } else {
       reporter::instance().fail(fwl.value, fwl.location);
     }
-    requirement_error::raise(fwl.location);
+    requirement_failed::raise(fwl.location);
   }
 
   /// Generates a message with the INFO severity level.

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -162,6 +162,101 @@ public:
   bool check(bool value, const detail::source_location& location
                          = detail::source_location::current());
 
+  /// Evaluates whether `lhs` and `rhs` are equal and fails otherwise.
+  template <class T0, class T1>
+  void require_eq(const T0& lhs, const T1& rhs,
+                  const detail::source_location& location
+                  = detail::source_location::current()) {
+    assert_save_comparison<T0, T1>();
+    if (lhs == rhs) {
+      reporter::instance().pass(location);
+      return;
+    }
+    reporter::instance().info(binary_predicate::eq, stringify(lhs),
+                              stringify(rhs), location);
+    fail({"requirement failed", location});
+  }
+
+  /// Evaluates whether `lhs` and `rhs` are unequal and fails otherwise.
+  template <class T0, class T1>
+  void require_ne(const T0& lhs, const T1& rhs,
+                  const detail::source_location& location
+                  = detail::source_location::current()) {
+    assert_save_comparison<T0, T1>();
+    if (lhs != rhs) {
+      reporter::instance().pass(location);
+      return;
+    }
+    reporter::instance().info(binary_predicate::ne, stringify(lhs),
+                              stringify(rhs), location);
+    fail({"requirement failed", location});
+  }
+
+  /// Evaluates whether `lhs` is less than `rhs` and fails otherwise
+  template <class T0, class T1>
+  void require_lt(const T0& lhs, const T1& rhs,
+                  const detail::source_location& location
+                  = detail::source_location::current()) {
+    assert_save_comparison<T0, T1>();
+    if (lhs < rhs) {
+      reporter::instance().pass(location);
+      return;
+    }
+    reporter::instance().info(binary_predicate::lt, stringify(lhs),
+                              stringify(rhs), location);
+    fail({"requirement failed", location});
+  }
+
+  /// Evaluates whether `lhs` less than or equal to `rhs` and fails otherwise.
+  template <class T0, class T1>
+  void require_le(const T0& lhs, const T1& rhs,
+                  const detail::source_location& location
+                  = detail::source_location::current()) {
+    assert_save_comparison<T0, T1>();
+    if (lhs <= rhs) {
+      reporter::instance().pass(location);
+      return;
+    }
+    reporter::instance().info(binary_predicate::le, stringify(lhs),
+                              stringify(rhs), location);
+    fail({"requirement failed", location});
+  }
+
+  /// Evaluates whether `lhs` is greater than `rhs` and fails otherwise.
+  template <class T0, class T1>
+  void require_gt(const T0& lhs, const T1& rhs,
+                  const detail::source_location& location
+                  = detail::source_location::current()) {
+    assert_save_comparison<T0, T1>();
+    if (lhs > rhs) {
+      reporter::instance().pass(location);
+      return;
+    }
+    reporter::instance().info(binary_predicate::gt, stringify(lhs),
+                              stringify(rhs), location);
+    fail({"requirement failed", location});
+  }
+
+  /// Evaluates whether `lhs` greater than or equal to `rhs` and fails
+  /// otherwise.
+  template <class T0, class T1>
+  void require_ge(const T0& lhs, const T1& rhs,
+                  const detail::source_location& location
+                  = detail::source_location::current()) {
+    assert_save_comparison<T0, T1>();
+    if (lhs >= rhs) {
+      reporter::instance().pass(location);
+      return;
+    }
+    reporter::instance().info(binary_predicate::ge, stringify(lhs),
+                              stringify(rhs), location);
+    fail({"requirement failed", location});
+  }
+
+  /// Evaluates whether `value` is `true` and fails otherwise.
+  void require(bool value, const detail::source_location& location
+                           = detail::source_location::current());
+
   /// Returns the `runnable` instance that is currently running.
   static runnable& current();
 

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -167,14 +167,8 @@ public:
   void require_eq(const T0& lhs, const T1& rhs,
                   const detail::source_location& location
                   = detail::source_location::current()) {
-    assert_save_comparison<T0, T1>();
-    if (lhs == rhs) {
-      reporter::instance().pass(location);
-      return;
-    }
-    reporter::instance().info(binary_predicate::eq, stringify(lhs),
-                              stringify(rhs), location);
-    fail({"requirement failed", location});
+    if (!check_eq(lhs, rhs, location))
+      requirement_failed::raise(location);
   }
 
   /// Evaluates whether `lhs` and `rhs` are unequal and fails otherwise.
@@ -182,14 +176,8 @@ public:
   void require_ne(const T0& lhs, const T1& rhs,
                   const detail::source_location& location
                   = detail::source_location::current()) {
-    assert_save_comparison<T0, T1>();
-    if (lhs != rhs) {
-      reporter::instance().pass(location);
-      return;
-    }
-    reporter::instance().info(binary_predicate::ne, stringify(lhs),
-                              stringify(rhs), location);
-    fail({"requirement failed", location});
+    if (!check_ne(lhs, rhs, location))
+      requirement_failed::raise(location);
   }
 
   /// Evaluates whether `lhs` is less than `rhs` and fails otherwise
@@ -197,14 +185,8 @@ public:
   void require_lt(const T0& lhs, const T1& rhs,
                   const detail::source_location& location
                   = detail::source_location::current()) {
-    assert_save_comparison<T0, T1>();
-    if (lhs < rhs) {
-      reporter::instance().pass(location);
-      return;
-    }
-    reporter::instance().info(binary_predicate::lt, stringify(lhs),
-                              stringify(rhs), location);
-    fail({"requirement failed", location});
+    if (!check_lt(lhs, rhs, location))
+      requirement_failed::raise(location);
   }
 
   /// Evaluates whether `lhs` less than or equal to `rhs` and fails otherwise.
@@ -212,14 +194,8 @@ public:
   void require_le(const T0& lhs, const T1& rhs,
                   const detail::source_location& location
                   = detail::source_location::current()) {
-    assert_save_comparison<T0, T1>();
-    if (lhs <= rhs) {
-      reporter::instance().pass(location);
-      return;
-    }
-    reporter::instance().info(binary_predicate::le, stringify(lhs),
-                              stringify(rhs), location);
-    fail({"requirement failed", location});
+    if (!check_le(lhs, rhs, location))
+      requirement_failed::raise(location);
   }
 
   /// Evaluates whether `lhs` is greater than `rhs` and fails otherwise.
@@ -227,14 +203,8 @@ public:
   void require_gt(const T0& lhs, const T1& rhs,
                   const detail::source_location& location
                   = detail::source_location::current()) {
-    assert_save_comparison<T0, T1>();
-    if (lhs > rhs) {
-      reporter::instance().pass(location);
-      return;
-    }
-    reporter::instance().info(binary_predicate::gt, stringify(lhs),
-                              stringify(rhs), location);
-    fail({"requirement failed", location});
+    if (!check_gt(lhs, rhs, location))
+      requirement_failed::raise(location);
   }
 
   /// Evaluates whether `lhs` greater than or equal to `rhs` and fails
@@ -243,14 +213,8 @@ public:
   void require_ge(const T0& lhs, const T1& rhs,
                   const detail::source_location& location
                   = detail::source_location::current()) {
-    assert_save_comparison<T0, T1>();
-    if (lhs >= rhs) {
-      reporter::instance().pass(location);
-      return;
-    }
-    reporter::instance().info(binary_predicate::ge, stringify(lhs),
-                              stringify(rhs), location);
-    fail({"requirement failed", location});
+    if (!check_ge(lhs, rhs, location))
+      requirement_failed::raise(location);
   }
 
   /// Evaluates whether `value` is `true` and fails otherwise.

--- a/libcaf_test/caf/test/runner.cpp
+++ b/libcaf_test/caf/test/runner.cpp
@@ -170,7 +170,7 @@ int runner::run(int argc, char** argv) {
       } catch (const nesting_error& ex) {
         default_reporter->unhandled_exception(ex.message(), ex.location());
         default_reporter->end_test();
-      } catch (const requirement_error& ex) {
+      } catch (const requirement_failed& ex) {
         default_reporter->end_test();
       } catch (const std::exception& ex) {
         default_reporter->unhandled_exception(ex.what());

--- a/libcaf_test/caf/test/runner.cpp
+++ b/libcaf_test/caf/test/runner.cpp
@@ -171,6 +171,7 @@ int runner::run(int argc, char** argv) {
         default_reporter->unhandled_exception(ex.message(), ex.location());
         default_reporter->end_test();
       } catch (const requirement_failed& ex) {
+        default_reporter->print_error(ex.message(), ex.location());
         default_reporter->end_test();
       } catch (const std::exception& ex) {
         default_reporter->unhandled_exception(ex.what());

--- a/libcaf_test/caf/test/test.test.cpp
+++ b/libcaf_test/caf/test/test.test.cpp
@@ -41,6 +41,8 @@ TEST("tests can contain different types of checks") {
   info("this test had {} checks", rep.test_stats().total());
 }
 
+#ifdef CAF_ENABLE_EXCEPTIONS
+
 TEST("tests fail when requirement errors occur") {
   auto& rep = caf::test::reporter::instance();
   SECTION("require_eq fails when lhs != rhs") {
@@ -81,6 +83,8 @@ TEST("tests fail when requirement errors occur") {
   }
   info("this test had {} checks", rep.test_stats().total());
 }
+
+#endif // CAF_ENABLE_EXCEPTIONS
 
 TEST("failed checks increment the failed counter") {
   check_eq(1, 2);

--- a/libcaf_test/caf/test/test.test.cpp
+++ b/libcaf_test/caf/test/test.test.cpp
@@ -4,6 +4,7 @@
 #include "caf/test/test.hpp"
 
 #include "caf/test/caf_test_main.hpp"
+#include "caf/test/requirement_error.hpp"
 
 using caf::test::block_type;
 
@@ -36,6 +37,47 @@ TEST("tests can contain different types of checks") {
     check_lt(1, 2);
     should_fail([this]() { check_lt(1, 1); });
     should_fail([this]() { check_lt(2, 1); });
+  }
+  info("this test had {} checks", rep.test_stats().total());
+}
+
+TEST("tests fail when requirement errors occur") {
+  auto& rep = caf::test::reporter::instance();
+  SECTION("require_eq fails when lhs != rhs") {
+    should_fail_with_exception<caf::test::requirement_error>(
+      [this]() { require_eq(1, 2); });
+    require_eq(1, 1);
+  }
+  SECTION("require_ne fails when lhs == rhs") {
+    should_fail_with_exception<caf::test::requirement_error>(
+      [this]() { require_ne(1, 1); });
+    require_ne(1, 2);
+  }
+  SECTION("require_le fails when lhs > rhs") {
+    should_fail_with_exception<caf::test::requirement_error>(
+      [this]() { require_le(2, 1); });
+    require_le(1, 2);
+    require_le(2, 2);
+  }
+  SECTION("require_lt fails when lhs >= rhs") {
+    should_fail_with_exception<caf::test::requirement_error>(
+      [this]() { require_lt(2, 2); });
+    should_fail_with_exception<caf::test::requirement_error>(
+      [this]() { require_lt(2, 1); });
+    require_lt(1, 2);
+  }
+  SECTION("require_ge fails when lhs < rhs") {
+    should_fail_with_exception<caf::test::requirement_error>(
+      [this]() { require_ge(1, 2); });
+    require_ge(2, 1);
+    require_ge(2, 2);
+  }
+  SECTION("require_gt fails when lhs <= rhs") {
+    should_fail_with_exception<caf::test::requirement_error>(
+      [this]() { require_gt(1, 1); });
+    should_fail_with_exception<caf::test::requirement_error>(
+      [this]() { require_gt(1, 2); });
+    require_gt(2, 1);
   }
   info("this test had {} checks", rep.test_stats().total());
 }

--- a/libcaf_test/caf/test/test.test.cpp
+++ b/libcaf_test/caf/test/test.test.cpp
@@ -4,7 +4,7 @@
 #include "caf/test/test.hpp"
 
 #include "caf/test/caf_test_main.hpp"
-#include "caf/test/requirement_error.hpp"
+#include "caf/test/requirement_failed.hpp"
 
 using caf::test::block_type;
 
@@ -46,38 +46,38 @@ TEST("tests can contain different types of checks") {
 TEST("tests fail when requirement errors occur") {
   auto& rep = caf::test::reporter::instance();
   SECTION("require_eq fails when lhs != rhs") {
-    should_fail_with_exception<caf::test::requirement_error>(
+    should_fail_with_exception<caf::test::requirement_failed>(
       [this]() { require_eq(1, 2); });
     require_eq(1, 1);
   }
   SECTION("require_ne fails when lhs == rhs") {
-    should_fail_with_exception<caf::test::requirement_error>(
+    should_fail_with_exception<caf::test::requirement_failed>(
       [this]() { require_ne(1, 1); });
     require_ne(1, 2);
   }
   SECTION("require_le fails when lhs > rhs") {
-    should_fail_with_exception<caf::test::requirement_error>(
+    should_fail_with_exception<caf::test::requirement_failed>(
       [this]() { require_le(2, 1); });
     require_le(1, 2);
     require_le(2, 2);
   }
   SECTION("require_lt fails when lhs >= rhs") {
-    should_fail_with_exception<caf::test::requirement_error>(
+    should_fail_with_exception<caf::test::requirement_failed>(
       [this]() { require_lt(2, 2); });
-    should_fail_with_exception<caf::test::requirement_error>(
+    should_fail_with_exception<caf::test::requirement_failed>(
       [this]() { require_lt(2, 1); });
     require_lt(1, 2);
   }
   SECTION("require_ge fails when lhs < rhs") {
-    should_fail_with_exception<caf::test::requirement_error>(
+    should_fail_with_exception<caf::test::requirement_failed>(
       [this]() { require_ge(1, 2); });
     require_ge(2, 1);
     require_ge(2, 2);
   }
   SECTION("require_gt fails when lhs <= rhs") {
-    should_fail_with_exception<caf::test::requirement_error>(
+    should_fail_with_exception<caf::test::requirement_failed>(
       [this]() { require_gt(1, 1); });
-    should_fail_with_exception<caf::test::requirement_error>(
+    should_fail_with_exception<caf::test::requirement_failed>(
       [this]() { require_gt(1, 2); });
     require_gt(2, 1);
   }

--- a/libcaf_test/caf/test/test.test.cpp
+++ b/libcaf_test/caf/test/test.test.cpp
@@ -44,40 +44,41 @@ TEST("tests can contain different types of checks") {
 #ifdef CAF_ENABLE_EXCEPTIONS
 
 TEST("tests fail when requirement errors occur") {
+  using caf::test::requirement_failed;
   auto& rep = caf::test::reporter::instance();
   SECTION("require_eq fails when lhs != rhs") {
-    should_fail_with_exception<caf::test::requirement_failed>(
+    should_fail_with_exception<requirement_failed>(
       [this]() { require_eq(1, 2); });
     require_eq(1, 1);
   }
   SECTION("require_ne fails when lhs == rhs") {
-    should_fail_with_exception<caf::test::requirement_failed>(
+    should_fail_with_exception<requirement_failed>(
       [this]() { require_ne(1, 1); });
     require_ne(1, 2);
   }
   SECTION("require_le fails when lhs > rhs") {
-    should_fail_with_exception<caf::test::requirement_failed>(
+    should_fail_with_exception<requirement_failed>(
       [this]() { require_le(2, 1); });
     require_le(1, 2);
     require_le(2, 2);
   }
   SECTION("require_lt fails when lhs >= rhs") {
-    should_fail_with_exception<caf::test::requirement_failed>(
+    should_fail_with_exception<requirement_failed>(
       [this]() { require_lt(2, 2); });
-    should_fail_with_exception<caf::test::requirement_failed>(
+    should_fail_with_exception<requirement_failed>(
       [this]() { require_lt(2, 1); });
     require_lt(1, 2);
   }
   SECTION("require_ge fails when lhs < rhs") {
-    should_fail_with_exception<caf::test::requirement_failed>(
+    should_fail_with_exception<requirement_failed>(
       [this]() { require_ge(1, 2); });
     require_ge(2, 1);
     require_ge(2, 2);
   }
   SECTION("require_gt fails when lhs <= rhs") {
-    should_fail_with_exception<caf::test::requirement_failed>(
+    should_fail_with_exception<requirement_failed>(
       [this]() { require_gt(1, 1); });
-    should_fail_with_exception<caf::test::requirement_failed>(
+    should_fail_with_exception<requirement_failed>(
       [this]() { require_gt(1, 2); });
     require_gt(2, 1);
   }


### PR DESCRIPTION
Relates https://github.com/actor-framework/actor-framework/issues/1479

@Neverlord a new `info()` function was added to in `reporter.cpp` to show the information without failing the test, as `fail()` will fail the test anyways. An alternative will be a `fail()` function which can take appropriate parameters as input and pass them to the `reporter.fail()` function. Let me know your opinion on this.