### PR TITLE
Clean up type ID list builder capacity management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Fix encoding of chunk size in chunked HTTP responses (#1587).
 - Fix leak when using `spawn_inactive` and not launching the actor explicitly
   (#1597).
+- Fix a minor bug in the deserialization of messages that caused CAF to allocate
+  more storage than necessary (#1614).
 
 ### Deprecated
 

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -179,6 +179,7 @@ caf_add_component(
     caf/detail/test_actor_clock.cpp
     caf/detail/thread_safe_actor_clock.cpp
     caf/detail/type_id_list_builder.cpp
+    caf/detail/type_id_list_builder.test.cpp
     caf/detail/unique_function.test.cpp
     caf/disposable.cpp
     caf/error.cpp

--- a/libcaf_core/caf/detail/type_id_list_builder.hpp
+++ b/libcaf_core/caf/detail/type_id_list_builder.hpp
@@ -16,45 +16,62 @@ class CAF_CORE_EXPORT type_id_list_builder {
 public:
   // -- constants --------------------------------------------------------------
 
+  /// The number of elements that we allocate at once.
   static constexpr size_t block_size = 8;
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  type_id_list_builder();
+  /// Constructs an empty type ID list builder.
+  type_id_list_builder() = default;
+
+  /// Constructs an empty type ID list builder that can hold at least
+  /// `size_hint` elements without reallocation.
+  explicit type_id_list_builder(size_t size_hint);
 
   ~type_id_list_builder();
 
-  // -- modifiers
-  // ---------------------------------------------------------------
+  // -- modifiers --------------------------------------------------------------
 
-  void reserve(size_t new_capacity);
-
+  /// Appends `id` to the type ID list.
   void push_back(type_id_t id);
 
-  void clear() noexcept {
-    if (storage_)
-      size_ = 1;
-  }
+  /// Removes all elements from the type ID list.
+  void clear() noexcept;
 
   // -- properties -------------------------------------------------------------
 
+  /// Returns the number of elements in the type ID list.
   size_t size() const noexcept;
 
+  /// Returns the number of element slots reserved in the type ID list.
+  /// @note The capacity is always a multiple of @ref block_size.
+  /// @note The capacity contains a dummy element at the beginning. Hence, the
+  ///       actual number of elements that can be stored is `capacity() - 1`.
+  size_t capacity() const noexcept {
+    return capacity_;
+  }
+
+  /// Returns the element at position `index`.
   /// @pre `index < size()`
   type_id_t operator[](size_t index) const noexcept;
 
   // -- conversions ------------------------------------------------------------
 
-  /// Convertes the internal buffer to a @ref type_id_list and returns it.
+  /// Converts the internal buffer to a @ref type_id_list and transfers
+  /// ownership of the data to the new list.
+  /// @note The builder is in a defined-but-invalid state after this operation.
+  ///       Calling `clear()` will restore the builder to a valid state.
   type_id_list move_to_list() noexcept;
 
-  /// Convertes the internal buffer to a @ref type_id_list and returns it.
+  /// Converts the internal buffer to a @ref type_id_list and returns it.
   type_id_list copy_to_list() const;
 
 private:
-  size_t size_;
-  size_t reserved_;
-  type_id_t* storage_;
+  void reserve(size_t new_capacity);
+
+  size_t size_ = 0;
+  size_t capacity_ = 0;
+  type_id_t* storage_ = nullptr;
 };
 
 } // namespace caf::detail

--- a/libcaf_core/caf/detail/type_id_list_builder.test.cpp
+++ b/libcaf_core/caf/detail/type_id_list_builder.test.cpp
@@ -1,0 +1,143 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/detail/type_id_list_builder.hpp"
+
+#include "caf/test/outline.hpp"
+#include "caf/test/scenario.hpp"
+
+#include "caf/type_id.hpp"
+
+using namespace caf;
+
+namespace {
+
+using builder_t = detail::type_id_list_builder;
+
+SCENARIO("a default-constructed type_id_list_builder is empty") {
+  GIVEN("a default-constructed type_id_list_builder") {
+    detail::type_id_list_builder builder;
+    WHEN("we ask for its size") {
+      THEN("we get 0") {
+        check_eq(builder.size(), 0u);
+      }
+    }
+    WHEN("we ask for its capacity") {
+      THEN("we get 0") {
+        check_eq(builder.capacity(), 0u);
+      }
+    }
+    WHEN("we call copy_to_list") {
+      auto list = builder.copy_to_list();
+      THEN("the returned list is empty") {
+        check_eq(list.size(), 0u);
+      }
+    }
+    WHEN("we call move_to_list") {
+      auto list = builder.copy_to_list();
+      THEN("the returned list is empty") {
+        check_eq(list.size(), 0u);
+      }
+    }
+  }
+}
+
+OUTLINE("push_back adds elements to the end of the list") {
+  GIVEN("an empty type_id_list_builder") {
+    detail::type_id_list_builder builder;
+    WHEN("calling push_back consecutively with values <values>") {
+      auto values = block_parameters<std::vector<type_id_t>>();
+      for (auto value : values) {
+        builder.push_back(value);
+      }
+      THEN("the list contains the elements") {
+        if (check_eq(builder.size(), values.size())) {
+          for (size_t index = 0; index < values.size(); ++index) {
+            check_eq(builder[index], values[index]);
+          }
+        }
+      }
+      AND_THEN("the builder has capacity <capacity>") {
+        auto capacity = block_parameters<size_t>();
+        check_eq(builder.capacity(), capacity);
+      }
+      AND_THEN("calling copy_to_list copies the elements to a type_id_list") {
+        auto list = builder.copy_to_list();
+        if (check_eq(builder.size(), values.size())) {
+          for (size_t index = 0; index < values.size(); ++index) {
+            check_eq(list[index], values[index]);
+          }
+        }
+      }
+      AND_THEN("calling move_to_list moves the elements to a type_id_list") {
+        auto list = builder.move_to_list();
+        if (check_eq(builder.size(), values.size())) {
+          for (size_t index = 0; index < values.size(); ++index) {
+            check_eq(list[index], values[index]);
+          }
+        }
+      }
+      AND_THEN("calling clear will restore the builder to its default state") {
+        builder.clear();
+        check_eq(builder.size(), 0u);
+        check_eq(builder.capacity(), 0u);
+      }
+    }
+  }
+  // Note:  6 = type_id_v<int8_t>
+  //        3 = type_id_v<int16_t>
+  //        4 = type_id_v<int32_t>
+  //        5 = type_id_v<int64_t>
+  //       11 = type_id_v<uint8_t>
+  //        8 = type_id_v<uint16_t>
+  //        9 = type_id_v<uint32_t>
+  //       10 = type_id_v<uint64_t>
+  EXAMPLES = R"(
+    | values                     | capacity |
+    | [6]                        |        8 |
+    | [6, 3]                     |        8 |
+    | [6, 3, 4]                  |        8 |
+    | [6, 3, 4, 5]               |        8 |
+    | [6, 3, 4, 5, 11]           |        8 |
+    | [6, 3, 4, 5, 11, 8]        |        8 |
+    | [6, 3, 4, 5, 11, 8, 9]     |        8 |
+    | [6, 3, 4, 5, 11, 8, 9, 10] |       16 |
+  )";
+}
+
+OUTLINE("passing an size hint to the builder pre-allocates memory") {
+  GIVEN("a size hint <hint>") {
+    auto hint = block_parameters<size_t>();
+    WHEN("constructing a builder with the size hint") {
+      detail::type_id_list_builder builder{hint};
+      THEN("the capacity capacity is <capacity>") {
+        auto capacity = block_parameters<size_t>();
+        check_eq(builder.capacity(), capacity);
+      }
+    }
+  }
+  // Note: the builder must have space for at least one extra element: the size
+  //       dummy. Hence, it will jump to the next block size if the hint is
+  //       exactly at the end of a block.
+  EXAMPLES = R"(
+    | hint | capacity |
+    |    0 |        0 |
+    |    1 |        8 |
+    |    2 |        8 |
+    |    3 |        8 |
+    |    4 |        8 |
+    |    5 |        8 |
+    |    6 |        8 |
+    |    7 |        8 |
+    |    8 |       16 |
+    |    9 |       16 |
+    |   15 |       16 |
+    |   16 |       24 |
+    |   17 |       24 |
+    |   23 |       24 |
+    |   24 |       32 |
+  )";
+}
+
+} // namespace

--- a/libcaf_core/caf/detail/type_id_list_builder.test.cpp
+++ b/libcaf_core/caf/detail/type_id_list_builder.test.cpp
@@ -35,7 +35,7 @@ SCENARIO("a default-constructed type_id_list_builder is empty") {
       }
     }
     WHEN("we call move_to_list") {
-      auto list = builder.copy_to_list();
+      auto list = builder.move_to_list();
       THEN("the returned list is empty") {
         check_eq(list.size(), 0u);
       }
@@ -111,7 +111,7 @@ OUTLINE("passing an size hint to the builder pre-allocates memory") {
     auto hint = block_parameters<size_t>();
     WHEN("constructing a builder with the size hint") {
       detail::type_id_list_builder builder{hint};
-      THEN("the capacity capacity is <capacity>") {
+      THEN("the capacity is <capacity>") {
         auto capacity = block_parameters<size_t>();
         check_eq(builder.capacity(), capacity);
       }

--- a/libcaf_core/caf/message.cpp
+++ b/libcaf_core/caf/message.cpp
@@ -60,8 +60,7 @@ bool load_data(Deserializer& source, message::data_ptr& data) {
              && source.end_field()           //
              && source.end_object();
     }
-    detail::type_id_list_builder ids;
-    ids.reserve(msg_size);
+    detail::type_id_list_builder ids{msg_size};
     size_t data_size = 0;
     for (size_t i = 0; i < msg_size; ++i) {
       type_id_t id = 0;

--- a/libcaf_core/caf/type_id_list.cpp
+++ b/libcaf_core/caf/type_id_list.cpp
@@ -39,8 +39,7 @@ type_id_list type_id_list::concat(span<type_id_list> lists) {
   auto total_size = size_t{0};
   for (auto ls : lists)
     total_size += ls.size();
-  detail::type_id_list_builder builder;
-  builder.reserve(total_size);
+  detail::type_id_list_builder builder{total_size};
   for (auto ls : lists)
     for (auto id : ls)
       builder.push_back(id);


### PR DESCRIPTION
Follow up to #1614 to document the merged fix and clean up the convoluted capacity management in the `type_id_list_builder`. Also adds new tests for the class.