### PR TITLE
Refactor logger to be an interface

### DIFF
--- a/.ci/windows/build.cmd
+++ b/.ci/windows/build.cmd
@@ -4,6 +4,7 @@ cmake.exe ^
   -G "Visual Studio 17 2022" ^
   -C ".ci\debug-flags.cmake" ^
   -DCAF_ENABLE_ROBOT_TESTS=ON ^
+  -DCAF_LOG_LEVEL=TRACE ^
   -DBUILD_SHARED_LIBS=OFF ^
   -DCMAKE_C_COMPILER=cl.exe ^
   -DCMAKE_CXX_COMPILER=cl.exe ^

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -26,6 +26,7 @@ jobs:
           -B build \
           -DCAF_ENABLE_ROBOT_TESTS:BOOL=ON \
           -DCAF_ENABLE_EXCEPTIONS:BOOL=OFF \
+          -DCAF_LOG_LEVEL:STRING=TRACE \
           -DCMAKE_CXX_FLAGS:STRING="-fno-exceptions -fprofile-arcs -ftest-coverage" \
           -DCMAKE_BUILD_TYPE:STRING=Debug \
           -DBUILD_SHARED_LIBS:BOOL=OFF

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -396,3 +396,10 @@ endif()
 if(CAF_ENABLE_TESTING AND CAF_ENABLE_EXCEPTIONS)
   caf_add_legacy_test_suites(caf-core-legacy-test custom_exception_handler)
 endif()
+
+caf_add_test_executable(
+  caf-core-logging-driver
+  SOURCES
+    tests/integration/logging.cpp
+  DEPENDENCIES
+    CAF::core)

--- a/libcaf_core/caf/actor_system.cpp
+++ b/libcaf_core/caf/actor_system.cpp
@@ -274,7 +274,6 @@ actor_system::actor_system(actor_system_config& cfg)
     dummy_execution_unit_(this),
     await_actors_before_shutdown_(true),
     cfg_(cfg),
-    logger_dtor_done_(false),
     tracing_context_(cfg.tracing_context),
     private_threads_(this) {
   CAF_SET_LOGGER_SYS(this);
@@ -400,10 +399,8 @@ actor_system::~actor_system() {
   }
   // reset logger and wait until dtor was called
   CAF_SET_LOGGER_SYS(nullptr);
+  logger_->stop();
   logger_.reset();
-  std::unique_lock<std::mutex> guard{logger_dtor_mtx_};
-  while (!logger_dtor_done_)
-    logger_dtor_cv_.wait(guard);
 }
 
 /// Returns the scheduler instance.

--- a/libcaf_core/caf/actor_system.cpp
+++ b/libcaf_core/caf/actor_system.cpp
@@ -268,7 +268,7 @@ actor_system::actor_system(actor_system_config& cfg)
     ids_(0),
     metrics_(cfg),
     base_metrics_(make_base_metrics(metrics_)),
-    logger_(new caf::logger(*this), false),
+    logger_(caf::logger::make(*this)),
     registry_(*this),
     groups_(*this),
     dummy_execution_unit_(this),
@@ -351,9 +351,6 @@ actor_system::actor_system(actor_system_config& cfg)
   // Initialize state for each module and give each module the opportunity to
   // adapt the system configuration.
   logger_->init(cfg);
-  // When running with the test coordinator, generate logs in the same thread.
-  if (!scheduler().detaches_utility_actors())
-    logger_->inline_output(true);
   CAF_SET_LOGGER_SYS(this);
   for (auto& mod : modules_)
     if (mod)

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -765,18 +765,6 @@ public:
     return tracing_context_;
   }
 
-  std::mutex& logger_dtor_mtx() noexcept {
-    return logger_dtor_mtx_;
-  }
-
-  std::condition_variable& logger_dtor_cv() noexcept {
-    return logger_dtor_cv_;
-  }
-
-  void logger_dtor_done(bool new_logger_dtor_done) noexcept {
-    logger_dtor_done_ = new_logger_dtor_done;
-  }
-
   detail::private_thread* acquire_private_thread();
 
   void release_private_thread(detail::private_thread*);
@@ -850,16 +838,6 @@ private:
 
   /// The system-wide, user-provided configuration.
   actor_system_config& cfg_;
-
-  /// Stores whether the logger has run its destructor and stopped any thread,
-  /// file handle, etc.
-  std::atomic<bool> logger_dtor_done_;
-
-  /// Guards `logger_dtor_done_`.
-  mutable std::mutex logger_dtor_mtx_;
-
-  /// Allows waiting on specific values for `logger_dtor_done_`.
-  mutable std::condition_variable logger_dtor_cv_;
 
   /// Stores the system-wide factory for deserializing tracing data.
   tracing_data_factory* tracing_context_;

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -765,6 +765,18 @@ public:
     return tracing_context_;
   }
 
+  std::mutex& logger_dtor_mtx() noexcept {
+    return logger_dtor_mtx_;
+  }
+
+  std::condition_variable& logger_dtor_cv() noexcept {
+    return logger_dtor_cv_;
+  }
+
+  void logger_dtor_done(bool new_logger_dtor_done) noexcept {
+    logger_dtor_done_ = new_logger_dtor_done;
+  }
+
   detail::private_thread* acquire_private_thread();
 
   void release_private_thread(detail::private_thread*);

--- a/libcaf_core/caf/logger.cpp
+++ b/libcaf_core/caf/logger.cpp
@@ -14,6 +14,7 @@
 #include "caf/detail/pretty_type_name.hpp"
 #include "caf/detail/set_thread_name.hpp"
 #include "caf/local_actor.hpp"
+#include "caf/make_counted.hpp"
 #include "caf/message.hpp"
 #include "caf/string_algorithms.hpp"
 #include "caf/term.hpp"
@@ -39,6 +40,21 @@ thread_local actor_id current_actor_id;
 
 // Stores a pointer to the system-wide logger.
 thread_local intrusive_ptr<logger> current_logger_ptr;
