### PR TITLE
Implement new scenario outlines

### DIFF
--- a/libcaf_test/CMakeLists.txt
+++ b/libcaf_test/CMakeLists.txt
@@ -28,6 +28,8 @@ caf_add_component(
     caf/test/fixture/flow.test.cpp
     caf/test/given.cpp
     caf/test/nesting_error.cpp
+    caf/test/outline.cpp
+    caf/test/outline.test.cpp
     caf/test/registry.cpp
     caf/test/reporter.cpp
     caf/test/requirement_failed.cpp

--- a/libcaf_test/README.md
+++ b/libcaf_test/README.md
@@ -169,6 +169,51 @@ will see the vector with its two initial elements. However, since `AND_*` blocks
 run after the previous block, the `AND_WHEN` block in the example above will see
 the vector with three elements.
 
+Scenario Outlines
+-----------------
+
+Scenario outlines allow users to run the same scenario with different inputs.
+The `GIVEN`, `WHEN`, `THEN`, etc. blocks inside of a scenario outline can use
+Gherkin-style placeholders to refer to input values using the syntax `<name>`.
+Further, an outline must contain an `EXAMPLE` block that defines the input
+values in Markdown table notation.
+
+To retrieve the values(s) for the placeholder(s) in a block, users can call
+`block_parameters<...>()` with `...` replaced by the desired type(s).
+
+The following example generates two scenarios from the outline. The first
+scenario will have `start = 12`, `eat = 5`, and `left = 7`. The second scenario
+will have `start = 20`, `eat = 5`, and `left = 15`.
+
+```cpp
+OUTLINE("eating cucumbers") {
+  GIVEN("there are <start> cucumbers") {
+    auto start = block_parameters<int>();
+    auto cucumbers = start;
+    WHEN("I eat <eat> cucumbers") {
+      auto eat = block_parameters<int>();
+      cucumbers -= eat;
+      THEN("I should have <left> cucumbers") {
+        auto left = block_parameters<int>();
+        check_eq(cucumbers, left);
+      }
+    }
+  }
+  EXAMPLES = R"(
+    | start | eat | left |
+    |    12 |   5 |    7 |
+    |    20 |   5 |   15 |
+  )";
+}
+```
+
+At runtime, CAF will replace all placeholders with their corresponding values
+from the `EXAMPLES` block in the test output. Further, the individual scenario
+runs are numbered in the test output. The example above would print
+`Scenario: eating cucumbers #1` when using the values from the first row of the
+`EXAMPLES` block and `Scenario: eating cucumbers #2` when using the values from
+the second row.
+
 Suites
 ------
 

--- a/libcaf_test/caf/test/block.hpp
+++ b/libcaf_test/caf/test/block.hpp
@@ -9,6 +9,7 @@
 #include "caf/detail/source_location.hpp"
 #include "caf/detail/test_export.hpp"
 
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -31,6 +32,11 @@ public:
   /// Returns the user-defined description of this block.
   std::string_view description() const noexcept {
     return description_;
+  }
+
+  /// Returns the parameters names from the description of this block.
+  const std::vector<std::string>& parameter_names() const noexcept {
+    return parameter_names_;
   }
 
   /// Returns the source location of this block.
@@ -103,13 +109,20 @@ public:
 protected:
   std::unique_ptr<block>& get_nested_or_construct(int id);
 
+  void lazy_init();
+
   context* ctx_;
   int id_ = 0;
-  std::string_view description_;
+  std::string_view raw_description_;
+  std::string description_;
   bool active_ = false;
   bool executed_ = false;
   std::vector<block*> nested_;
   detail::source_location loc_;
+  std::vector<std::string> parameter_names_;
+
+private:
+  void layz_init();
 };
 
 } // namespace caf::test

