### PR TITLE
Fix clang-tidy implicit move constructor

### DIFF
--- a/libcaf_core/caf/catch_all.hpp
+++ b/libcaf_core/caf/catch_all.hpp
@@ -22,12 +22,11 @@ struct catch_all {
 
   F handler;
 
-  catch_all(catch_all&& x) : handler(std::move(x.handler)) {
-    // nop
-  }
+  catch_all(catch_all&& x) = default;
 
-  template <class T>
-  catch_all(T&& x) : handler(std::forward<T>(x)) {
+  template <class T, class = std::enable_if_t<
+                       !std::is_same_v<std::decay_t<T>, catch_all>>>
+  explicit catch_all(T&& x) : handler(std::forward<T>(x)) {
     // nop
   }
 

--- a/libcaf_core/caf/others.hpp
+++ b/libcaf_core/caf/others.hpp
@@ -18,7 +18,7 @@ struct others_t {
 
   template <class F>
   catch_all<F> operator>>(F fun) const {
-    return {fun};
+    return catch_all<F>{fun};
   }
 };
 

--- a/libcaf_core/caf/others.hpp
+++ b/libcaf_core/caf/others.hpp
@@ -17,7 +17,7 @@ struct others_t {
   }
 
   template <class F>
-  catch_all<F> operator>>(F fun) const {
+  auto operator>>(F fun) const {
     return catch_all<F>{fun};
   }
 };

--- a/libcaf_core/caf/unit.hpp
+++ b/libcaf_core/caf/unit.hpp
@@ -20,7 +20,8 @@ struct unit_t : detail::comparable<unit_t> {
 
   constexpr unit_t& operator=(const unit_t&) noexcept = default;
 
-  template <class T>
+  template <class T,
+            class = std::enable_if_t<!std::is_same_v<std::decay_t<T>, unit_t>>>
   explicit constexpr unit_t(T&&) noexcept {
     // nop
   }

--- a/libcaf_core/tests/legacy/detail/parser/read_number.cpp
+++ b/libcaf_core/tests/legacy/detail/parser/read_number.cpp
@@ -56,10 +56,6 @@ struct range_consumer {
 
 struct res_t {
   std::variant<pec, double, int64_t> val;
-  template <class T>
-  explicit res_t(T x) noexcept : val(x) {
-    // nop
-  }
 };
 
 std::string to_string(const res_t& x) {

--- a/libcaf_core/tests/legacy/detail/parser/read_number.cpp
+++ b/libcaf_core/tests/legacy/detail/parser/read_number.cpp
@@ -56,11 +56,11 @@ struct range_consumer {
 
 struct res_t {
   std::variant<pec, double, int64_t> val;
-  res_t(const res_t&) = default;
-  res_t(res_t&&) = default;
+  res_t(const res_t&) noexcept = default;
+  
   template <class T,
-            class E = std::enable_if_t<!std::is_same_v<std::decay_t<T>, res_t>>>
-  explicit res_t(T&& x) : val(std::forward<T>(x)) {
+            class E = std::enable_if_t<!std::is_same_v<T, res_t>>>
+  explicit res_t(T x) noexcept : val(x) {
     // nop
   }
 };

--- a/libcaf_core/tests/legacy/detail/parser/read_number.cpp
+++ b/libcaf_core/tests/legacy/detail/parser/read_number.cpp
@@ -56,8 +56,11 @@ struct range_consumer {
 
 struct res_t {
   std::variant<pec, double, int64_t> val;
-  template <class T>
-  res_t(T&& x) : val(std::forward<T>(x)) {
+  res_t(const res_t&) = default;
+  res_t(res_t&&) = default;
+  template <class T,
+            class E = std::enable_if_t<!std::is_same_v<std::decay_t<T>, res_t>>>
+  explicit res_t(T&& x) : val(std::forward<T>(x)) {
     // nop
   }
 };
@@ -106,12 +109,12 @@ struct range_parser {
 
 template <class T>
 std::enable_if_t<std::is_integral_v<T>, res_t> res(T x) {
-  return {static_cast<int64_t>(x)};
+  return res_t{static_cast<int64_t>(x)};
 }
 
 template <class T>
 std::enable_if_t<std::is_floating_point_v<T>, res_t> res(T x) {
-  return {static_cast<double>(x)};
+  return res_t{static_cast<double>(x)};
 }
 
 struct fixture {
@@ -189,7 +192,7 @@ CAF_TEST(octal numbers) {
   CHECK_NUMBER(-00);
   CHECK_NUMBER(-0123);
   // invalid numbers
-  CHECK_EQ(p("018"), pec::trailing_character);
+  CHECK_EQ(p("018"), res_t{pec::trailing_character});
 }
 
 CAF_TEST(decimal numbers) {
@@ -210,9 +213,11 @@ CAF_TEST(hexadecimal numbers) {
   CHECK_NUMBER(-0x123);
   CHECK_NUMBER(-0xaf01);
   // invalid numbers
-  CHECK_EQ(p("0xFG"), pec::trailing_character);
-  CHECK_EQ(p("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), pec::integer_overflow);
-  CHECK_EQ(p("-0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), pec::integer_underflow);
+  CHECK_EQ(p("0xFG"), res_t{pec::trailing_character});
+  CHECK_EQ(p("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
+           res_t{pec::integer_overflow});
+  CHECK_EQ(p("-0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
+           res_t{pec::integer_underflow});
 }
 
 CAF_TEST(floating point numbers) {
@@ -263,8 +268,8 @@ CAF_TEST(integer mantissa with negative exponent) {
   CHECK_NUMBER(1e-5);
   CHECK_NUMBER(1e-6);
   // invalid numbers
-  CHECK_EQ(p("-9.9999e-e511"), pec::unexpected_character);
-  CHECK_EQ(p("-9.9999e-511"), pec::exponent_underflow);
+  CHECK_EQ(p("-9.9999e-e511"), res_t{pec::unexpected_character});
+  CHECK_EQ(p("-9.9999e-511"), res_t{pec::exponent_underflow});
 }
 
 CAF_TEST(fractional mantissa with positive exponent) {

--- a/libcaf_core/tests/legacy/detail/parser/read_number.cpp
+++ b/libcaf_core/tests/legacy/detail/parser/read_number.cpp
@@ -56,10 +56,7 @@ struct range_consumer {
 
 struct res_t {
   std::variant<pec, double, int64_t> val;
-  res_t(const res_t&) noexcept = default;
-  
-  template <class T,
-            class E = std::enable_if_t<!std::is_same_v<T, res_t>>>
+  template <class T>
   explicit res_t(T x) noexcept : val(x) {
     // nop
   }

--- a/libcaf_core/tests/legacy/detail/parser/read_number_or_timespan.cpp
+++ b/libcaf_core/tests/legacy/detail/parser/read_number_or_timespan.cpp
@@ -29,10 +29,6 @@ struct number_or_timespan_parser_consumer {
 
 struct res_t {
   std::variant<pec, double, int64_t, timespan> val;
-  template <class T>
-  explicit res_t(T x) : val(x) {
-    // nop
-  }
 };
 
 std::string to_string(const res_t& x) {

--- a/libcaf_core/tests/legacy/detail/parser/read_number_or_timespan.cpp
+++ b/libcaf_core/tests/legacy/detail/parser/read_number_or_timespan.cpp
@@ -29,7 +29,10 @@ struct number_or_timespan_parser_consumer {
 
 struct res_t {
   std::variant<pec, double, int64_t, timespan> val;
-  template <class T>
+  res_t(const res_t&) = default;
+  res_t(res_t&&) = default;
+  template <class T,
+            class E = std::enable_if_t<!std::is_same_v<std::decay_t<T>, res_t>>>
   explicit res_t(T&& x) : val(std::forward<T>(x)) {
     // nop
   }

--- a/libcaf_core/tests/legacy/detail/parser/read_number_or_timespan.cpp
+++ b/libcaf_core/tests/legacy/detail/parser/read_number_or_timespan.cpp
@@ -29,11 +29,8 @@ struct number_or_timespan_parser_consumer {
 
 struct res_t {
   std::variant<pec, double, int64_t, timespan> val;
-  res_t(const res_t&) = default;
-  res_t(res_t&&) = default;
-  template <class T,
-            class E = std::enable_if_t<!std::is_same_v<std::decay_t<T>, res_t>>>
-  explicit res_t(T&& x) : val(std::forward<T>(x)) {
+  template <class T>
+  explicit res_t(T x) : val(x) {
     // nop
   }
 };


### PR DESCRIPTION
Clang-tidy complained that having a constructor accepting a forward reference may act as a move constructor. 
Pulled out of #1565. 