### PR TITLE
Add print for debug, warning and trace severities

### DIFF
--- a/libcaf_core/caf/detail/ring_buffer.test.cpp
+++ b/libcaf_core/caf/detail/ring_buffer.test.cpp
@@ -19,14 +19,14 @@ int pop(ring_buffer<int>& buf) {
 
 TEST("push_back adds element") {
   ring_buffer<int> buf{3};
-  print_info("full capacity of ring buffer");
+  print_debug("full capacity of ring buffer");
   for (int i = 1; i <= 3; ++i) {
     buf.push_back(i);
   }
   check_eq(buf.full(), true);
   check_eq(buf.empty(), false);
   check_eq(buf.front(), 1);
-  print_info("additional element after full capacity");
+  print_debug("additional element after full capacity");
   buf.push_back(4);
   check_eq(buf.full(), true);
   check_eq(buf.empty(), false);
@@ -43,14 +43,14 @@ TEST("push_back adds element") {
 
 TEST("pop_front removes the oldest element") {
   ring_buffer<int> buf{3};
-  print_info("full capacity of ring buffer");
+  print_debug("full capacity of ring buffer");
   for (int i = 1; i <= 3; ++i) {
     buf.push_back(i);
   }
   check_eq(buf.full(), true);
   check_eq(buf.empty(), false);
   check_eq(buf.front(), 1);
-  print_info("remove element from buffer");
+  print_debug("remove element from buffer");
   buf.pop_front();
   check_eq(buf.full(), false);
   check_eq(buf.empty(), false);
@@ -65,14 +65,14 @@ TEST("pop_front removes the oldest element") {
 
 TEST("circular buffer overwrites oldest element after it is full") {
   ring_buffer<int> buf{5};
-  print_info("full capacity of ring buffer");
+  print_debug("full capacity of ring buffer");
   for (int i = 1; i <= 5; ++i) {
     buf.push_back(i);
   }
   check_eq(buf.full(), true);
   check_eq(buf.empty(), false);
   check_eq(buf.front(), 1);
-  print_info("add some elements into buffer");
+  print_debug("add some elements into buffer");
   buf.push_back(6);
   buf.push_back(7);
   check_eq(buf.full(), true);
@@ -90,14 +90,14 @@ TEST("circular buffer overwrites oldest element after it is full") {
 
 TEST("pop_front removes the oldest element from the buffer") {
   ring_buffer<int> buf{5};
-  print_info("full capacity of ring buffer");
+  print_debug("full capacity of ring buffer");
   for (int i = 1; i <= 5; ++i) {
     buf.push_back(i);
   }
   check_eq(buf.full(), true);
   check_eq(buf.empty(), false);
   check_eq(buf.front(), 1);
-  print_info("remove some element from buffer");
+  print_debug("remove some element from buffer");
   buf.pop_front();
   check_eq(buf.full(), false);
   check_eq(buf.empty(), false);
@@ -105,7 +105,7 @@ TEST("pop_front removes the oldest element from the buffer") {
   buf.pop_front();
   check_eq(buf.full(), false);
   check_eq(buf.front(), 3);
-  print_info("add some elements into buffer");
+  print_debug("add some elements into buffer");
   buf.push_back(6);
   buf.push_back(7);
   check_eq(buf.full(), true);
@@ -123,29 +123,29 @@ TEST("pop_front removes the oldest element from the buffer") {
 
 TEST("push_back does nothing for ring buffer with a capacity of 0") {
   ring_buffer<int> buf{0};
-  print_info("empty buffer is initialized");
+  print_debug("empty buffer is initialized");
   check_eq(buf.size(), 0u);
   for (int i = 1; i <= 3; ++i) {
     buf.push_back(i);
   }
-  print_info("buffer size after adding some elements");
+  print_debug("buffer size after adding some elements");
   check_eq(buf.size(), 0u);
 }
 
 TEST("size() returns the number of elements in a buffer") {
   ring_buffer<int> buf{5};
-  print_info("empty buffer is initialized");
+  print_debug("empty buffer is initialized");
   check_eq(buf.size(), 0u);
   for (int i = 1; i <= 3; ++i) {
     buf.push_back(i);
   }
-  print_info("buffer size after adding some elements");
+  print_debug("buffer size after adding some elements");
   check_eq(buf.size(), 3u);
 }
 
 TEST("ring-buffers are copiable") {
   ring_buffer<int> buf{5};
-  print_info("empty buffer is initialized");
+  print_debug("empty buffer is initialized");
   check_eq(buf.size(), 0u);
   for (int i = 1; i <= 3; ++i) {
     buf.push_back(i);
@@ -154,7 +154,7 @@ TEST("ring-buffers are copiable") {
   SECTION("copy-assignment") {
     ring_buffer<int> new_buf{0};
     new_buf = buf;
-    print_info("check size and elements of new_buf after copy-assignment");
+    print_debug("check size and elements of new_buf after copy-assignment");
     check_eq(new_buf.size(), 3u);
     check_eq(pop(new_buf), 1);
     check_eq(pop(new_buf), 2);
@@ -163,14 +163,14 @@ TEST("ring-buffers are copiable") {
   }
   SECTION("copy constructor") {
     ring_buffer<int> new_buf{buf};
-    print_info("check size and elements of new_buf after copy constructor");
+    print_debug("check size and elements of new_buf after copy constructor");
     check_eq(new_buf.size(), 3u);
     check_eq(pop(new_buf), 1);
     check_eq(pop(new_buf), 2);
     check_eq(pop(new_buf), 3);
     check_eq(new_buf.empty(), true);
   }
-  print_info("check size and elements of buf after copy");
+  print_debug("check size and elements of buf after copy");
   check_eq(buf.size(), 3u);
   check_eq(pop(buf), 1);
   check_eq(pop(buf), 2);

--- a/libcaf_core/caf/detail/ring_buffer.test.cpp
+++ b/libcaf_core/caf/detail/ring_buffer.test.cpp
@@ -19,14 +19,14 @@ int pop(ring_buffer<int>& buf) {
 
 TEST("push_back adds element") {
   ring_buffer<int> buf{3};
-  info("full capacity of ring buffer");
+  print_info("full capacity of ring buffer");
   for (int i = 1; i <= 3; ++i) {
     buf.push_back(i);
   }
   check_eq(buf.full(), true);
   check_eq(buf.empty(), false);
   check_eq(buf.front(), 1);
-  info("additional element after full capacity");
+  print_info("additional element after full capacity");
   buf.push_back(4);
   check_eq(buf.full(), true);
   check_eq(buf.empty(), false);
@@ -43,14 +43,14 @@ TEST("push_back adds element") {
 
 TEST("pop_front removes the oldest element") {
   ring_buffer<int> buf{3};
-  info("full capacity of ring buffer");
+  print_info("full capacity of ring buffer");
   for (int i = 1; i <= 3; ++i) {
     buf.push_back(i);
   }
   check_eq(buf.full(), true);
   check_eq(buf.empty(), false);
   check_eq(buf.front(), 1);
-  info("remove element from buffer");
+  print_info("remove element from buffer");
   buf.pop_front();
   check_eq(buf.full(), false);
   check_eq(buf.empty(), false);
@@ -65,14 +65,14 @@ TEST("pop_front removes the oldest element") {
 
 TEST("circular buffer overwrites oldest element after it is full") {
   ring_buffer<int> buf{5};
-  info("full capacity of ring buffer");
+  print_info("full capacity of ring buffer");
   for (int i = 1; i <= 5; ++i) {
     buf.push_back(i);
   }
   check_eq(buf.full(), true);
   check_eq(buf.empty(), false);
   check_eq(buf.front(), 1);
-  info("add some elements into buffer");
+  print_info("add some elements into buffer");
   buf.push_back(6);
   buf.push_back(7);
   check_eq(buf.full(), true);
@@ -90,14 +90,14 @@ TEST("circular buffer overwrites oldest element after it is full") {
 
 TEST("pop_front removes the oldest element from the buffer") {
   ring_buffer<int> buf{5};
-  info("full capacity of ring buffer");
+  print_info("full capacity of ring buffer");
   for (int i = 1; i <= 5; ++i) {
     buf.push_back(i);
   }
   check_eq(buf.full(), true);
   check_eq(buf.empty(), false);
   check_eq(buf.front(), 1);
-  info("remove some element from buffer");
+  print_info("remove some element from buffer");
   buf.pop_front();
   check_eq(buf.full(), false);
   check_eq(buf.empty(), false);
@@ -105,7 +105,7 @@ TEST("pop_front removes the oldest element from the buffer") {
   buf.pop_front();
   check_eq(buf.full(), false);
   check_eq(buf.front(), 3);
-  info("add some elements into buffer");
+  print_info("add some elements into buffer");
   buf.push_back(6);
   buf.push_back(7);
   check_eq(buf.full(), true);
@@ -123,29 +123,29 @@ TEST("pop_front removes the oldest element from the buffer") {
 
 TEST("push_back does nothing for ring buffer with a capacity of 0") {
   ring_buffer<int> buf{0};
-  info("empty buffer is initialized");
+  print_info("empty buffer is initialized");
   check_eq(buf.size(), 0u);
   for (int i = 1; i <= 3; ++i) {
     buf.push_back(i);
   }
-  info("buffer size after adding some elements");
+  print_info("buffer size after adding some elements");
   check_eq(buf.size(), 0u);
 }
 
 TEST("size() returns the number of elements in a buffer") {
   ring_buffer<int> buf{5};
-  info("empty buffer is initialized");
+  print_info("empty buffer is initialized");
   check_eq(buf.size(), 0u);
   for (int i = 1; i <= 3; ++i) {
     buf.push_back(i);
   }
-  info("buffer size after adding some elements");
+  print_info("buffer size after adding some elements");
   check_eq(buf.size(), 3u);
 }
 
 TEST("ring-buffers are copiable") {
   ring_buffer<int> buf{5};
-  info("empty buffer is initialized");
+  print_info("empty buffer is initialized");
   check_eq(buf.size(), 0u);
   for (int i = 1; i <= 3; ++i) {
     buf.push_back(i);
@@ -154,7 +154,7 @@ TEST("ring-buffers are copiable") {
   SECTION("copy-assignment") {
     ring_buffer<int> new_buf{0};
     new_buf = buf;
-    info("check size and elements of new_buf after copy-assignment");
+    print_info("check size and elements of new_buf after copy-assignment");
     check_eq(new_buf.size(), 3u);
     check_eq(pop(new_buf), 1);
     check_eq(pop(new_buf), 2);
@@ -163,14 +163,14 @@ TEST("ring-buffers are copiable") {
   }
   SECTION("copy constructor") {
     ring_buffer<int> new_buf{buf};
-    info("check size and elements of new_buf after copy constructor");
+    print_info("check size and elements of new_buf after copy constructor");
     check_eq(new_buf.size(), 3u);
     check_eq(pop(new_buf), 1);
     check_eq(pop(new_buf), 2);
     check_eq(pop(new_buf), 3);
     check_eq(new_buf.empty(), true);
   }
-  info("check size and elements of buf after copy");
+  print_info("check size and elements of buf after copy");
   check_eq(buf.size(), 3u);
   check_eq(pop(buf), 1);
   check_eq(pop(buf), 2);

--- a/libcaf_core/caf/detail/sync_ring_buffer.test.cpp
+++ b/libcaf_core/caf/detail/sync_ring_buffer.test.cpp
@@ -44,18 +44,18 @@ TEST("a default-constructed ring buffer is empty") {
 
 TEST("push_back adds one element to the ring buffer") {
   int_buffer buf;
-  print_info("add one element");
+  print_debug("add one element");
   buf.push_back(42);
   check(!buf.empty());
   check(!buf.full());
   check_eq(buf.size(), 1u);
   check_eq(buf.front(), 42);
-  print_info("remove element");
+  print_debug("remove element");
   buf.pop_front();
   check(buf.empty());
   check(!buf.full());
   check_eq(buf.size(), 0u);
-  print_info("fill buffer");
+  print_debug("fill buffer");
   for (int i = 0; i < static_cast<int>(int_buffer_size - 1); ++i)
     buf.push_back(std::move(i));
   check(!buf.empty());
@@ -74,19 +74,19 @@ TEST("get_all returns all elements from the ring buffer") {
     auto e = buf.get_all(i);
     return vector_type(i, e);
   };
-  print_info("add five element");
+  print_debug("add five element");
   for (int i = 0; i < 5; ++i)
     buf.push_back(std::move(i));
   check(!buf.empty());
   check(!buf.full());
   check_eq(buf.size(), 5u);
   check_eq(buf.front(), 0);
-  print_info("drain elements");
+  print_debug("drain elements");
   check_eq(fetch_all(), vector_type({0, 1, 2, 3, 4}));
   check(buf.empty());
   check(!buf.full());
   check_eq(buf.size(), 0u);
-  print_info("add 60 elements (wraps around)");
+  print_debug("add 60 elements (wraps around)");
   vector_type expected;
   for (int i = 0; i < 60; ++i) {
     expected.push_back(i);

--- a/libcaf_core/caf/detail/sync_ring_buffer.test.cpp
+++ b/libcaf_core/caf/detail/sync_ring_buffer.test.cpp
@@ -44,18 +44,18 @@ TEST("a default-constructed ring buffer is empty") {
 
 TEST("push_back adds one element to the ring buffer") {
   int_buffer buf;
-  info("add one element");
+  print_info("add one element");
   buf.push_back(42);
   check(!buf.empty());
   check(!buf.full());
   check_eq(buf.size(), 1u);
   check_eq(buf.front(), 42);
-  info("remove element");
+  print_info("remove element");
   buf.pop_front();
   check(buf.empty());
   check(!buf.full());
   check_eq(buf.size(), 0u);
-  info("fill buffer");
+  print_info("fill buffer");
   for (int i = 0; i < static_cast<int>(int_buffer_size - 1); ++i)
     buf.push_back(std::move(i));
   check(!buf.empty());
@@ -74,19 +74,19 @@ TEST("get_all returns all elements from the ring buffer") {
     auto e = buf.get_all(i);
     return vector_type(i, e);
   };
-  info("add five element");
+  print_info("add five element");
   for (int i = 0; i < 5; ++i)
     buf.push_back(std::move(i));
   check(!buf.empty());
   check(!buf.full());
   check_eq(buf.size(), 5u);
   check_eq(buf.front(), 0);
-  info("drain elements");
+  print_info("drain elements");
   check_eq(fetch_all(), vector_type({0, 1, 2, 3, 4}));
   check(buf.empty());
   check(!buf.full());
   check_eq(buf.size(), 0u);
-  info("add 60 elements (wraps around)");
+  print_info("add 60 elements (wraps around)");
   vector_type expected;
   for (int i = 0; i < 60; ++i) {
     expected.push_back(i);

--- a/libcaf_test/caf/test/reporter.cpp
+++ b/libcaf_test/caf/test/reporter.cpp
@@ -373,8 +373,8 @@ public:
               ' ', indent_, location.file_name(), location.line(), msg);
   }
 
-  void info(std::string_view msg,
-            const detail::source_location& location) override {
+  void print_info(std::string_view msg,
+                  const detail::source_location& location) override {
     using detail::format_to;
     if (level_ < CAF_LOG_LEVEL_INFO)
       return;
@@ -393,7 +393,46 @@ public:
       return;
     set_live();
     format_to(colored(),
-              "{0:{1}}$R(error):\n"
+              "{0:{1}}$M(info):\n"
+              "{0:{1}}  loc: $C({2}):$Y({3})$0\n"
+              "{0:{1}}  msg: {4}\n",
+              ' ', indent_, location.file_name(), location.line(), msg);
+  }
+
+  void print_debug(std::string_view msg,
+                   const detail::source_location& location) override {
+    using detail::format_to;
+    if (level_ < CAF_LOG_LEVEL_DEBUG)
+      return;
+    set_live();
+    format_to(colored(),
+              "{0:{1}}$R(debug):\n"
+              "{0:{1}}  loc: $C({2}):$Y({3})$0\n"
+              "{0:{1}}  msg: {4}\n",
+              ' ', indent_, location.file_name(), location.line(), msg);
+  }
+
+  void print_trace(std::string_view msg,
+                   const detail::source_location& location) override {
+    using detail::format_to;
+    if (level_ < CAF_LOG_LEVEL_TRACE)
+      return;
+    set_live();
+    format_to(colored(),
+              "{0:{1}}$R(trace):\n"
+              "{0:{1}}  loc: $C({2}):$Y({3})$0\n"
+              "{0:{1}}  msg: {4}\n",
+              ' ', indent_, location.file_name(), location.line(), msg);
+  }
+
+  void print_warning(std::string_view msg,
+                     const detail::source_location& location) override {
+    using detail::format_to;
+    if (level_ < CAF_LOG_LEVEL_WARNING)
+      return;
+    set_live();
+    format_to(colored(),
+              "{0:{1}}$R(warning):\n"
               "{0:{1}}  loc: $C({2}):$Y({3})$0\n"
               "{0:{1}}  msg: {4}\n",
               ' ', indent_, location.file_name(), location.line(), msg);

--- a/libcaf_test/caf/test/reporter.cpp
+++ b/libcaf_test/caf/test/reporter.cpp
@@ -375,7 +375,7 @@ public:
 
   void print_info(std::string_view msg,
                   const detail::source_location& location) override {
-    print_impl(CAF_LOG_LEVEL_INFO, 'C', "info", msg, location);
+    print_impl(CAF_LOG_LEVEL_INFO, 'M', "info", msg, location);
   }
 
   void print_error(std::string_view msg,
@@ -391,21 +391,6 @@ public:
   void print_warning(std::string_view msg,
                      const detail::source_location& location) override {
     print_impl(CAF_LOG_LEVEL_WARNING, 'Y', "warning", msg, location);
-  }
-
-  void print_impl(unsigned level, char color_code, std::string_view prefix,
-                  std::string_view msg,
-                  const detail::source_location& location) {
-    using detail::format_to;
-    if (level_ < level)
-      return;
-    set_live();
-    format_to(colored(),
-              "{0:{1}}${2}({3}):\n"
-              "{0:{1}}  loc: $C({4}):$Y({5})$0\n"
-              "{0:{1}}  msg: {6}\n",
-              ' ', indent_, color_code, prefix, location.file_name(),
-              location.line(), msg);
   }
 
   unsigned verbosity(unsigned level) override {
@@ -435,6 +420,21 @@ public:
   }
 
 private:
+  void print_impl(unsigned level, char color_code, std::string_view level_name,
+                  std::string_view msg,
+                  const detail::source_location& location) {
+    using detail::format_to;
+    if (level_ < level)
+      return;
+    set_live();
+    format_to(colored(),
+              "{0:{1}}${2}({3}):\n"
+              "{0:{1}}  loc: $C({4}):$Y({5})$0\n"
+              "{0:{1}}  msg: {6}\n",
+              ' ', indent_, color_code, level_name, location.file_name(),
+              location.line(), msg);
+  }
+
   void print_indent(size_t indent) {
     for (size_t i = 0; i < indent; ++i)
       std::cout << ' ';

--- a/libcaf_test/caf/test/reporter.cpp
+++ b/libcaf_test/caf/test/reporter.cpp
@@ -375,54 +375,37 @@ public:
 
   void print_info(std::string_view msg,
                   const detail::source_location& location) override {
-    using detail::format_to;
-    if (level_ < CAF_LOG_LEVEL_INFO)
-      return;
-    set_live();
-    format_to(colored(),
-              "{0:{1}}$M(info):\n"
-              "{0:{1}}  loc: $C({2}):$Y({3})$0\n"
-              "{0:{1}}  msg: {4}\n",
-              ' ', indent_, location.file_name(), location.line(), msg);
+    print_impl(CAF_LOG_LEVEL_INFO, 'C', "info", msg, location);
   }
 
   void print_error(std::string_view msg,
                    const detail::source_location& location) override {
-    using detail::format_to;
-    if (level_ < CAF_LOG_LEVEL_ERROR)
-      return;
-    set_live();
-    format_to(colored(),
-              "{0:{1}}$M(info):\n"
-              "{0:{1}}  loc: $C({2}):$Y({3})$0\n"
-              "{0:{1}}  msg: {4}\n",
-              ' ', indent_, location.file_name(), location.line(), msg);
+    print_impl(CAF_LOG_LEVEL_ERROR, 'R', "error", msg, location);
   }
 
   void print_debug(std::string_view msg,
                    const detail::source_location& location) override {
-    using detail::format_to;
-    if (level_ < CAF_LOG_LEVEL_DEBUG)
-      return;
-    set_live();
-    format_to(colored(),
-              "{0:{1}}$R(debug):\n"
-              "{0:{1}}  loc: $C({2}):$Y({3})$0\n"
-              "{0:{1}}  msg: {4}\n",
-              ' ', indent_, location.file_name(), location.line(), msg);
+    print_impl(CAF_LOG_LEVEL_DEBUG, 'B', "debug", msg, location);
   }
 
   void print_warning(std::string_view msg,
                      const detail::source_location& location) override {
+    print_impl(CAF_LOG_LEVEL_WARNING, 'Y', "warning", msg, location);
+  }
+
+  void print_impl(unsigned level, char color_code, std::string_view prefix,
+                  std::string_view msg,
+                  const detail::source_location& location) {
     using detail::format_to;
-    if (level_ < CAF_LOG_LEVEL_WARNING)
+    if (level_ < level)
       return;
     set_live();
     format_to(colored(),
-              "{0:{1}}$R(warning):\n"
-              "{0:{1}}  loc: $C({2}):$Y({3})$0\n"
-              "{0:{1}}  msg: {4}\n",
-              ' ', indent_, location.file_name(), location.line(), msg);
+              "{0:{1}}${2}({3}):\n"
+              "{0:{1}}  loc: $C({4}):$Y({5})$0\n"
+              "{0:{1}}  msg: {6}\n",
+              ' ', indent_, color_code, prefix, location.file_name(),
+              location.line(), msg);
   }
 
   unsigned verbosity(unsigned level) override {

--- a/libcaf_test/caf/test/reporter.cpp
+++ b/libcaf_test/caf/test/reporter.cpp
@@ -412,19 +412,6 @@ public:
               ' ', indent_, location.file_name(), location.line(), msg);
   }
 
-  void print_trace(std::string_view msg,
-                   const detail::source_location& location) override {
-    using detail::format_to;
-    if (level_ < CAF_LOG_LEVEL_TRACE)
-      return;
-    set_live();
-    format_to(colored(),
-              "{0:{1}}$R(trace):\n"
-              "{0:{1}}  loc: $C({2}):$Y({3})$0\n"
-              "{0:{1}}  msg: {4}\n",
-              ' ', indent_, location.file_name(), location.line(), msg);
-  }
-
   void print_warning(std::string_view msg,
                      const detail::source_location& location) override {
     using detail::format_to;

--- a/libcaf_test/caf/test/reporter.hpp
+++ b/libcaf_test/caf/test/reporter.hpp
@@ -114,11 +114,6 @@ public:
 
   /// Creates a default reporter that writes to the standard output.
   static std::unique_ptr<reporter> make_default();
-
-private:
-  void print_impl(unsigned level, char color_code, std::string_view level_name,
-                  std::string_view msg,
-                  const detail::source_location& location);
 };
 
 } // namespace caf::test

--- a/libcaf_test/caf/test/reporter.hpp
+++ b/libcaf_test/caf/test/reporter.hpp
@@ -84,10 +84,6 @@ public:
     = 0;
 
   virtual void
-  print_trace(std::string_view msg, const detail::source_location& location)
-    = 0;
-
-  virtual void
   print_error(std::string_view msg, const detail::source_location& location)
     = 0;
 

--- a/libcaf_test/caf/test/reporter.hpp
+++ b/libcaf_test/caf/test/reporter.hpp
@@ -114,6 +114,12 @@ public:
 
   /// Creates a default reporter that writes to the standard output.
   static std::unique_ptr<reporter> make_default();
+
+private:
+  virtual void print_impl(unsigned level, char color_code,
+                          std::string_view prefix, std::string_view msg,
+                          const detail::source_location& location)
+    = 0;
 };
 
 } // namespace caf::test

--- a/libcaf_test/caf/test/reporter.hpp
+++ b/libcaf_test/caf/test/reporter.hpp
@@ -72,7 +72,19 @@ public:
     = 0;
 
   virtual void
-  info(std::string_view msg, const detail::source_location& location)
+  print_info(std::string_view msg, const detail::source_location& location)
+    = 0;
+
+  virtual void
+  print_debug(std::string_view msg, const detail::source_location& location)
+    = 0;
+
+  virtual void
+  print_warning(std::string_view msg, const detail::source_location& location)
+    = 0;
+
+  virtual void
+  print_trace(std::string_view msg, const detail::source_location& location)
     = 0;
 
   virtual void

--- a/libcaf_test/caf/test/reporter.hpp
+++ b/libcaf_test/caf/test/reporter.hpp
@@ -116,10 +116,9 @@ public:
   static std::unique_ptr<reporter> make_default();
 
 private:
-  virtual void print_impl(unsigned level, char color_code,
-                          std::string_view prefix, std::string_view msg,
-                          const detail::source_location& location)
-    = 0;
+  void print_impl(unsigned level, char color_code, std::string_view level_name,
+                  std::string_view msg,
+                  const detail::source_location& location);
 };
 
 } // namespace caf::test

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -62,9 +62,9 @@ public:
   void info(detail::format_string_with_location fwl, Ts&&... xs) {
     if constexpr (sizeof...(Ts) > 0) {
       auto msg = detail::format(fwl.value, std::forward<Ts>(xs)...);
-      reporter::instance().info(msg, fwl.location);
+      reporter::instance().print_info(msg, fwl.location);
     } else {
-      reporter::instance().info(fwl.value, fwl.location);
+      reporter::instance().print_info(fwl.value, fwl.location);
     }
   }
 

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -59,12 +59,45 @@ public:
 
   /// Generates a message with the INFO severity level.
   template <class... Ts>
-  void info(detail::format_string_with_location fwl, Ts&&... xs) {
+  void print_info(detail::format_string_with_location fwl, Ts&&... xs) {
     if constexpr (sizeof...(Ts) > 0) {
       auto msg = detail::format(fwl.value, std::forward<Ts>(xs)...);
       reporter::instance().print_info(msg, fwl.location);
     } else {
       reporter::instance().print_info(fwl.value, fwl.location);
+    }
+  }
+
+  /// Generates a message with the DEBUG severity level.
+  template <class... Ts>
+  void print_debug(detail::format_string_with_location fwl, Ts&&... xs) {
+    if constexpr (sizeof...(Ts) > 0) {
+      auto msg = detail::format(fwl.value, std::forward<Ts>(xs)...);
+      reporter::instance().print_debug(msg, fwl.location);
+    } else {
+      reporter::instance().print_debug(fwl.value, fwl.location);
+    }
+  }
+
+  /// Generates a message with the WARNING severity level.
+  template <class... Ts>
+  void print_warning(detail::format_string_with_location fwl, Ts&&... xs) {
+    if constexpr (sizeof...(Ts) > 0) {
+      auto msg = detail::format(fwl.value, std::forward<Ts>(xs)...);
+      reporter::instance().print_warning(msg, fwl.location);
+    } else {
+      reporter::instance().print_warning(fwl.value, fwl.location);
+    }
+  }
+
+  /// Generates a message with the ERROR severity level.
+  template <class... Ts>
+  void print_error(detail::format_string_with_location fwl, Ts&&... xs) {
+    if constexpr (sizeof...(Ts) > 0) {
+      auto msg = detail::format(fwl.value, std::forward<Ts>(xs)...);
+      reporter::instance().print_error(msg, fwl.location);
+    } else {
+      reporter::instance().print_error(fwl.value, fwl.location);
     }
   }
 

--- a/libcaf_test/caf/test/test.test.cpp
+++ b/libcaf_test/caf/test/test.test.cpp
@@ -38,7 +38,7 @@ TEST("tests can contain different types of checks") {
     should_fail([this]() { check_lt(1, 1); });
     should_fail([this]() { check_lt(2, 1); });
   }
-  info("this test had {} checks", rep.test_stats().total());
+  print_info("this test had {} checks", rep.test_stats().total());
 }
 
 #ifdef CAF_ENABLE_EXCEPTIONS
@@ -82,7 +82,7 @@ TEST("tests fail when requirement errors occur") {
       [this]() { require_gt(1, 2); });
     require_gt(2, 1);
   }
-  info("this test had {} checks", rep.test_stats().total());
+  print_info("this test had {} checks", rep.test_stats().total());
 }
 
 #endif // CAF_ENABLE_EXCEPTIONS
@@ -92,7 +92,7 @@ TEST("failed checks increment the failed counter") {
   auto stats = caf::test::reporter::instance().test_stats();
   check_eq(stats.passed, 0u);
   check_eq(stats.failed, 1u);
-  info("reset error count to not fail the test");
+  print_info("reset error count to not fail the test");
   caf::test::reporter::instance().test_stats({2, 0});
 }
 

--- a/libcaf_test/caf/test/test.test.cpp
+++ b/libcaf_test/caf/test/test.test.cpp
@@ -38,7 +38,7 @@ TEST("tests can contain different types of checks") {
     should_fail([this]() { check_lt(1, 1); });
     should_fail([this]() { check_lt(2, 1); });
   }
-  print_info("this test had {} checks", rep.test_stats().total());
+  print_debug("this test had {} checks", rep.test_stats().total());
 }
 
 #ifdef CAF_ENABLE_EXCEPTIONS
@@ -82,7 +82,7 @@ TEST("tests fail when requirement errors occur") {
       [this]() { require_gt(1, 2); });
     require_gt(2, 1);
   }
-  print_info("this test had {} checks", rep.test_stats().total());
+  print_debug("this test had {} checks", rep.test_stats().total());
 }
 
 #endif // CAF_ENABLE_EXCEPTIONS
@@ -92,7 +92,7 @@ TEST("failed checks increment the failed counter") {
   auto stats = caf::test::reporter::instance().test_stats();
   check_eq(stats.passed, 0u);
   check_eq(stats.failed, 1u);
-  print_info("reset error count to not fail the test");
+  print_debug("reset error count to not fail the test");
   caf::test::reporter::instance().test_stats({2, 0});
 }
 


### PR DESCRIPTION
Relates https://github.com/actor-framework/actor-framework/issues/1479

Complete issue by adding the remaining print functions for debug, warning and trace severities.