--- a/libcaf_test/caf/test/context.cpp
+++ b/libcaf_test/caf/test/context.cpp
@@ -35,7 +35,7 @@ bool context::can_run() {
 
 block* context::find_predecessor_block(int caller_id, block_type type) {
   // Find the caller.
-  auto i = steps.find(caller_id);
+  auto i = steps.find(std::make_pair(caller_id, example_id));
   if (i == steps.end())
     return nullptr;
   // Find the first step of type `T` that precedes the caller.

--- a/libcaf_test/caf/test/outline.cpp
+++ b/libcaf_test/caf/test/outline.cpp
@@ -1,0 +1,118 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/test/outline.hpp"
+
+#include "caf/string_algorithms.hpp"
+
+namespace {
+
+void trim_all(std::vector<std::string_view>& elements) {
+  for (auto& element : elements)
+    element = caf::trim(element);
+}
+
+bool has_duplicates(const std::vector<std::string_view>& elements) {
+  std::set<std::string_view> tmp;
+  for (auto& element : elements)
+    if (!tmp.insert(element).second)
+      return true;
+  return false;
+}
+
+void remove_empty_entries(std::vector<std::string_view>& elements) {
+  auto i = std::remove_if(elements.begin(), elements.end(),
+                          [](const auto& x) { return x.empty(); });
+  elements.erase(i, elements.end());
+}
+} // namespace
+
+namespace caf::test {
+
+outline::examples_setter&
+outline::examples_setter::operator=(std::string_view str) {
+  if (!examples_)
+    return *this;
+  // Split up the string into lines.
+  std::vector<std::string_view> lines;
+  split(lines, str, '\n', token_compress_on);
+  trim_all(lines);
+  remove_empty_entries(lines);
+  if (lines.size() < 2)
+    CAF_RAISE_ERROR(std::logic_error, "invalid examples table");
+  // Make sure each line is a Markdown-style table row.
+  auto is_valid_line = [](std::string_view line) {
+    return line.size() > 2 && line.front() == '|' && line.back() == '|';
+  };
+  if (!std::all_of(lines.begin(), lines.end(), is_valid_line))
+    CAF_RAISE_ERROR(std::logic_error, "invalid examples table: syntax error");
+  // Strip the leading and trailing pipes.
+  for (auto& line : lines)
+    line = trim(line.substr(1, line.size() - 2));
+  // Split up the first line into column names.
+  auto is_non_empty = [](std::string_view str) { return !str.empty(); };
+  std::vector<std::string_view> names;
+  split(names, lines.front(), '|');
+  trim_all(names);
+  if (!std::all_of(names.begin(), names.end(), is_non_empty))
+    CAF_RAISE_ERROR(std::logic_error,
+                    "invalid examples table: empty column names");
+  if (has_duplicates(names))
+    CAF_RAISE_ERROR(std::logic_error,
+                    "invalid examples table: duplicate column names");
+  // Parse the remaining lines.
+  for (size_t i = 1; i < lines.size(); ++i) {
+    std::vector<std::string_view> values;
+    split(values, lines[i], '|');
+    trim_all(values);
+    if (values.size() != names.size())
+      CAF_RAISE_ERROR(std::logic_error,
+                      "invalid examples table: wrong number of columns");
+    std::map<std::string, std::string> row;
+    for (size_t j = 0; j < names.size(); ++j)
+      row.emplace(std::string{names[j]}, std::string{values[j]});
+    examples_->emplace_back(std::move(row));
+  }
+  return *this;
+}
+
+void outline::run() {
+  if (ctx_->example_parameters.empty()) {
+    if (auto guard = ctx_->get<scenario>(-1, description_, loc_)->commit()) {
+      // By placing a dummy scenario on the unwind stack, we render all blocks
+      // inactive. We are only interested in the assignment to
+      // example_parameters.
+      scenario dummy{ctx_.get(), -2, description_, loc_};
+      ctx_->unwind_stack.push_back(&dummy);
+      call_do_run();
+      if (ctx_->example_parameters.empty())
+        CAF_RAISE_ERROR(std::logic_error,
+                        "failed to run outline: no examples found");
+    } else {
+      CAF_RAISE_ERROR(std::logic_error,
+                      "failed to select the root block for the outline");
+    }
+    ctx_->unwind_stack.clear();
+    // Create all descriptions for the examples.
+    for (size_t index = 0; index < ctx_->example_parameters.size(); ++index)
+      ctx_->example_names.emplace_back(
+        detail::format("{} #{}", description_, index + 1));
+    // Create all root steps ahead of time.
+    for (size_t index = 0; index < ctx_->example_parameters.size(); ++index) {
+      auto& ptr = ctx_->steps[std::make_pair(0, index)];
+      ptr = std::make_unique<scenario>(ctx_.get(), 0,
+                                       ctx_->example_names[index], loc_);
+    }
+  }
+  ctx_->parameters = ctx_->example_parameters[ctx_->example_id];
+  auto guard = detail::make_scope_guard([this] {
+    auto& ptr = ctx_->steps[std::make_pair(0, ctx_->example_id)];
+    if (!ptr->can_run()
+        && ctx_->example_id + 1 < ctx_->example_parameters.size())
+      ++ctx_->example_id;
+  });
+  super::run();
+}
+
+} // namespace caf::test

--- a/libcaf_test/caf/test/outline.hpp
+++ b/libcaf_test/caf/test/outline.hpp
@@ -1,0 +1,61 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/test/context.hpp"
+#include "caf/test/scenario.hpp"
+
+namespace caf::test {
+
+class outline : public runnable {
+public:
+  using super = runnable;
+
+  class examples_setter {
+  public:
+    using examples_t = std::vector<std::map<std::string, std::string>>;
+
+    explicit examples_setter(examples_t* examples) : examples_(examples) {
+      // nop
+    }
+
+    examples_setter(const examples_setter&) = default;
+
+    examples_setter& operator=(const examples_setter&) = default;
+
+    examples_setter& operator=(std::string_view str);
+
+  private:
+    examples_t* examples_;
+  };
+
+  using super::super;
+
+  void run() override;
+
+  auto make_examples_setter() {
+    if (ctx_->example_parameters.empty())
+      return examples_setter{&ctx_->example_parameters};
+    else
+      return examples_setter{nullptr};
+  }
+};
+
+} // namespace caf::test
+
+#define OUTLINE(description)                                                   \
+  struct CAF_PP_UNIFYN(outline_)                                               \
+    : caf::test::outline, caf_test_case_auto_fixture {                         \
+    using super = caf::test::outline;                                          \
+    using super::super;                                                        \
+    void do_run() override;                                                    \
+    static ptrdiff_t register_id;                                              \
+  };                                                                           \
+  ptrdiff_t CAF_PP_UNIFYN(outline_)::register_id                               \
+    = caf::test::registry::add<CAF_PP_UNIFYN(outline_)>(                       \
+      caf_test_suite_name, description, caf::test::block_type::scenario);      \
+  void CAF_PP_UNIFYN(outline_)::do_run()
+
+#define EXAMPLES this->make_examples_setter()

--- a/libcaf_test/caf/test/outline.test.cpp
+++ b/libcaf_test/caf/test/outline.test.cpp
@@ -1,0 +1,54 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/test/outline.hpp"
+
+#include "caf/test/caf_test_main.hpp"
+
+#include <numeric>
+
+OUTLINE("eating cucumbers") {
+  GIVEN("there are <start> cucumbers") {
+    auto start = block_parameters<int>();
+    auto cucumbers = start;
+    print_debug("cucumbers: {}", cucumbers);
+    WHEN("I eat <eat> cucumbers") {
+      auto eat = block_parameters<int>();
+      cucumbers -= eat;
+      print_debug("cucumbers: {}", cucumbers);
+      THEN("I should have <left> cucumbers") {
+        auto left = block_parameters<int>();
+        check_eq(cucumbers, left);
+      }
+    }
+  }
+  EXAMPLES = R"(
+    | start | eat | left |
+    |    12 |   5 |    7 |
+    |    20 |   5 |   15 |
+  )";
+}
+
+OUTLINE("counting numbers") {
+  GIVEN("the list <values>") {
+    auto values = block_parameters<std::vector<int>>();
+    WHEN("accumulating all values") {
+      auto result = std::accumulate(values.begin(), values.end(), 0);
+      THEN("the result should be <sum>") {
+        auto sum = block_parameters<int>();
+        check_eq(result, sum);
+      }
+    }
+  }
+  // Note: unused variables are ignored.
+  EXAMPLES = R"(
+    |    values | sum | unused |
+    |        [] |   0 |      1 |
+    |       [1] |   1 |    foo |
+    |    [1, 2] |   3 |    bar |
+    | [1, 2, 3] |   6 |   okay |
+  )";
+}
+
+CAF_TEST_MAIN()

