### PR TITLE
Manually set system openssl in windows runner

### DIFF
--- a/.ci/windows/build.cmd
+++ b/.ci/windows/build.cmd
@@ -8,6 +8,7 @@ cmake.exe ^
   -DBUILD_SHARED_LIBS=OFF ^
   -DCMAKE_C_COMPILER=cl.exe ^
   -DCMAKE_CXX_COMPILER=cl.exe ^
+  -DOPENSSL_ROOT_DIR="C:\Program Files\OpenSSL" ^
   -DCMAKE_CXX_FLAGS="/WX"
 
 cmake.exe --build build --parallel %NUMBER_OF_PROCESSORS% --target install --config debug || exit \b 1


### PR DESCRIPTION
Test setting manually the OpenSSL path. The path has changed slightly since last time we used this method. 