### PR TITLE
Switch back to single test binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,18 @@ function(caf_add_component name)
   add_library(${obj_lib_target} OBJECT ${CAF_ADD_COMPONENT_HEADERS})
   set_property(TARGET ${obj_lib_target} PROPERTY POSITION_INDEPENDENT_CODE ON)
   target_link_libraries(${obj_lib_target} ${CAF_ADD_COMPONENT_DEPENDENCIES})
+  if(CAF_ENABLE_TESTING)
+    add_executable("caf-${name}-test" ${CMAKE_CURRENT_SOURCE_DIR}/main.test.cpp
+                   $<TARGET_OBJECTS:${obj_lib_target}>)
+    target_compile_definitions(
+      "caf-${name}-test" PRIVATE
+      CAF_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/data")
+    target_link_libraries("caf-${name}-test" PRIVATE libcaf_test
+                          ${CAF_ADD_COMPONENT_DEPENDENCIES})
+    target_include_directories("caf-${name}-test" PRIVATE
+                               "${CMAKE_CURRENT_SOURCE_DIR}"
+                               "${CMAKE_CURRENT_BINARY_DIR}")
+  endif()
   foreach(source_file ${CAF_ADD_COMPONENT_SOURCES})
     get_filename_component(ext ${source_file} EXT)
     if(ext STREQUAL ".cpp")
@@ -289,19 +301,11 @@ function(caf_add_component name)
     elseif(ext STREQUAL ".test.cpp" AND CAF_ENABLE_TESTING)
       get_filename_component(test_name ${source_file} NAME_WE)
       get_filename_component(test_path ${source_file} DIRECTORY)
-      string(REPLACE "/" "-" test_name "${test_path}/${test_name}-test")
-      string(REPLACE "_" "-" test_name "${test_name}")
-      add_executable("${test_name}" ${source_file}
-                     $<TARGET_OBJECTS:${obj_lib_target}>)
-      target_compile_definitions(
-        "${test_name}" PRIVATE
-        CAF_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/data")
-      target_link_libraries(${test_name} PRIVATE libcaf_test
-                            ${CAF_ADD_COMPONENT_DEPENDENCIES})
-      target_include_directories(${test_name} PRIVATE
-                                 "${CMAKE_CURRENT_SOURCE_DIR}"
-                                 "${CMAKE_CURRENT_BINARY_DIR}")
-      add_test(NAME ${test_name} COMMAND ${test_name} -n -v5)
+      string(REPLACE "/" "." test_name "${test_path}/${test_name}")
+      target_sources("caf-${name}-test" PRIVATE ${source_file})
+      set_property(SOURCE ${source_file} PROPERTY COMPILE_DEFINITIONS
+                   CAF_TEST_SUITE_NAME=${test_name})
+      add_test(NAME ${test_name} COMMAND "caf-${name}-test" -s "^${test_name}$" -n -v5)
       set_tests_properties(${test_name} PROPERTIES TIMEOUT 300)
     endif()
   endforeach()

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -172,7 +172,6 @@ caf_add_component(
     caf/detail/test_actor_clock.cpp
     caf/detail/thread_safe_actor_clock.cpp
     caf/detail/type_id_list_builder.cpp
-    caf/detail/type_id_list_builder.test.cpp
     caf/detail/unique_function.test.cpp
     caf/disposable.cpp
     caf/error.cpp

--- a/libcaf_core/caf/action.test.cpp
+++ b/libcaf_core/caf/action.test.cpp
@@ -4,13 +4,14 @@
 
 #include "caf/action.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/fixture/deterministic.hpp"
 #include "caf/test/scenario.hpp"
 
 #include "caf/event_based_actor.hpp"
 
 using namespace caf;
+
+namespace {
 
 SCENARIO("actions wrap function calls") {
   GIVEN("an action wrapping a lambda") {
@@ -130,4 +131,4 @@ SCENARIO("actors run actions that they receive") {
 
 } // WITH_FIXTURE(test::fixture::deterministic)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/actor_companion.test.cpp
+++ b/libcaf_core/caf/actor_companion.test.cpp
@@ -4,13 +4,14 @@
 
 #include "caf/actor_companion.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/fixture/deterministic.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/mailbox_element.hpp"
 
 using namespace caf;
+
+namespace {
 
 WITH_FIXTURE(test::fixture::deterministic) {
 
@@ -41,4 +42,4 @@ TEST("actor_companion calls the on_exit handler on shutdown") {
 
 } // WITH_FIXTURE(test::fixture::deterministic)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/actor_system.test.cpp
+++ b/libcaf_core/caf/actor_system.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/actor_system.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/actor_system_config.hpp"
@@ -14,6 +13,8 @@
 #include <memory>
 
 using namespace caf;
+
+namespace {
 
 using shared_bool_ptr = std::shared_ptr<bool>;
 
@@ -73,4 +74,4 @@ TEST("spawn_inactive creates an actor without launching it") {
   }
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/actor_system.test.cpp
+++ b/libcaf_core/caf/actor_system.test.cpp
@@ -41,37 +41,30 @@ TEST("spawn_inactive creates an actor without launching it") {
   actor_system_config cfg;
   put(cfg.content, "caf.scheduler.max-threads", 1);
   actor_system sys{cfg};
-  scoped_actor self{sys};
   SECTION("users may launch the actor manually") {
-    actor hdl;
-    {
-      auto [self, launch] = sys.spawn_inactive<dummy_actor>(flag);
-      check_eq(self->ctrl()->strong_refs, 1u); // 1 ref by launch
-      hdl = self;
-      check(!*flag);
+    auto [self, launch] = sys.spawn_inactive<dummy_actor>(flag);
+    check_eq(self->ctrl()->strong_refs, 1u); // 1 ref by launch
+    check(!*flag);
+    launch();
+    check(*flag);
+    SECTION("calling launch() twice is a no-op") {
+      *flag = false;
       launch();
-      check(*flag);
-      SECTION("calling launch() twice is a no-op") {
-        *flag = false;
-        launch();
-        check(!*flag);
-      }
+      check(!*flag);
     }
-    self->wait_for(hdl);
-    check_eq(hdl->ctrl()->strong_refs, 1u); // launch must have dropped its ref
   }
   SECTION("the actor launches automatically at scope exit") {
-    actor hdl;
     {
       auto [self, launch] = sys.spawn_inactive<dummy_actor>(flag);
       check_eq(self->ctrl()->strong_refs, 1u); // 1 ref by launch
-      hdl = self;
       check(!*flag);
     }
-    self->wait_for(hdl);
+    sys.await_all_actors_done();
     check(*flag);
-    check_eq(hdl->ctrl()->strong_refs, 1u); // launch must have dropped its ref
   }
+  // Note: checking the ref count at the end to verify that `launch` has dropped
+  //       its reference to the actor is unreliable, because the scheduler holds
+  //       on to a reference as well that may not be dropped yet.
 }
 
 } // namespace

--- a/libcaf_core/caf/async/batch.test.cpp
+++ b/libcaf_core/caf/async/batch.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/async/batch.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/scenario.hpp"
 
 #include "caf/binary_deserializer.hpp"
@@ -18,6 +17,8 @@
 
 using namespace caf;
 using namespace std::literals;
+
+namespace {
 
 template <class T>
 auto to_vec(span<const T> xs) {
@@ -259,4 +260,4 @@ SCENARIO("serializing and then deserializing a batch makes a deep copy") {
   }
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/async/file.test.cpp
+++ b/libcaf_core/caf/async/file.test.cpp
@@ -4,11 +4,12 @@
 
 #include "caf/async/file.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/fixture/flow.hpp"
 #include "caf/test/nil.hpp"
 #include "caf/test/test.hpp"
 
+#include "caf/actor_system.hpp"
+#include "caf/actor_system_config.hpp"
 #include "caf/event_based_actor.hpp"
 #include "caf/flow/observable.hpp"
 
@@ -18,6 +19,8 @@
 
 using namespace caf;
 using namespace std::literals;
+
+namespace {
 
 constexpr const char* quotes_file = CAF_TEST_DATA_DIR "/quotes.txt";
 
@@ -112,4 +115,4 @@ TEST("async file I/O") {
   }
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/behavior.test.cpp
+++ b/libcaf_core/caf/behavior.test.cpp
@@ -4,10 +4,11 @@
 
 #include "caf/behavior.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 using namespace caf;
+
+namespace {
 
 class nocopy_fun {
 public:
@@ -152,4 +153,4 @@ TEST("a handler that takes a message argument is a catch-all handler") {
 
 } // WITH_FIXTURE(fixture)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/delegate.test.cpp
+++ b/libcaf_core/caf/delegate.test.cpp
@@ -2,7 +2,6 @@
 // the main distribution directory for license terms and copyright or visit
 // https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/fixture/deterministic.hpp"
 #include "caf/test/test.hpp"
 
@@ -10,6 +9,8 @@
 #include "caf/sec.hpp"
 
 using namespace caf;
+
+namespace {
 
 WITH_FIXTURE(test::fixture::deterministic) {
 
@@ -74,4 +75,4 @@ TEST("delegation moves responsibility for a request to another actor") {
 
 } // WITH_FIXTURE(test::fixture::deterministic)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/base64.test.cpp
+++ b/libcaf_core/caf/detail/base64.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/base64.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include <string_view>
@@ -14,6 +13,8 @@ using namespace std::literals;
 using namespace std::literals::string_literals;
 
 using caf::detail::base64;
+
+namespace {
 
 TEST("encoding") {
   check_eq(base64::encode("A"sv), "QQ=="sv);
@@ -31,4 +32,4 @@ TEST("decoding") {
            "https://actor-framework.org"s);
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/bounds_checker.test.cpp
+++ b/libcaf_core/caf/detail/bounds_checker.test.cpp
@@ -4,10 +4,11 @@
 
 #include "caf/detail/bounds_checker.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include <cstdint>
+
+namespace {
 
 template <class T, class U>
 bool bounds_check(U x) {
@@ -41,4 +42,4 @@ TEST("large unsigned integers") {
   check_eq(bounds_check<uint64_t>(std::numeric_limits<uint64_t>::max()), true);
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/config_consumer.test.cpp
+++ b/libcaf_core/caf/detail/config_consumer.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/config_consumer.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/detail/parser/read_config.hpp"
@@ -56,8 +55,6 @@ struct fixture {
   }
 };
 
-} // namespace
-
 WITH_FIXTURE(fixture) {
 
 TEST("config_consumer") {
@@ -95,4 +92,4 @@ TEST("simplified syntax") {
 
 } // WITH_FIXTURE(fixture)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/default_mailbox.test.cpp
+++ b/libcaf_core/caf/detail/default_mailbox.test.cpp
@@ -4,10 +4,11 @@
 
 #include "caf/detail/default_mailbox.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 using namespace caf;
+
+namespace {
 
 using ires = intrusive::inbox_result;
 
@@ -76,4 +77,4 @@ TEST("calling push_front inserts messages at the beginning") {
   }
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/format.test.cpp
+++ b/libcaf_core/caf/detail/format.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/format.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #if !defined(CAF_USE_STD_FORMAT) && !defined(CAF_USE_SYSTEM_LIBFMT)
@@ -13,6 +12,8 @@
 
 using namespace caf;
 using namespace std::literals;
+
+namespace {
 
 TEST("format strings without placeholders copies verbatim") {
   check_eq(detail::format("hello world"), "hello world");
@@ -106,4 +107,4 @@ TEST("ill-formatted formatting strings throw") {
 
 #endif
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/ieee_754.test.cpp
+++ b/libcaf_core/caf/detail/ieee_754.test.cpp
@@ -4,15 +4,14 @@
 
 #include "caf/detail/ieee_754.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include <limits>
 
-namespace {
-
 using caf::detail::pack754;
 using caf::detail::unpack754;
+
+namespace {
 
 template <class T>
 T roundtrip(T x) {
@@ -22,8 +21,6 @@ T roundtrip(T x) {
 using flimits = std::numeric_limits<float>;
 
 using dlimits = std::numeric_limits<double>;
-
-} // namespace
 
 #define CHECK_RT(value) check_eq(roundtrip(value), value)
 
@@ -100,4 +97,4 @@ TEST("packing and then unpacking doubles returns the original value") {
   }
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/json.test.cpp
+++ b/libcaf_core/caf/detail/json.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/json.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 using namespace caf;
@@ -159,8 +158,6 @@ std::string stringify(const detail::json::value& val) {
   return result;
 }
 
-} // namespace
-
 TEST("json baselines") {
   size_t baseline_index = 0;
   detail::monotonic_buffer_resource resource;
@@ -174,4 +171,4 @@ TEST("json baselines") {
   }
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/latch.test.cpp
+++ b/libcaf_core/caf/detail/latch.test.cpp
@@ -4,10 +4,13 @@
 
 #include "caf/detail/latch.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/scenario.hpp"
 
+#include <thread>
+
 using namespace caf;
+
+namespace {
 
 SCENARIO("latches synchronize threads") {
   GIVEN("a latch and three threads") {
@@ -27,4 +30,4 @@ SCENARIO("latches synchronize threads") {
   }
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/mailbox_factory.test.cpp
+++ b/libcaf_core/caf/detail/mailbox_factory.test.cpp
@@ -4,9 +4,10 @@
 
 #include "caf/detail/mailbox_factory.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
+#include "caf/actor_system.hpp"
+#include "caf/actor_system_config.hpp"
 #include "caf/blocking_actor.hpp"
 #include "caf/detail/default_mailbox.hpp"
 #include "caf/event_based_actor.hpp"
@@ -14,6 +15,8 @@
 #include "caf/scheduler/test_coordinator.hpp"
 
 using namespace caf;
+
+namespace {
 
 class dummy_mailbox_factory : public detail::mailbox_factory {
 public:
@@ -79,4 +82,4 @@ TEST("a mailbox factory creates mailboxes for actors") {
   }
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/meta_object.test.cpp
+++ b/libcaf_core/caf/detail/meta_object.test.cpp
@@ -4,7 +4,7 @@
 
 #include "caf/detail/meta_object.hpp"
 
-#include "caf/test/caf_test_main.hpp"
+#include "caf/test/registry.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/binary_deserializer.hpp"
@@ -18,7 +18,8 @@
 struct i32_wrapper;
 struct i64_wrapper;
 
-CAF_BEGIN_TYPE_ID_BLOCK(meta_object_test, caf::first_custom_type_id)
+// +5 to avoid clash with caf.message_builder test
+CAF_BEGIN_TYPE_ID_BLOCK(meta_object_test, caf::first_custom_type_id + 5)
   CAF_ADD_TYPE_ID(meta_object_test, (i32_wrapper))
   CAF_ADD_TYPE_ID(meta_object_test, (i64_wrapper))
 CAF_END_TYPE_ID_BLOCK(meta_object_test)
@@ -76,6 +77,8 @@ size_t i32_wrapper::instances = 0;
 
 size_t i64_wrapper::instances = 0;
 
+namespace {
+
 TEST("meta objects allow construction and destruction of objects") {
   auto meta_i32_wrapper = make_meta_object<i32_wrapper>("i32_wrapper");
   alignas(i32_wrapper) std::byte storage[sizeof(i32_wrapper)];
@@ -119,4 +122,8 @@ TEST("init_global_meta_objects takes care of creating a meta object table") {
   check(std::equal(xs.begin(), xs.end(), ys.begin(), ys.end(), same));
 }
 
-CAF_TEST_MAIN(caf::id_block::meta_object_test)
+TEST_INIT() {
+  init_global_meta_objects<id_block::meta_object_test>();
+}
+
+} // namespace

--- a/libcaf_core/caf/detail/monotonic_buffer_resource.test.cpp
+++ b/libcaf_core/caf/detail/monotonic_buffer_resource.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/monotonic_buffer_resource.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/scenario.hpp"
 
 #include <list>
@@ -12,6 +11,8 @@
 #include <vector>
 
 using namespace caf;
+
+namespace {
 
 SCENARIO("monotonic buffers group allocations") {
   GIVEN("a monotonic buffer resource") {
@@ -113,4 +114,4 @@ SCENARIO("monotonic buffers provide storage for STL containers") {
   }
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/parse.test.cpp
+++ b/libcaf_core/caf/detail/parse.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/parse.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/expected.hpp"
@@ -53,8 +52,6 @@ expected<T> read(std::string_view str) {
     return result;
   return make_error(ps);
 }
-
-} // namespace
 
 #define CHECK_NUMBER(type, value) check_eq(read<type>(#value), type(value))
 
@@ -208,4 +205,4 @@ TEST("IPv6 endpoint") {
   check_eq(read<ipv6_endpoint>("[1::2]:8080"), ipv6_endpoint({{1}, {2}}, 8080));
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/parser/read_bool.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_bool.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/parser/read_bool.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/parser_state.hpp"
@@ -14,6 +13,8 @@
 #include <variant>
 
 using namespace caf;
+
+namespace {
 
 struct bool_parser_consumer {
   bool x;
@@ -64,4 +65,4 @@ TEST("invalid booleans") {
 
 } // WITH_FIXTURE(fixture)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/parser/read_config.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_config.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/parser/read_config.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/config_value.hpp"
@@ -14,6 +13,8 @@
 #include <string_view>
 
 using namespace caf;
+
+namespace {
 
 using log_type = std::vector<std::string>;
 
@@ -220,4 +221,4 @@ TEST("read_config feeds into a consumer") {
 
 } // WITH_FIXTURE(fixture)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/parser/read_floating_point.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_floating_point.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/parser/read_floating_point.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/parser_state.hpp"
@@ -14,6 +13,8 @@
 #include <variant>
 
 using namespace caf;
+
+namespace {
 
 struct double_consumer {
   using value_type = double;
@@ -84,4 +85,4 @@ TEST("scientific noation") {
   check_eq(read("-12e-3"), -12e-3);
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/parser/read_number.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_number.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/parser/read_number.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/detail/nearly_equal.hpp"
@@ -19,6 +18,8 @@
 #include <variant>
 
 using namespace caf;
+
+namespace {
 
 struct number_consumer {
   std::variant<int64_t, double> x;
@@ -348,4 +349,4 @@ TEST("the parser rejects invalid step values") {
 
 } // WITH_FIXTURE(fixture)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/parser/read_number_or_timespan.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_number_or_timespan.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/parser/read_number_or_timespan.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/detail/nearly_equal.hpp"
@@ -16,6 +15,8 @@
 
 using namespace caf;
 using namespace std::chrono;
+
+namespace {
 
 struct number_or_timespan_parser_consumer {
   std::variant<int64_t, double, timespan> x;
@@ -108,4 +109,4 @@ TEST("invalid timespans") {
 
 } // WITH_FIXTURE(fixture)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/parser/read_signed_integer.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_signed_integer.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/parser/read_signed_integer.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/parser_state.hpp"
@@ -61,8 +60,6 @@ template <class T>
 T max_val() {
   return std::numeric_limits<T>::max();
 }
-
-} // namespace
 
 #define ZERO_VALUE(type, literal) check_eq(read<type>(#literal), type(0));
 
@@ -175,4 +172,4 @@ TEST("maximal value") {
   OVERFLOW(int64_t, 0x8000000000000000);
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/parser/read_string.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_string.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/parser/read_string.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/expected.hpp"
@@ -39,8 +38,6 @@ struct string_parser {
 struct fixture {
   string_parser p;
 };
-
-} // namespace
 
 WITH_FIXTURE(fixture) {
 
@@ -99,4 +96,4 @@ TEST("invalid strings") {
 
 } // WITH_FIXTURE(fixture)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/parser/read_timespan.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_timespan.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/parser/read_timespan.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/parser_state.hpp"
@@ -57,8 +56,6 @@ std::optional<timespan> read(std::string_view str) {
   return consumer.x;
 }
 
-} // namespace
-
 TEST("todo") {
   check_eq(read("12ns"), 12_ns);
   check_eq(read("34us"), 34_us);
@@ -68,4 +65,4 @@ TEST("todo") {
   check_eq(read("90h"), 90_h);
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/parser/read_unsigned_integer.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_unsigned_integer.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/parser/read_unsigned_integer.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/parser_state.hpp"
@@ -48,8 +47,6 @@ template <class T>
 T max_val() {
   return std::numeric_limits<T>::max();
 }
-
-} // namespace
 
 #define ZERO_VALUE(type, literal) check_eq(read<type>(#literal), type(0));
 
@@ -114,4 +111,4 @@ TEST("maximal value") {
   OVERFLOW(uint64_t, 0x10000000000000000);
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/pp.hpp
+++ b/libcaf_core/caf/detail/pp.hpp
@@ -72,6 +72,8 @@
 #define CAF_PP_STR_9(x1, x2, x3, x4, x5, x6, x7, x8, x9) #x1 ", " #x2 ", " #x3 ", " #x4 ", " #x5 ", " #x6 ", " #x7 ", " #x8 ", " #x9
 // clang-format on
 
+#define CAF_PP_XSTR(arg) CAF_PP_STR_1(arg)
+
 #ifdef CAF_MSVC
 #  define CAF_PP_STR(...)                                                      \
     CAF_PP_CAT(CAF_PP_OVERLOAD(CAF_PP_STR_, __VA_ARGS__)(__VA_ARGS__),         \

--- a/libcaf_core/caf/detail/private_thread_pool.test.cpp
+++ b/libcaf_core/caf/detail/private_thread_pool.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/private_thread_pool.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/fixture/deterministic.hpp"
 #include "caf/test/scenario.hpp"
 
@@ -12,6 +11,8 @@
 #include "caf/resumable.hpp"
 
 using namespace caf;
+
+namespace {
 
 WITH_FIXTURE(test::fixture::deterministic) {
 
@@ -84,4 +85,4 @@ SCENARIO("private threads rerun their resumable when it returns resume_later") {
 
 } // WITH_FIXTURE(test::fixture::deterministic)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/rfc3629.test.cpp
+++ b/libcaf_core/caf/detail/rfc3629.test.cpp
@@ -4,13 +4,14 @@
 
 #include "caf/detail/rfc3629.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 using namespace caf;
 using detail::rfc3629;
 
 using res_t = std::pair<size_t, bool>;
+
+namespace {
 
 bool valid_utf8(const_byte_span bytes) noexcept {
   return detail::rfc3629::valid(bytes);
@@ -220,4 +221,4 @@ TEST("rfc3629::validate stops at the first invalid byte") {
   }
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/ring_buffer.test.cpp
+++ b/libcaf_core/caf/detail/ring_buffer.test.cpp
@@ -4,12 +4,13 @@
 
 #include "caf/detail/ring_buffer.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 using namespace caf;
 
 using detail::ring_buffer;
+
+namespace {
 
 int pop(ring_buffer<int>& buf) {
   auto result = buf.front();
@@ -178,4 +179,4 @@ TEST("ring-buffers are copiable") {
   check_eq(buf.empty(), true);
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/serialized_size.test.cpp
+++ b/libcaf_core/caf/detail/serialized_size.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/serialized_size.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/binary_serializer.hpp"
@@ -29,8 +28,6 @@ struct fixture : test_coordinator_fixture<> {
     return buf.size();
   }
 };
-
-} // namespace
 
 #define check_SAME_SIZE(value)                                                 \
   check_eq(serialized_size(value), actual_size(value))
@@ -64,4 +61,4 @@ TEST("messages") {
 
 } // WITH_FIXTURE(fixture)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/sync_ring_buffer.test.cpp
+++ b/libcaf_core/caf/detail/sync_ring_buffer.test.cpp
@@ -4,10 +4,10 @@
 
 #include "caf/detail/sync_ring_buffer.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include <algorithm>
+#include <thread>
 #include <vector>
 
 using namespace caf;
@@ -32,8 +32,6 @@ void producer(int_buffer& buf, int first, int last) {
   for (auto i = first; i != last; ++i) // NOLINT(bugprone-use-after-move)
     buf.push_back(std::move(i));
 }
-
-} // namespace
 
 TEST("a default-constructed ring buffer is empty") {
   int_buffer buf;
@@ -116,4 +114,4 @@ TEST("sync_ring_buffer can be used with multiple producers") {
     t.join();
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/tick_emitter.test.cpp
+++ b/libcaf_core/caf/detail/tick_emitter.test.cpp
@@ -16,7 +16,6 @@
 
 #include "caf/detail/tick_emitter.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/detail/gcd.hpp"
@@ -34,8 +33,6 @@ namespace {
 
 timespan credit_interval{200};
 timespan force_batch_interval{50};
-
-} // namespace
 
 TEST("start_and_stop") {
   detail::tick_emitter x;
@@ -134,4 +131,4 @@ TEST("next_timeout") {
   check_eq(next, start + timespan((2 * 7) * interval));
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/detail/unique_function.test.cpp
+++ b/libcaf_core/caf/detail/unique_function.test.cpp
@@ -4,10 +4,11 @@
 
 #include "caf/detail/unique_function.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 using int_fun = caf::detail::unique_function<int()>;
+
+namespace {
 
 int forty_two() {
   return 42;
@@ -162,4 +163,4 @@ TEST("move assign") {
 
 // NOLINTEND(bugprone-use-after-move)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/event_based_actor.test.cpp
+++ b/libcaf_core/caf/event_based_actor.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/event_based_actor.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/fixture/deterministic.hpp"
 #include "caf/test/scenario.hpp"
 #include "caf/test/test.hpp"
@@ -14,6 +13,8 @@
 #include "caf/send.hpp"
 
 using namespace caf;
+
+namespace {
 
 WITH_FIXTURE(test::fixture::deterministic) {
 
@@ -79,9 +80,7 @@ SCENARIO("request(...).await(...) suspends the regular actor behavior") {
     WHEN("the actor receives an exit_msg while waiting for the response") {
       THEN("the actor processes the exit messages immediately") {
         auto server = sys.spawn(server_impl);
-        printf("server is %d\n", (int) server.id());
         auto aut = sys.spawn(uut_impl, server);
-        printf("aut is %d\n", (int) aut.id());
         inject().with(exit_msg{server.address(), exit_reason::kill}).to(aut);
         check(terminated(aut));
         expect<int>().with(42).from(aut).to(server);
@@ -92,4 +91,4 @@ SCENARIO("request(...).await(...) suspends the regular actor behavior") {
 
 } // WITH_FIXTURE(test::fixture::deterministic)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/flow/observable.test.cpp
+++ b/libcaf_core/caf/flow/observable.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/flow/observable.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/fixture/flow.hpp"
 #include "caf/test/nil.hpp"
 #include "caf/test/test.hpp"
@@ -13,6 +12,8 @@ using caf::test::nil;
 using std::vector;
 
 using namespace caf;
+
+namespace {
 
 WITH_FIXTURE(test::fixture::flow) {
 
@@ -321,4 +322,4 @@ TEST("on_error_return_item() replaces an error with a value") {
 
 } // WITH_FIXTURE(test::fixture::flow)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/flow/step/ignore_elements.test.cpp
+++ b/libcaf_core/caf/flow/step/ignore_elements.test.cpp
@@ -4,7 +4,7 @@
 
 #include "caf/flow/step/ignore_elements.hpp"
 
-#include "caf/test/caf_test_main.hpp"
+#include "caf/test/fixture/flow.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/flow/scoped_coordinator.hpp"
@@ -16,65 +16,31 @@ using namespace caf;
 
 using caf::flow::make_observer;
 
-struct fixture {
-  flow::scoped_coordinator_ptr ctx = flow::make_scoped_coordinator();
+namespace {
 
-  template <class... Ts>
-  static auto ls(Ts... xs) {
-    return std::vector<int>{xs...};
-  }
-};
-
-WITH_FIXTURE(fixture) {
+WITH_FIXTURE(test::fixture::flow) {
 
 TEST("calling ignore_elements on range(1, 10) produces []") {
-  auto result = std::vector<int>{};
   SECTION("blueprint") {
-    ctx->make_observable().range(1, 10).ignore_elements().for_each(
-      [&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 10).ignore_elements()), std::vector<int>{});
   }
   SECTION("observable") {
-    ctx->make_observable()
-      .range(1, 10)
-      .as_observable()
-      .ignore_elements()
-      .for_each([&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 10).as_observable().ignore_elements()),
+             std::vector<int>{});
   }
-  ctx->run();
-  check_eq(result.size(), 0u);
 }
 
 TEST("ignore_elements operator forwards errors") {
-  caf::error result;
-  auto outputs = std::vector<int>{};
   SECTION("blueprint") {
-    ctx->make_observable()
-      .fail<int>(make_error(sec::runtime_error))
-      .ignore_elements()
-      .do_on_error([&result](const error& err) { result = err; })
-      .for_each([&](const int& result_observable) {
-        outputs.emplace_back(result_observable);
-      });
+    check_eq(collect(obs_error<int>().ignore_elements()),
+             make_error(sec::runtime_error));
   }
   SECTION("observable") {
-    ctx->make_observable()
-      .fail<int>(make_error(sec::runtime_error))
-      .as_observable()
-      .ignore_elements()
-      .do_on_error([&result](const error& err) { result = err; })
-      .for_each([&](const int& result_observable) {
-        outputs.emplace_back(result_observable);
-      });
+    check_eq(collect(obs_error<int>().as_observable().ignore_elements()),
+             make_error(sec::runtime_error));
   }
-  ctx->run();
-  check_eq(result, caf::sec::runtime_error);
-  check_eq(outputs.size(), 0u);
 }
 
-} // WITH_FIXTURE(fixture)
+} // WITH_FIXTURE(test::fixture::flow)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/flow/step/skip_last.test.cpp
+++ b/libcaf_core/caf/flow/step/skip_last.test.cpp
@@ -4,7 +4,7 @@
 
 #include "caf/flow/step/skip_last.hpp"
 
-#include "caf/test/caf_test_main.hpp"
+#include "caf/test/fixture/flow.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/flow/scoped_coordinator.hpp"
@@ -16,122 +16,61 @@ using namespace caf;
 
 using caf::flow::make_observer;
 
-struct fixture {
-  flow::scoped_coordinator_ptr ctx = flow::make_scoped_coordinator();
+namespace {
 
-  template <class... Ts>
-  static auto ls(Ts... xs) {
-    return std::vector<int>{xs...};
-  }
-};
-
-WITH_FIXTURE(fixture) {
+WITH_FIXTURE(test::fixture::flow) {
 
 TEST("calling skip_last(5) on range(1, 10) produces [1, 2, 3, 4, 5]") {
-  auto result = std::vector<int>{};
   SECTION("blueprint") {
-    ctx->make_observable().range(1, 10).skip_last(5).for_each(
-      [&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 10).skip_last(5)), std::vector{1, 2, 3, 4, 5});
   }
   SECTION("observable") {
-    ctx->make_observable().range(1, 10).as_observable().skip_last(5).for_each(
-      [&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 10).as_observable().skip_last(5)),
+             std::vector{1, 2, 3, 4, 5});
   }
-  ctx->run();
-  check_eq(result.size(), 5u);
-  check_eq(result, ls(1, 2, 3, 4, 5));
 }
 
 TEST("calling skip_last(5) on range(1, 5) produces []") {
-  auto result = std::vector<int>{};
   SECTION("blueprint") {
-    ctx->make_observable().range(1, 5).skip_last(5).for_each(
-      [&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 5).skip_last(5)), std::vector<int>{});
   }
   SECTION("observable") {
-    ctx->make_observable().range(1, 5).as_observable().skip_last(5).for_each(
-      [&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 5).as_observable().skip_last(5)),
+             std::vector<int>{});
   }
-  ctx->run();
-  check_eq(result.size(), 0u);
 }
 
 TEST("calling skip_last(5) on range(1, 3) produces []") {
-  auto result = std::vector<int>{};
   SECTION("blueprint") {
-    ctx->make_observable().range(1, 3).skip_last(5).for_each(
-      [&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 3).skip_last(5)), std::vector<int>{});
   }
   SECTION("observable") {
-    ctx->make_observable().range(1, 3).as_observable().skip_last(5).for_each(
-      [&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 3).as_observable().skip_last(5)),
+             std::vector<int>{});
   }
-  ctx->run();
-  check_eq(result.size(), 0u);
 }
 
 TEST("calling take(3) on skip_last(5) ignores the last two items") {
-  auto result = std::vector<int>{};
   SECTION("blueprint") {
-    ctx->make_observable().range(1, 10).skip_last(5).take(3).for_each(
-      [&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 10).skip_last(5).take(3)), std::vector{1, 2, 3});
   }
   SECTION("observable") {
-    ctx->make_observable()
-      .range(1, 100)
-      .as_observable()
-      .skip_last(5)
-      .take(3)
-      .for_each([&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 10).as_observable().skip_last(5).take(3)),
+             std::vector{1, 2, 3});
   }
-  ctx->run();
-  check_eq(result.size(), 3u);
-  check_eq(result, ls(1, 2, 3));
 }
 
 TEST("skip_last operator forwards errors") {
-  caf::error result;
-  auto outputs = std::vector<int>{};
   SECTION("blueprint") {
-    ctx->make_observable()
-      .fail<int>(make_error(sec::runtime_error))
-      .skip_last(5)
-      .do_on_error([&result](const error& err) { result = err; })
-      .for_each([&](const int& result_observable) {
-        outputs.emplace_back(result_observable);
-      });
+    check_eq(collect(obs_error<int>().skip_last(5)),
+             make_error(sec::runtime_error));
   }
   SECTION("observable") {
-    ctx->make_observable()
-      .fail<int>(make_error(sec::runtime_error))
-      .as_observable()
-      .skip_last(5)
-      .do_on_error([&result](const error& err) { result = err; })
-      .for_each([&](const int& result_observable) {
-        outputs.emplace_back(result_observable);
-      });
+    check_eq(collect(obs_error<int>().as_observable().skip_last(5)),
+             make_error(sec::runtime_error));
   }
-  ctx->run();
-  check_eq(result, caf::sec::runtime_error);
-  check_eq(outputs.size(), 0u);
 }
 
-} // WITH_FIXTURE(fixture)
+} // WITH_FIXTURE(test::fixture::flow)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/flow/step/take_last.test.cpp
+++ b/libcaf_core/caf/flow/step/take_last.test.cpp
@@ -4,7 +4,7 @@
 
 #include "caf/flow/step/take_last.hpp"
 
-#include "caf/test/caf_test_main.hpp"
+#include "caf/test/fixture/flow.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/flow/scoped_coordinator.hpp"
@@ -16,124 +16,63 @@ using namespace caf;
 
 using caf::flow::make_observer;
 
-struct fixture {
-  flow::scoped_coordinator_ptr ctx = flow::make_scoped_coordinator();
+namespace {
 
-  template <class... Ts>
-  static auto ls(Ts... xs) {
-    return std::vector<int>{xs...};
-  }
-};
-
-WITH_FIXTURE(fixture) {
+WITH_FIXTURE(test::fixture::flow) {
 
 TEST("calling take_last(5) on range(1, 100) produces[96, 97, 98, 99, 100]") {
-  auto result = std::vector<int>{};
   SECTION("blueprint") {
-    ctx->make_observable().range(1, 100).take_last(5).for_each(
-      [&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 100).take_last(5)),
+             std::vector{96, 97, 98, 99, 100});
   }
   SECTION("observable") {
-    ctx->make_observable().range(1, 100).as_observable().take_last(5).for_each(
-      [&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 100).as_observable().take_last(5)),
+             std::vector{96, 97, 98, 99, 100});
   }
-  ctx->run();
-  check_eq(result.size(), 5u);
-  check_eq(result, ls(96, 97, 98, 99, 100));
 }
 
 TEST("calling take_last(5) on range(1, 5) produces[1, 2, 3, 4, 5]") {
-  auto result = std::vector<int>{};
   SECTION("blueprint") {
-    ctx->make_observable().range(1, 5).take_last(5).for_each(
-      [&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 5).take_last(5)), std::vector{1, 2, 3, 4, 5});
   }
   SECTION("observable") {
-    ctx->make_observable().range(1, 5).as_observable().take_last(5).for_each(
-      [&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 5).as_observable().take_last(5)),
+             std::vector{1, 2, 3, 4, 5});
   }
-  ctx->run();
-  check_eq(result.size(), 5u);
-  check_eq(result, ls(1, 2, 3, 4, 5));
 }
 
 TEST("calling take_last(5) on range(1, 3) produces[1, 2, 3]") {
-  auto result = std::vector<int>{};
   SECTION("blueprint") {
-    ctx->make_observable().range(1, 3).take_last(5).for_each(
-      [&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 3).take_last(5)), std::vector{1, 2, 3});
   }
   SECTION("observable") {
-    ctx->make_observable().range(1, 3).as_observable().take_last(5).for_each(
-      [&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 3).as_observable().take_last(5)),
+             std::vector{1, 2, 3});
   }
-  ctx->run();
-  check_eq(result.size(), 3u);
-  check_eq(result, ls(1, 2, 3));
 }
 
 TEST("calling take(3) on take_last(5) ignores the last two items") {
-  auto result = std::vector<int>{};
   SECTION("blueprint") {
-    ctx->make_observable().range(1, 100).take_last(5).take(3).for_each(
-      [&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 100).take_last(5).take(3)),
+             std::vector{96, 97, 98});
   }
   SECTION("observable") {
-    ctx->make_observable()
-      .range(1, 100)
-      .as_observable()
-      .take_last(5)
-      .take(3)
-      .for_each([&](const int& result_observable) {
-        result.emplace_back(result_observable);
-      });
+    check_eq(collect(range(1, 100).as_observable().take_last(5).take(3)),
+             std::vector{96, 97, 98});
   }
-  ctx->run();
-  check_eq(result.size(), 3u);
-  check_eq(result, ls(96, 97, 98));
 }
 
 TEST("take_last operator forwards errors") {
-  caf::error result;
-  auto outputs = std::vector<int>{};
   SECTION("blueprint") {
-    ctx->make_observable()
-      .fail<int>(make_error(sec::runtime_error))
-      .take_last(5)
-      .do_on_error([&result](const error& err) { result = err; })
-      .for_each([&](const int& result_observable) {
-        outputs.emplace_back(result_observable);
-      });
+    check_eq(collect(obs_error<int>().take_last(5)),
+             make_error(sec::runtime_error));
   }
   SECTION("observable") {
-    ctx->make_observable()
-      .fail<int>(make_error(sec::runtime_error))
-      .as_observable()
-      .take_last(5)
-      .do_on_error([&result](const error& err) { result = err; })
-      .for_each([&](const int& result_observable) {
-        outputs.emplace_back(result_observable);
-      });
+    check_eq(collect(obs_error<int>().as_observable().take_last(5)),
+             make_error(sec::runtime_error));
   }
-  ctx->run();
-  check_eq(result, caf::sec::runtime_error);
-  check_eq(outputs.size(), 0u);
 }
 
-} // WITH_FIXTURE(fixture)
+} // WITH_FIXTURE(test::fixture::flow)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/flow/string.test.cpp
+++ b/libcaf_core/caf/flow/string.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/flow/string.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/fixture/flow.hpp"
 #include "caf/test/scenario.hpp"
 
@@ -15,6 +14,8 @@
 
 using namespace caf;
 using namespace std::literals;
+
+namespace {
 
 auto tostr(const std::vector<char>& chars) {
   return std::string{chars.begin(), chars.end()};
@@ -124,4 +125,4 @@ SCENARIO("to_lines splits a character sequence into lines") {
 
 } // WITH_FIXTURE(test::fixture::flow)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/hash/fnv.test.cpp
+++ b/libcaf_core/caf/hash/fnv.test.cpp
@@ -4,12 +4,13 @@
 
 #include "caf/hash/fnv.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include <string>
 
 using namespace std::literals;
+
+namespace {
 
 TEST("hash::fnv can build hash values incrementally") {
   caf::hash::fnv<uint32_t> f;
@@ -54,4 +55,4 @@ TEST("fnv::compute can create hash values for types with inspect overloads") {
   check_eq(hash_type::compute(foo{"C++ Actor Framework"}), 0x2FF91FE5u);
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/intrusive/lifo_inbox.test.cpp
+++ b/libcaf_core/caf/intrusive/lifo_inbox.test.cpp
@@ -4,8 +4,9 @@
 
 #include "caf/intrusive/lifo_inbox.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
+
+#include "caf/intrusive/singly_linked.hpp"
 
 #include <memory>
 #include <numeric>
@@ -13,6 +14,8 @@
 using namespace caf;
 
 using intrusive::inbox_result;
+
+namespace {
 
 struct inode : intrusive::singly_linked<inode> {
   explicit inode(int x = 0) : value(x) {
@@ -67,4 +70,4 @@ TEST("push_front unblocks a blocked reader") {
   check_eq(drain(uut), "[2, 1]");
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/intrusive/linked_list.test.cpp
+++ b/libcaf_core/caf/intrusive/linked_list.test.cpp
@@ -4,15 +4,18 @@
 
 #include "caf/intrusive/linked_list.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
+
+#include "caf/intrusive/singly_linked.hpp"
 
 #include <memory>
 #include <numeric>
 
 using namespace caf;
 
-struct inode : intrusive::singly_linked<inode> {
+namespace {
+
+struct inode : caf::intrusive::singly_linked<inode> {
   explicit inode(int x = 0) : value(x) {
     // nop
   }
@@ -154,4 +157,4 @@ TEST("pop_front removes the oldest element of a list and returns it") {
   check(uut.empty());
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/intrusive/stack.test.cpp
+++ b/libcaf_core/caf/intrusive/stack.test.cpp
@@ -4,10 +4,13 @@
 
 #include "caf/intrusive/stack.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
+#include "caf/intrusive/singly_linked.hpp"
+
 using namespace caf;
+
+namespace {
 
 struct int_node : intrusive::singly_linked<int_node> {
   explicit int_node(int x) : value(x) {
@@ -60,4 +63,4 @@ TEST("popping values from a stack returns the last pushed value") {
   check(uut.empty());
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_core/caf/message_builder.test.cpp
+++ b/libcaf_core/caf/message_builder.test.cpp
@@ -4,8 +4,10 @@
 
 #include "caf/message_builder.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
+
+#include "caf/init_global_meta_objects.hpp"
+#include "caf/type_id.hpp"
 
 using namespace caf;
 
@@ -53,12 +55,14 @@ bool inspect(Inspector& f, counted_int_ptr& x) {
   }
 }
 
-CAF_BEGIN_TYPE_ID_BLOCK(counted_int_block, caf::first_custom_type_id)
+CAF_BEGIN_TYPE_ID_BLOCK(message_builder_test, caf::first_custom_type_id)
 
-  CAF_ADD_TYPE_ID(counted_int_block, (counted_int))
-  CAF_ADD_TYPE_ID(counted_int_block, (counted_int_ptr))
+  CAF_ADD_TYPE_ID(message_builder_test, (counted_int))
+  CAF_ADD_TYPE_ID(message_builder_test, (counted_int_ptr))
 
-CAF_END_TYPE_ID_BLOCK(counted_int_block)
+CAF_END_TYPE_ID_BLOCK(message_builder_test)
+
+namespace {
 
 TEST("message_builder can build messages incrementally") {
   message_builder builder;
@@ -201,4 +205,8 @@ TEST("message_builder can build messages from iterator pairs") {
   check_eq(msg.get_as<int32_t>(2), 3);
 }
 
-CAF_TEST_MAIN(id_block::counted_int_block)
+TEST_INIT() {
+  init_global_meta_objects<id_block::message_builder_test>();
+}
+
+} // namespace

--- a/libcaf_core/main.test.cpp
+++ b/libcaf_core/main.test.cpp
@@ -2,25 +2,6 @@
 // the main distribution directory for license terms and copyright or visit
 // https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
 
-#include "caf/detail/type_id_list_builder.hpp"
-
 #include "caf/test/caf_test_main.hpp"
-#include "caf/test/test.hpp"
-
-using namespace caf;
-
-namespace {
-
-struct fixture {};
-
-} // namespace
-
-WITH_FIXTURE(fixture) {
-
-TEST("todo") {
-  // implement me
-}
-
-} // WITH_FIXTURE(fixture)
 
 CAF_TEST_MAIN()

--- a/libcaf_io/caf/io/network/receive_buffer.test.cpp
+++ b/libcaf_io/caf/io/network/receive_buffer.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/io/network/receive_buffer.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include <algorithm>
@@ -13,6 +12,8 @@
 using namespace std::literals;
 
 using caf::io::network::receive_buffer;
+
+namespace {
 
 TEST("construction") {
   SECTION("default-constructed buffers are empty") {
@@ -175,4 +176,4 @@ TEST("swap exchanges the content of two buffers") {
   check(buf2.data() == buf1_data);
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_io/main.test.cpp
+++ b/libcaf_io/main.test.cpp
@@ -1,0 +1,7 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/test/caf_test_main.hpp"
+
+CAF_TEST_MAIN()

--- a/libcaf_net/caf/detail/rfc6455.test.cpp
+++ b/libcaf_net/caf/detail/rfc6455.test.cpp
@@ -4,7 +4,6 @@
 
 #include "caf/detail/rfc6455.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/byte_buffer.hpp"
@@ -18,6 +17,8 @@
 using namespace caf;
 
 using impl = detail::rfc6455;
+
+namespace {
 
 auto bytes(std::initializer_list<uint8_t> xs) {
   byte_buffer result;
@@ -313,4 +314,4 @@ TEST("decode a header with valid mask key plus large data") {
   check_eq(hdr.payload_len, data.size());
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_net/caf/net/http/header.test.cpp
+++ b/libcaf_net/caf/net/http/header.test.cpp
@@ -4,11 +4,12 @@
 
 #include "caf/net/http/header.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 using namespace caf;
 using namespace std::literals;
+
+namespace {
 
 TEST("parsing a http request") {
   net::http::header hdr;
@@ -73,4 +74,4 @@ TEST("parsing a http request") {
   }
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_net/caf/net/http/request_header.test.cpp
+++ b/libcaf_net/caf/net/http/request_header.test.cpp
@@ -4,12 +4,13 @@
 
 #include "caf/net/http/request_header.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/outline.hpp"
 #include "caf/test/test.hpp"
 
 using namespace caf;
 using namespace std::literals;
+
+namespace {
 
 TEST("parsing a http request") {
   net::http::request_header hdr;
@@ -53,8 +54,8 @@ OUTLINE("parsing requests") {
     |  method  | enum value |
     | GET      |     0      |
     | HEAD     |     1      |
-    | POST     |     2      | 
-    | PUT      |     3      | 
+    | POST     |     2      |
+    | PUT      |     3      |
     | DELETE   |     4      |
     | CONNECT  |     5      |
     | OPTIONS  |     6      |
@@ -185,4 +186,4 @@ TEST("invalid request headers are copyable and movable") {
   }
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_net/caf/net/http/response_header.test.cpp
+++ b/libcaf_net/caf/net/http/response_header.test.cpp
@@ -4,11 +4,12 @@
 
 #include "caf/net/http/response_header.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 using namespace caf;
 using namespace std::literals;
+
+namespace {
 
 TEST("parsing a valid http response") {
   net::http::response_header hdr;
@@ -178,4 +179,4 @@ TEST("copying and moving invalid response header results in invalid requests") {
   }
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_net/main.test.cpp
+++ b/libcaf_net/main.test.cpp
@@ -1,0 +1,7 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/test/caf_test_main.hpp"
+
+CAF_TEST_MAIN()

--- a/libcaf_openssl/main.test.cpp
+++ b/libcaf_openssl/main.test.cpp
@@ -1,0 +1,7 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/test/caf_test_main.hpp"
+
+CAF_TEST_MAIN()

--- a/libcaf_test/caf/test/block_type.test.cpp
+++ b/libcaf_test/caf/test/block_type.test.cpp
@@ -4,10 +4,11 @@
 
 #include "caf/test/block_type.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 using caf::test::block_type;
+
+namespace {
 
 TEST("is_extension checks whether a block type needs a predecessor") {
   using caf::test::is_extension;
@@ -27,4 +28,4 @@ TEST("is_extension checks whether a block type needs a predecessor") {
   }
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_test/caf/test/caf_test_main.hpp
+++ b/libcaf_test/caf/test/caf_test_main.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "caf/test/registry.hpp"
 #include "caf/test/runner.hpp"
 
 #include "caf/exec_main.hpp"
@@ -14,6 +15,7 @@
       caf::detail::type_list<>{}, caf::detail::type_list<__VA_ARGS__>{});      \
     caf::exec_main_init_meta_objects<__VA_ARGS__>();                           \
     caf::core::init_global_meta_objects();                                     \
+    caf::test::registry::run_init_callbacks();                                 \
     caf::test::runner runner;                                                  \
     return runner.run(argc, argv);                                             \
   }

--- a/libcaf_test/caf/test/fixture/deterministic.test.cpp
+++ b/libcaf_test/caf/test/fixture/deterministic.test.cpp
@@ -4,10 +4,11 @@
 
 #include "caf/test/fixture/deterministic.hpp"
 
-#include "caf/test/caf_test_main.hpp"
+#include "caf/test/registry.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/event_based_actor.hpp"
+#include "caf/init_global_meta_objects.hpp"
 #include "caf/scoped_actor.hpp"
 #include "caf/send.hpp"
 
@@ -38,11 +39,13 @@ bool operator!=(my_int lhs, my_int rhs) noexcept {
   return lhs.value != rhs.value;
 }
 
-CAF_BEGIN_TYPE_ID_BLOCK(test, caf::first_custom_type_id)
+CAF_BEGIN_TYPE_ID_BLOCK(deterministic_fixture_test, caf::first_custom_type_id)
 
-  CAF_ADD_TYPE_ID(test, (my_int))
+  CAF_ADD_TYPE_ID(deterministic_fixture_test, (my_int))
 
-CAF_END_TYPE_ID_BLOCK(test)
+CAF_END_TYPE_ID_BLOCK(deterministic_fixture_test)
+
+namespace {
 
 WITH_FIXTURE(fixture::deterministic) {
 
@@ -343,4 +346,8 @@ TEST("evaluator expressions can check or extract individual values") {
 
 } // WITH_FIXTURE(fixture::deterministic)
 
-CAF_TEST_MAIN(caf::id_block::test)
+TEST_INIT() {
+  caf::init_global_meta_objects<caf::id_block::deterministic_fixture_test>();
+}
+
+} // namespace

--- a/libcaf_test/caf/test/fixture/flow.test.cpp
+++ b/libcaf_test/caf/test/fixture/flow.test.cpp
@@ -4,12 +4,13 @@
 
 #include "caf/test/fixture/flow.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/flow/observable.hpp"
 
 using namespace caf;
+
+namespace {
 
 WITH_FIXTURE(test::fixture::flow) {
 
@@ -31,4 +32,4 @@ TEST("collect() eagerly evaluates an observable and returns a vector") {
 
 } // WITH_FIXTURE(test::fixture::flow)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_test/caf/test/outline.test.cpp
+++ b/libcaf_test/caf/test/outline.test.cpp
@@ -4,9 +4,9 @@
 
 #include "caf/test/outline.hpp"
 
-#include "caf/test/caf_test_main.hpp"
-
 #include <numeric>
+
+namespace {
 
 OUTLINE("eating cucumbers") {
   GIVEN("there are <start> cucumbers") {
@@ -69,4 +69,4 @@ OUTLINE("counting numbers") {
   )";
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_test/caf/test/scenario.test.cpp
+++ b/libcaf_test/caf/test/scenario.test.cpp
@@ -4,11 +4,12 @@
 
 #include "caf/test/scenario.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/nesting_error.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/config.hpp"
+
+namespace {
 
 #ifdef CAF_ENABLE_EXCEPTIONS
 SCENARIO("a scenario may not contain a section") {
@@ -138,4 +139,4 @@ SCENARIO("scenario-1") {
   }
 }
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_test/caf/test/suite.hpp
+++ b/libcaf_test/caf/test/suite.hpp
@@ -9,7 +9,12 @@
 
 #include <string_view>
 
+#ifndef CAF_TEST_SUITE_NAME
 [[maybe_unused]] constexpr caf::unit_t caf_test_suite_name = caf::unit;
+#else
+[[maybe_unused]] constexpr std::string_view caf_test_suite_name
+  = CAF_PP_XSTR(CAF_TEST_SUITE_NAME);
+#endif
 
 struct caf_test_case_auto_fixture {};
 

--- a/libcaf_test/caf/test/test.test.cpp
+++ b/libcaf_test/caf/test/test.test.cpp
@@ -3,10 +3,11 @@
 
 #include "caf/test/test.hpp"
 
-#include "caf/test/caf_test_main.hpp"
 #include "caf/test/requirement_failed.hpp"
 
 using caf::test::block_type;
+
+namespace {
 
 TEST("tests can contain different types of checks") {
   auto& rep = caf::test::reporter::instance();
@@ -127,4 +128,4 @@ TEST("each run starts with a fresh fixture") {
 
 } // WITH_FIXTURE(int_fixture)
 
-CAF_TEST_MAIN()
+} // namespace

--- a/libcaf_test/main.test.cpp
+++ b/libcaf_test/main.test.cpp
@@ -1,0 +1,7 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/test/caf_test_main.hpp"
+
+CAF_TEST_MAIN()


### PR DESCRIPTION
Too many test binaries cause builds to fail because the runners run out of disk space. Hence, we switch back to a single binary per CAF module to avoid CI failures.

Also streamlined a couple of flow unit tests with our new fixture.