### PR TITLE
Fix heap-use-after-free with the testing mailbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 - The class `caf::test::outline` is now properly exported from the test module.
   This fixes builds with dynamic linking against `libcaf_test`.
+- Fix a crash with the new deterministic test fixture when cleaning up actors
+  with stashed messages (#1589).
 
 ### Deprecated
 

--- a/libcaf_core/caf/actor_control_block.hpp
+++ b/libcaf_core/caf/actor_control_block.hpp
@@ -127,7 +127,12 @@ CAF_CORE_EXPORT bool intrusive_ptr_upgrade_weak(actor_control_block* x);
 
 /// @relates actor_control_block
 inline void intrusive_ptr_add_weak_ref(actor_control_block* x) {
+#ifdef NDEBUG
   x->weak_refs.fetch_add(1, std::memory_order_relaxed);
+#else
+  if (x->weak_refs.fetch_add(1, std::memory_order_relaxed) == 0)
+    CAF_CRITICAL("increased the weak reference count of an expired actor");
+#endif
 }
 
 /// @relates actor_control_block
@@ -135,7 +140,12 @@ CAF_CORE_EXPORT void intrusive_ptr_release_weak(actor_control_block* x);
 
 /// @relates actor_control_block
 inline void intrusive_ptr_add_ref(actor_control_block* x) {
+#ifdef NDEBUG
   x->strong_refs.fetch_add(1, std::memory_order_relaxed);
+#else
+  if (x->strong_refs.fetch_add(1, std::memory_order_relaxed) == 0)
+    CAF_CRITICAL("increased the strong reference count of an expired actor");
+#endif
 }
 
 /// @relates actor_control_block

--- a/libcaf_core/caf/event_based_actor.test.cpp
+++ b/libcaf_core/caf/event_based_actor.test.cpp
@@ -41,6 +41,15 @@ TEST("unexpected messages result in an error by default") {
   expect<int32_t>().with(3).from(receiver).to(sender2);
 }
 
+TEST("GH-1589 regression") {
+  auto dummy2 = sys.spawn([](event_based_actor* self) {
+    self->set_default_handler(skip);
+    return behavior{[](int) {}};
+  });
+  inject().with(dummy2.address()).to(dummy2);
+  // No crash means success.
+}
+
 } // WITH_FIXTURE(test::fixture::deterministic)
 
 CAF_TEST_MAIN()


### PR DESCRIPTION
That was nasty. The issue here was that we have unstashed skipped items by putting them back into the mailbox. Our new mailbox from the deterministic mailbox will then store this in the global list of messages alongside a strong pointer to the receiver. If the receiver is being cleaned up as a result of becoming unreachable, we increment the strong ref count from 0 back to 1... The default mailbox is not affected by this.

Closes #1589.