### PR TITLE
Make to_stream available on observable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,20 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## [Unreleased]
 
+### Added
+
+- An `observable` that runs on an actor can now be converted to a `stream` or
+  `typed_stream` directly by calling `to_stream` or `to_typed_stream` on it.
+
 ### Fixed
 
 - The class `caf::test::outline` is now properly exported from the test module.
   This fixes builds with dynamic linking against `libcaf_test`.
+
+### Deprecated
+
+- Calling `to_stream` or `to_typed_stream` on an actor is now deprecated. Simply
+  call `to_stream` or `to_typed_stream` directly on the `observable` instead.
 
 ## [0.19.4] - 2023-09-29
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,7 @@ ignore:
   - libcaf_net/tests
   - libcaf_openssl
   - libcaf_test
+  - robot
   - tools
   - "**/*.test.cpp"
 coverage:

--- a/libcaf_core/caf/flow/coordinator.cpp
+++ b/libcaf_core/caf/flow/coordinator.cpp
@@ -17,4 +17,10 @@ observable_builder coordinator::make_observable() {
   return observable_builder{this};
 }
 
+stream coordinator::to_stream_impl(cow_string,
+                                   intrusive_ptr<flow::op::base<async::batch>>,
+                                   type_id_t, size_t) {
+  return stream{};
+}
+
 } // namespace caf::flow

--- a/libcaf_core/caf/flow/coordinator.hpp
+++ b/libcaf_core/caf/flow/coordinator.hpp
@@ -6,6 +6,8 @@
 
 #include "caf/action.hpp"
 #include "caf/async/execution_context.hpp"
+#include "caf/async/fwd.hpp"
+#include "caf/cow_string.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/flow/fwd.hpp"
 #include "caf/flow/subscription.hpp"
@@ -22,6 +24,11 @@ namespace caf::flow {
 /// objects since the coordinator guarantees synchronous execution.
 class CAF_CORE_EXPORT coordinator : public async::execution_context {
 public:
+  // -- friends ----------------------------------------------------------------
+
+  template <class>
+  friend class observable;
+
   // -- member types -----------------------------------------------------------
 
   /// A time point of the monotonic clock.
@@ -31,7 +38,7 @@ public:
 
   virtual ~coordinator();
 
-  // -- conversions ------------------------------------------------------------
+  // -- factories --------------------------------------------------------------
 
   /// Returns a factory object for new observable objects on this coordinator.
   [[nodiscard]] observable_builder make_observable();
@@ -80,6 +87,12 @@ public:
     return delay_until(steady_time() + rel_time,
                        make_action(std::forward<F>(what)));
   }
+
+private:
+  virtual stream
+  to_stream_impl(cow_string name,
+                 intrusive_ptr<flow::op::base<async::batch>> batch_op,
+                 type_id_t item_type, size_t max_items_per_batch);
 };
 
 /// @relates coordinator

--- a/libcaf_core/caf/flow/fwd.hpp
+++ b/libcaf_core/caf/flow/fwd.hpp
@@ -133,3 +133,10 @@ using assert_scheduled_actor_hdr_t
   = std::enable_if_t<assert_scheduled_actor_hdr<T>::value, V>;
 
 } // namespace caf::flow
+
+namespace caf::flow::op {
+
+template <class T>
+class base;
+
+} // namespace caf::flow::op

--- a/libcaf_core/caf/flow/observable_decl.hpp
+++ b/libcaf_core/caf/flow/observable_decl.hpp
@@ -273,6 +273,42 @@ public:
   /// Creates a publisher that makes emitted items available asynchronously.
   async::publisher<T> to_publisher();
 
