### PR TITLE
Fix clang-tidy related if statements with branch clone

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,11 @@
 ---
-Checks:          '-*,bugprone-*,-bugprone-easily-swappable-parameters,-bugprone-macro-parentheses'
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-macro-parentheses,
+  -bugprone-forward-declaration-namespace,
+  -bugprone-branch-clone,
 WarningsAsErrors: ''
 HeaderFilterRegex: '/caf/'
 AnalyzeTemporaryDtors: false

--- a/libcaf_core/caf/config_value.hpp
+++ b/libcaf_core/caf/config_value.hpp
@@ -278,9 +278,8 @@ private:
       return static_cast<int64_t>(x);
     } else if constexpr (std::is_same_v<T, float>) {
       return static_cast<double>(x);
-    } else if constexpr (std::is_convertible_v<T, const char*>) {
-      return std::string{x};
-    } else if constexpr (std::is_same_v<T, std::string_view>) {
+    } else if constexpr (std::is_convertible_v<T, const char*>
+                         || std::is_same_v<T, std::string_view>) {
       return std::string{x};
     } else {
       static_assert(detail::is_iterable_v<T>);

--- a/libcaf_core/caf/detail/glob_match.cpp
+++ b/libcaf_core/caf/detail/glob_match.cpp
@@ -109,6 +109,7 @@ bool match(const char* text, const char* glob) {
           if (last < 0x10ffff && *glob == '-' && glob[1] != ']'
                   && glob[1] != '\0'
                 ? chr <= utf8(&++glob) && chr >= last
+                // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
                 : chr == (last = utf8(&glob)))
             matched = true;
         if (matched == reverse)

--- a/libcaf_core/caf/detail/stringification_inspector.hpp
+++ b/libcaf_core/caf/detail/stringification_inspector.hpp
@@ -171,7 +171,8 @@ public:
       sep();
       result_ += "null";
       return true;
-    } else if constexpr (std::is_same_v<T, char>) {
+    }
+    if constexpr (std::is_same_v<T, char>) {
       return value(std::string_view{x, strlen(x)});
     } else if constexpr (std::is_same_v<T, void>) {
       sep();

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -366,11 +366,9 @@ void scheduled_actor::quit(error x) {
 void scheduled_actor::set_receive_timeout() {
   CAF_LOG_TRACE("");
   pending_timeout_.dispose();
-  if (bhvr_stack_.empty()) {
-    // nop
-  } else if (auto delay = bhvr_stack_.back().timeout(); delay == infinite) {
-    // nop
-  } else {
+  if (bhvr_stack_.empty())
+    return;
+  if (auto delay = bhvr_stack_.back().timeout(); delay != infinite) {
     pending_timeout_ = run_delayed(delay, [this] {
       if (!bhvr_stack_.empty())
         bhvr_stack_.back().handle_timeout();

--- a/libcaf_core/tests/legacy/settings.cpp
+++ b/libcaf_core/tests/legacy/settings.cpp
@@ -55,12 +55,12 @@ config_value unpack(const settings& x, std::string_view key) {
 template <class... Ts>
 config_value unpack(const settings& x, std::string_view key,
                     const char* next_key, Ts... keys) {
-  if (auto i = x.find(key); i == x.end())
+  auto i = x.find(key);
+  if (i == x.end())
     return {};
-  else if (auto ptr = get_if<settings>(std::addressof(i->second)))
+  if (auto ptr = get_if<settings>(std::addressof(i->second)))
     return unpack(*ptr, {next_key, strlen(next_key)}, keys...);
-  else
-    return {};
+  return {};
 }
 
 struct foobar {

--- a/libcaf_test/caf/test/dsl.hpp
+++ b/libcaf_test/caf/test/dsl.hpp
@@ -561,14 +561,13 @@ public:
       << term::yellow << "  -> " << term::reset
       << test::logger::stream::reset_flags_t{} << "allow" << type_str << "."
       << fields_str << " [line " << src_line_ << "]\n";
-    if (!dest_) {
+    if (!dest_)
       return false;
-    }
-    if (auto msg_ptr = dest_->peek_at_next_mailbox_element(); !msg_ptr) {
+    if (auto msg_ptr = dest_->peek_at_next_mailbox_element(); !msg_ptr)
       return false;
-    } else if (src_ && msg_ptr->sender != src_) {
+    if (src_ && msg_ptr->sender != src_)
       return false;
-    } else if (peek_()) {
+    if (peek_()) {
       run_once();
       return true;
     } else {

--- a/libcaf_test/caf/test/dsl.hpp
+++ b/libcaf_test/caf/test/dsl.hpp
@@ -563,9 +563,8 @@ public:
       << fields_str << " [line " << src_line_ << "]\n";
     if (!dest_)
       return false;
-    if (auto msg_ptr = dest_->peek_at_next_mailbox_element(); !msg_ptr)
-      return false;
-    if (src_ && msg_ptr->sender != src_)
+    if (auto msg_ptr = dest_->peek_at_next_mailbox_element();
+        !msg_ptr || (src_ && msg_ptr->sender != src_))
       return false;
     if (peek_()) {
       run_once();


### PR DESCRIPTION
Fixing if statements regarding bugprone-branch-clone.
I've disabled the warnings for further use since it gets in the way a lot. 
To avoid merge conflicts, this PR also disables bugprone-forward-declaration-namespace. This complains a lot because of `fwd.hpp` style headers. 
Pulled from #1565.
Relates #1435. 