### PR TITLE
Fix type-ids check in load_data for Message

### DIFF
--- a/libcaf_core/caf/detail/type_id_list_builder.cpp
+++ b/libcaf_core/caf/detail/type_id_list_builder.cpp
@@ -102,7 +102,7 @@ void type_id_list_builder::reserve(size_t num_elements) {
 }
 
 void type_id_list_builder::push_back(type_id_t id) {
-  if ((size_ + 1) >= reserved_)
+  if (size_ >= reserved_)
     reserve(reserved_ + block_size);
   storage_[size_++] = id;
 }

--- a/libcaf_core/caf/detail/type_id_list_builder.hpp
+++ b/libcaf_core/caf/detail/type_id_list_builder.hpp
@@ -43,16 +43,6 @@ public:
   /// @pre `index < size()`
   type_id_t operator[](size_t index) const noexcept;
 
-  // -- iterator access --------------------------------------------------------
-
-  auto begin() const noexcept {
-    return storage_;
-  }
-
-  auto end() const noexcept {
-    return storage_ + size_;
-  }
-
   // -- conversions ------------------------------------------------------------
 
   /// Convertes the internal buffer to a @ref type_id_list and returns it.

--- a/libcaf_core/caf/message.cpp
+++ b/libcaf_core/caf/message.cpp
@@ -62,20 +62,18 @@ bool load_data(Deserializer& source, message::data_ptr& data) {
     }
     detail::type_id_list_builder ids;
     ids.reserve(msg_size);
+    size_t data_size = 0;
     for (size_t i = 0; i < msg_size; ++i) {
       type_id_t id = 0;
       GUARDED(source.value(id));
-      ids.push_back(id);
-    }
-    GUARDED(source.end_sequence());
-    CAF_ASSERT(ids.size() == msg_size);
-    size_t data_size = 0;
-    for (auto id : ids) {
       if (auto meta = detail::global_meta_object_or_null(id))
         data_size += meta->padded_size;
       else
         STOP(sec::unknown_type);
+      ids.push_back(id);
     }
+    GUARDED(source.end_sequence());
+    CAF_ASSERT(ids.size() == msg_size);
     intrusive_ptr<detail::message_data> ptr;
     if (auto vptr = malloc(sizeof(detail::message_data) + data_size)) {
       // We don't need to worry about exceptions here: the message_data


### PR DESCRIPTION
Hi,

i discovered that the `load_data` https://github.com/actor-framework/actor-framework/blob/0.19.4/libcaf_core/caf/message.cpp#L73 iterates over the placeholder for the actual-size of the `type_id_list`. 