### PR TITLE
Add new flow on_error_return with tests

### DIFF
--- a/libcaf_core/caf/flow/observable.hpp
+++ b/libcaf_core/caf/flow/observable.hpp
@@ -334,6 +334,12 @@ public:
     return add_step(step::on_error_return_item<output_type>{std::move(item)});
   }
 
+  template <class ErrorHandler>
+  auto on_error_return(ErrorHandler error_handler) && {
+    return add_step(
+      step::on_error_return<ErrorHandler>{std::move(error_handler)});
+  }
+
   /// Materializes the @ref observable.
   observable<output_type> as_observable() && {
     return materialize();
@@ -637,6 +643,13 @@ transformation<step::map<F>> observable<T>::map(F f) {
 template <class T>
 transformation<step::on_error_complete<T>> observable<T>::on_error_complete() {
   return transform(step::on_error_complete<T>{});
+}
+
+template <class T>
+template <class ErrorHandler>
+transformation<step::on_error_return<ErrorHandler>>
+observable<T>::on_error_return(ErrorHandler error_handler) {
+  return transform(step::on_error_return{std::move(error_handler)});
 }
 
 template <class T>

--- a/libcaf_core/caf/flow/observable.test.cpp
+++ b/libcaf_core/caf/flow/observable.test.cpp
@@ -320,6 +320,181 @@ TEST("on_error_return_item() replaces an error with a value") {
   }
 }
 
+TEST("on_error_return() replaces an error with a value") {
+  SECTION("on_error_return() does nothing if no error occurs") {
+    SECTION("blueprint") {
+      check_eq(collect(range(1, 1).on_error_return(
+                 [](const error&) { return expected<int>{42}; })),
+               vector{1});
+      check_eq(collect(range(1, 2).on_error_return(
+                 [](const error&) { return expected<int>{42}; })),
+               vector{1, 2});
+      check_eq(collect(range(1, 3).on_error_return(
+                 [](const error&) { return expected<int>{42}; })),
+               vector{1, 2, 3});
+      check_eq(collect(range(1, 0).on_error_return(
+                 [](const error&) { return expected<int>{42}; })),
+               nil);
+    }
+    SECTION("observable") {
+      check_eq(collect(mat(range(1, 1)).on_error_return([](const error&) {
+                 return expected<int>{42};
+               })),
+               vector{1});
+      check_eq(collect(mat(range(1, 2)).on_error_return([](const error&) {
+                 return expected<int>{42};
+               })),
+               vector{1, 2});
+      check_eq(collect(mat(range(1, 3)).on_error_return([](const error&) {
+                 return expected<int>{42};
+               })),
+               vector{1, 2, 3});
+      check_eq(collect(mat(range(1, 0)).on_error_return([](const error&) {
+                 return expected<int>{42};
+               })),
+               nil);
+    }
+  }
+  SECTION("on_error_return() returns from predicate when an error occurs") {
+    SECTION("blueprint") {
+      check_eq(collect(range(1, 0)
+                         .concat(obs_error(sec::runtime_error))
+                         .on_error_return(
+                           [](const error&) { return expected<int>{42}; })),
+               vector{42});
+      check_eq(collect(range(1, 2)
+                         .concat(obs_error(sec::runtime_error))
+                         .concat(range(1, 2))
+                         .on_error_return(
+                           [](const error&) { return expected<int>{42}; })),
+               vector{1, 2, 42});
+      check_eq(collect(range(1, 3)
+                         .concat(obs_error(sec::runtime_error))
+                         .concat(range(1, 3))
+                         .on_error_return(
+                           [](const error&) { return expected<int>{42}; })),
+               vector{1, 2, 3, 42});
+      check_eq(collect(range(1, 2)
+                         .concat(obs_error(sec::runtime_error))
+                         .on_error_return(
+                           [](const error&) { return expected<int>{42}; })
+                         .take(2)),
+               vector{1, 2});
+      check_eq(collect(range(1, 3)
+                         .concat(obs_error(sec::runtime_error))
+                         .on_error_return(
+                           [](const error&) { return expected<int>{42}; })
+                         .take(3)),
+               vector{1, 2, 3});
+    }
+    SECTION("observable") {
+      check_eq(collect(mat(range(1, 0).concat(obs_error(sec::runtime_error)))
+                         .on_error_return(
+                           [](const error&) { return expected<int>{42}; })),
+               vector{42});
+      check_eq(collect(mat(range(1, 2)
+                             .concat(obs_error(sec::runtime_error))
+                             .concat(range(1, 2)))
+                         .on_error_return(
+                           [](const error&) { return expected<int>{42}; })),
+               vector{1, 2, 42});
+      check_eq(collect(mat(range(1, 3)
+                             .concat(obs_error(sec::runtime_error))
+                             .concat(range(1, 3)))
+                         .on_error_return(
+                           [](const error&) { return expected<int>{42}; })),
+               vector{1, 2, 3, 42});
+      check_eq(collect(mat(range(1, 2).concat(obs_error(sec::runtime_error)))
+                         .on_error_return(
+                           [](const error&) { return expected<int>{42}; })
+                         .take(2)),
+               vector{1, 2});
+      check_eq(collect(mat(range(1, 3).concat(obs_error(sec::runtime_error)))
+                         .on_error_return(
+                           [](const error&) { return expected<int>{42}; })
+                         .take(3)),
+               vector{1, 2, 3});
+    }
+  }
+  SECTION("on_error_return() returns error from predicate") {
+    SECTION("blueprint") {
+      check_eq(collect(range(1, 0)
+                         .concat(obs_error(sec::runtime_error))
+                         .on_error_return([](const error&) {
+                           return expected<int>{
+                             make_error(sec::unexpected_message)};
+                         })),
+               sec::unexpected_message);
+      check_eq(collect(range(1, 2)
+                         .concat(obs_error(sec::runtime_error))
+                         .concat(range(1, 2))
+                         .on_error_return([](const error&) {
+                           return expected<int>{
+                             make_error(sec::unexpected_message)};
+                         })),
+               sec::unexpected_message);
+      check_eq(collect(range(1, 3)
+                         .concat(obs_error(sec::runtime_error))
+                         .concat(range(1, 3))
+                         .on_error_return([](const error& what) {
+                           return expected<int>{what};
+                         })),
+               sec::runtime_error);
+      check_eq(collect(range(1, 2)
+                         .concat(obs_error(sec::runtime_error))
+                         .on_error_return([](const error& what) {
+                           return expected<int>{what};
+                         })
+                         .take(2)),
+               sec::runtime_error);
+      check_eq(collect(range(1, 3)
+                         .concat(obs_error(sec::runtime_error))
+                         .on_error_return([](const error&) {
+                           return expected<int>{
+                             make_error(sec::unexpected_message)};
+                         })
+                         .take(3)),
+               sec::unexpected_message);
+    }
+    SECTION("observable") {
+      check_eq(collect(mat(range(1, 0).concat(obs_error(sec::runtime_error)))
+                         .on_error_return([](const error&) {
+                           return expected<int>{
+                             make_error(sec::unexpected_message)};
+                         })),
+               sec::unexpected_message);
+      check_eq(collect(mat(range(1, 2)
+                             .concat(obs_error(sec::runtime_error))
+                             .concat(range(1, 2)))
+                         .on_error_return([](const error&) {
+                           return expected<int>{
+                             make_error(sec::unexpected_message)};
+                         })),
+               sec::unexpected_message);
+      check_eq(collect(mat(range(1, 3)
+                             .concat(obs_error(sec::runtime_error))
+                             .concat(range(1, 3)))
+                         .on_error_return([](const error& what) {
+                           return expected<int>{what};
+                         })),
+               sec::runtime_error);
+      check_eq(collect(mat(range(1, 2).concat(obs_error(sec::runtime_error)))
+                         .on_error_return([](const error& what) {
+                           return expected<int>{what};
+                         })
+                         .take(2)),
+               sec::runtime_error);
+      check_eq(collect(mat(range(1, 3).concat(obs_error(sec::runtime_error)))
+                         .on_error_return([](const error&) {
+                           return expected<int>{
+                             make_error(sec::unexpected_message)};
+                         })
+                         .take(3)),
+               sec::unexpected_message);
+    }
+  }
+}
+
 } // WITH_FIXTURE(test::fixture::flow)
 
 } // namespace

