### PR TITLE
Remove obsolete type traits

### DIFF
--- a/libcaf_core/caf/actor.hpp
+++ b/libcaf_core/caf/actor.hpp
@@ -51,13 +51,13 @@ public:
   actor(const scoped_actor&);
 
   template <class T,
-            class = detail::enable_if_t<actor_traits<T>::is_dynamically_typed>>
+            class = std::enable_if_t<actor_traits<T>::is_dynamically_typed>>
   actor(T* ptr) : ptr_(ptr->ctrl()) {
     CAF_ASSERT(ptr != nullptr);
   }
 
   template <class T,
-            class = detail::enable_if_t<actor_traits<T>::is_dynamically_typed>>
+            class = std::enable_if_t<actor_traits<T>::is_dynamically_typed>>
   actor& operator=(intrusive_ptr<T> ptr) {
     actor tmp{std::move(ptr)};
     swap(tmp);
@@ -65,7 +65,7 @@ public:
   }
 
   template <class T,
-            class = detail::enable_if_t<actor_traits<T>::is_dynamically_typed>>
+            class = std::enable_if_t<actor_traits<T>::is_dynamically_typed>>
   actor& operator=(T* ptr) {
     actor tmp{ptr};
     swap(tmp);

--- a/libcaf_core/caf/actor_factory.hpp
+++ b/libcaf_core/caf/actor_factory.hpp
@@ -142,7 +142,7 @@ actor_factory_result dyn_spawn_class(actor_config& cfg, message& msg) {
 
 template <class T, class... Ts>
 actor_factory make_actor_factory() {
-  static_assert(detail::conjunction_v<std::is_lvalue_reference_v<Ts>...>,
+  static_assert((std::is_lvalue_reference_v<Ts> && ...),
                 "all Ts must be lvalue references");
   static_assert(std::is_base_of_v<local_actor, T>,
                 "T is not derived from local_actor");

--- a/libcaf_core/caf/config_value.hpp
+++ b/libcaf_core/caf/config_value.hpp
@@ -97,8 +97,8 @@ public:
 
   config_value(const config_value& other) = default;
 
-  template <class T, class E = detail::enable_if_t<
-                       !std::is_same_v<detail::decay_t<T>, config_value>>>
+  template <class T, class = std::enable_if_t<
+                       !std::is_same_v<std::decay_t<T>, config_value>>>
   explicit config_value(T&& x) : data_(lift(std::forward<T>(x))) {
     // nop
   }
@@ -107,8 +107,8 @@ public:
 
   config_value& operator=(const config_value& other) = default;
 
-  template <class T, class E = detail::enable_if_t<
-                       !std::is_same_v<detail::decay_t<T>, config_value>>>
+  template <class T, class = std::enable_if_t<
+                       !std::is_same_v<std::decay_t<T>, config_value>>>
   config_value& operator=(T&& x) {
     data_ = lift(std::forward<T>(x));
     return *this;

--- a/libcaf_core/caf/detail/parse.hpp
+++ b/libcaf_core/caf/detail/parse.hpp
@@ -72,8 +72,7 @@ CAF_CORE_EXPORT void parse(string_parser_state& ps, uint64_t& x);
 // -- non-fixed size integer types ---------------------------------------------
 
 template <class T>
-detail::enable_if_t<std::is_integral_v<T>>
-parse(string_parser_state& ps, T& x) {
+std::enable_if_t<std::is_integral_v<T>> parse(string_parser_state& ps, T& x) {
   using squashed_type = squashed_int_t<T>;
   return parse(ps, reinterpret_cast<squashed_type&>(x));
 }

--- a/libcaf_core/caf/detail/parser/add_ascii.hpp
+++ b/libcaf_core/caf/detail/parser/add_ascii.hpp
@@ -10,6 +10,7 @@
 #include "caf/detail/type_traits.hpp"
 
 #include <limits>
+#include <type_traits>
 
 namespace caf::detail::parser {
 
@@ -18,7 +19,8 @@ namespace caf::detail::parser {
 // @pre `isdigit(c) || (Base == 16 && isxdigit(c))`
 // @warning can leave `x` in an intermediate state when retuning `false`
 template <int Base, class T>
-bool add_ascii(T& x, char c, enable_if_tt<std::is_integral<T>, int> u = 0) {
+bool add_ascii(T& x, char c,
+               std::enable_if_t<std::is_integral_v<T>, int> u = 0) {
   CAF_IGNORE_UNUSED(u);
   if (x > (std::numeric_limits<T>::max() / Base))
     return false;
@@ -33,7 +35,7 @@ bool add_ascii(T& x, char c, enable_if_tt<std::is_integral<T>, int> u = 0) {
 
 template <int Base, class T>
 bool add_ascii(T& x, char c,
-               enable_if_tt<std::is_floating_point<T>, int> u = 0) {
+               std::enable_if_t<std::is_floating_point_v<T>, int> u = 0) {
   CAF_IGNORE_UNUSED(u);
   ascii_to_int<Base, T> f;
   x = (x * Base) + f(c);

--- a/libcaf_core/caf/detail/parser/sub_ascii.hpp
+++ b/libcaf_core/caf/detail/parser/sub_ascii.hpp
@@ -9,6 +9,7 @@
 #include "caf/detail/type_traits.hpp"
 
 #include <limits>
+#include <type_traits>
 
 namespace caf::detail::parser {
 
@@ -17,7 +18,8 @@ namespace caf::detail::parser {
 // @pre `isdigit(c) || (Base == 16 && isxdigit(c))`
 // @warning can leave `x` in an intermediate state when retuning `false`
 template <int Base, class T>
-bool sub_ascii(T& x, char c, enable_if_tt<std::is_integral<T>, int> u = 0) {
+bool sub_ascii(T& x, char c,
+               std::enable_if_t<std::is_integral_v<T>, int> u = 0) {
   CAF_IGNORE_UNUSED(u);
   if (x < (std::numeric_limits<T>::min() / Base))
     return false;
@@ -32,7 +34,7 @@ bool sub_ascii(T& x, char c, enable_if_tt<std::is_integral<T>, int> u = 0) {
 
 template <int Base, class T>
 bool sub_ascii(T& x, char c,
-               enable_if_tt<std::is_floating_point<T>, int> u = 0) {
+               std::enable_if_t<std::is_floating_point_v<T>, int> u = 0) {
   CAF_IGNORE_UNUSED(u);
   ascii_to_int<Base, T> f;
   x = static_cast<T>((x * Base) - f(c));

--- a/libcaf_core/caf/detail/spawnable.hpp
+++ b/libcaf_core/caf/detail/spawnable.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "caf/detail/type_traits.hpp"
 #include "caf/infer_handle.hpp"
 
 #include <type_traits>
@@ -15,8 +14,7 @@ namespace caf::detail {
 /// implementation `Impl` with arguments of type `Ts...`.
 template <class F, class Impl, class... Ts>
 constexpr bool spawnable() {
-  return is_callable_with<F, Ts...>::value
-         || is_callable_with<F, Impl*, Ts...>::value;
+  return std::is_invocable_v<F, Ts...> || std::is_invocable_v<F, Impl*, Ts...>;
 }
 
 } // namespace caf::detail

--- a/libcaf_core/caf/intrusive_ptr.hpp
+++ b/libcaf_core/caf/intrusive_ptr.hpp
@@ -231,28 +231,28 @@ bool operator!=(std::nullptr_t, const intrusive_ptr<T>& x) {
 
 /// @relates intrusive_ptr
 template <class T, class U>
-detail::enable_if_t<detail::is_comparable<T*, U*>::value, bool>
+std::enable_if_t<detail::is_comparable<T*, U*>::value, bool>
 operator==(const intrusive_ptr<T>& lhs, const U* rhs) {
   return lhs.get() == rhs;
 }
 
 /// @relates intrusive_ptr
 template <class T, class U>
-detail::enable_if_t<detail::is_comparable<T*, U*>::value, bool>
+std::enable_if_t<detail::is_comparable<T*, U*>::value, bool>
 operator==(const T* lhs, const intrusive_ptr<U>& rhs) {
   return lhs == rhs.get();
 }
 
 /// @relates intrusive_ptr
 template <class T, class U>
-detail::enable_if_t<detail::is_comparable<T*, U*>::value, bool>
+std::enable_if_t<detail::is_comparable<T*, U*>::value, bool>
 operator!=(const intrusive_ptr<T>& lhs, const U* rhs) {
   return lhs.get() != rhs;
 }
 
 /// @relates intrusive_ptr
 template <class T, class U>
-detail::enable_if_t<detail::is_comparable<T*, U*>::value, bool>
+std::enable_if_t<detail::is_comparable<T*, U*>::value, bool>
 operator!=(const T* lhs, const intrusive_ptr<U>& rhs) {
   return lhs != rhs.get();
 }
@@ -261,14 +261,14 @@ operator!=(const T* lhs, const intrusive_ptr<U>& rhs) {
 
 /// @relates intrusive_ptr
 template <class T, class U>
-detail::enable_if_t<detail::is_comparable_v<T*, U*>, bool>
+std::enable_if_t<detail::is_comparable_v<T*, U*>, bool>
 operator==(const intrusive_ptr<T>& x, const intrusive_ptr<U>& y) {
   return x.get() == y.get();
 }
 
 /// @relates intrusive_ptr
 template <class T, class U>
-detail::enable_if_t<detail::is_comparable_v<T*, U*>, bool>
+std::enable_if_t<detail::is_comparable_v<T*, U*>, bool>
 operator!=(const intrusive_ptr<T>& x, const intrusive_ptr<U>& y) {
   return x.get() != y.get();
 }

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -165,7 +165,7 @@ public:
     line_builder();
 
     template <class T>
-    detail::enable_if_t<!std::is_pointer_v<T>, line_builder&>
+    std::enable_if_t<!std::is_pointer_v<T>, line_builder&>
     operator<<(const T& x) {
       if (!str_.empty())
         str_ += " ";

--- a/libcaf_core/caf/may_have_timeout.hpp
+++ b/libcaf_core/caf/may_have_timeout.hpp
@@ -26,4 +26,7 @@ struct may_have_timeout<timeout_definition<F>> {
   static constexpr bool value = true;
 };
 
+template <class T>
+inline constexpr bool may_have_timeout_v = may_have_timeout<T>::value;
+
 } // namespace caf

--- a/libcaf_core/caf/message_handler.hpp
+++ b/libcaf_core/caf/message_handler.hpp
@@ -61,9 +61,8 @@ public:
   template <class... Ts>
   void assign(Ts... xs) {
     static_assert(sizeof...(Ts) > 0, "assign without arguments called");
-    static_assert(
-      !detail::disjunction<may_have_timeout<std::decay_t<Ts>>::value...>::value,
-      "Timeouts are only allowed in behaviors");
+    static_assert(!(may_have_timeout_v<std::decay_t<Ts>> || ...),
+                  "Timeouts are only allowed in behaviors");
     impl_ = detail::make_behavior(xs...);
   }
 
@@ -83,9 +82,8 @@ public:
   /// Returns a new handler that concatenates this handler
   /// with a new handler from `xs...`.
   template <class... Ts>
-  std::conditional_t<
-    detail::disjunction_v<may_have_timeout<std::decay_t<Ts>>::value...>,
-    behavior, message_handler>
+  std::conditional_t<(may_have_timeout_v<std::decay_t<Ts>> || ...), behavior,
+                     message_handler>
   or_else(Ts&&... xs) const {
     // using a behavior is safe here, because we "cast"
     // it back to a message_handler when appropriate

--- a/libcaf_core/caf/mixin/requester.hpp
+++ b/libcaf_core/caf/mixin/requester.hpp
@@ -50,7 +50,7 @@ public:
                Ts&&... xs) {
     using namespace detail;
     static_assert(sizeof...(Ts) > 0, "no message to send");
-    using token = type_list<implicit_conversions_t<decay_t<Ts>>...>;
+    using token = type_list<implicit_conversions_t<std::decay_t<Ts>>...>;
     static_assert(response_type_unbox<signatures_of_t<Handle>, token>::valid,
                   "receiver does not accept given message");
     auto self = static_cast<Subtype*>(this);
@@ -67,7 +67,7 @@ public:
     }
     using response_type
       = response_type_t<typename Handle::signatures,
-                        detail::implicit_conversions_t<detail::decay_t<Ts>>...>;
+                        detail::implicit_conversions_t<std::decay_t<Ts>>...>;
     using handle_type
       = response_handle<Subtype, policy::single_response<response_type>>;
     return handle_type{self, req_id.response_id(), std::move(pending_msg)};
@@ -101,7 +101,7 @@ public:
     using handle_type = typename Container::value_type;
     using namespace detail;
     static_assert(sizeof...(Ts) > 0, "no message to send");
-    using token = type_list<implicit_conversions_t<decay_t<Ts>>...>;
+    using token = type_list<implicit_conversions_t<std::decay_t<Ts>>...>;
     static_assert(
       response_type_unbox<signatures_of_t<handle_type>, token>::valid,
       "receiver does not accept given message");
@@ -128,7 +128,7 @@ public:
     }
     using response_type
       = response_type_t<typename handle_type::signatures,
-                        detail::implicit_conversions_t<detail::decay_t<Ts>>...>;
+                        detail::implicit_conversions_t<std::decay_t<Ts>>...>;
     using result_type = response_handle<Subtype, MergePolicy<response_type>>;
     return result_type{dptr, std::move(ids),
                        disposable::make_composite(std::move(pending_msgs))};

--- a/libcaf_core/caf/mixin/sender.hpp
+++ b/libcaf_core/caf/mixin/sender.hpp
@@ -67,7 +67,7 @@ public:
   /// Sends `{xs...}` as an asynchronous message to `dest` with priority `mp`.
   template <message_priority P = message_priority::normal, class Dest,
             class... Ts>
-  detail::enable_if_t<!std::is_same_v<group, Dest>>
+  std::enable_if_t<!std::is_same_v<group, Dest>>
   send(const Dest& dest, Ts&&... xs) {
     static_assert(sizeof...(Ts) > 0, "no message to send");
     static_assert((detail::sendable<Ts> && ...),
@@ -99,7 +99,7 @@ public:
   /// passed already).
   template <message_priority P = message_priority::normal, class Dest = actor,
             class... Ts>
-  detail::enable_if_t<!std::is_same_v<Dest, group>, disposable>
+  std::enable_if_t<!std::is_same_v<Dest, group>, disposable>
   scheduled_send(const Dest& dest, actor_clock::time_point timeout,
                  Ts&&... xs) {
     static_assert(sizeof...(Ts) > 0, "no message to send");
@@ -139,7 +139,7 @@ public:
   /// Sends a message after a relative timeout.
   template <message_priority P = message_priority::normal, class Rep = int,
             class Period = std::ratio<1>, class Dest = actor, class... Ts>
-  detail::enable_if_t<!std::is_same_v<Dest, group>, disposable>
+  std::enable_if_t<!std::is_same_v<Dest, group>, disposable>
   delayed_send(const Dest& dest, std::chrono::duration<Rep, Period> rel_timeout,
                Ts&&... xs) {
     static_assert(sizeof...(Ts) > 0, "no message to send");
@@ -230,12 +230,12 @@ private:
   }
 
   template <class T = Base>
-  detail::enable_if_t<std::is_base_of_v<abstract_actor, T>, Subtype*> dptr() {
+  std::enable_if_t<std::is_base_of_v<abstract_actor, T>, Subtype*> dptr() {
     return static_cast<Subtype*>(this);
   }
 
-  template <class T = Subtype, class = detail::enable_if_t<std::is_base_of<
-                                 typed_actor_view_base, T>::value>>
+  template <class T = Subtype, class = std::enable_if_t<
+                                 std::is_base_of_v<typed_actor_view_base, T>>>
   typename T::pointer dptr() {
     return static_cast<Subtype*>(this)->internal_ptr();
   }

--- a/libcaf_core/caf/policy/select_all.hpp
+++ b/libcaf_core/caf/policy/select_all.hpp
@@ -140,7 +140,7 @@ public:
   template <class Fun>
   using type_checker
     = detail::type_checker<response_type,
-                           detail::select_all_helper_t<detail::decay_t<Fun>>>;
+                           detail::select_all_helper_t<std::decay_t<Fun>>>;
 
   explicit select_all(message_id_list ids, disposable pending_timeouts)
     : ids_(std::move(ids)), pending_timeouts_(std::move(pending_timeouts)) {
@@ -171,7 +171,7 @@ public:
   template <class Self, class F, class G>
   void receive(Self* self, F&& f, G&& g) {
     CAF_LOG_TRACE(CAF_ARG(ids_));
-    using helper_type = detail::select_all_helper_t<detail::decay_t<F>>;
+    using helper_type = detail::select_all_helper_t<std::decay_t<F>>;
     helper_type helper{ids_.size(), pending_timeouts_, std::forward<F>(f)};
     auto error_handler = [&](error& err) mutable {
       if (*helper.pending > 0) {
@@ -200,7 +200,7 @@ private:
   template <class F, class OnError>
   behavior make_behavior(F&& f, OnError&& g) {
     using namespace detail;
-    using helper_type = select_all_helper_t<decay_t<F>>;
+    using helper_type = select_all_helper_t<std::decay_t<F>>;
     helper_type helper{ids_.size(), pending_timeouts_, std::forward<F>(f)};
     auto pending = helper.pending;
     auto error_handler = [pending{std::move(pending)},

--- a/libcaf_core/caf/policy/select_any.hpp
+++ b/libcaf_core/caf/policy/select_any.hpp
@@ -55,8 +55,7 @@ public:
   using message_id_list = std::vector<message_id>;
 
   template <class Fun>
-  using type_checker
-    = detail::type_checker<response_type, detail::decay_t<Fun>>;
+  using type_checker = detail::type_checker<response_type, std::decay_t<Fun>>;
 
   explicit select_any(message_id_list ids, disposable pending_timeouts)
     : ids_(std::move(ids)), pending_timeouts_(std::move(pending_timeouts)) {

--- a/libcaf_core/caf/send.hpp
+++ b/libcaf_core/caf/send.hpp
@@ -90,7 +90,7 @@ void anon_send(const Dest& dest, Ts&&... xs) {
 
 template <message_priority P = message_priority::normal, class Dest = actor,
           class Rep = int, class Period = std::ratio<1>, class... Ts>
-detail::enable_if_t<!std::is_same_v<Dest, group>>
+std::enable_if_t<!std::is_same_v<Dest, group>>
 delayed_anon_send(const Dest& dest, std::chrono::duration<Rep, Period> rtime,
                   Ts&&... xs) {
   static_assert(sizeof...(Ts) > 0, "no message to send");

--- a/libcaf_core/caf/span.hpp
+++ b/libcaf_core/caf/span.hpp
@@ -207,7 +207,7 @@ span<std::byte> as_writable_bytes(span<T> xs) {
 /// Convenience function to make using `caf::span` more convenient without the
 /// deduction guides.
 template <class T>
-auto make_span(T& xs) -> span<detail::remove_reference_t<decltype(xs[0])>> {
+auto make_span(T& xs) -> span<std::remove_reference_t<decltype(xs[0])>> {
   return {xs.data(), xs.size()};
 }
 

--- a/libcaf_core/caf/typed_actor.hpp
+++ b/libcaf_core/caf/typed_actor.hpp
@@ -121,7 +121,7 @@ public:
 
   // allow `handle_type{this}` for typed actors
   template <class T,
-            class = detail::enable_if_t<actor_traits<T>::is_statically_typed>>
+            class = std::enable_if_t<actor_traits<T>::is_statically_typed>>
   typed_actor(T* ptr) : ptr_(ptr->ctrl()) {
     static_assert(
       detail::tl_subset_of<signatures, typename T::signatures>::value,

--- a/libcaf_core/caf/typed_actor_pointer.hpp
+++ b/libcaf_core/caf/typed_actor_pointer.hpp
@@ -23,7 +23,7 @@ public:
   }
 
   template <class Supertype,
-            class = detail::enable_if_t< //
+            class = std::enable_if_t< //
               detail::tl_subset_of<detail::type_list<Sigs...>,
                                    typename Supertype::signatures>::value>>
   typed_actor_pointer(Supertype* selfptr) : view_(selfptr) {
@@ -31,7 +31,7 @@ public:
   }
 
   template <class... OtherSigs,
-            class = detail::enable_if_t< //
+            class = std::enable_if_t< //
               detail::tl_subset_of<detail::type_list<Sigs...>,
                                    detail::type_list<OtherSigs...>>::value>>
   typed_actor_pointer(typed_actor_pointer<OtherSigs...> other)
@@ -58,7 +58,7 @@ public:
   }
 
   template <class... OtherSigs,
-            class = detail::enable_if_t< //
+            class = std::enable_if_t< //
               detail::tl_subset_of<detail::type_list<Sigs...>,
                                    detail::type_list<OtherSigs...>>::value>>
   typed_actor_pointer& operator=(typed_actor_pointer<OtherSigs...> other) {

--- a/libcaf_test/caf/test/dsl.hpp
+++ b/libcaf_test/caf/test/dsl.hpp
@@ -165,7 +165,7 @@ public:
     return *this;
   }
 
-  template <class T, class E = caf::detail::enable_if_t<!std::is_pointer_v<T>>>
+  template <class T, class E = std::enable_if_t<!std::is_pointer_v<T>>>
   caf_handle& operator=(const T& x) {
     set(x);
     return *this;

--- a/libcaf_test/caf/test/io_dsl.hpp
+++ b/libcaf_test/caf/test/io_dsl.hpp
@@ -119,7 +119,7 @@ public:
 
 template <class Iterator>
 void exec_all_fixtures(Iterator first, Iterator last) {
-  using fixture_ptr = caf::detail::decay_t<decltype(*first)>;
+  using fixture_ptr = std::decay_t<decltype(*first)>;
   auto advance = [](fixture_ptr x) {
     return x->sched.try_run_once() || x->mpx.read_data()
            || x->mpx.try_exec_runnable() || x->mpx.try_accept_connection();

--- a/libcaf_test/caf/test/unit_test.hpp
+++ b/libcaf_test/caf/test/unit_test.hpp
@@ -68,7 +68,7 @@ struct equality_operator {
 
   template <
     class T, class U,
-    detail::enable_if_t<
+    std::enable_if_t<
       ((std::is_floating_point_v<T> && std::is_convertible_v<U, double>)
        || (std::is_floating_point_v<U> && std::is_convertible_v<T, double>) )
         && detail::is_comparable_v<T, U>,
@@ -84,7 +84,7 @@ struct equality_operator {
 
   template <
     class T, class U,
-    detail::enable_if_t<
+    std::enable_if_t<
       !((std::is_floating_point_v<T> && std::is_convertible_v<U, double>)
         || (std::is_floating_point_v<U> && std::is_convertible_v<T, double>) )
         && detail::is_comparable_v<T, U>,


### PR DESCRIPTION
This PR removes a couple of traits that either were backports of standard library features or that became straight up obsolete when switching to C++17 (such as `conjunction`).