### PR TITLE
Overload dump_content for examples

### DIFF
--- a/examples/flow/iota.cpp
+++ b/examples/flow/iota.cpp
@@ -9,18 +9,25 @@
 
 namespace {
 
+constexpr size_t default_num_values = 10;
+
 struct config : caf::actor_system_config {
   config() {
     opt_group{custom_options_, "global"} //
-      .add(n, "num-values,n", "number of values produced by the source");
+      .add<size_t>("num-values,n", "number of values produced by the source");
   }
 
-  size_t n = 10;
+  caf::settings dump_content() const override {
+    auto result = actor_system_config::dump_content();
+    caf::put_missing(result, "num-values", default_num_values);
+    return result;
+  }
 };
 
 // --(rst-main-begin)--
 void caf_main(caf::actor_system& sys, const config& cfg) {
-  sys.spawn([n = cfg.n](caf::event_based_actor* self) {
+  auto n = get_or(cfg, "num-values", default_num_values);
+  sys.spawn([n](caf::event_based_actor* self) {
     self
       // Get an observable factory.
       ->make_observable()

--- a/examples/http/rest.cpp
+++ b/examples/http/rest.cpp
@@ -38,6 +38,13 @@ struct config : caf::actor_system_config {
       .add<std::string>("key-file,k", "path to the private key file")
       .add<std::string>("cert-file,c", "path to the certificate file");
   }
+
+  caf::settings dump_content() const override {
+    auto result = actor_system_config::dump_content();
+    caf::put_missing(result, "port", default_port);
+    caf::put_missing(result, "max-connections", default_max_connections);
+    return result;
+  }
 };
 
 // -- our key-value store actor ------------------------------------------------

--- a/examples/http/time-server.cpp
+++ b/examples/http/time-server.cpp
@@ -31,6 +31,13 @@ struct config : caf::actor_system_config {
       .add<std::string>("key-file,k", "path to the private key file")
       .add<std::string>("cert-file,c", "path to the certificate file");
   }
+
+  caf::settings dump_content() const override {
+    auto result = actor_system_config::dump_content();
+    caf::put_missing(result, "port", default_port);
+    caf::put_missing(result, "max-connections", default_max_connections);
+    return result;
+  }
 };
 
 // -- main ---------------------------------------------------------------------

--- a/examples/length_prefix_framing/chat-client.cpp
+++ b/examples/length_prefix_framing/chat-client.cpp
@@ -26,6 +26,8 @@ static constexpr uint16_t default_port = 7788;
 
 static constexpr std::string_view default_host = "localhost";
 
+static constexpr std::string_view default_name = "";
+
 // -- configuration setup ------------------------------------------------------
 
 struct config : caf::actor_system_config {
@@ -38,6 +40,14 @@ struct config : caf::actor_system_config {
       .add<bool>("enable", "enables encryption via TLS")
       .add<std::string>("ca-file", "CA file for trusted servers");
   }
+
+  caf::settings dump_content() const override {
+    auto result = actor_system_config::dump_content();
+    caf::put_missing(result, "port", default_port);
+    caf::put_missing(result, "host", default_host);
+    caf::put_missing(result, "name", default_name);
+    return result;
+  }
 };
 
 // -- main ---------------------------------------------------------------------
@@ -47,7 +57,7 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
   auto use_ssl = caf::get_or(cfg, "tls.enable", false);
   auto port = caf::get_or(cfg, "port", default_port);
   auto host = caf::get_or(cfg, "host", default_host);
-  auto name = caf::get_or(cfg, "name", "");
+  auto name = caf::get_or(cfg, "name", default_name);
   auto ca_file = caf::get_as<std::string>(cfg, "tls.ca-file");
   if (name.empty()) {
     std::cerr << "*** mandatory parameter 'name' missing or empty\n";

--- a/examples/length_prefix_framing/chat-server.cpp
+++ b/examples/length_prefix_framing/chat-server.cpp
@@ -32,6 +32,13 @@ struct config : caf::actor_system_config {
       .add<std::string>("key-file,k", "path to the private key file")
       .add<std::string>("cert-file,c", "path to the certificate file");
   }
+
+  caf::settings dump_content() const override {
+    auto result = actor_system_config::dump_content();
+    caf::put_missing(result, "port", default_port);
+    caf::put_missing(result, "max-connections", default_max_connections);
+    return result;
+  }
 };
 
 // -- multiplexing logic -------------------------------------------------------

--- a/examples/web_socket/echo.cpp
+++ b/examples/web_socket/echo.cpp
@@ -29,6 +29,13 @@ struct config : caf::actor_system_config {
       .add<std::string>("key-file,k", "path to the private key file")
       .add<std::string>("cert-file,c", "path to the certificate file");
   }
+
+  caf::settings dump_content() const override {
+    auto result = actor_system_config::dump_content();
+    caf::put_missing(result, "port", default_port);
+    caf::put_missing(result, "max-connections", default_max_connections);
+    return result;
+  }
 };
 
 // -- main ---------------------------------------------------------------------

--- a/examples/web_socket/quote-server.cpp
+++ b/examples/web_socket/quote-server.cpp
@@ -80,6 +80,13 @@ struct config : caf::actor_system_config {
       .add<std::string>("key-file,k", "path to the private key file")
       .add<std::string>("cert-file,c", "path to the certificate file");
   }
+
+  caf::settings dump_content() const override {
+    auto result = actor_system_config::dump_content();
+    caf::put_missing(result, "port", default_port);
+    caf::put_missing(result, "max-connections", default_max_connections);
+    return result;
+  }
 };
 
 // -- helper functions ---------------------------------------------------------

--- a/examples/web_socket/stock-ticker.cpp
+++ b/examples/web_socket/stock-ticker.cpp
@@ -28,7 +28,7 @@ static constexpr uint16_t default_port = 8080;
 
 static constexpr size_t default_max_connections = 128;
 
-static constexpr caf::timespan default_interval = caf::timespan{1s};
+static constexpr caf::timespan default_interval = 1s;
 
 // -- custom types -------------------------------------------------------------
 

--- a/examples/web_socket/stock-ticker.cpp
+++ b/examples/web_socket/stock-ticker.cpp
@@ -28,6 +28,8 @@ static constexpr uint16_t default_port = 8080;
 
 static constexpr size_t default_max_connections = 128;
 
+static constexpr caf::timespan default_interval = caf::timespan{1s};
+
 // -- custom types -------------------------------------------------------------
 
 namespace stock {
@@ -153,6 +155,14 @@ struct config : caf::actor_system_config {
       .add<std::string>("key-file,k", "path to the private key file")
       .add<std::string>("cert-file,c", "path to the certificate file");
   }
+
+  caf::settings dump_content() const override {
+    auto result = actor_system_config::dump_content();
+    caf::put_missing(result, "port", default_port);
+    caf::put_missing(result, "max-connections", default_max_connections);
+    caf::put_missing(result, "interval", default_interval);
+    return result;
+  }
 };
 
 // -- main ---------------------------------------------------------------------
@@ -162,7 +172,7 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
   namespace ssl = caf::net::ssl;
   namespace ws = caf::net::web_socket;
   // Read the configuration.
-  auto interval = caf::get_or(cfg, "interval", caf::timespan{1s});
+  auto interval = caf::get_or(cfg, "interval", default_interval);
   auto port = caf::get_or(cfg, "port", default_port);
   auto pem = ssl::format::pem;
   auto key_file = caf::get_as<std::string>(cfg, "tls.key-file");


### PR DESCRIPTION
Relates https://github.com/actor-framework/actor-framework/issues/1444

Updated examples with `dump_content` to ensure `--dump-config` prints all of the default config values.