+  /// Creates a type-erased stream that makes emitted items available in
+  /// batches. Requires that this observable runs on an actor, otherwise returns
+  /// an invalid stream.
+  /// @param name The human-readable name for this stream.
+  /// @param max_delay The maximum delay between emitting two batches.
+  /// @param max_items_per_batch The maximum amount of items per batch.
+  /// @returns a @ref stream that makes this observable available to other
+  ///          actors or an invalid stream if this observable does not run on an
+  ///          actor.
+  template <class U = T>
+  stream
+  to_stream(cow_string name, timespan max_delay, size_t max_items_per_batch);
+
+  /// @copydoc to_stream(cow_string, timespan, size_t)
+  template <class U = T>
+  stream
+  to_stream(std::string name, timespan max_delay, size_t max_items_per_batch);
+
+  /// Creates a stream that makes emitted items available in batches. Requires
+  /// that this observable runs on an actor, otherwise returns an invalid
+  /// stream.
+  /// @param name The human-readable name for this stream.
+  /// @param max_delay The maximum delay between emitting two batches.
+  /// @param max_items_per_batch The maximum amount of items per batch.
+  /// @returns a @ref typed_stream that makes this observable available to other
+  ///          actors or an invalid stream if this observable does not run on an
+  ///          actor.
+  template <class U = T>
+  typed_stream<U> to_typed_stream(cow_string name, timespan max_delay,
+                                  size_t max_items_per_batch);
+
+  /// @copydoc to_typed_stream(cow_string, timespan, size_t)
+  template <class U = T>
+  typed_stream<U> to_typed_stream(std::string name, timespan max_delay,
+                                  size_t max_items_per_batch);
+
   const observable& as_observable() const& noexcept {
     return *this;
   }

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -440,12 +440,14 @@ public:
   /// @param obs An observable sequence of items.
   /// @returns a @ref stream that makes @p obs available to other actors.
   template <class Observable>
+  [[deprecated("call to_stream on the observable instead")]] //
   flow::assert_scheduled_actor_hdr_t<Observable, stream>
   to_stream(std::string name, timespan max_delay, size_t max_items_per_batch,
             Observable&& obs);
 
   /// @copydoc to_stream
   template <class Observable>
+  [[deprecated("call to_stream on the observable instead")]] //
   flow::assert_scheduled_actor_hdr_t<Observable, stream>
   to_stream(cow_string name, timespan max_delay, size_t max_items_per_batch,
             Observable&& obs);
@@ -459,20 +461,22 @@ public:
     size_t max_items_per_batch;
     template <class Observable>
     auto operator()(Observable&& what) {
-      return self->to_stream(name, max_delay, max_items_per_batch,
-                             std::forward<Observable>(what));
+      return std::forward<Observable>(what).to_stream(name, max_delay,
+                                                      max_items_per_batch);
     }
   };
 
   /// Returns a function object for passing it to @c compose.
