### PR TITLE
Re-enable FixNamespaceComments in clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,7 +24,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 2
 Cpp11BracedListStyle: true
-FixNamespaceComments: false
+FixNamespaceComments: true
 IncludeBlocks: Regroup
 # Include order: Main header, CAF headers: test/io/openssl/net/core, 3rd-party
 # headers, standard headers.

--- a/libcaf_test/caf/test/fixture/deterministic.cpp
+++ b/libcaf_test/caf/test/fixture/deterministic.cpp
@@ -321,4 +321,4 @@ size_t deterministic::dispatch_messages() {
   return result;
 }
 
-} // namespace caf::test
+} // namespace caf::test::fixture

--- a/libcaf_test/caf/test/fixture/deterministic.hpp
+++ b/libcaf_test/caf/test/fixture/deterministic.hpp
@@ -440,4 +440,4 @@ private:
   mailbox_element_ptr pop_msg_impl(scheduled_actor* receiver);
 };
 
-} // namespace caf::test
+} // namespace caf::test::fixture


### PR DESCRIPTION
We've ended up disabling this option, because it raised errors in the pipeline with the `SUITE` macro. However, we've ended up not using the suites anyway.