### PR TITLE
Integrate ostream output into deterministic tests

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -106,6 +106,7 @@ caf_add_component(
     caf/deserializer.cpp
     caf/detail/abstract_worker.cpp
     caf/detail/abstract_worker_hub.cpp
+    caf/detail/actor_local_printer.cpp
     caf/detail/atomic_ref_counted.cpp
     caf/detail/base64.cpp
     caf/detail/behavior_impl.cpp
@@ -148,6 +149,7 @@ caf_add_component(
     caf/disposable.cpp
     caf/error.cpp
     caf/event_based_actor.cpp
+    caf/event_based_actor.test.cpp
     caf/execution_unit.cpp
     caf/flow/coordinated.cpp
     caf/flow/coordinator.cpp

--- a/libcaf_core/caf/actor_ostream.hpp
+++ b/libcaf_core/caf/actor_ostream.hpp
@@ -6,6 +6,7 @@
 
 #include "caf/actor.hpp"
 #include "caf/deep_to_string.hpp"
+#include "caf/detail/actor_local_printer.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/typed_actor_pointer.hpp"
 
@@ -39,10 +40,16 @@ public:
   }
 
   /// Writes `arg` to the buffer allocated for the calling actor.
-  actor_ostream& write(std::string arg);
+  actor_ostream& write(std::string arg) {
+    printer_->write(std::move(arg));
+    return *this;
+  }
 
   /// Flushes the buffer allocated for the calling actor.
-  actor_ostream& flush();
+  actor_ostream& flush() {
+    printer_->flush();
+    return *this;
+  }
 
   /// Redirects all further output from `self` to `file_name`.
   [[deprecated]] static void redirect(abstract_actor* self, std::string fn,
@@ -55,12 +62,14 @@ public:
 
   /// Writes `arg` to the buffer allocated for the calling actor.
   actor_ostream& operator<<(const char* arg) {
-    return write(arg);
+    printer_->write(arg);
+    return *this;
   }
 
   /// Writes `arg` to the buffer allocated for the calling actor.
   actor_ostream& operator<<(std::string arg) {
-    return write(std::move(arg));
+    printer_->write(std::move(arg));
+    return *this;
   }
 
   /// Writes `to_string(arg)` to the buffer allocated for the calling actor,
@@ -68,7 +77,8 @@ public:
   /// the argument.
   template <class T>
   actor_ostream& operator<<(const T& arg) {
-    return write(deep_to_string(arg));
+    printer_->write(deep_to_string(arg));
+    return *this;
   }
 
   /// Apply `f` to `*this`.
@@ -77,10 +87,7 @@ public:
   }
 
 private:
-  void init(abstract_actor*);
-
-  actor_id self_;
-  actor printer_;
+  detail::actor_local_printer_ptr printer_;
 };
 
 /// Convenience factory function for creating an actor output stream.

--- a/libcaf_core/caf/detail/actor_local_printer.cpp
+++ b/libcaf_core/caf/detail/actor_local_printer.cpp
@@ -1,0 +1,13 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/detail/actor_local_printer.hpp"
+
+namespace caf::detail {
+
+actor_local_printer::~actor_local_printer() {
+  // nop
+}
+
+} // namespace caf::detail

--- a/libcaf_core/caf/detail/actor_local_printer.hpp
+++ b/libcaf_core/caf/detail/actor_local_printer.hpp
@@ -1,0 +1,28 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/detail/core_export.hpp"
+#include "caf/intrusive_ptr.hpp"
+#include "caf/ref_counted.hpp"
+
+#include <string_view>
+
+namespace caf::detail {
+
+class CAF_CORE_EXPORT actor_local_printer : public ref_counted {
+public:
+  ~actor_local_printer() override;
+
+  virtual void write(std::string&& arg) = 0;
+
+  virtual void write(const char* arg) = 0;
+
+  virtual void flush() = 0;
+};
+
+using actor_local_printer_ptr = intrusive_ptr<actor_local_printer>;
+
+} // namespace caf::detail

--- a/libcaf_core/caf/event_based_actor.test.cpp
+++ b/libcaf_core/caf/event_based_actor.test.cpp
@@ -1,0 +1,37 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/event_based_actor.hpp"
+
+#include "caf/test/caf_test_main.hpp"
+#include "caf/test/fixture/deterministic.hpp"
+#include "caf/test/test.hpp"
+
+#include "caf/event_based_actor.hpp"
+#include "caf/scoped_actor.hpp"
+#include "caf/send.hpp"
+
+using namespace caf;
+
+WITH_FIXTURE(test::fixture::deterministic) {
+
+TEST("unexpected messages result in an error by default") {
+  auto receiver = sys.spawn([](event_based_actor*) -> behavior {
+    return {
+      [](int32_t) {},
+    };
+  });
+  auto sender = sys.spawn([receiver](event_based_actor* self) -> behavior {
+    self->send(receiver, "hello world");
+    return {
+      [](int32_t) {},
+    };
+  });
+  expect<std::string>().from(sender).to(receiver);
+  expect<error>().with(sec::unexpected_message).from(receiver).to(sender);
+}
+
+} // WITH_FIXTURE(test::fixture::deterministic)
+
+CAF_TEST_MAIN()