-  to_stream_t to_stream(std::string name, timespan max_delay,
-                        size_t max_items_per_batch) {
+  [[deprecated("call to_stream on the observable instead")]] //
+  to_stream_t
+  to_stream(std::string name, timespan max_delay, size_t max_items_per_batch) {
     return {this, cow_string{std::move(name)}, max_delay, max_items_per_batch};
   }
 
   /// Returns a function object for passing it to @c compose.
-  to_stream_t to_stream(cow_string name, timespan max_delay,
-                        size_t max_items_per_batch) {
+  [[deprecated("call to_stream on the observable instead")]] //
+  to_stream_t
+  to_stream(cow_string name, timespan max_delay, size_t max_items_per_batch) {
     return {this, std::move(name), max_delay, max_items_per_batch};
   }
 
@@ -484,6 +488,7 @@ public:
   /// @param obs An observable sequence of items.
   /// @returns a @ref stream that makes @p obs available to other actors.
   template <class Observable>
+  [[deprecated("call to_typed_stream on the observable instead")]] //
   flow::assert_scheduled_actor_hdr_t<
     Observable, typed_stream<typename Observable::output_type>>
   to_typed_stream(std::string name, timespan max_delay,
@@ -491,6 +496,7 @@ public:
 
   /// @copydoc to_stream
   template <class Observable>
+  [[deprecated("call to_typed_stream on the observable instead")]] //
   flow::assert_scheduled_actor_hdr_t<
     Observable, typed_stream<typename Observable::output_type>>
   to_typed_stream(cow_string name, timespan max_delay,
@@ -505,20 +511,24 @@ public:
     size_t max_items_per_batch;
     template <class Observable>
     auto operator()(Observable&& what) {
-      return self->to_typed_stream(name, max_delay, max_items_per_batch,
-                                   std::forward<Observable>(what));
+      return std::forward<Observable>(what).to_typed_stream(
+        name, max_delay, max_items_per_batch);
     }
   };
 
   /// Returns a function object for passing it to @c compose.
-  to_typed_stream_t to_typed_stream(std::string name, timespan max_delay,
-                                    size_t max_items_per_batch) {
+  [[deprecated("call to_typed_stream on the observable instead")]] //
+  to_typed_stream_t
+  to_typed_stream(std::string name, timespan max_delay,
+                  size_t max_items_per_batch) {
     return {this, cow_string{std::move(name)}, max_delay, max_items_per_batch};
   }
 
   /// Returns a function object for passing it to @c compose.
-  to_typed_stream_t to_typed_stream(cow_string name, timespan max_delay,
-                                    size_t max_items_per_batch) {
+  [[deprecated("call to_typed_stream on the observable instead")]] //
+  to_typed_stream_t
+  to_typed_stream(cow_string name, timespan max_delay,
+                  size_t max_items_per_batch) {
     return {this, std::move(name), max_delay, max_items_per_batch};
   }
 
@@ -777,7 +787,8 @@ private:
 
   /// Implementation detail for to_stream.
   stream to_stream_impl(cow_string name, batch_op_ptr batch_op,
-                        type_id_t item_type, size_t max_items_per_batch);
+                        type_id_t item_type,
+                        size_t max_items_per_batch) override;
 
   /// Registers a stream bridge at the actor (callback for
   /// detail::stream_bridge).

--- a/libcaf_core/caf/scheduled_actor/flow.hpp
+++ b/libcaf_core/caf/scheduled_actor/flow.hpp
@@ -26,48 +26,6 @@ struct has_impl_include<scheduled_actor> {
 
 } // namespace caf::flow
 
-namespace caf::detail {
-
-template <class T>
-class unbatch {
-public:
-  using input_type = async::batch;
-
-  using output_type = T;
-
-  template <class Next, class... Steps>
-  bool on_next(const async::batch& xs, Next& next, Steps&... steps) {
-    for (const auto& item : xs.template items<T>())
-      if (!next.on_next(item, steps...))
-        return false;
-    return true;
-  }
-
-  template <class Next, class... Steps>
-  void on_complete(Next& next, Steps&... steps) {
-    next.on_complete(steps...);
-  }
-
-  template <class Next, class... Steps>
-  void on_error(const error& what, Next& next, Steps&... steps) {
-    next.on_error(what, steps...);
-  }
-};
-
-template <class T>
-struct batching_trait {
-  static constexpr bool skip_empty = true;
-  using input_type = T;
-  using output_type = async::batch;
-  using select_token_type = int64_t;
-
-  output_type operator()(const std::vector<input_type>& xs) {
-    return async::make_batch(make_span(xs));
-  }
-};
-
-} // namespace caf::detail
-
 namespace caf {
 
 template <class T, class Policy>
@@ -90,23 +48,16 @@ template <class Observable>
 flow::assert_scheduled_actor_hdr_t<Observable, stream>
 scheduled_actor::to_stream(std::string name, timespan max_delay,
                            size_t max_items_per_batch, Observable&& obs) {
-  return to_stream(cow_string{std::move(name)}, max_delay, max_items_per_batch,
-                   std::forward<Observable>(obs));
+  return std::forward<Observable>(obs).to_stream(std::move(name), max_delay,
+                                                 max_items_per_batch);
 }
 
 template <class Observable>
 flow::assert_scheduled_actor_hdr_t<Observable, stream>
 scheduled_actor::to_stream(cow_string name, timespan max_delay,
                            size_t max_items_per_batch, Observable&& obs) {
-  using obs_t = std::decay_t<Observable>;
-  using val_t = typename obs_t::output_type;
-  using trait_t = detail::batching_trait<val_t>;
-  using impl_t = flow::op::buffer<trait_t>;
-  auto batch_op = make_counted<impl_t>(
-    this, max_items_per_batch, std::forward<Observable>(obs).as_observable(),
-    flow::make_observable<flow::op::interval>(this, max_delay, max_delay));
-  return to_stream_impl(std::move(name), std::move(batch_op), type_id_v<val_t>,
-                        max_items_per_batch);
+  return std::forward<Observable>(obs).to_stream(std::move(name), max_delay,
+                                                 max_items_per_batch);
 }
 
 template <class Observable>
@@ -114,9 +65,9 @@ flow::assert_scheduled_actor_hdr_t<
   Observable, typed_stream<typename Observable::output_type>>
 scheduled_actor::to_typed_stream(std::string name, timespan max_delay,
                                  size_t max_items_per_batch, Observable obs) {
-  auto res = to_stream(std::move(name), max_delay, max_items_per_batch,
-                       std::move(obs));
-  return {res.source(), res.name(), res.id()};
+  return std::forward<Observable>(obs).to_typed_stream(std::move(name),
+                                                       max_delay,
+                                                       max_items_per_batch);
 }
 
 template <class Observable>
@@ -124,9 +75,9 @@ flow::assert_scheduled_actor_hdr_t<
   Observable, typed_stream<typename Observable::output_type>>
 scheduled_actor::to_typed_stream(cow_string name, timespan max_delay,
                                  size_t max_items_per_batch, Observable obs) {
-  auto res = to_stream(std::move(name), max_delay, max_items_per_batch,
-                       std::move(obs));
-  return {res.source(), res.name(), res.id()};
+  return std::forward<Observable>(obs).to_typed_stream(std::move(name),
+                                                       max_delay,
+                                                       max_items_per_batch);
 }
 
 template <class T>

--- a/libcaf_core/caf/typed_actor_view.hpp
+++ b/libcaf_core/caf/typed_actor_view.hpp
@@ -319,10 +319,13 @@ public:
     return self->make_observable();
   }
 
+  CAF_PUSH_DEPRECATED_WARNING
+
   /// @copydoc scheduled_actor::to_stream
   template <class Observable>
-  auto to_stream(cow_string name, timespan max_delay,
-                 size_t max_items_per_batch, Observable&& obs) {
+  [[deprecated("call to_stream on the observable instead")]] auto
+  to_stream(cow_string name, timespan max_delay, size_t max_items_per_batch,
+            Observable&& obs) {
     auto self = typed_actor_view_flow_access<Observable>(self_);
     return self->to_stream(std::move(name), max_delay, max_items_per_batch,
                            std::forward<Observable>(obs));
@@ -330,29 +333,33 @@ public:
 
   /// @copydoc scheduled_actor::to_stream
   template <class Observable>
-  auto to_stream(std::string name, timespan max_delay,
-                 size_t max_items_per_batch, Observable&& obs) {
+  [[deprecated("call to_stream on the observable instead")]] auto
+  to_stream(std::string name, timespan max_delay, size_t max_items_per_batch,
+            Observable&& obs) {
     return to_stream(cow_string{std::move(name)}, max_delay,
                      max_items_per_batch, std::forward<Observable>(obs));
   }
 
   /// Returns a function object for passing it to @c compose.
-  scheduled_actor::to_stream_t to_stream(cow_string name, timespan max_delay,
-                                         size_t max_items_per_batch) {
+  [[deprecated("call to_stream on the observable instead")]] //
+  scheduled_actor::to_stream_t
+  to_stream(cow_string name, timespan max_delay, size_t max_items_per_batch) {
     return {self_, std::move(name), max_delay, max_items_per_batch};
   }
 
   /// Returns a function object for passing it to @c compose.
-  scheduled_actor::to_stream_t to_stream(std::string name, timespan max_delay,
-                                         size_t max_items_per_batch) {
+  [[deprecated("call to_stream on the observable instead")]] //
+  scheduled_actor::to_stream_t
+  to_stream(std::string name, timespan max_delay, size_t max_items_per_batch) {
     return to_stream(cow_string{std::move(name)}, max_delay,
                      max_items_per_batch);
   }
 
   /// @copydoc scheduled_actor::to_typed_stream
   template <class Observable>
-  auto to_typed_stream(cow_string name, timespan max_delay,
-                       size_t max_items_per_batch, Observable obs) {
+  [[deprecated("call to_typed_stream on the observable instead")]] auto
+  to_typed_stream(cow_string name, timespan max_delay,
+                  size_t max_items_per_batch, Observable obs) {
     auto self = typed_actor_view_flow_access<Observable>(self_);
     return self->to_typed_stream(std::move(name), max_delay,
                                  max_items_per_batch, std::move(obs));
@@ -360,13 +367,15 @@ public:
 
   /// @copydoc scheduled_actor::to_typed_stream
   template <class Observable>
-  auto to_typed_stream(std::string name, timespan max_delay,
-                       size_t max_items_per_batch, Observable obs) {
+  [[deprecated("call to_typed_stream on the observable instead")]] auto
+  to_typed_stream(std::string name, timespan max_delay,
+                  size_t max_items_per_batch, Observable obs) {
     return to_typed_stream(cow_string{std::move(name)}, max_delay,
                            max_items_per_batch, std::move(obs));
   }
 
   /// Returns a function object for passing it to @c compose.
+  [[deprecated("call to_typed_stream on the observable instead")]] //
   scheduled_actor::to_typed_stream_t
   to_typed_stream(cow_string name, timespan max_delay,
                   size_t max_items_per_batch) {
@@ -374,12 +383,15 @@ public:
   }
 
   /// Returns a function object for passing it to @c compose.
+  [[deprecated("call to_typed_stream on the observable instead")]] //
   scheduled_actor::to_typed_stream_t
   to_typed_stream(std::string name, timespan max_delay,
                   size_t max_items_per_batch) {
     return to_typed_stream(cow_string{std::move(name)}, max_delay,
                            max_items_per_batch);
   }
+
+  CAF_POP_WARNINGS
 
   /// @copydoc scheduled_actor::observe
   template <class T>

--- a/libcaf_core/tests/legacy/stream.cpp
+++ b/libcaf_core/tests/legacy/stream.cpp
@@ -72,6 +72,8 @@ TEST_CASE("value-constructed") {
   CHECK_EQ(uut, deep_copy(uut));
 }
 
+CAF_PUSH_DEPRECATED_WARNING
+
 TEST_CASE("streams allow actors to transmit flow items to others") {
   auto res = ivec{};
   res.resize(256);
@@ -101,5 +103,7 @@ TEST_CASE("streams allow actors to transmit flow items to others") {
   CHECK_EQ(*r1, res);
   CHECK_EQ(*r2, res);
 }
+
+CAF_POP_WARNINGS
 
 END_FIXTURE_SCOPE()

--- a/libcaf_core/tests/legacy/typed_actor_view.cpp
+++ b/libcaf_core/tests/legacy/typed_actor_view.cpp
@@ -73,6 +73,8 @@ struct fixture : test_coordinator_fixture<> {
 
 BEGIN_FIXTURE_SCOPE(fixture)
 
+CAF_PUSH_DEPRECATED_WARNING
+
 SCENARIO("typed actors may use the flow API") {
   GIVEN("a typed actor") {
     WHEN("the actor calls make_observable") {
@@ -179,5 +181,7 @@ SCENARIO("typed actors may use the flow API") {
     }
   }
 }
+
+CAF_POP_WARNINGS
 
 END_FIXTURE_SCOPE()

--- a/libcaf_core/tests/legacy/typed_stream.cpp
+++ b/libcaf_core/tests/legacy/typed_stream.cpp
@@ -69,6 +69,8 @@ TEST_CASE("value-constructed") {
   CHECK_EQ(uut, deep_copy(uut));
 }
 
+CAF_PUSH_DEPRECATED_WARNING
+
 TEST_CASE("streams allow actors to transmit flow items to others") {
   auto res = ivec{};
   res.resize(256);
@@ -98,5 +100,7 @@ TEST_CASE("streams allow actors to transmit flow items to others") {
   CHECK_EQ(*r1, res);
   CHECK_EQ(*r2, res);
 }
+
+CAF_POP_WARNINGS
 
 END_FIXTURE_SCOPE()

--- a/robot/stream/driver.cpp
+++ b/robot/stream/driver.cpp
@@ -51,7 +51,7 @@ behavior producer(event_based_actor* self) {
         .map([](int x) {
           return point{x, x * x};
         })
-        .compose(self->to_stream("points", max_batch_delay, max_batch_size));
+        .to_stream("points", max_batch_delay, max_batch_size);
     },
   };
 }


### PR DESCRIPTION
This makes the API more intuitive to use for users, but the main reason is actually #1573: I've played a bit with the design and the current iteration spins up an (inactive) actor, creates an `observable` on it and then hands that to the user for further setup. Since we don't want to hand the `self` pointer to users, the only option is calling `to_stream` directly on the `observable` in case the user wants to consume items from a stream (the alternative is producing a `publisher`).