### PR TITLE
Verify type IDs when creating messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   positive value from `consume`.
 - When constructing a `behavior` or `message_handler`, callbacks that take a
   `message` argument are now treated as catch-all handlers.
+- When creating a message with a non-existing type ID, CAF now prints a
+  human-readable error message and calls `abort` instead of crashing the
+  application.
 
 ### Fixed
 

--- a/libcaf_core/caf/detail/message_data.cpp
+++ b/libcaf_core/caf/detail/message_data.cpp
@@ -23,6 +23,8 @@ message_data::message_data(type_id_list types) noexcept
 }
 
 message_data::~message_data() noexcept {
+  // Note: no need to perform bound checks or nullptr checks here, because
+  //       we verify the type IDs while constructing the message.
   auto gmos = global_meta_objects();
   auto ptr = storage();
   if (constructed_elements_ == types_.size()) {
@@ -41,6 +43,8 @@ message_data::~message_data() noexcept {
 }
 
 message_data* message_data::copy() const {
+  // Note: no need to perform bound checks or nullptr checks here, because
+  //       we verify the type IDs while constructing the original message.
   auto gmos = global_meta_objects();
   size_t storage_size = 0;
   for (auto id : types_)
@@ -64,10 +68,9 @@ message_data* message_data::copy() const {
 
 intrusive_ptr<message_data>
 message_data::make_uninitialized(type_id_list types) {
-  auto gmos = global_meta_objects();
   size_t storage_size = 0;
   for (auto id : types)
-    storage_size += gmos[id].padded_size;
+    storage_size += global_meta_object(id).padded_size;
   auto total_size = sizeof(message_data) + storage_size;
   auto vptr = malloc(total_size);
   if (vptr == nullptr)


### PR DESCRIPTION
Closes #973.

@riemass can you double-check that there aren't more places where CAF could crash from accessing the meta object table unchecked? We do verify all IDs in `load_data` (`message.cpp`), so this was the only place that looked like it needed the checked access. Also left some comments at the other places where we can safely skip the checks.