--- a/libcaf_test/caf/test/runnable.cpp
+++ b/libcaf_test/caf/test/runnable.cpp
@@ -49,6 +49,12 @@ void runnable::run() {
   }
 }
 
+void runnable::call_do_run() {
+  current_runnable = this;
+  auto guard = detail::make_scope_guard([] { current_runnable = nullptr; });
+  do_run();
+}
+
 bool runnable::check(bool value, const detail::source_location& location) {
   if (value) {
     reporter::instance().pass(location);

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -5,17 +5,21 @@
 #pragma once
 
 #include "caf/test/binary_predicate.hpp"
+#include "caf/test/block.hpp"
 #include "caf/test/block_type.hpp"
+#include "caf/test/context.hpp"
 #include "caf/test/fwd.hpp"
 #include "caf/test/reporter.hpp"
 #include "caf/test/requirement_failed.hpp"
 
 #include "caf/config.hpp"
+#include "caf/config_value.hpp"
 #include "caf/deep_to_string.hpp"
 #include "caf/detail/format.hpp"
 #include "caf/detail/scope_guard.hpp"
 #include "caf/detail/source_location.hpp"
 #include "caf/detail/test_export.hpp"
+#include "caf/expected.hpp"
 #include "caf/raise_error.hpp"
 
 #include <string_view>
@@ -43,7 +47,7 @@ public:
   virtual ~runnable();
 
   /// Runs the next branch of the test.
-  void run();
+  virtual void run();
 
   /// Generates a message with the INFO severity level.
   template <class... Ts>
@@ -261,6 +265,28 @@ public:
     }
   }
 