--- a/libcaf_core/caf/scheduler/abstract_coordinator.hpp
+++ b/libcaf_core/caf/scheduler/abstract_coordinator.hpp
@@ -9,6 +9,7 @@
 #include "caf/actor_cast.hpp"
 #include "caf/actor_clock.hpp"
 #include "caf/actor_system.hpp"
+#include "caf/detail/actor_local_printer.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/fwd.hpp"
 #include "caf/message.hpp"
@@ -33,6 +34,8 @@ public:
   actor printer() const {
     return actor_cast<actor>(utility_actors_[printer_id]);
   }
+
+  virtual detail::actor_local_printer_ptr printer_for(local_actor* self);
 
   /// Returns the number of utility actors.
   size_t num_utility_actors() const {

--- a/libcaf_test/caf/test/fixture/deterministic.cpp
+++ b/libcaf_test/caf/test/fixture/deterministic.cpp
@@ -128,6 +128,45 @@ private:
 
 // -- scheduler ----------------------------------------------------------------
 
+namespace {
+
+class actor_local_printer_impl : public detail::actor_local_printer {
+public:
+  explicit actor_local_printer_impl(local_actor* self) : self_(self) {
+    // nop
+  }
+
+  void write(std::string&& arg) override {
+    append(arg);
+  }
+
+  void write(const char* arg) override {
+    append(std::string_view{arg});
+  }
+
+  void flush() override {
+    auto str = std::string{line_.begin(), line_.end()};
+    reporter::instance().print_actor_output(self_, str);
+    line_.clear();
+  }
+
+private:
+  void append(std::string_view str) {
+    for (auto c : str) {
+      if (c == '\n') {
+        flush();
+      } else {
+        line_.push_back(c);
+      }
+    }
+  }
+
+  local_actor* self_;
+  std::vector<char> line_;
+};
+
+} // namespace
+
 class deterministic::scheduler_impl : public scheduler::abstract_coordinator {
 public:
   using super = caf::scheduler::abstract_coordinator;
@@ -135,6 +174,13 @@ public:
   scheduler_impl(actor_system& sys, deterministic* fix)
     : super(sys), fix_(fix) {
     // nop
+  }
+
+  detail::actor_local_printer_ptr printer_for(local_actor* self) override {
+    auto& ptr = printers_[self->id()];
+    if (!ptr)
+      ptr = make_counted<actor_local_printer_impl>(self);
+    return ptr;
   }
 
   bool detaches_utility_actors() const override {
@@ -181,6 +227,9 @@ private:
 
   /// Allows users to fake time at will.
   detail::test_actor_clock clock_;
+
+  /// Maps actors to their designated printer.
+  std::map<actor_id, detail::actor_local_printer_ptr> printers_;
 };
 
 // -- config -------------------------------------------------------------------

--- a/libcaf_test/caf/test/reporter.cpp
+++ b/libcaf_test/caf/test/reporter.cpp
@@ -11,6 +11,7 @@
 
 #include "caf/detail/format.hpp"
 #include "caf/detail/log_level.hpp"
+#include "caf/local_actor.hpp"
 #include "caf/raise_error.hpp"
 #include "caf/term.hpp"
 
@@ -391,6 +392,18 @@ public:
   void print_warning(std::string_view msg,
                      const detail::source_location& location) override {
     print_impl(CAF_LOG_LEVEL_WARNING, 'Y', "warning", msg, location);
+  }
+
+  void print_actor_output(local_actor* self, std::string_view msg) override {
+    using detail::format_to;
+    if (level_ < CAF_LOG_LEVEL_INFO)
+      return;
+    set_live();
+    format_to(colored(),
+              "{0:{1}}$M(info):\n"
+              "{0:{1}}  src: $0{2} [ID {3}]\n"
+              "{0:{1}}  msg: {4}\n",
+              ' ', indent_, self->name(), self->id(), msg);
   }
 
   unsigned verbosity(unsigned level) override {

--- a/libcaf_test/caf/test/reporter.hpp
+++ b/libcaf_test/caf/test/reporter.hpp
@@ -8,6 +8,7 @@
 
 #include "caf/detail/source_location.hpp"
 #include "caf/detail/test_export.hpp"
+#include "caf/fwd.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -86,6 +87,8 @@ public:
   virtual void
   print_error(std::string_view msg, const detail::source_location& location)
     = 0;
+
+  virtual void print_actor_output(local_actor* self, std::string_view msg) = 0;
 
   /// Sets the verbosity level of the reporter and returns the previous value.
   virtual unsigned verbosity(unsigned level) = 0;


### PR DESCRIPTION
Fixes an issue with the deterministic fixture where it crashed when an actor used `aout`.