--- a/libcaf_core/caf/flow/observable_decl.hpp
+++ b/libcaf_core/caf/flow/observable_decl.hpp
@@ -113,6 +113,11 @@ public:
   transformation<step::on_error_complete<T>> on_error_complete();
 
   /// Recovers from errors by returning an item.
+  template <class ErrorHandler>
+  transformation<step::on_error_return<ErrorHandler>>
+  on_error_return(ErrorHandler error_handler);
+
+  /// Recovers from errors by returning an item.
   transformation<step::on_error_return_item<T>> on_error_return_item(T item);
 
   /// Reduces the entire sequence of items to a single value. Other names for

--- a/libcaf_core/caf/flow/step/all.hpp
+++ b/libcaf_core/caf/flow/step/all.hpp
@@ -8,6 +8,7 @@
 #include "caf/flow/step/ignore_elements.hpp"
 #include "caf/flow/step/map.hpp"
 #include "caf/flow/step/on_error_complete.hpp"
+#include "caf/flow/step/on_error_return.hpp"
 #include "caf/flow/step/on_error_return_item.hpp"
 #include "caf/flow/step/reduce.hpp"
 #include "caf/flow/step/skip.hpp"

--- a/libcaf_core/caf/flow/step/fwd.hpp
+++ b/libcaf_core/caf/flow/step/fwd.hpp
@@ -31,6 +31,9 @@ template <class>
 class on_error_complete;
 
 template <class>
