### PR TITLE
Add additional tests for event_based_actor

### DIFF
--- a/libcaf_core/caf/event_based_actor.test.cpp
+++ b/libcaf_core/caf/event_based_actor.test.cpp
@@ -30,16 +30,15 @@ TEST("unexpected messages result in an error by default") {
   });
   expect<std::string>().from(sender1).to(receiver);
   expect<error>().with(sec::unexpected_message).from(receiver).to(sender1);
-  SECTION("receiver continues to receive message after returning error") {
-    auto sender2 = sys.spawn([receiver](event_based_actor* self) -> behavior {
-      self->send(receiver, 2);
-      return {
-        [](int32_t) {},
-      };
-    });
-    expect<int32_t>().with(2).from(sender2).to(receiver);
-    expect<int32_t>().with(3).from(receiver).to(sender2);
-  }
+  // Receivers continue receiving messages after unexpected messages.
+  auto sender2 = sys.spawn([receiver](event_based_actor* self) -> behavior {
+    self->send(receiver, 2);
+    return {
+      [](int32_t) {},
+    };
+  });
+  expect<int32_t>().with(2).from(sender2).to(receiver);
+  expect<int32_t>().with(3).from(receiver).to(sender2);
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)

--- a/libcaf_core/caf/event_based_actor.test.cpp
+++ b/libcaf_core/caf/event_based_actor.test.cpp
@@ -19,30 +19,26 @@ WITH_FIXTURE(test::fixture::deterministic) {
 TEST("unexpected messages result in an error by default") {
   auto receiver = sys.spawn([](event_based_actor*) -> behavior {
     return {
-      [](int32_t x) { return ++x; },
+      [](int32_t x) { return x + 1; },
     };
   });
-  auto sender = sys.spawn([receiver](event_based_actor* self) -> behavior {
+  auto sender1 = sys.spawn([receiver](event_based_actor* self) -> behavior {
     self->send(receiver, "hello world");
     return {
       [](int32_t) {},
     };
   });
-  expect<std::string>().from(sender).to(receiver);
-  SECTION("receiver sends an unexpected_message error to sender") {
-    expect<error>().with(sec::unexpected_message).from(receiver).to(sender);
-  }
+  expect<std::string>().from(sender1).to(receiver);
+  expect<error>().with(sec::unexpected_message).from(receiver).to(sender1);
   SECTION("receiver continues to receive message after returning error") {
-    expect<error>().with(sec::unexpected_message).from(receiver).to(sender);
-    auto integer_sender
-      = sys.spawn([receiver](event_based_actor* self) -> behavior {
-          self->send(receiver, 2);
-          return {
-            [](int32_t) {},
-          };
-        });
-    expect<int32_t>().with(2).from(integer_sender).to(receiver);
-    expect<int32_t>().with(3).from(receiver).to(integer_sender);
+    auto sender2 = sys.spawn([receiver](event_based_actor* self) -> behavior {
+      self->send(receiver, 2);
+      return {
+        [](int32_t) {},
+      };
+    });
+    expect<int32_t>().with(2).from(sender2).to(receiver);
+    expect<int32_t>().with(3).from(receiver).to(sender2);
   }
 }
 


### PR DESCRIPTION
Relates https://github.com/actor-framework/actor-framework/issues/1051
Added additional tests in `event_based_actor` to verify that the actors continue receiving messages after returning error.