### PR TITLE
Fix clang-tidy related use after move warnings

### DIFF
--- a/libcaf_core/caf/async/future.hpp
+++ b/libcaf_core/caf/async/future.hpp
@@ -62,6 +62,8 @@ public:
       }
     }
     if (fire_immediately)
+      // Note: clang-tidy gets confused by fire_immediately.
+      // NOLINTNEXTLINE(bugprone-use-after-move)
       event.first->schedule(std::move(event.second));
     auto res = std::move(cb_action).as_disposable();
     ctx_->watch(res);

--- a/libcaf_core/caf/detail/sync_ring_buffer.test.cpp
+++ b/libcaf_core/caf/detail/sync_ring_buffer.test.cpp
@@ -29,7 +29,7 @@ std::vector<int> consumer(int_buffer& buf, size_t num) {
 }
 
 void producer(int_buffer& buf, int first, int last) {
-  for (auto i = first; i != last; ++i)
+  for (auto i = first; i != last; ++i) // NOLINT(bugprone-use-after-move)
     buf.push_back(std::move(i));
 }
 
@@ -56,6 +56,7 @@ TEST("push_back adds one element to the ring buffer") {
   check(!buf.full());
   check_eq(buf.size(), 0u);
   print_debug("fill buffer");
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   for (int i = 0; i < static_cast<int>(int_buffer_size - 1); ++i)
     buf.push_back(std::move(i));
   check(!buf.empty());
@@ -75,7 +76,7 @@ TEST("get_all returns all elements from the ring buffer") {
     return vector_type(i, e);
   };
   print_debug("add five element");
-  for (int i = 0; i < 5; ++i)
+  for (int i = 0; i < 5; ++i) // NOLINT(bugprone-use-after-move)
     buf.push_back(std::move(i));
   check(!buf.empty());
   check(!buf.full());
@@ -88,7 +89,7 @@ TEST("get_all returns all elements from the ring buffer") {
   check_eq(buf.size(), 0u);
   print_debug("add 60 elements (wraps around)");
   vector_type expected;
-  for (int i = 0; i < 60; ++i) {
+  for (int i = 0; i < 60; ++i) { // NOLINT(bugprone-use-after-move)
     expected.push_back(i);
     buf.push_back(std::move(i));
   }

--- a/libcaf_core/caf/intrusive/linked_list.test.cpp
+++ b/libcaf_core/caf/intrusive/linked_list.test.cpp
@@ -76,7 +76,7 @@ TEST("lists are movable") {
   SECTION("move constructor") {
     fill(uut, 1, 2, 3);
     list_type q2 = std::move(uut);
-    check_eq(uut.empty(), true);
+    check_eq(uut.empty(), true); // NOLINT(bugprone-use-after-move)
     check_eq(q2.empty(), false);
     check_eq(deep_to_string(q2), "[1, 2, 3]");
   }
@@ -84,7 +84,7 @@ TEST("lists are movable") {
     list_type q2;
     fill(q2, 1, 2, 3);
     uut = std::move(q2);
-    check_eq(q2.empty(), true);
+    check_eq(q2.empty(), true); // NOLINT(bugprone-use-after-move)
     check_eq(uut.empty(), false);
     check_eq(deep_to_string(uut), "[1, 2, 3]");
   }

--- a/libcaf_core/tests/legacy/async/spsc_buffer.cpp
+++ b/libcaf_core/tests/legacy/async/spsc_buffer.cpp
@@ -132,17 +132,17 @@ TEST_CASE("resources may be moved") {
   CHECK(wr);
   // Test move constructor.
   async::consumer_resource<int> rd2{std::move(rd)};
-  CHECK(!rd);
+  CHECK(!rd); // NOLINT(bugprone-use-after-move)
   CHECK(rd2);
   async::producer_resource<int> wr2{std::move(wr)};
-  CHECK(!wr);
+  CHECK(!wr); // NOLINT(bugprone-use-after-move)
   CHECK(wr2);
   // Test move-assignment.
   async::consumer_resource<int> rd3{std::move(rd2)};
-  CHECK(!rd2);
+  CHECK(!rd2); // NOLINT(bugprone-use-after-move)
   CHECK(rd3);
   async::producer_resource<int> wr3{std::move(wr2)};
-  CHECK(!wr2);
+  CHECK(!wr2); // NOLINT(bugprone-use-after-move)
   CHECK(wr3);
 }
 

--- a/libcaf_core/tests/legacy/cow_string.cpp
+++ b/libcaf_core/tests/legacy/cow_string.cpp
@@ -54,7 +54,7 @@ SCENARIO("COW string are constructible from STD strings") {
       CHECK(!str.empty());
       CHECK_NE(str.begin(), str.end());
       CHECK_NE(str.rbegin(), str.rend());
-      CHECK_NE(str, std_str);
+      CHECK_NE(str, std_str); // NOLINT(bugprone-use-after-move)
       CHECK_EQ(str, "hello world");
     }
     AND("the reference count is exactly 1") {

--- a/libcaf_core/tests/legacy/cow_tuple.cpp
+++ b/libcaf_core/tests/legacy/cow_tuple.cpp
@@ -41,7 +41,7 @@ CAF_TEST(copy_construction) {
 CAF_TEST(move_construction) {
   cow_tuple<int, int> x{1, 2};
   cow_tuple<int, int> y{std::move(x)};
-  CHECK_EQ(x.ptr(), nullptr);
+  CHECK_EQ(x.ptr(), nullptr); // NOLINT(bugprone-use-after-move)
   CHECK_EQ(y, make_tuple(1, 2));
   CHECK_EQ(y.unique(), true);
 }

--- a/libcaf_core/tests/legacy/detail/unique_function.cpp
+++ b/libcaf_core/tests/legacy/detail/unique_function.cpp
@@ -89,6 +89,8 @@ CAF_TEST(custom wrapper construction) {
   CHECK(instances == 0);
 }
 
+// NOLINTBEGIN(bugprone-use-after-move)
+
 CAF_TEST(function move construction) {
   int_fun f{forty_two};
   int_fun g{std::move(f)};
@@ -162,3 +164,5 @@ CAF_TEST(move assign) {
   CHECK_INVALID(g);
   CHECK_INVALID(h);
 }
+
+// NOLINTEND(bugprone-use-after-move)

--- a/libcaf_core/tests/legacy/expected.cpp
+++ b/libcaf_core/tests/legacy/expected.cpp
@@ -44,6 +44,8 @@ using e_iptr = expected<counted_int_ptr>;
 
 } // namespace
 
+// NOLINTBEGIN(bugprone-use-after-move)
+
 TEST_CASE("expected reports its status via has_value() or operator bool()") {
   e_int x{42};
   CHECK(x);
@@ -935,3 +937,5 @@ TEST_CASE("transform_or does nothing when called with a value") {
     CHECK(v5);
   }
 }
+
+// NOLINTEND(bugprone-use-after-move)

--- a/libcaf_core/tests/legacy/function_view.cpp
+++ b/libcaf_core/tests/legacy/function_view.cpp
@@ -87,7 +87,7 @@ CAF_TEST(single_res_function_view) {
   CHECK(nullptr != f);
   function_view<calculator> g;
   g = std::move(f);
-  CHECK(f == nullptr);
+  CHECK(f == nullptr); // NOLINT(bugprone-use-after-move)
   CHECK(nullptr == f);
   CHECK(g != nullptr);
   CHECK(nullptr != g);

--- a/libcaf_io/caf/io/middleman.cpp
+++ b/libcaf_io/caf/io/middleman.cpp
@@ -427,7 +427,7 @@ strong_actor_ptr middleman::remote_lookup(std::string name,
       return message{};
     },
     after(std::chrono::minutes(5)) >>
-      [&] { CAF_LOG_WARNING("remote_lookup for" << name << "timed out"); });
+      [&] { CAF_LOG_WARNING("remote_lookup timed out"); });
   return result;
 }
 

--- a/libcaf_net/caf/net/http/server_factory.hpp
+++ b/libcaf_net/caf/net/http/server_factory.hpp
@@ -217,7 +217,7 @@ private:
     auto producer = detail::http_request_producer::make(cfg.mpx,
                                                         push.try_open());
     routes.push_back(make_route([producer](responder& res) {
-      if (!producer->push(std::move(res).to_request())) {
+      if (!producer->push(responder{res}.to_request())) {
         auto err = make_error(sec::runtime_error, "flow disconnected");
         res.router()->shutdown(err);
       }

--- a/libcaf_test/caf/test/block.cpp
+++ b/libcaf_test/caf/test/block.cpp
@@ -136,6 +136,7 @@ void block::lazy_init() {
           case '>':
             description_ += ctx_->parameter(parameter_name);
             parameter_names_.push_back(std::move(parameter_name));
+            parameter_name.clear();
             state = cpy_state::verbatim;
             break;
           default:


### PR DESCRIPTION
Pulled out of #1565.