### PR TITLE
Fix unused-lambda-capture warnings on clang

### DIFF
--- a/examples/message_passing/fixed_stack.cpp
+++ b/examples/message_passing/fixed_stack.cpp
@@ -64,8 +64,8 @@ class fixed_stack : public event_based_actor {
 public:
   fixed_stack(actor_config& cfg, size_t stack_size)
     : event_based_actor(cfg), size_(stack_size) {
-    full_.assign( //
-      [this](push_atom, int) -> error {
+    full_.assign(
+      [](push_atom, int) -> error { //
         return fixed_stack_errc::push_to_full;
       },
       [this](pop_atom) -> int {
@@ -74,7 +74,7 @@ public:
         become(filled_);
         return result;
       });
-    filled_.assign( //
+    filled_.assign(
       [this](push_atom, int what) {
         data_.push_back(what);
         if (data_.size() == size_)
@@ -87,7 +87,7 @@ public:
           become(empty_);
         return result;
       });
-    empty_.assign( //
+    empty_.assign(
       [this](push_atom, int what) {
         data_.push_back(what);
         become(filled_);

--- a/libcaf_core/tests/legacy/dynamic_spawn.cpp
+++ b/libcaf_core/tests/legacy/dynamic_spawn.cpp
@@ -39,11 +39,11 @@ public:
   event_testee(actor_config& cfg) : event_based_actor(cfg) {
     inc_actor_instances();
     wait4string.assign([this](const std::string&) { become(wait4int); },
-                       [this](get_atom) { return "wait4string"; });
+                       [](get_atom) { return "wait4string"; });
     wait4float.assign([this](float) { become(wait4string); },
-                      [this](get_atom) { return "wait4float"; });
+                      [](get_atom) { return "wait4float"; });
     wait4int.assign([this](int) { become(wait4float); },
-                    [this](get_atom) { return "wait4int"; });
+                    [](get_atom) { return "wait4int"; });
   }
 
   ~event_testee() override {

--- a/libcaf_core/tests/legacy/message_lifetime.cpp
+++ b/libcaf_core/tests/legacy/message_lifetime.cpp
@@ -58,11 +58,13 @@ public:
   behavior make_behavior() override {
     monitor(aut_);
     send(aut_, msg_);
-    return {[this](int a, int b, int c) {
-      CHECK_EQ(a, 1);
-      CHECK_EQ(b, 2);
-      CHECK_EQ(c, 3);
-    }};
+    return {
+      [](int a, int b, int c) {
+        CHECK_EQ(a, 1);
+        CHECK_EQ(b, 2);
+        CHECK_EQ(c, 3);
+      },
+    };
   }
 
 private:

--- a/libcaf_core/tests/legacy/typed_spawn.cpp
+++ b/libcaf_core/tests/legacy/typed_spawn.cpp
@@ -93,7 +93,7 @@ public:
   behavior_type wait4string() {
     return {
       partial_behavior_init,
-      [this](get_state_atom) { return "wait4string"; },
+      [](get_state_atom) { return "wait4string"; },
       [this](const string&) { become(wait4int()); },
     };
   }
@@ -101,7 +101,7 @@ public:
   behavior_type wait4int() {
     return {
       partial_behavior_init,
-      [this](get_state_atom) { return "wait4int"; },
+      [](get_state_atom) { return "wait4int"; },
       [this](int) -> int {
         become(wait4float());
         return 42;
@@ -112,7 +112,7 @@ public:
   behavior_type wait4float() {
     return {
       partial_behavior_init,
-      [this](get_state_atom) { return "wait4float"; },
+      [](get_state_atom) { return "wait4float"; },
       [this](float) { become(wait4string()); },
     };
   }


### PR DESCRIPTION
Pulling out the unused capture warnings from #1565. These show up locally for me, so I'd like to get them out asap.