+class on_error_return;
+
+template <class>
 class on_error_return_item;
 
 template <class>

--- a/libcaf_core/caf/flow/step/on_error_return.hpp
+++ b/libcaf_core/caf/flow/step/on_error_return.hpp
@@ -14,10 +14,6 @@ namespace caf::flow::step {
 template <class ErrorHandler>
 class on_error_return {
 public:
-  using trait = detail::get_callable_trait_t<ErrorHandler>;
-
-  static_assert(trait::num_args == 1, "error_handler must take an argument");
-
   using handler_res
     = decltype(std::declval<ErrorHandler&>()(std::declval<const error&>()));
 

--- a/libcaf_core/caf/flow/step/on_error_return.hpp
+++ b/libcaf_core/caf/flow/step/on_error_return.hpp
@@ -1,0 +1,63 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/detail/type_traits.hpp"
+#include "caf/fwd.hpp"
+
+#include <utility>
+
+namespace caf::flow::step {
+
+template <class ErrorHandler>
+class on_error_return {
+public:
+  using trait = detail::get_callable_trait_t<ErrorHandler>;
+
+  static_assert(trait::num_args == 1, "error_handler must take an argument");
+
+  using handler_res
+    = decltype(std::declval<ErrorHandler&>()(std::declval<const error&>()));
+
+  static_assert(detail::is_expected_v<handler_res>,
+                "error_handler must return a caf::expected type");
+
+  using input_type = typename handler_res::value_type;
+
+  using output_type = input_type;
+
+  explicit on_error_return(ErrorHandler fn) : fn_(std::move(fn)) {
+    // nop
+  }
+
+  on_error_return(on_error_return&&) = default;
+  on_error_return(const on_error_return&) = default;
+  on_error_return& operator=(on_error_return&&) = default;
+  on_error_return& operator=(const on_error_return&) = default;
+
+  template <class Next, class... Steps>
+  bool on_next(const input_type& item, Next& next, Steps&... steps) {
+    return next.on_next(item, steps...);
+  }
+
+  template <class Next, class... Steps>
+  void on_complete(Next& next, Steps&... steps) {
+    next.on_complete(steps...);
+  }
+
+  template <class Next, class... Steps>
+  void on_error(const error& what, Next& next, Steps&... steps) {
+    if (auto result = fn_(what)) {
+      if (next.on_next(std::move(*result), steps...))
+        next.on_complete(steps...);
+    } else
+      next.on_error(result.error(), steps...);
+  }
+
+private:
+  ErrorHandler fn_;
+};
+
+} // namespace caf::flow::step


### PR DESCRIPTION
Relates https://github.com/actor-framework/actor-framework/issues/1389

Adds new flow on_error_return for observables.