### PR TITLE
Fix clang-tidy related conversion warnings

### DIFF
--- a/examples/qtsupport/chatwidget.cpp
+++ b/examples/qtsupport/chatwidget.cpp
@@ -44,7 +44,9 @@ void ChatWidget::init(actor_system& system, const std::string& name,
       auto str = std::string_view{reinterpret_cast<const char*>(bytes.data()),
                                   bytes.size()};
       if (std::all_of(str.begin(), str.end(), ::isprint)) {
-        print(QString::fromUtf8(str.data(), str.size()));
+        auto qstr = QString::fromUtf8(str.data(),
+                                      static_cast<qsizetype>(str.size()));
+        print(qstr);
       } else {
         QString msg = "<non-ascii-data of size ";
         msg += QString::number(bytes.size());

--- a/libcaf_core/caf/chrono.cpp
+++ b/libcaf_core/caf/chrono.cpp
@@ -46,7 +46,7 @@ time_t tm_to_time_t(tm& time_buf) noexcept {
 
 namespace {
 
-int utc_offset(const tm& time_buf) noexcept {
+auto utc_offset(const tm& time_buf) noexcept {
   return time_buf.tm_gmtoff;
 }
 

--- a/libcaf_core/caf/detail/monotonic_buffer_resource.cpp
+++ b/libcaf_core/caf/detail/monotonic_buffer_resource.cpp
@@ -13,8 +13,8 @@ namespace caf::detail {
 
 monotonic_buffer_resource::monotonic_buffer_resource() {
   // 8kb blocks for the small and medium sized buckets.
-  small_.block_size = 8 * 1024;
-  medium_.block_size = 8 * 1024;
+  small_.block_size = 8 * 1024ul;
+  medium_.block_size = 8 * 1024ul;
 }
 
 monotonic_buffer_resource::~monotonic_buffer_resource() {

--- a/libcaf_core/caf/hash/sha1.cpp
+++ b/libcaf_core/caf/hash/sha1.cpp
@@ -63,7 +63,7 @@ void sha1::process_message_block() {
   };
   uint32_t W[80];         // Word sequence.
   uint32_t A, B, C, D, E; // Word buffers.
-  for (auto t = 0; t < 16; t++) {
+  for (auto t = 0ul; t < 16ul; t++) {
     W[t] = message_block_[t * 4] << 24;
     W[t] |= message_block_[t * 4 + 1] << 16;
     W[t] |= message_block_[t * 4 + 2] << 8;

--- a/libcaf_core/caf/json_reader.cpp
+++ b/libcaf_core/caf/json_reader.cpp
@@ -606,10 +606,10 @@ bool json_reader::value(double& x) {
         x = std::get<double>(val.data);
         return true;
       case detail::json::value::integer_index:
-        x = std::get<int64_t>(val.data);
+        x = static_cast<double>(std::get<int64_t>(val.data));
         return true;
       case detail::json::value::unsigned_index:
-        x = std::get<uint64_t>(val.data);
+        x = static_cast<double>(std::get<uint64_t>(val.data));
         return true;
       default:
         emplace_error(sec::runtime_error, class_name, fn, current_field_name(),

--- a/libcaf_core/caf/string_algorithms.cpp
+++ b/libcaf_core/caf/string_algorithms.cpp
@@ -94,11 +94,12 @@ void replace_all(std::string& str, std::string_view what,
   };
   auto i = next(str.begin());
   while (i != str.end()) {
-    auto before = static_cast<size_t>(std::distance(str.begin(), i));
-    str.replace(i, i + what.size(), with.begin(), with.end());
+    auto before = std::distance(str.begin(), i);
+    str.replace(i, i + static_cast<ptrdiff_t>(what.size()), with.begin(),
+                with.end());
     // Iterator i became invalidated -> use new iterator pointing to the first
     // character after the replaced text.
-    i = next(str.begin() + before + with.size());
+    i = next(str.begin() + before + static_cast<ptrdiff_t>(with.size()));
   }
 }
 

--- a/libcaf_core/caf/telemetry/importer/process.cpp
+++ b/libcaf_core/caf/telemetry/importer/process.cpp
@@ -251,9 +251,9 @@ sys_stats read_sys_stats() {
     }
     result.rss = static_cast<int64_t>(rss_pages) * page_size;
     result.vms = static_cast<int64_t>(vmsize_bytes);
-    result.cpu_time = utime_ticks;
-    result.cpu_time += stime_ticks;
-    result.cpu_time /= ticks_per_second;
+    result.cpu_time = static_cast<double>(utime_ticks);
+    result.cpu_time += static_cast<double>(stime_ticks);
+    result.cpu_time /= static_cast<double>(ticks_per_second);
   }
   result.fds = count_entries_in_directory("/proc/self/fd");
   return result;

--- a/libcaf_io/caf/detail/prometheus_broker.cpp
+++ b/libcaf_io/caf/detail/prometheus_broker.cpp
@@ -16,7 +16,7 @@ namespace caf::detail {
 namespace {
 
 // Cap incoming HTTP requests.
-constexpr size_t max_request_size = 512 * 1024;
+constexpr size_t max_request_size = 512 * 1024ul;
 
 // HTTP response for requests that exceed the size limit.
 constexpr std::string_view request_too_large
@@ -95,7 +95,7 @@ behavior prometheus_broker::make_behavior() {
     [this](const io::new_connection_msg& msg) {
       // Pre-allocate buffer for maximum request size.
       auto& req = requests_[msg.handle];
-      req.reserve(512 * 1024);
+      req.reserve(max_request_size);
       configure_read(msg.handle, io::receive_policy::at_most(1024));
     },
     [this](const io::connection_closed_msg& msg) {

--- a/libcaf_net/caf/net/lp/framing.cpp
+++ b/libcaf_net/caf/net/lp/framing.cpp
@@ -123,7 +123,7 @@ bool framing::end_message() {
   using detail::to_network_order;
   auto& buf = down_->output_buffer();
   CAF_ASSERT(message_offset_ < buf.size());
-  auto msg_begin = buf.begin() + message_offset_;
+  auto msg_begin = buf.begin() + static_cast<ptrdiff_t>(message_offset_);
   auto msg_size = std::distance(msg_begin + 4, buf.end());
   if (msg_size > 0 && static_cast<size_t>(msg_size) < max_message_length) {
     auto u32_size = to_network_order(static_cast<uint32_t>(msg_size));

--- a/libcaf_net/caf/net/octet_stream/transport.cpp
+++ b/libcaf_net/caf/net/octet_stream/transport.cpp
@@ -155,7 +155,7 @@ error transport::start(socket_manager* owner) {
   if (auto socket_buf_size = send_buffer_size(policy_->handle())) {
     max_write_buf_size_ = *socket_buf_size;
     CAF_ASSERT(max_write_buf_size_ > 0);
-    write_buf_.reserve(max_write_buf_size_ * 2);
+    write_buf_.reserve(max_write_buf_size_ * 2ul);
   } else {
     CAF_LOG_ERROR("send_buffer_size: " << socket_buf_size.error());
     return std::move(socket_buf_size.error());

--- a/libcaf_net/caf/net/octet_stream/transport.hpp
+++ b/libcaf_net/caf/net/octet_stream/transport.hpp
@@ -69,7 +69,7 @@ public:
 
   // -- constants --------------------------------------------------------------
 
-  static constexpr size_t default_buf_size = 4 * 1024; // 4 KiB
+  static constexpr size_t default_buf_size = 4 * 1024ul; // 4 KiB
 
   // -- constructors, destructors, and assignment operators --------------------
 

--- a/libcaf_net/caf/net/web_socket/server.cpp
+++ b/libcaf_net/caf/net/web_socket/server.cpp
@@ -38,7 +38,7 @@ ptrdiff_t server::consume(byte_span input, byte_span) {
   } else if (!handle_header(hdr)) {
     return -1;
   } else {
-    return hdr.size();
+    return static_cast<ptrdiff_t>(hdr.size());
   }
 }
 


### PR DESCRIPTION
Pulled out of #1565 