+
+struct print_adapter {
+  std::ostream& out;
+  void push_back(char c) {
+    out.put(c);
+  }
+  int end() {
+    return 0;
+  }
+  template <class Iterator, class Sentinel>
+  void insert(int, Iterator iter, Sentinel sentinel) {
+    while (iter != sentinel)
+      out.put(*iter++);
+  }
+};
 
 constexpr std::string_view log_level_name[] = {
   "QUIET", "",     "", "ERROR", "",      "", "WARN", "",
@@ -158,16 +174,484 @@ std::string_view reduce_symbol(std::ostream& out, std::string_view symbol) {
   return symbol;
 }
 
-} // namespace
+// Default logger implementation.
+class default_logger : public logger, public detail::atomic_ref_counted {
+public:
+  // -- constants --------------------------------------------------------------
 
-logger::config::config()
-  : verbosity(CAF_LOG_LEVEL),
-    file_verbosity(CAF_LOG_LEVEL),
-    console_verbosity(CAF_LOG_LEVEL),
-    inline_output(false),
-    console_coloring(false) {
-  // nop
-}
+  /// Configures the size of the circular event queue.
+  static constexpr size_t queue_size = 128;
+
+  // -- member types -----------------------------------------------------------
+
+  /// Combines various logging-related flags and parameters into a bitfield.
+  struct config {
+    /// Stores `max(file_verbosity, console_verbosity)`.
+    unsigned verbosity : 4;
+
+    /// Configures the verbosity for file output.
+    unsigned file_verbosity : 4;
+
+    /// Configures the verbosity for console output.
+    unsigned console_verbosity : 4;
+
+    /// Configures whether the logger immediately writes its output in the
+    /// calling thread, bypassing its queue. Use this option only in
+    /// single-threaded test environments.
+    bool inline_output : 1;
+
+    /// Configures whether the logger generates colored output.
+    bool console_coloring : 1;
+
+    config()
+      : verbosity(CAF_LOG_LEVEL),
+        file_verbosity(CAF_LOG_LEVEL),
+        console_verbosity(CAF_LOG_LEVEL),
+        inline_output(false),
+        console_coloring(false) {
+      // nop
+    }
+  };
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  default_logger(actor_system& sys) : t0_(make_timestamp()), system_(sys) {
+    // nop
+  }
+
+  virtual ~default_logger() {
+    stop();
+    // tell system our dtor is done
+    std::unique_lock<std::mutex> guard{system_.logger_dtor_mtx()};
+    system_.logger_dtor_done(true);
+    system_.logger_dtor_cv().notify_one();
+  }
+
+  // -- logging ----------------------------------------------------------------
+
+  /// Writes an entry to the event-queue of the logger.
+  /// @thread-safe
+  void log(event&& x) override {
+    if (cfg_.inline_output)
+      handle_event(x);
+    else
+      queue_.push_back(std::move(x));
+  }
+
+  // -- properties -------------------------------------------------------------
+  /// Returns whether the logger is configured to accept input for given
+  /// component and log level.
+  bool accepts(unsigned level, std::string_view component_name) override {
+    if (level > cfg_.verbosity)
+      return false;
+    return std::none_of(global_filter_.begin(), global_filter_.end(),
+                        [=](std::string_view name) {
+                          return name == component_name;
+                        });
+  }
+
+  /// Returns the output format used for the log file.
+  const line_format& file_format() const {
+    return file_format_;
+  }
+
+  /// Returns the output format used for the console.
+  const line_format& console_format() const {
+    return console_format_;
+  }
+
+  unsigned verbosity() const noexcept {
+    return cfg_.verbosity;
+  }
+
+  unsigned file_verbosity() const noexcept {
+    return cfg_.file_verbosity;
+  }
+
+  unsigned console_verbosity() const noexcept {
+    return cfg_.console_verbosity;
+  }
+
+  // -- static utility functions -----------------------------------------------
+
+  /// Renders the name of a fully qualified function.
+  static void render_fun_name(std::ostream& out, const event& e) {
+    out << e.simple_fun;
+  }
+
+  /// Renders the date of `x` in ISO 8601 format.
+  static void render_date(std::ostream& out, timestamp x) {
+    print_adapter adapter{out};
+    detail::print(adapter, x);
+  }
+
+  /// Parses `format_str` into a format description vector.
+  /// @warning The returned vector can have pointers into `format_str`.
+  static line_format parse_format(const std::string& format_str) {
+    std::vector<field> res;
+    auto plain_text_first = format_str.begin();
+    bool read_percent_sign = false;
+    auto i = format_str.begin();
+    for (; i != format_str.end(); ++i) {
+      if (read_percent_sign) {
+        field_type ft;
+        // clang-format off
+      switch (*i) {
+        case 'c': ft = category_field;     break;
+        case 'C': ft = class_name_field;   break;
+        case 'd': ft = date_field;         break;
+        case 'F': ft =  file_field;        break;
+        case 'L': ft = line_field;         break;
+        case 'm': ft = message_field;      break;
+        case 'M': ft = method_field;       break;
+        case 'n': ft = newline_field;      break;
+        case 'p': ft = priority_field;     break;
+        case 'r': ft = runtime_field;      break;
+        case 't': ft = thread_field;       break;
+        case 'a': ft = actor_field;        break;
+        case '%': ft = percent_sign_field; break;
+        default:
+          ft = invalid_field;
+          std::cerr << "invalid field specifier in format string: "
+                    << *i << std::endl;
+      }
+        // clang-format on
+        if (ft != invalid_field)
+          res.emplace_back(field{ft, std::string{}});
+        plain_text_first = i + 1;
+        read_percent_sign = false;
+      } else {
+        if (*i == '%') {
+          if (plain_text_first != i)
+            res.emplace_back(
+              field{plain_text_field, std::string{plain_text_first, i}});
+          read_percent_sign = true;
+        }
+      }
+    }
+    if (plain_text_first != i)
+      res.emplace_back(
+        field{plain_text_field, std::string{plain_text_first, i}});
+    return res;
+  }
+
+  /// Renders `x` using the line format `lf` to `out`.
+  void render(std::ostream& out, const line_format& lf, const event& x) const {
+    auto ms_time_diff = [](timestamp t0, timestamp tn) {
+      using namespace std::chrono;
+      return duration_cast<milliseconds>(tn - t0).count();
+    };
+    // clang-format off
+  for (auto& f : lf)
+    switch (f.kind) {
+      case category_field:     out << x.category_name;             break;
+      case class_name_field:   render_fun_prefix(out, x);          break;
+      case date_field:         render_date(out, x.tstamp);         break;
+      case file_field:         out << x.file_name;                 break;
+      case line_field:         out << x.line_number;               break;
+      case message_field:      out << x.message;                   break;
+      case method_field:       render_fun_name(out, x);            break;
+      case newline_field:      out << std::endl;                   break;
+      case priority_field:     out << log_level_name[x.level];     break;
+      case runtime_field:      out << ms_time_diff(t0_, x.tstamp); break;
+      case thread_field:       out << x.tid;                       break;
+      case actor_field:        out << "actor" << x.aid;            break;
+      case percent_sign_field: out << '%';                         break;
+      case plain_text_field:   out << f.text;                      break;
+      default: ; // nop
+    }
+    // clang-format on
+  }
+
+  // -- reference counting -----------------------------------------------------
+
+  /// Increases the reference count of the coordinated.
+  void ref_logger() const noexcept final {
+    this->ref();
+  }
+
+  /// Decreases the reference count of the coordinated and destroys the object
+  /// if necessary.
+  void deref_logger() const noexcept final {
+    this->deref();
+  }
+
+private:
+  // -- called by the actor_system when running with a test coordinator --------
+
+  void inline_output(bool value) noexcept {
+    cfg_.inline_output = value;
+  }
+
+  // -- initialization ---------------------------------------------------------
+
+  void init(actor_system_config& cfg) {
+    CAF_IGNORE_UNUSED(cfg);
+    namespace lg = defaults::logger;
+    using std::string;
+    using string_list = std::vector<std::string>;
+    auto get_verbosity = [&cfg](std::string_view key) -> unsigned {
+      if (auto str = get_if<string>(&cfg, key))
+        return to_level_int(*str);
+      return CAF_LOG_LEVEL_QUIET;
+    };
+    auto read_filter = [&cfg](string_list& var, std::string_view key) {
+      if (auto lst = get_as<string_list>(cfg, key))
+        var = std::move(*lst);
+    };
+    cfg_.file_verbosity = get_verbosity("caf.logger.file.verbosity");
+    cfg_.console_verbosity = get_verbosity("caf.logger.console.verbosity");
+    cfg_.verbosity = std::max(cfg_.file_verbosity, cfg_.console_verbosity);
+    if (cfg_.verbosity == CAF_LOG_LEVEL_QUIET)
+      return;
+    if (cfg_.file_verbosity > CAF_LOG_LEVEL_QUIET
+        && cfg_.console_verbosity > CAF_LOG_LEVEL_QUIET) {
+      read_filter(file_filter_, "caf.logger.file.excluded-components");
+      read_filter(console_filter_, "caf.logger.console.excluded-components");
+      std::sort(file_filter_.begin(), file_filter_.end());
+      std::sort(console_filter_.begin(), console_filter_.end());
+      std::set_intersection(file_filter_.begin(), file_filter_.end(),
+                            console_filter_.begin(), console_filter_.end(),
+                            std::back_inserter(global_filter_));
+    } else if (cfg_.file_verbosity > CAF_LOG_LEVEL_QUIET) {
+      read_filter(file_filter_, "caf.logger.file.excluded-components");
+      global_filter_ = file_filter_;
+    } else {
+      read_filter(console_filter_, "caf.logger.console.excluded-components");
+      global_filter_ = console_filter_;
+    }
+    // Parse the format string.
+    file_format_
+      = parse_format(get_or(cfg, "caf.logger.file.format", lg::file::format));
+    console_format_ = parse_format(
+      get_or(cfg, "caf.logger.console.format", lg::console::format));
+    // If not set to `false`, CAF enables colored output when writing to TTYs.
+    cfg_.console_coloring = get_or(cfg, "caf.logger.console.colored", true);
+  }
+
+  bool open_file() {
+    if (file_verbosity() == CAF_LOG_LEVEL_QUIET || file_name_.empty())
+      return false;
+    file_.open(file_name_, std::ios::out | std::ios::app);
+    if (!file_) {
+      std::cerr << "unable to open log file " << file_name_ << std::endl;
+      return false;
+    }
+    return true;
+  }
+
+  // -- event handling ---------------------------------------------------------
+
+  void handle_event(const event& x) {
+    handle_file_event(x);
+    handle_console_event(x);
+  }
+
+  void handle_file_event(const event& x) {
+    // Print to file if available.
+    if (file_ && x.level <= file_verbosity()
+        && none_of(file_filter_.begin(), file_filter_.end(),
+                   [&x](std::string_view name) {
+                     return name == x.category_name;
+                   }))
+      render(file_, file_format_, x);
+  }
+
+  void handle_console_event(const event& x) {
+    if (x.level > console_verbosity())
+      return;
+    if (std::any_of(console_filter_.begin(), console_filter_.end(),
+                    [&x](std::string_view name) {
+                      return name == x.category_name;
+                    }))
+      return;
+    if (cfg_.console_coloring) {
+      switch (x.level) {
+        default:
+          break;
+        case CAF_LOG_LEVEL_ERROR:
+          std::clog << term::red;
+          break;
+        case CAF_LOG_LEVEL_WARNING:
+          std::clog << term::yellow;
+          break;
+        case CAF_LOG_LEVEL_INFO:
+          std::clog << term::green;
+          break;
+        case CAF_LOG_LEVEL_DEBUG:
+          std::clog << term::cyan;
+          break;
+        case CAF_LOG_LEVEL_TRACE:
+          std::clog << term::blue;
+          break;
+      }
+      render(std::clog, console_format_, x);
+      std::clog << term::reset_endl;
+    } else {
+      render(std::clog, console_format_, x);
+      std::clog << std::endl;
+    }
+  }
+
+  void log_first_line() {
+    auto e = CAF_LOG_MAKE_EVENT(0, CAF_LOG_COMPONENT, CAF_LOG_LEVEL_DEBUG, "");
+    auto make_message = [&](int level, const auto& filter) {
+      auto lvl_str = log_level_name[level];
+      std::string msg = "verbosity = ";
+      msg.insert(msg.end(), lvl_str.begin(), lvl_str.end());
+      msg += ", node = ";
+      msg += to_string(system_.node());
+      msg += ", excluded-components = ";
+      detail::stringification_inspector f{msg};
+      detail::save(f, filter);
+      return msg;
+    };
+    namespace lg = defaults::logger;
+    e.message = make_message(cfg_.file_verbosity, file_filter_);
+    handle_file_event(e);
+    e.message = make_message(cfg_.console_verbosity, console_filter_);
+    handle_console_event(e);
+  }
+
+  void log_last_line() {
+    auto e = CAF_LOG_MAKE_EVENT(0, CAF_LOG_COMPONENT, CAF_LOG_LEVEL_DEBUG, "");
+    handle_event(e);
+  }
+
+  // -- thread management ------------------------------------------------------
+
+  void run() {
+    // Bail out without printing anything if the first event we receive is the
+    // shutdown (empty) event.
+    queue_.wait_nonempty();
+    if (queue_.front().message.empty())
+      return;
+    if (!open_file() && console_verbosity() == CAF_LOG_LEVEL_QUIET)
+      return;
+    log_first_line();
+    // Loop until receiving an empty message.
+    for (;;) {
+      // Handle current head of the queue.
+      auto& e = queue_.front();
+      if (e.message.empty()) {
+        log_last_line();
+        return;
+      }
+      handle_event(e);
+      // Prepare next iteration.
+      queue_.pop_front();
+      queue_.wait_nonempty();
+    }
+  }
+
+  void start() {
+    parent_thread_ = std::this_thread::get_id();
+    if (verbosity() == CAF_LOG_LEVEL_QUIET)
+      return;
+    file_name_ = get_or(system_.config(), "caf.logger.file.path",
+                        defaults::logger::file::path);
+    if (file_name_.empty()) {
+      // No need to continue if console and log file are disabled.
+      if (console_verbosity() == CAF_LOG_LEVEL_QUIET)
+        return;
+    } else {
+      // Replace placeholders.
+      const char pid[] = "[PID]";
+      auto i = std::search(file_name_.begin(), file_name_.end(),
+                           std::begin(pid), std::end(pid) - 1);
+      if (i != file_name_.end()) {
+        auto id = std::to_string(detail::get_process_id());
+        file_name_.replace(i, i + sizeof(pid) - 1, id);
+      }
+      const char ts[] = "[TIMESTAMP]";
+      i = std::search(file_name_.begin(), file_name_.end(), std::begin(ts),
+                      std::end(ts) - 1);
+      if (i != file_name_.end()) {
+        auto t0_str = timestamp_to_string(t0_);
+        file_name_.replace(i, i + sizeof(ts) - 1, t0_str);
+      }
+      const char node[] = "[NODE]";
+      i = std::search(file_name_.begin(), file_name_.end(), std::begin(node),
+                      std::end(node) - 1);
+      if (i != file_name_.end()) {
+        auto nid = to_string(system_.node());
+        file_name_.replace(i, i + sizeof(node) - 1, nid);
+      }
+    }
+    if (cfg_.inline_output) {
+      // Open file immediately for inline output.
+      open_file();
+      log_first_line();
+    } else {
+      // Note: we don't call system_->launch_thread here since we don't want to
+      //       set a logger context in the logger thread.
+      auto f = [this](auto guard) {
+        CAF_IGNORE_UNUSED(guard);
+        detail::set_thread_name("caf.logger");
+        system_.thread_started(thread_owner::system);
+        run();
+        system_.thread_terminates();
+      };
+      thread_ = std::thread{f, detail::global_meta_objects_guard()};
+    }
+  }
+
+  void stop() {
+    if (cfg_.inline_output) {
+      log_last_line();
+      return;
+    }
+    if (!thread_.joinable())
+      return;
+    // A default-constructed event causes the logger to shutdown.
+    queue_.push_back(event{});
+    thread_.join();
+  }
+
+  // -- member variables -------------------------------------------------------
+
+  // Configures verbosity and output generation.
+  config cfg_;
+
+  // Filters events by component name before enqueuing a log event. Intersection
+  // of file_filter_ and console_filter_ if both outputs are enabled.
+  std::vector<std::string> global_filter_;
+
+  // Filters events by component name for file output.
+  std::vector<std::string> file_filter_;
+
+  // Filters events by component name for console output.
+  std::vector<std::string> console_filter_;
+
+  // Identifies the thread that called `logger::start`.
+  std::thread::id parent_thread_;
+
+  // Format for generating file output.
+  line_format file_format_;
+
+  // Format for generating console output.
+  line_format console_format_;
+
+  // Stream for file output.
+  std::fstream file_;
+
+  // Filled with log events by other threads.
+  detail::sync_ring_buffer<event, queue_size> queue_;
+
+  // Stores the assembled name of the log file.
+  std::string file_name_;
+
+  // Executes `logger::run`.
+  std::thread thread_;
+
+  // Timestamp of the first log event.
+  timestamp t0_;
+
+  // References the parent system.
+  actor_system& system_;
+};
+
+} // namespace
 
 logger::event::event(unsigned lvl, unsigned line, std::string_view cat,
                      std::string_view full_fun, std::string_view fun,
@@ -233,11 +717,8 @@ actor_id logger::thread_local_aid(actor_id aid) {
   return aid;
 }
 
-void logger::log(event&& x) {
-  if (cfg_.inline_output)
-    handle_event(x);
-  else
-    queue_.push_back(std::move(x));
+intrusive_ptr<logger> logger::make(actor_system& sys) {
+  return make_counted<default_logger>(sys);
 }
 
 void logger::set_current_actor_system(actor_system* x) {
@@ -246,80 +727,6 @@ void logger::set_current_actor_system(actor_system* x) {
 
 logger* logger::current_logger() {
   return current_logger_ptr.get();
-}
-
-bool logger::accepts(unsigned level, std::string_view cname) {
-  if (level > cfg_.verbosity)
-    return false;
-  return std::none_of(global_filter_.begin(), global_filter_.end(),
-                      [=](std::string_view name) { return name == cname; });
-}
-
-logger::logger(actor_system& sys) : system_(sys), t0_(make_timestamp()) {
-  // nop
-}
-
-logger::~logger() {
-  stop();
-  // tell system our dtor is done
-  std::unique_lock<std::mutex> guard{system_.logger_dtor_mtx_};
-  system_.logger_dtor_done_ = true;
-  system_.logger_dtor_cv_.notify_one();
-}
-
-void logger::init(actor_system_config& cfg) {
-  CAF_IGNORE_UNUSED(cfg);
-  namespace lg = defaults::logger;
-  using std::string;
-  using string_list = std::vector<std::string>;
-  auto get_verbosity = [&cfg](std::string_view key) -> unsigned {
-    if (auto str = get_if<string>(&cfg, key))
-      return to_level_int(*str);
-    return CAF_LOG_LEVEL_QUIET;
-  };
-  auto read_filter = [&cfg](string_list& var, std::string_view key) {
-    if (auto lst = get_as<string_list>(cfg, key))
-      var = std::move(*lst);
-  };
-  cfg_.file_verbosity = get_verbosity("caf.logger.file.verbosity");
-  cfg_.console_verbosity = get_verbosity("caf.logger.console.verbosity");
-  cfg_.verbosity = std::max(cfg_.file_verbosity, cfg_.console_verbosity);
-  if (cfg_.verbosity == CAF_LOG_LEVEL_QUIET)
-    return;
-  if (cfg_.file_verbosity > CAF_LOG_LEVEL_QUIET
-      && cfg_.console_verbosity > CAF_LOG_LEVEL_QUIET) {
-    read_filter(file_filter_, "caf.logger.file.excluded-components");
-    read_filter(console_filter_, "caf.logger.console.excluded-components");
-    std::sort(file_filter_.begin(), file_filter_.end());
-    std::sort(console_filter_.begin(), console_filter_.end());
-    std::set_intersection(file_filter_.begin(), file_filter_.end(),
-                          console_filter_.begin(), console_filter_.end(),
-                          std::back_inserter(global_filter_));
-  } else if (cfg_.file_verbosity > CAF_LOG_LEVEL_QUIET) {
-    read_filter(file_filter_, "caf.logger.file.excluded-components");
-    global_filter_ = file_filter_;
-  } else {
-    read_filter(console_filter_, "caf.logger.console.excluded-components");
-    global_filter_ = console_filter_;
-  }
-  // Parse the format string.
-  file_format_
-    = parse_format(get_or(cfg, "caf.logger.file.format", lg::file::format));
-  console_format_ = parse_format(
-    get_or(cfg, "caf.logger.console.format", lg::console::format));
-  // If not set to `false`, CAF enables colored output when writing to TTYs.
-  cfg_.console_coloring = get_or(cfg, "caf.logger.console.colored", true);
-}
-
-bool logger::open_file() {
-  if (file_verbosity() == CAF_LOG_LEVEL_QUIET || file_name_.empty())
-    return false;
-  file_.open(file_name_, std::ios::out | std::ios::app);
-  if (!file_) {
-    std::cerr << "unable to open log file " << file_name_ << std::endl;
-    return false;
-  }
-  return true;
 }
 
 void logger::render_fun_prefix(std::ostream& out, const event& x) {
@@ -376,278 +783,11 @@ void logger::render_fun_prefix(std::ostream& out, const event& x) {
   reduce_symbol(out, reduced);
 }
 
-void logger::render_fun_name(std::ostream& out, const event& e) {
-  out << e.simple_fun;
-}
-
-namespace {
-
-struct print_adapter {
-  std::ostream& out;
-  void push_back(char c) {
-    out.put(c);
-  }
-  int end() {
-    return 0;
-  }
-  template <class Iterator, class Sentinel>
-  void insert(int, Iterator iter, Sentinel sentinel) {
-    while (iter != sentinel)
-      out.put(*iter++);
-  }
-};
-
-} // namespace
-
-void logger::render_date(std::ostream& out, timestamp x) {
-  print_adapter adapter{out};
-  detail::print(adapter, x);
-}
-
-void logger::render(std::ostream& out, const line_format& lf,
-                    const event& x) const {
-  auto ms_time_diff = [](timestamp t0, timestamp tn) {
-    using namespace std::chrono;
-    return duration_cast<milliseconds>(tn - t0).count();
-  };
-  // clang-format off
-  for (auto& f : lf)
-    switch (f.kind) {
-      case category_field:     out << x.category_name;             break;
-      case class_name_field:   render_fun_prefix(out, x);          break;
-      case date_field:         render_date(out, x.tstamp);         break;
-      case file_field:         out << x.file_name;                 break;
-      case line_field:         out << x.line_number;               break;
-      case message_field:      out << x.message;                   break;
-      case method_field:       render_fun_name(out, x);            break;
-      case newline_field:      out << std::endl;                   break;
-      case priority_field:     out << log_level_name[x.level];     break;
-      case runtime_field:      out << ms_time_diff(t0_, x.tstamp); break;
-      case thread_field:       out << x.tid;                       break;
-      case actor_field:        out << "actor" << x.aid;            break;
-      case percent_sign_field: out << '%';                         break;
-      case plain_text_field:   out << f.text;                      break;
-      default: ; // nop
-    }
-  // clang-format on
-}
-
-logger::line_format logger::parse_format(const std::string& format_str) {
-  std::vector<field> res;
-  auto plain_text_first = format_str.begin();
-  bool read_percent_sign = false;
-  auto i = format_str.begin();
-  for (; i != format_str.end(); ++i) {
-    if (read_percent_sign) {
-      field_type ft;
-      // clang-format off
-      switch (*i) {
-        case 'c': ft = category_field;     break;
-        case 'C': ft = class_name_field;   break;
-        case 'd': ft = date_field;         break;
-        case 'F': ft =  file_field;        break;
-        case 'L': ft = line_field;         break;
-        case 'm': ft = message_field;      break;
-        case 'M': ft = method_field;       break;
-        case 'n': ft = newline_field;      break;
-        case 'p': ft = priority_field;     break;
-        case 'r': ft = runtime_field;      break;
-        case 't': ft = thread_field;       break;
-        case 'a': ft = actor_field;        break;
-        case '%': ft = percent_sign_field; break;
-        default:
-          ft = invalid_field;
-          std::cerr << "invalid field specifier in format string: "
-                    << *i << std::endl;
-      }
-      // clang-format on
-      if (ft != invalid_field)
-        res.emplace_back(field{ft, std::string{}});
-      plain_text_first = i + 1;
-      read_percent_sign = false;
-    } else {
-      if (*i == '%') {
-        if (plain_text_first != i)
-          res.emplace_back(
-            field{plain_text_field, std::string{plain_text_first, i}});
-        read_percent_sign = true;
-      }
-    }
-  }
-  if (plain_text_first != i)
-    res.emplace_back(field{plain_text_field, std::string{plain_text_first, i}});
-  return res;
-}
-
 std::string_view logger::skip_path(std::string_view path) {
   auto find_slash = [&] { return path.find('/'); };
   for (auto p = find_slash(); p != std::string_view::npos; p = find_slash())
     path.remove_prefix(p + 1);
   return path;
-}
-
-void logger::run() {
-  // Bail out without printing anything if the first event we receive is the
-  // shutdown (empty) event.
-  queue_.wait_nonempty();
-  if (queue_.front().message.empty())
-    return;
-  if (!open_file() && console_verbosity() == CAF_LOG_LEVEL_QUIET)
-    return;
-  log_first_line();
-  // Loop until receiving an empty message.
-  for (;;) {
-    // Handle current head of the queue.
-    auto& e = queue_.front();
-    if (e.message.empty()) {
-      log_last_line();
-      return;
-    }
-    handle_event(e);
-    // Prepare next iteration.
-    queue_.pop_front();
-    queue_.wait_nonempty();
-  }
-}
-
-void logger::handle_file_event(const event& x) {
-  // Print to file if available.
-  if (file_ && x.level <= file_verbosity()
-      && none_of(file_filter_.begin(), file_filter_.end(),
-                 [&x](std::string_view name) {
-                   return name == x.category_name;
-                 }))
-    render(file_, file_format_, x);
-}
-
-void logger::handle_console_event(const event& x) {
-  if (x.level > console_verbosity())
-    return;
-  if (std::any_of(console_filter_.begin(), console_filter_.end(),
-                  [&x](std::string_view name) {
-                    return name == x.category_name;
-                  }))
-    return;
-  if (cfg_.console_coloring) {
-    switch (x.level) {
-      default:
-        break;
-      case CAF_LOG_LEVEL_ERROR:
-        std::clog << term::red;
-        break;
-      case CAF_LOG_LEVEL_WARNING:
-        std::clog << term::yellow;
-        break;
-      case CAF_LOG_LEVEL_INFO:
-        std::clog << term::green;
-        break;
-      case CAF_LOG_LEVEL_DEBUG:
-        std::clog << term::cyan;
-        break;
-      case CAF_LOG_LEVEL_TRACE:
-        std::clog << term::blue;
-        break;
-    }
-    render(std::clog, console_format_, x);
-    std::clog << term::reset_endl;
-  } else {
-    render(std::clog, console_format_, x);
-    std::clog << std::endl;
-  }
-}
-
-void logger::handle_event(const event& x) {
-  handle_file_event(x);
-  handle_console_event(x);
-}
-
-void logger::log_first_line() {
-  auto e = CAF_LOG_MAKE_EVENT(0, CAF_LOG_COMPONENT, CAF_LOG_LEVEL_DEBUG, "");
-  auto make_message = [&](int level, const auto& filter) {
-    auto lvl_str = log_level_name[level];
-    std::string msg = "verbosity = ";
-    msg.insert(msg.end(), lvl_str.begin(), lvl_str.end());
-    msg += ", node = ";
-    msg += to_string(system_.node());
-    msg += ", excluded-components = ";
-    detail::stringification_inspector f{msg};
-    detail::save(f, filter);
-    return msg;
-  };
-  namespace lg = defaults::logger;
-  e.message = make_message(cfg_.file_verbosity, file_filter_);
-  handle_file_event(e);
-  e.message = make_message(cfg_.console_verbosity, console_filter_);
-  handle_console_event(e);
-}
-
-void logger::log_last_line() {
-  auto e = CAF_LOG_MAKE_EVENT(0, CAF_LOG_COMPONENT, CAF_LOG_LEVEL_DEBUG, "");
-  handle_event(e);
-}
-
-void logger::start() {
-  parent_thread_ = std::this_thread::get_id();
-  if (verbosity() == CAF_LOG_LEVEL_QUIET)
-    return;
-  file_name_ = get_or(system_.config(), "caf.logger.file.path",
-                      defaults::logger::file::path);
-  if (file_name_.empty()) {
-    // No need to continue if console and log file are disabled.
-    if (console_verbosity() == CAF_LOG_LEVEL_QUIET)
-      return;
-  } else {
-    // Replace placeholders.
-    const char pid[] = "[PID]";
-    auto i = std::search(file_name_.begin(), file_name_.end(), std::begin(pid),
-                         std::end(pid) - 1);
-    if (i != file_name_.end()) {
-      auto id = std::to_string(detail::get_process_id());
-      file_name_.replace(i, i + sizeof(pid) - 1, id);
-    }
-    const char ts[] = "[TIMESTAMP]";
-    i = std::search(file_name_.begin(), file_name_.end(), std::begin(ts),
-                    std::end(ts) - 1);
-    if (i != file_name_.end()) {
-      auto t0_str = timestamp_to_string(t0_);
-      file_name_.replace(i, i + sizeof(ts) - 1, t0_str);
-    }
-    const char node[] = "[NODE]";
-    i = std::search(file_name_.begin(), file_name_.end(), std::begin(node),
-                    std::end(node) - 1);
-    if (i != file_name_.end()) {
-      auto nid = to_string(system_.node());
-      file_name_.replace(i, i + sizeof(node) - 1, nid);
-    }
-  }
-  if (cfg_.inline_output) {
-    // Open file immediately for inline output.
-    open_file();
-    log_first_line();
-  } else {
-    // Note: we don't call system_->launch_thread here since we don't want to
-    //       set a logger context in the logger thread.
-    auto f = [this](auto guard) {
-      CAF_IGNORE_UNUSED(guard);
-      detail::set_thread_name("caf.logger");
-      system_.thread_started(thread_owner::system);
-      run();
-      system_.thread_terminates();
-    };
-    thread_ = std::thread{f, detail::global_meta_objects_guard()};
-  }
-}
-
-void logger::stop() {
-  if (cfg_.inline_output) {
-    log_last_line();
-    return;
-  }
-  if (!thread_.joinable())
-    return;
-  // A default-constructed event causes the logger to shutdown.
-  queue_.push_back(event{});
-  thread_.join();
 }
 
 std::string to_string(logger::field_type x) {

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -46,41 +46,8 @@ namespace caf {
 /// Centrally logs events from all actors in an actor system. To enable
 /// logging in your application, you need to define `CAF_LOG_LEVEL`. Per
 /// default, the logger generates log4j compatible output.
-class CAF_CORE_EXPORT logger : public ref_counted {
+class CAF_CORE_EXPORT logger {
 public:
-  // -- friends ----------------------------------------------------------------
-
-  friend class actor_system;
-
-  // -- constants --------------------------------------------------------------
-
-  /// Configures the size of the circular event queue.
-  static constexpr size_t queue_size = 128;
-
-  // -- member types -----------------------------------------------------------
-
-  /// Combines various logging-related flags and parameters into a bitfield.
-  struct config {
-    /// Stores `max(file_verbosity, console_verbosity)`.
-    unsigned verbosity : 4;
-
-    /// Configures the verbosity for file output.
-    unsigned file_verbosity : 4;
-
-    /// Configures the verbosity for console output.
-    unsigned console_verbosity : 4;
-
-    /// Configures whether the logger immediately writes its output in the
-    /// calling thread, bypassing its queue. Use this option only in
-    /// single-threaded test environments.
-    bool inline_output : 1;
-
-    /// Configures whether the logger generates colored output.
-    bool console_coloring : 1;
-
-    config();
-  };
-
   /// Encapsulates a single logging event.
   struct CAF_CORE_EXPORT event {
     // -- constructors, destructors, and assignment operators ------------------
@@ -191,13 +158,13 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  ~logger() override;
+  virtual ~logger() = default;
 
   // -- logging ----------------------------------------------------------------
 
   /// Writes an entry to the event-queue of the logger.
   /// @thread-safe
-  void log(event&& x);
+  virtual void log(event&& x) = 0;
 
   // -- properties -------------------------------------------------------------
 
@@ -209,52 +176,18 @@ public:
 
   /// Returns whether the logger is configured to accept input for given
   /// component and log level.
-  bool accepts(unsigned level, std::string_view component_name);
-
-  /// Returns the output format used for the log file.
-  const line_format& file_format() const {
-    return file_format_;
-  }
-
-  /// Returns the output format used for the console.
-  const line_format& console_format() const {
-    return console_format_;
-  }
-
-  unsigned verbosity() const noexcept {
-    return cfg_.verbosity;
-  }
-
-  unsigned file_verbosity() const noexcept {
-    return cfg_.file_verbosity;
-  }
-
-  unsigned console_verbosity() const noexcept {
-    return cfg_.console_verbosity;
-  }
+  virtual bool accepts(unsigned level, std::string_view component_name) = 0;
 
   // -- static utility functions -----------------------------------------------
+
+  /// Creates a new logger instance.
+  static intrusive_ptr<logger> make(actor_system& sys);
 
   /// Renders the prefix (namespace and class) of a fully qualified function.
   static void render_fun_prefix(std::ostream& out, const event& x);
 
-  /// Renders the name of a fully qualified function.
-  static void render_fun_name(std::ostream& out, const event& x);
-
-  /// Renders the date of `x` in ISO 8601 format.
-  static void render_date(std::ostream& out, timestamp x);
-
-  /// Parses `format_str` into a format description vector.
-  /// @warning The returned vector can have pointers into `format_str`.
-  static line_format parse_format(const std::string& format_str);
-
   /// Skips path in `filename`.
   static std::string_view skip_path(std::string_view filename);
-
-  // -- utility functions ------------------------------------------------------
-
-  /// Renders `x` using the line format `lf` to `out`.
-  void render(std::ostream& out, const line_format& lf, const event& x) const;
 
   // -- thread-local properties ------------------------------------------------
 
@@ -265,84 +198,28 @@ public:
   /// registered.
   static logger* current_logger();
 
-private:
-  // -- constructors, destructors, and assignment operators --------------------
+  // -- reference counting -----------------------------------------------------
 
-  logger(actor_system& sys);
+  /// Increases the reference count of the logger.
+  virtual void ref_logger() const noexcept = 0;
 
-  // -- called by the actor_system when running with a test coordinator --------
+  /// Decreases the reference count of the logger and destroys the object
+  /// if necessary.
+  virtual void deref_logger() const noexcept = 0;
 
-  void inline_output(bool value) noexcept {
-    cfg_.inline_output = value;
+  friend void intrusive_ptr_add_ref(const logger* ptr) noexcept {
+    ptr->ref_logger();
+  }
+
+  friend void intrusive_ptr_release(const logger* ptr) noexcept {
+    ptr->deref_logger();
   }
 
   // -- initialization ---------------------------------------------------------
 
-  void init(actor_system_config& cfg);
+  virtual void init(actor_system_config& cfg) = 0;
 
-  bool open_file();
-
-  // -- event handling ---------------------------------------------------------
-
-  void handle_event(const event& x);
-
-  void handle_file_event(const event& x);
-
-  void handle_console_event(const event& x);
-
-  void log_first_line();
-
-  void log_last_line();
-
-  // -- thread management ------------------------------------------------------
-
-  void run();
-
-  void start();
-
-  void stop();
-
-  // -- member variables -------------------------------------------------------
-
-  // Configures verbosity and output generation.
-  config cfg_;
-
-  // Filters events by component name before enqueuing a log event. Intersection
-  // of file_filter_ and console_filter_ if both outputs are enabled.
-  std::vector<std::string> global_filter_;
-
-  // Filters events by component name for file output.
-  std::vector<std::string> file_filter_;
-
-  // Filters events by component name for console output.
-  std::vector<std::string> console_filter_;
-
-  // References the parent system.
-  actor_system& system_;
-
-  // Identifies the thread that called `logger::start`.
-  std::thread::id parent_thread_;
-
-  // Timestamp of the first log event.
-  timestamp t0_;
-
-  // Format for generating file output.
-  line_format file_format_;
-
-  // Format for generating console output.
-  line_format console_format_;
-
-  // Stream for file output.
-  std::fstream file_;
-
-  // Filled with log events by other threads.
-  detail::sync_ring_buffer<event, queue_size> queue_;
-
-  // Stores the assembled name of the log file.
-  std::string file_name_;
-
-  // Executes `logger::run`.
-  std::thread thread_;
+  virtual void start() = 0;
 };
 
 CAF_CORE_EXPORT std::string to_string(logger::field_type x);

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -48,6 +48,8 @@ namespace caf {
 /// default, the logger generates log4j compatible output.
 class CAF_CORE_EXPORT logger {
 public:
+  // -- member types -----------------------------------------------------------
+
   /// Encapsulates a single logging event.
   struct CAF_CORE_EXPORT event {
     // -- constructors, destructors, and assignment operators ------------------
@@ -116,15 +118,6 @@ public:
     percent_sign_field,
     plain_text_field
   };
-
-  /// Represents a single format string field.
-  struct field {
-    field_type kind;
-    std::string text;
-  };
-
-  /// Stores a parsed format string as list of fields.
-  using line_format = std::vector<field>;
 
   /// Utility class for building user-defined log messages with `CAF_ARG`.
   class CAF_CORE_EXPORT line_builder {
@@ -217,18 +210,15 @@ public:
 
   // -- initialization ---------------------------------------------------------
 
-  virtual void init(actor_system_config& cfg) = 0;
+  /// Allows the logger to read its configuration from the actor system config.
+  virtual void init(const actor_system_config& cfg) = 0;
 
+  /// Starts any background threads needed by the logger.
   virtual void start() = 0;
+
+  /// Stops all background threads of the logger.
+  virtual void stop() = 0;
 };
-
-CAF_CORE_EXPORT std::string to_string(logger::field_type x);
-
-/// @relates logger::field
-CAF_CORE_EXPORT std::string to_string(const logger::field& x);
-
-/// @relates logger::field
-CAF_CORE_EXPORT bool operator==(const logger::field& x, const logger::field& y);
 
 } // namespace caf
 

--- a/libcaf_core/tests/integration/logging.cpp
+++ b/libcaf_core/tests/integration/logging.cpp
@@ -1,0 +1,19 @@
+#define CAF_LOG_COMPONENT "app"
+
+#include "caf/caf_main.hpp"
+#include "caf/logger.hpp"
+
+void foo([[maybe_unused]] int value) {
+  CAF_LOG_TRACE(CAF_ARG(value));
+  CAF_LOG_DEBUG("this is a debug message");
+  CAF_LOG_INFO("this is an info message");
+  CAF_LOG_WARNING("this is a warning message");
+  CAF_LOG_ERROR("this is an error message");
+}
+
+void caf_main(caf::actor_system&) {
+  foo(42);
+}
+
+// creates a main function for us that calls our caf_main
+CAF_MAIN()

--- a/libcaf_core/tests/legacy/logger.cpp
+++ b/libcaf_core/tests/legacy/logger.cpp
@@ -52,15 +52,6 @@ struct fixture {
     cfg.set("caf.logger.file.path", "");
   }
 
-  void add(logger::field_type kind) {
-    lf.emplace_back(logger::field{kind, std::string{}});
-  }
-
-  template <size_t N>
-  void add(logger::field_type kind, const char (&str)[N]) {
-    lf.emplace_back(logger::field{kind, std::string{str, str + (N - 1)}});
-  }
-
   template <class F, class... Ts>
   string render(F f, Ts&&... xs) {
     std::ostringstream oss;
@@ -69,7 +60,6 @@ struct fixture {
   }
 
   actor_system_config cfg;
-  logger::line_format lf;
 };
 
 void fun() {
@@ -117,8 +107,6 @@ struct tpl {
 };
 
 } // namespace foo
-
-constexpr const char* file_format = "%r %c %p %a %t %C %M %F:%L %m%n";
 
 } // namespace
 

--- a/libcaf_core/tests/legacy/logger.cpp
+++ b/libcaf_core/tests/legacy/logger.cpp
@@ -124,42 +124,12 @@ constexpr const char* file_format = "%r %c %p %a %t %C %M %F:%L %m%n";
 
 BEGIN_FIXTURE_SCOPE(fixture)
 
-// copy construction, copy assign, move construction, move assign
-// and finally serialization round-trip
-CAF_TEST(parse_default_format_strings) {
-  actor_system sys{cfg};
-  add(logger::runtime_field);
-  add(logger::plain_text_field, " ");
-  add(logger::category_field);
-  add(logger::plain_text_field, " ");
-  add(logger::priority_field);
-  add(logger::plain_text_field, " ");
-  add(logger::actor_field);
-  add(logger::plain_text_field, " ");
-  add(logger::thread_field);
-  add(logger::plain_text_field, " ");
-  add(logger::class_name_field);
-  add(logger::plain_text_field, " ");
-  add(logger::method_field);
-  add(logger::plain_text_field, " ");
-  add(logger::file_field);
-  add(logger::plain_text_field, ":");
-  add(logger::line_field);
-  add(logger::plain_text_field, " ");
-  add(logger::message_field);
-  add(logger::newline_field);
-  CHECK_EQ(logger::parse_format(file_format), lf);
-  CHECK_EQ(sys.logger().file_format(), lf);
-}
-
 CAF_TEST(rendering) {
   // Rendering of time points.
   timestamp t0;
   time_t t0_t = 0;
   char t0_buf[50];
   strftime(t0_buf, sizeof(t0_buf), "%Y-%m-%dT%H:%M:%S", localtime(&t0_t));
-  // Note: we use starts_with because we cannot predict the exact time zone.
-  CHECK(starts_with(render(logger::render_date, t0), t0_buf));
   // Rendering of events.
   logger::event e{
     CAF_LOG_LEVEL_WARNING,
@@ -173,16 +143,7 @@ CAF_TEST(rendering) {
     0,
     t0,
   };
-  CHECK_EQ(render(logger::render_fun_name, e), "bar"sv);
   CHECK_EQ(render(logger::render_fun_prefix, e), "ns.foo"sv);
-  // Exclude %r and %t from rendering test because they are nondeterministic.
-  actor_system sys{cfg};
-  auto lf = logger::parse_format("%c %p %a %C %M %F:%L %m");
-  auto& lg = sys.logger();
-  using namespace std::placeholders;
-  auto render_event = bind(&logger::render, &lg, _1, _2, _3);
-  CHECK_EQ(render(render_event, lf, e),
-           "unit_test WARN actor0 ns.foo bar foo.cpp:42 hello world");
 }
 
 CAF_TEST(render_fun_prefix) {

--- a/robot/CMakeLists.txt
+++ b/robot/CMakeLists.txt
@@ -35,6 +35,17 @@ add_test(
       --variable SSL_PATH:${CMAKE_CURRENT_SOURCE_DIR}
       "${CMAKE_CURRENT_SOURCE_DIR}/http/rest.robot")
 
+# The logging test assumes that the CAF_LOG_LEVEL is set to TRACE.
+if (CAF_LOG_LEVEL STREQUAL "TRACE")
+  add_test(
+    NAME "robot-logging-output"
+    COMMAND
+      ${Python_EXECUTABLE}
+        -m robot
+        --variable BINARY_PATH:$<TARGET_FILE:caf-core-logging-driver>
+        "${CMAKE_CURRENT_SOURCE_DIR}/logging/output.robot")
+endif()
+
 add_test(
   NAME "robot-web-socket-quote-server"
   COMMAND

--- a/robot/logging/base.cfg
+++ b/robot/logging/base.cfg
@@ -1,0 +1,13 @@
+caf {
+  logger {
+    console {
+      format = "%p %c %m"
+      excluded-components = ["caf", "caf_flow"]
+    }
+    file {
+      path = "app.log"
+      format = "%p %c %m%n"
+      excluded-components = ["caf", "caf_flow"]
+    }
+  }
+}

--- a/robot/logging/output.robot
+++ b/robot/logging/output.robot
@@ -1,0 +1,150 @@
+*** Settings ***
+Documentation       A test suite for --dump-config.
+
+Library             OperatingSystem
+Library             Process
+
+
+*** Variables ***
+${BINARY_PATH}          /path/to/the/test/binary
+
+${TRACE_BASELINE}=      SEPARATOR=
+...                     TRACE app ENTRY value = 42\n
+...                     DEBUG app this is a debug message\n
+...                     INFO app this is an info message\n
+...                     WARN app this is a warning message\n
+...                     ERROR app this is an error message\n
+...                     TRACE app EXIT\n
+
+${DEBUG_BASELINE}=      SEPARATOR=
+...                     DEBUG app this is a debug message\n
+...                     INFO app this is an info message\n
+...                     WARN app this is a warning message\n
+...                     ERROR app this is an error message\n
+
+${INFO_BASELINE}=       SEPARATOR=
+...                     INFO app this is an info message\n
+...                     WARN app this is a warning message\n
+...                     ERROR app this is an error message\n
+
+${WARN_BASELINE}=       SEPARATOR=
+...                     WARN app this is a warning message\n
+...                     ERROR app this is an error message\n
+
+${ERROR_BASELINE}=      SEPARATOR=
+...                     ERROR app this is an error message\n
+
+
+*** Test Cases ***
+The console logger prints everything when setting the log level to TRACE
+    [Tags]    logging
+    Remove File    app.out
+    Run Process    ${BINARY_PATH}
+    ...    --config-file\=${CURDIR}${/}base.cfg
+    ...    --caf.logger.console.verbosity\=trace
+    ...    stderr=app.out
+    ${found}=    Get File    app.out
+    Should Be Equal As Strings  ${TRACE_BASELINE}  ${found}  formatter=repr
+
+The file logger prints everything when setting the log level to TRACE
+    [Tags]    logging
+    Remove File    app.log
+    Run Process    ${BINARY_PATH}
+    ...    --config-file\=${CURDIR}${/}base.cfg
+    ...    --caf.logger.file.verbosity\=trace
+    ${found}=    Get File    app.log
+    Should Be Equal As Strings  ${TRACE_BASELINE}  ${found}  formatter=repr
+
+The console logger prints a subset when setting the log level to DEBUG
+    [Tags]    logging
+    Remove File    app.out
+    Run Process    ${BINARY_PATH}
+    ...    --config-file\=${CURDIR}${/}base.cfg
+    ...    --caf.logger.console.verbosity\=debug
+    ...    stderr=app.out
+    ${found}=    Get File    app.out
+    Should Be Equal As Strings  ${DEBUG_BASELINE}  ${found}  formatter=repr
+
+The file logger prints a subset when setting the log level to DEBUG
+    [Tags]    logging
+    Remove File    app.log
+    Run Process    ${BINARY_PATH}
+    ...    --config-file\=${CURDIR}${/}base.cfg
+    ...    --caf.logger.file.verbosity\=debug
+    ${found}=    Get File    app.log
+    Should Be Equal As Strings  ${DEBUG_BASELINE}  ${found}  formatter=repr
+
+The console logger prints a subset when setting the log level to INFO
+    [Tags]    logging
+    Remove File    app.out
+    Run Process    ${BINARY_PATH}
+    ...    --config-file\=${CURDIR}${/}base.cfg
+    ...    --caf.logger.console.verbosity\=info
+    ...    stderr=app.out
+    ${found}=    Get File    app.out
+    Should Be Equal As Strings  ${INFO_BASELINE}  ${found}  formatter=repr
+
+The file logger prints a subset when setting the log level to INFO
+    [Tags]    logging
+    Remove File    app.log
+    Run Process    ${BINARY_PATH}
+    ...    --config-file\=${CURDIR}${/}base.cfg
+    ...    --caf.logger.file.verbosity\=info
+    ${found}=    Get File    app.log
+    Should Be Equal As Strings  ${INFO_BASELINE}  ${found}  formatter=repr
+
+The console logger prints a subset when setting the log level to WARN
+    [Tags]    logging
+    Remove File    app.out
+    Run Process    ${BINARY_PATH}
+    ...    --config-file\=${CURDIR}${/}base.cfg
+    ...    --caf.logger.console.verbosity\=warning
+    ...    stderr=app.out
+    ${found}=    Get File    app.out
+    Should Be Equal As Strings  ${WARN_BASELINE}  ${found}  formatter=repr
+
+The file logger prints a subset when setting the log level to WARN
+    [Tags]    logging
+    Remove File    app.log
+    Run Process    ${BINARY_PATH}
+    ...    --config-file\=${CURDIR}${/}base.cfg
+    ...    --caf.logger.file.verbosity\=warning
+    ${found}=    Get File    app.log
+    Should Be Equal As Strings  ${WARN_BASELINE}  ${found}  formatter=repr
+
+The console logger prints a subset when setting the log level to ERROR
+    [Tags]    logging
+    Remove File    app.out
+    Run Process    ${BINARY_PATH}
+    ...    --config-file\=${CURDIR}${/}base.cfg
+    ...    --caf.logger.console.verbosity\=error
+    ...    stderr=app.out
+    ${found}=    Get File    app.out
+    Should Be Equal As Strings  ${ERROR_BASELINE}  ${found}  formatter=repr
+
+The applications prints a subset when setting the log level to ERROR
+    [Tags]    logging
+    Remove File    app.log
+    Run Process    ${BINARY_PATH}
+    ...    --config-file\=${CURDIR}${/}base.cfg
+    ...    --caf.logger.file.verbosity\=error
+    ${found}=    Get File    app.log
+    Should Be Equal As Strings  ${ERROR_BASELINE}  ${found}  formatter=repr
+
+The console logger prints nothing when setting the log level to QUIET
+    [Tags]    logging
+    Remove File    app.out
+    Run Process    ${BINARY_PATH}
+    ...    --config-file\=${CURDIR}${/}base.cfg
+    ...    --caf.logger.console.verbosity\=quiet
+    ...    stderr=app.out
+    ${found}=    Get File    app.out
+    Should Be Empty    ${found}
+
+The file logger prints nothing when setting the log level to QUIET
+    [Tags]    logging
+    Remove File    app.log
+    Run Process    ${BINARY_PATH}
+    ...    --config-file\=${CURDIR}${/}base.cfg
+    ...    --caf.logger.file.verbosity\=quiet
+    File Should Not Exist    app.log


### PR DESCRIPTION
Relates https://github.com/actor-framework/actor-framework/issues/588

@Neverlord , I would like to get your feedback regarding the refactor. The code will not compile due to the tests in `libcaf_core\tests\legacy\logger.cpp`. The public interface has changed and some functions are not testable now. We could approach this in two ways, one would be to make the tested functions public again and then they will compile and the tests will pass too. Another would be to remove these tests as they are not relevant anymore.