### PR TITLE
Add export specifier to the outline class

### DIFF
--- a/libcaf_test/caf/test/outline.hpp
+++ b/libcaf_test/caf/test/outline.hpp
@@ -9,7 +9,7 @@
 
 namespace caf::test {
 
-class outline : public runnable {
+class CAF_TEST_EXPORT outline : public runnable {
 public:
   using super = runnable;
 


### PR DESCRIPTION
Fixes the linking process when using test outlines on release builds. 