### PR TITLE
Use short names for CAF enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Fix a minor bug in the deserialization of messages that caused CAF to allocate
   more storage than necessary (#1614).
 
+### Changed
+
+- Calling `to_string` on any of CAF's enum types now represents the enum value
+  using the short name instead of the fully qualified name. For example,
+  `to_string(sec::none)` now returns `"none"` instead of `"caf::sec::none"`.
+  Accordingly, `from_string` now accepts the short name (in additional to the
+  fully qualified name).
+
 ### Deprecated
 
 - Calling `to_stream` or `to_typed_stream` on an actor is now deprecated. Simply

--- a/cmake/caf-generate-enum-strings.cmake
+++ b/cmake/caf-generate-enum-strings.cmake
@@ -56,7 +56,7 @@ macro(write_enum_file)
   foreach(label IN LISTS enum_values)
     list(APPEND out
       "    case ${label_prefix}${label}:\n"
-      "      return \"${namespace_str}::${enum_name}::${label}\"\;\n")
+      "      return \"${label}\"\;\n")
   endforeach()
   list(APPEND out
     "  }\n"
@@ -67,7 +67,8 @@ macro(write_enum_file)
     "bool from_string(std::string_view in, ${enum_name}& out) {\n")
   foreach(label IN LISTS enum_values)
     list(APPEND out
-      "  if (in == \"${namespace_str}::${enum_name}::${label}\") {\n"
+      "  if (in == \"${label}\"\n"
+      "      || in == \"${namespace_str}::${enum_name}::${label}\") {\n"
       "    out = ${label_prefix}${label}\;\n"
       "    return true\;\n"
       "  }\n")

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -102,7 +102,6 @@ caf_add_component(
     caf/async/spsc_buffer.test.cpp
     caf/attachable.cpp
     caf/behavior.cpp
-    caf/delegate.test.cpp
     caf/behavior.test.cpp
     caf/binary_deserializer.cpp
     caf/binary_serializer.cpp
@@ -116,6 +115,7 @@ caf_add_component(
     caf/config_value_writer.cpp
     caf/decorator/sequencer.cpp
     caf/default_attachable.cpp
+    caf/delegate.test.cpp
     caf/deserializer.cpp
     caf/detail/abstract_worker.cpp
     caf/detail/abstract_worker_hub.cpp
@@ -246,6 +246,7 @@ caf_add_component(
     caf/scheduler/test_coordinator.cpp
     caf/scoped_actor.cpp
     caf/scoped_execution_unit.cpp
+    caf/sec.test.cpp
     caf/serializer.cpp
     caf/settings.cpp
     caf/skip.cpp

--- a/libcaf_core/caf/sec.test.cpp
+++ b/libcaf_core/caf/sec.test.cpp
@@ -1,0 +1,63 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/sec.hpp"
+
+#include "caf/test/test.hpp"
+
+#include "caf/binary_deserializer.hpp"
+#include "caf/binary_serializer.hpp"
+#include "caf/json_reader.hpp"
+#include "caf/json_writer.hpp"
+
+#include <optional>
+
+using namespace caf;
+using namespace std::literals;
+
+namespace {
+
+TEST("system error codes are convertible to strings") {
+  check_eq(to_string(sec::none), "none");
+  check_eq(to_string(sec::invalid_argument), "invalid_argument");
+  check_eq(to_string(sec::no_such_key), "no_such_key");
+}
+
+TEST("system error codes are convertible from strings") {
+  auto to_sec = [](std::string_view str) -> std::optional<sec> {
+    sec result;
+    if (from_string(str, result))
+      return result;
+    return std::nullopt;
+  };
+  check_eq(to_sec("none"), sec::none);
+  check_eq(to_sec("invalid_argument"), sec::invalid_argument);
+  check_eq(to_sec("no_such_key"), sec::no_such_key);
+}
+
+TEST("system error codes are inspectable") {
+  SECTION("human-readable representation") {
+    json_writer writer;
+    auto val = sec::no_such_key;
+    check(inspect(writer, val));
+    check_eq(writer.str(), R"_("no_such_key")_");
+    json_reader reader;
+    auto copy = sec::none;
+    check(reader.load(writer.str()));
+    check(inspect(reader, copy));
+    check_eq(copy, val);
+  }
+  SECTION("binary representation") {
+    byte_buffer buf;
+    auto val = sec::no_such_key;
+    binary_serializer sink{nullptr, buf};
+    check(inspect(sink, val));
+    auto copy = sec::none;
+    binary_deserializer source{nullptr, buf};
+    check(inspect(source, copy));
+    check_eq(copy, val);
+  }
+}
+
+} // namespace

--- a/libcaf_core/tests/legacy/error.cpp
+++ b/libcaf_core/tests/legacy/error.cpp
@@ -50,19 +50,19 @@ SCENARIO("errors provide human-readable to_string output") {
   GIVEN("an error object") {
     WHEN("converting an error without context to a string") {
       THEN("the output is only the error code") {
-        CHECK_EQ(err_str(sec::invalid_argument), "caf::sec::invalid_argument");
+        CHECK_EQ(err_str(sec::invalid_argument), "invalid_argument");
       }
     }
     WHEN("converting an error with a context containing one element") {
       THEN("the output is the error code plus the context") {
         CHECK_EQ(err_str(sec::invalid_argument, "foo is not bar"),
-                 R"_(caf::sec::invalid_argument("foo is not bar"))_");
+                 R"_(invalid_argument("foo is not bar"))_");
       }
     }
     WHEN("converting an error with a context containing two or more elements") {
       THEN("the output is the error code plus all elements in the context") {
         CHECK_EQ(err_str(sec::invalid_argument, "want foo", "got bar"),
-                 R"_(caf::sec::invalid_argument("want foo", "got bar"))_");
+                 R"_(invalid_argument("want foo", "got bar"))_");
       }
     }
   }


### PR DESCRIPTION
I recently suggested using enums in outlines, but then I realized that the enum rendering in CAF is quite verbose at the moment. So this is bascially a quality of life change.