### PR TITLE
Add delegate tests with deterministic fixture

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -72,6 +72,7 @@ caf_add_component(
     caf/abstract_mailbox.cpp
     caf/action.cpp
     caf/action.test.cpp
+    caf/delegate.test.cpp
     caf/actor.cpp
     caf/actor_addr.cpp
     caf/actor_clock.cpp

--- a/libcaf_core/caf/delegate.test.cpp
+++ b/libcaf_core/caf/delegate.test.cpp
@@ -49,7 +49,7 @@ TEST("delegation moves responsibility for a request to another actor") {
     check_eq(*count, 5);
   }
   SECTION("the delegatee sends errors to the original sender") {
-    auto client = sys.spawn([count, delegator](event_based_actor* self) {
+    auto client = sys.spawn([delegator](event_based_actor* self) {
       self->send(delegator, "foo");
       return behavior{
         [](int32_t) {},
@@ -57,7 +57,7 @@ TEST("delegation moves responsibility for a request to another actor") {
     });
     auto observer = sys.spawn([client](event_based_actor* self) {
       self->monitor(client);
-      self->set_down_handler([](down_msg&) {});
+      self->set_down_handler([](const down_msg&) {});
       return behavior{
         [](int32_t) {},
       };
@@ -66,7 +66,7 @@ TEST("delegation moves responsibility for a request to another actor") {
     expect<std::string>().with("foo").from(client).to(worker);
     expect<error>().with(sec::unexpected_message).from(worker).to(client);
     expect<down_msg>()
-      .with(down_msg{client->address(), sec::unexpected_message})
+      .with(down_msg{client.address(), sec::unexpected_message})
       .from(client)
       .to(observer);
   }

--- a/libcaf_core/caf/delegate.test.cpp
+++ b/libcaf_core/caf/delegate.test.cpp
@@ -1,0 +1,62 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/test/caf_test_main.hpp"
+#include "caf/test/fixture/deterministic.hpp"
+#include "caf/test/test.hpp"
+
+#include "caf/event_based_actor.hpp"
+#include "caf/scoped_actor.hpp"
+#include "caf/sec.hpp"
+#include "caf/send.hpp"
+
+namespace fixture = caf::test::fixture;
+
+WITH_FIXTURE(fixture::deterministic) {
+
+#ifdef CAF_ENABLE_EXCEPTIONS
+TEST("delegates pass on the response properly") {
+  using namespace caf;
+  auto worker = sys.spawn([] {
+    return behavior{[](int32_t value) { return value * 2; },
+                    [](std::string value) {
+                      return make_error(caf::sec::runtime_error,
+                                        "Invalid type");
+                    }};
+  });
+  auto delegator = sys.spawn(
+    [](event_based_actor* self, caf::actor worker) {
+      return caf::behavior{
+        [self, worker](int32_t x) {
+          auto promise = self->make_response_promise<int>();
+          return promise.delegate(worker, x);
+        },
+        [self, worker](std::string x) {
+          auto promise = self->make_response_promise<error>();
+          return promise.delegate(worker, x);
+        },
+      };
+    },
+    worker);
+  scoped_actor self{sys};
+  SECTION("successful requests are propagated to sender") {
+    self->send(delegator, 2);
+    check_eq(mail_count(delegator), 1u);
+    check(dispatch_messages());
+    self->receive([&](int32_t result) { check_eq(result, 4); });
+  }
+  SECTION("failed requests are propagated to sender") {
+    self->send(delegator, "2");
+    check_eq(mail_count(delegator), 1u);
+    check(dispatch_messages());
+    self->receive([&](caf::error& err) {
+      check_eq(err, make_error(sec::runtime_error, "Invalid type"));
+    });
+  }
+}
+#endif // CAF_ENABLE_EXCEPTIONS
+
+} // WITH_FIXTURE(fixture::deterministic)
+
+CAF_TEST_MAIN()


### PR DESCRIPTION
relates https://github.com/actor-framework/actor-framework/issues/1051

Initial tests have been written that checks that delegates passes error and successful responses to the original sender.