### PR TITLE
Fix clang-tidy unchecked optional access

### DIFF
--- a/libcaf_core/caf/detail/format.cpp
+++ b/libcaf_core/caf/detail/format.cpp
@@ -57,8 +57,8 @@ struct copy_state {
   // Callback for the format string parser.
   void after_width() {
     CAF_ASSERT(width.has_value());
-    if (align == 0) // if alignment is set, we manage the width ourselves
-      print(fstr, *width);
+    if (align == 0)        // if alignment is set, we manage the width ourselves
+      print(fstr, *width); // NOLINT(bugprone-unchecked-optional-access)
   }
 
   // Callback for the format string parser.

--- a/libcaf_core/caf/expected.hpp
+++ b/libcaf_core/caf/expected.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
+
 #include "caf/config.hpp"
 #include "caf/deep_to_string.hpp"
 #include "caf/detail/type_traits.hpp"
@@ -1005,3 +1007,5 @@ operator<<(ostream& oss, const caf::expected<T>& x) -> decltype(oss << *x) {
 }
 
 } // namespace std
+
+// NOLINTEND(bugprone-unchecked-optional-access)

--- a/libcaf_core/caf/inspector_access.hpp
+++ b/libcaf_core/caf/inspector_access.hpp
@@ -284,12 +284,12 @@ struct inspector_access;
 struct optional_inspector_traits_base {
   template <class T>
   static auto& deref_load(T& x) {
-    return *x;
+    return *x; // NOLINT(bugprone-unchecked-optional-access)
   }
 
   template <class T>
   static auto& deref_save(T& x) {
-    return *x;
+    return *x; // NOLINT(bugprone-unchecked-optional-access)
   }
 };
 

--- a/libcaf_net/caf/net/dsl/arg.hpp
+++ b/libcaf_net/caf/net/dsl/arg.hpp
@@ -111,7 +111,7 @@ public:
   val& operator=(const val&) = default;
 
   const T& get() const noexcept {
-    return *data_;
+    return *data_; // NOLINT(bugprone-unchecked-optional-access)
   }
 
   explicit operator bool() const noexcept {


### PR DESCRIPTION
Pulled out of #1565. 