### PR TITLE
Fix compiler complaints on GCC 13 with C++23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   with stashed messages (#1589).
 - When using `request(...).await(...)`, the actor no longer suspends handling of
   system messages while waiting for the response (#1584).
+- Fix compiler errors and warnings for GCC 13 in C++23 mode (#1583).
 
 ### Deprecated
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ cmake_dependent_option(CAF_ENABLE_OPENSSL_MODULE "Build OpenSSL module" ON
 
 # -- CAF options with non-boolean values ---------------------------------------
 
+set(CAF_CXX_VERSION 17 CACHE STRING "Set the C++ version to use for CAF")
 set(CAF_LOG_LEVEL "QUIET" CACHE STRING "Set log verbosity of CAF components")
 set(CAF_EXCLUDE_TESTS "" CACHE STRING "List of excluded test suites")
 set(CAF_SANITIZERS "" CACHE STRING
@@ -93,8 +94,9 @@ endif()
 # their own CMake scaffold (e.g., via FetchContent) may pass this target in with
 # some properties predefined in order to force compiler flags or dependencies.
 if(NOT TARGET caf_internal)
+  message(STATUS "Build CAF with C++${CAF_CXX_VERSION}")
   add_library(caf_internal INTERFACE)
-  target_compile_features(caf_internal INTERFACE cxx_std_17)
+  target_compile_features(caf_internal INTERFACE cxx_std_${CAF_CXX_VERSION})
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,7 @@ config = [
             builds: ['release'],
             extraBuildFlags: [
                 'CMAKE_CXX_FLAGS:STRING=-Werror -Wno-maybe-uninitialized -Wno-array-bounds',
+                'CAF_CXX_VERSION:STRING=23',
             ],
         ]],
         ['ubuntu-20.04', [ // April 2025

--- a/libcaf_core/caf/config_value_reader.cpp
+++ b/libcaf_core/caf/config_value_reader.cpp
@@ -89,6 +89,25 @@ config_value_reader::associative_array::current() {
 
 // -- constructors, destructors, and assignment operators ----------------------
 
+config_value_reader::config_value_reader(const config_value* input,
+                                         actor_system& sys)
+  : super(sys) {
+  st_.push(input);
+  has_human_readable_format_ = true;
+}
+
+config_value_reader::config_value_reader(const config_value* input,
+                                         execution_unit* ctx)
+  : super(ctx) {
+  st_.push(input);
+  has_human_readable_format_ = true;
+}
+
+config_value_reader::config_value_reader(const config_value* input)
+  : config_value_reader(input, nullptr) {
+  // nop
+}
+
 config_value_reader::~config_value_reader() {
   // nop
 }

--- a/libcaf_core/caf/config_value_reader.hpp
+++ b/libcaf_core/caf/config_value_reader.hpp
@@ -55,21 +55,11 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  config_value_reader(const config_value* input, actor_system& sys)
-    : super(sys) {
-    st_.push(input);
-    has_human_readable_format_ = true;
-  }
+  config_value_reader(const config_value* input, actor_system& sys);
 
-  config_value_reader(const config_value* input, execution_unit* ctx)
-    : super(ctx) {
-    st_.push(input);
-    has_human_readable_format_ = true;
-  }
-  explicit config_value_reader(const config_value* input)
-    : config_value_reader(input, nullptr) {
-    // nop
-  }
+  config_value_reader(const config_value* input, execution_unit* ctx);
+
+  explicit config_value_reader(const config_value* input);
 
   ~config_value_reader() override;
 

--- a/libcaf_core/caf/ipv6_address.cpp
+++ b/libcaf_core/caf/ipv6_address.cpp
@@ -75,12 +75,11 @@ ipv6_address::ipv6_address() {
 
 ipv6_address::ipv6_address(uint16_ilist prefix, uint16_ilist suffix) {
   CAF_ASSERT((prefix.size() + suffix.size()) <= 8);
-  auto addr_fill = [&](uint16_ilist chunks) {
+  auto addr_fill = [&](uint16_ilist chunks, size_t p) {
     union {
       uint16_t i;
       std::array<uint8_t, 2> a;
     } tmp;
-    size_t p = 0;
     for (auto chunk : chunks) {
       tmp.i = detail::to_network_order(chunk);
       bytes_[p++] = tmp.a[0];
@@ -88,9 +87,8 @@ ipv6_address::ipv6_address(uint16_ilist prefix, uint16_ilist suffix) {
     }
   };
   bytes_.fill(0);
-  addr_fill(suffix);
-  std::rotate(bytes_.begin(), bytes_.begin() + suffix.size() * 2, bytes_.end());
-  addr_fill(prefix);
+  addr_fill(prefix, 0);
+  addr_fill(suffix, num_bytes - (suffix.size() * 2));
 }
 
 ipv6_address::ipv6_address(ipv4_address addr) {

--- a/libcaf_core/caf/json_writer.cpp
+++ b/libcaf_core/caf/json_writer.cpp
@@ -460,7 +460,8 @@ json_writer::type json_writer::top() {
 
 // Enters a new level of nesting.
 void json_writer::push(type t) {
-  stack_.push_back({t, false});
+  auto tmp = entry{t, false};
+  stack_.push_back(tmp);
 }
 
 // Backs up one level of nesting.

--- a/libcaf_core/tests/legacy/detail/format.cpp
+++ b/libcaf_core/tests/legacy/detail/format.cpp
@@ -12,86 +12,85 @@
 #  define CAF_MINIMAL_FORMATTING
 #endif
 
+using namespace caf;
 using namespace std::literals;
 
-using caf::detail::format;
-using caf::detail::format_to;
-
 TEST_CASE("format strings without placeholders copies verbatim") {
-  CHECK_EQ(format("hello world"), "hello world");
-  CHECK_EQ(format("foo {{bar}}"), "foo {bar}");
-  CHECK_EQ(format("foo {{bar}} baz"), "foo {bar} baz");
+  CHECK_EQ(detail::format("hello world"), "hello world");
+  CHECK_EQ(detail::format("foo {{bar}}"), "foo {bar}");
+  CHECK_EQ(detail::format("foo {{bar}} baz"), "foo {bar} baz");
 }
 
 TEST_CASE("format strings without indexes iterate over their arguments") {
-  CHECK_EQ(format("foo: {}{}", true, '!'), "foo: true!");
-  CHECK_EQ(format("bar: {}{}", false, '?'), "bar: false?");
-  CHECK_EQ(format("{} {} {} {} {}", 1, 2u, 2.5f, 4.5, "5"s), "1 2 2.5 4.5 5");
+  CHECK_EQ(detail::format("foo: {}{}", true, '!'), "foo: true!");
+  CHECK_EQ(detail::format("bar: {}{}", false, '?'), "bar: false?");
+  CHECK_EQ(detail::format("{} {} {} {} {}", 1, 2u, 2.5f, 4.5, "5"s),
+           "1 2 2.5 4.5 5");
 }
 
 TEST_CASE("format strings with indexes uses the specified arguments") {
-  CHECK_EQ(format("{1} {2} {0}", 3, 1, 2), "1 2 3");
-  CHECK_EQ(format("{1} {0} {1}", 1, 2), "2 1 2");
+  CHECK_EQ(detail::format("{1} {2} {0}", 3, 1, 2), "1 2 3");
+  CHECK_EQ(detail::format("{1} {0} {1}", 1, 2), "2 1 2");
 }
 
 TEST_CASE("format strings can specify rendering of floating point numbers") {
-  CHECK_EQ(format("{}", 2.5), "2.5");
-  CHECK_EQ(format("{:.3f}", 2.5), "2.500");
-  CHECK_EQ(format("{:.3F}", 2.5), "2.500");
-  CHECK_EQ(format("{:g}", 2.5), "2.5");
-  CHECK_EQ(format("{:G}", 2.5), "2.5");
-  CHECK_EQ(format("{:.0e}", 10.0), "1e+01");
-  CHECK_EQ(format("{:.0E}", 10.0), "1E+01");
+  CHECK_EQ(detail::format("{}", 2.5), "2.5");
+  CHECK_EQ(detail::format("{:.3f}", 2.5), "2.500");
+  CHECK_EQ(detail::format("{:.3F}", 2.5), "2.500");
+  CHECK_EQ(detail::format("{:g}", 2.5), "2.5");
+  CHECK_EQ(detail::format("{:G}", 2.5), "2.5");
+  CHECK_EQ(detail::format("{:.0e}", 10.0), "1e+01");
+  CHECK_EQ(detail::format("{:.0E}", 10.0), "1E+01");
 }
 
 TEST_CASE("format strings can specify rendering of integers") {
-  CHECK_EQ(format("{}", 42), "42");
-  CHECK_EQ(format("{:d}", 42), "42");
-  CHECK_EQ(format("{:c}", 42), "*");
-  CHECK_EQ(format("{:o}", 42), "52");
-  CHECK_EQ(format("{:#o}", 42), "052");
-  CHECK_EQ(format("{:x}", 42), "2a");
-  CHECK_EQ(format("{:X}", 42), "2A");
-  CHECK_EQ(format("{:#x}", 42), "0x2a");
-  CHECK_EQ(format("{:#X}", 42), "0X2A");
-  CHECK_EQ(format("{}", 42u), "42");
-  CHECK_EQ(format("{:d}", 42u), "42");
-  CHECK_EQ(format("{:c}", 42u), "*");
-  CHECK_EQ(format("{:o}", 42u), "52");
-  CHECK_EQ(format("{:#o}", 42u), "052");
-  CHECK_EQ(format("{:x}", 42u), "2a");
-  CHECK_EQ(format("{:X}", 42u), "2A");
-  CHECK_EQ(format("{:#x}", 42u), "0x2a");
-  CHECK_EQ(format("{:#X}", 42u), "0X2A");
-  CHECK_EQ(format("'{:+}' '{:-}' '{: }'", 1, 1, 1), "'+1' '1' ' 1'");
-  CHECK_EQ(format("'{:+}' '{:-}' '{: }'", -1, -1, -1), "'-1' '-1' '-1'");
+  CHECK_EQ(detail::format("{}", 42), "42");
+  CHECK_EQ(detail::format("{:d}", 42), "42");
+  CHECK_EQ(detail::format("{:c}", 42), "*");
+  CHECK_EQ(detail::format("{:o}", 42), "52");
+  CHECK_EQ(detail::format("{:#o}", 42), "052");
+  CHECK_EQ(detail::format("{:x}", 42), "2a");
+  CHECK_EQ(detail::format("{:X}", 42), "2A");
+  CHECK_EQ(detail::format("{:#x}", 42), "0x2a");
+  CHECK_EQ(detail::format("{:#X}", 42), "0X2A");
+  CHECK_EQ(detail::format("{}", 42u), "42");
+  CHECK_EQ(detail::format("{:d}", 42u), "42");
+  CHECK_EQ(detail::format("{:c}", 42u), "*");
+  CHECK_EQ(detail::format("{:o}", 42u), "52");
+  CHECK_EQ(detail::format("{:#o}", 42u), "052");
+  CHECK_EQ(detail::format("{:x}", 42u), "2a");
+  CHECK_EQ(detail::format("{:X}", 42u), "2A");
+  CHECK_EQ(detail::format("{:#x}", 42u), "0x2a");
+  CHECK_EQ(detail::format("{:#X}", 42u), "0X2A");
+  CHECK_EQ(detail::format("{:+} '{:-}' '{: }'", 1, 1, 1), "+1 '1' ' 1'");
+  CHECK_EQ(detail::format("{:+} '{:-}' '{: }'", -1, -1, -1), "-1 '-1' '-1'");
 }
 
 TEST_CASE("format strings may specify the width of the output") {
-  CHECK_EQ(format("{0:0{1}}", 1, 2), "01");
-  CHECK_EQ(format("{1:02} {0:02}", 1, 2), "02 01");
-  CHECK_EQ(format("{:!<3}?{:!>3}", 0, 0), "0!!?!!0");
-  CHECK_EQ(format("{:!^3}?{:!^3}", 'A', 'A'), "!A!?!A!");
-  CHECK_EQ(format("{0:!^{1}}", 'A', 5), "!!A!!");
-  CHECK_EQ(format("{:<3}?{:>3}", 0, 0), "0  ?  0");
+  CHECK_EQ(detail::format("{0:0{1}}", 1, 2), "01");
+  CHECK_EQ(detail::format("{1:02} {0:02}", 1, 2), "02 01");
+  CHECK_EQ(detail::format("{:!<3}?{:!>3}", 0, 0), "0!!?!!0");
+  CHECK_EQ(detail::format("{:!^3}?{:!^3}", 'A', 'A'), "!A!?!A!");
+  CHECK_EQ(detail::format("{0:!^{1}}", 'A', 5), "!!A!!");
+  CHECK_EQ(detail::format("{:<3}?{:>3}", 0, 0), "0  ?  0");
 }
 
 TEST_CASE("format strings accept various string types as values") {
   using namespace std::literals;
   const auto* cstr = "C-string";
-  CHECK_EQ(format("{}", cstr), "C-string");
-  CHECK_EQ(format("{}", "string literal"), "string literal");
-  CHECK_EQ(format("{}", "std::string"s), "std::string");
-  CHECK_EQ(format("{}", "std::string_view"sv), "std::string_view");
+  CHECK_EQ(detail::format("{}", cstr), "C-string");
+  CHECK_EQ(detail::format("{}", "string literal"), "string literal");
+  CHECK_EQ(detail::format("{}", "std::string"s), "std::string");
+  CHECK_EQ(detail::format("{}", "std::string_view"sv), "std::string_view");
 }
 
 TEST_CASE("format_to can incrementally build a string") {
   std::string str;
-  format_to(std::back_inserter(str), "foo");
+  detail::format_to(std::back_inserter(str), "foo");
   CHECK_EQ(str, "foo");
-  format_to(std::back_inserter(str), "bar");
+  detail::format_to(std::back_inserter(str), "bar");
   CHECK_EQ(str, "foobar");
-  format_to(std::back_inserter(str), "baz");
+  detail::format_to(std::back_inserter(str), "baz");
   CHECK_EQ(str, "foobarbaz");
 }
 
@@ -101,9 +100,9 @@ TEST_CASE("format_to can incrementally build a string") {
 //       error for these test cases. Only our minimal implementation throws.
 
 TEST_CASE("ill-formatted formatting strings throw") {
-  CHECK_THROWS_AS(format("foo {"), std::logic_error);
-  CHECK_THROWS_AS(format("foo } bar"), std::logic_error);
-  CHECK_THROWS_AS(format("{1}", 1), std::logic_error);
+  CHECK_THROWS_AS(detail::format("foo {"), std::logic_error);
+  CHECK_THROWS_AS(detail::format("foo } bar"), std::logic_error);
+  CHECK_THROWS_AS(detail::format("{1}", 1), std::logic_error);
 }
 
 #endif

--- a/libcaf_core/tests/legacy/detail/meta_object.cpp
+++ b/libcaf_core/tests/legacy/detail/meta_object.cpp
@@ -39,7 +39,7 @@ BEGIN_FIXTURE_SCOPE(fixture)
 
 CAF_TEST(meta objects allow construction and destruction of objects) {
   auto meta_i32_wrapper = make_meta_object<i32_wrapper>("i32_wrapper");
-  std::aligned_storage_t<sizeof(i32_wrapper), alignof(i32_wrapper)> storage;
+  alignas(i32_wrapper) std::byte storage[sizeof(i32_wrapper)];
   meta_i32_wrapper.default_construct(&storage);
   CHECK_EQ(i32_wrapper::instances, 1u);
   meta_i32_wrapper.destroy(&storage);
@@ -49,7 +49,7 @@ CAF_TEST(meta objects allow construction and destruction of objects) {
 CAF_TEST(meta objects allow serialization of objects) {
   byte_buffer buf;
   auto meta_i32_wrapper = make_meta_object<i32_wrapper>("i32_wrapper");
-  std::aligned_storage_t<sizeof(i32_wrapper), alignof(i32_wrapper)> storage;
+  alignas(i32_wrapper) std::byte storage[sizeof(i32_wrapper)];
   binary_serializer sink{nullptr, buf};
   meta_i32_wrapper.default_construct(&storage);
   CHECK_EQ(i32_wrapper::instances, 1u);


### PR DESCRIPTION
Closes #1583.

The ticket mentioned Clang 17. Fedora 38 only has 15, so I've tested with GCC 13 instead and enabled a C++23 build in our CI pipeline.

Most errors are due to ADL picking up `std::format`. I've also included the user-reported patch.

Also, today I learned that C++23 deprecates `std::aligned_storage_t`. 🙂