+  template <class... Ts>
+  auto block_parameters() {
+    static_assert(sizeof...(Ts) != 0);
+    const auto& params = current_block().parameter_names();
+    if (params.size() != sizeof...(Ts))
+      CAF_RAISE_ERROR(std::logic_error,
+                      "block_parameters: invalid number of parameters");
+    std::array<config_value, sizeof...(Ts)> cfg_vals;
+    for (size_t index = 0; index < sizeof...(Ts); ++index)
+      cfg_vals[index] = ctx_->parameter(params[index]);
+    auto ok = false;
+    auto vals = convert_all<Ts...>(cfg_vals, std::index_sequence_for<Ts...>{},
+                                   ok);
+    if (!ok)
+      CAF_RAISE_ERROR(std::logic_error,
+                      "block_parameters: conversion(s) failed");
+    if constexpr (sizeof...(Ts) == 1)
+      return std::move(*std::get<0>(vals));
+    else
+      return unbox_all(vals, std::index_sequence_for<Ts...>{});
+  }
+
 #ifdef CAF_ENABLE_EXCEPTIONS
 
   /// Checks whether `expr()` throws an exception of type `Exception`.
@@ -335,12 +361,28 @@ public:
 #endif
 
 protected:
+  void call_do_run();
+
   context_ptr ctx_;
   std::string_view description_;
   block_type root_type_;
   detail::source_location loc_;
 
 private:
+  template <class... Ts, class Array, size_t... Is>
+  std::tuple<expected<Ts>...>
+  convert_all(Array& arr, std::index_sequence<Is...>, bool& ok) {
+    auto result = std::make_tuple(get_as<Ts>(arr[Is])...);
+    ok = (std::get<Is>(result).has_value() && ...);
+    return result;
+  }
+
+  template <class... Ts, size_t... Is>
+  std::tuple<Ts...>
+  unbox_all(std::tuple<expected<Ts>...>& vals, std::index_sequence<Is...>) {
+    return std::make_tuple((*std::move(std::get<Is>(vals)) && ...));
+  }
+
   template <class T0, class T1>
   static void assert_save_comparison() {
     if constexpr (std::is_integral_v<T0> && std::is_integral_v<T1>) {

--- a/libcaf_test/caf/test/runner.cpp
+++ b/libcaf_test/caf/test/runner.cpp
@@ -159,10 +159,13 @@ int runner::run(int argc, char** argv) {
         continue;
       auto state = std::make_shared<context>();
 #ifdef CAF_ENABLE_EXCEPTIONS
+      // Must be outside of the try block to make sure the object still exists
+      // in the catch block.
+      std::unique_ptr<runnable> def;
       try {
         do {
           default_reporter->begin_test(state, test_name);
-          auto def = factory_instance->make(state);
+          def = factory_instance->make(state);
           def->run();
           default_reporter->end_test();
           state->clear_stacks();


### PR DESCRIPTION
We have a couple of cases where we basically repeat `WHEN` blocks to call to the same API with different data. Scenario outlines will allow us to do this more directly less code duplication.