### PR TITLE
Restrict scope guard to noexcept functions

### DIFF
--- a/examples/qtsupport/chatwidget.cpp
+++ b/examples/qtsupport/chatwidget.cpp
@@ -71,7 +71,8 @@ void ChatWidget::init(actor_system& system, const std::string& name,
 }
 
 void ChatWidget::sendChatMessage() {
-  auto cleanup = detail::make_scope_guard([=] { input()->setText(QString()); });
+  auto cleanup
+    = detail::make_scope_guard([=]() noexcept { input()->setText(QString()); });
   QString line = input()->text();
   if (line.isEmpty()) {
     // Ignore empty lines.

--- a/examples/qtsupport/chatwidget.cpp
+++ b/examples/qtsupport/chatwidget.cpp
@@ -71,8 +71,6 @@ void ChatWidget::init(actor_system& system, const std::string& name,
 }
 
 void ChatWidget::sendChatMessage() {
-  auto cleanup
-    = detail::make_scope_guard([=]() noexcept { input()->setText(QString()); });
   QString line = input()->text();
   if (line.isEmpty()) {
     // Ignore empty lines.
@@ -89,7 +87,6 @@ void ChatWidget::sendChatMessage() {
     } else {
       print("*** list of commands:\n"
             "/setName <new name>\n");
-      return;
     }
   } else {
     auto msg = name_;
@@ -100,6 +97,7 @@ void ChatWidget::sendChatMessage() {
       publisher_->push(msg);
     }
   }
+  input()->setText(QString());
 }
 
 void ChatWidget::changeName() {

--- a/libcaf_core/caf/blocking_actor.cpp
+++ b/libcaf_core/caf/blocking_actor.cpp
@@ -279,7 +279,8 @@ void blocking_actor::receive_impl(receive_cond& rcc, message_id mid,
     // Blocking actors can nest receives => push/pop `current_element_`
     auto prev_element = current_element_;
     current_element_ = ptr.get();
-    auto g = detail::make_scope_guard([&] { current_element_ = prev_element; });
+    auto g = detail::make_scope_guard(
+      [&]() noexcept { current_element_ = prev_element; });
     // Dispatch on the current mailbox element.
     if (consume()) {
       unstash();

--- a/libcaf_core/caf/config_value.cpp
+++ b/libcaf_core/caf/config_value.cpp
@@ -197,9 +197,10 @@ error_code<sec> config_value::default_construct(type_id_t id) {
       if (auto meta = detail::global_meta_object_or_null(id)) {
         using detail::make_scope_guard;
         auto ptr = malloc(meta->padded_size);
-        auto free_guard = make_scope_guard([ptr] { free(ptr); });
+        auto free_guard = make_scope_guard([ptr]() noexcept { free(ptr); });
         meta->default_construct(ptr);
-        auto destroy_guard = make_scope_guard([=] { meta->destroy(ptr); });
+        auto destroy_guard
+          = make_scope_guard([=]() noexcept { meta->destroy(ptr); });
         config_value_writer writer{this};
         if (meta->save(writer, ptr)) {
           return sec::none;

--- a/libcaf_core/caf/detail/config_consumer.cpp
+++ b/libcaf_core/caf/detail/config_consumer.cpp
@@ -82,14 +82,16 @@ config_consumer::config_consumer(settings& cfg) : cfg_(&cfg) {
 }
 
 config_consumer::config_consumer(config_consumer&& other)
-  : options_(other.options_), parent_(other.parent_), cfg_(other.cfg_) {
+  : options_(other.options_),
+    parent_(std::move(other.parent_)),
+    cfg_(other.cfg_) {
   other.parent_ = none;
 }
 
 config_consumer& config_consumer::operator=(config_consumer&& other) {
   destroy();
   options_ = other.options_;
-  parent_ = other.parent_;
+  parent_ = std::move(other.parent_);
   cfg_ = other.cfg_;
   other.parent_ = none;
   return *this;

--- a/libcaf_core/caf/detail/format.cpp
+++ b/libcaf_core/caf/detail/format.cpp
@@ -10,7 +10,6 @@
 #include "caf/detail/parser/is_char.hpp"
 #include "caf/detail/parser/read_unsigned_integer.hpp"
 #include "caf/detail/print.hpp"
-#include "caf/detail/scope_guard.hpp"
 #include "caf/parser_state.hpp"
 #include "caf/pec.hpp"
 #include "caf/raise_error.hpp"
@@ -309,10 +308,6 @@ void copy_verbatim(ParserState& ps, copy_state& cs);
 template <class ParserState>
 void copy_formatted(ParserState& ps, copy_state& cs) {
   cs.reset();
-  auto guard = make_scope_guard([&]() noexcept {
-    if (ps.code <= pec::trailing_character)
-      cs.fn = copy_verbatim<string_parser_state>;
-  });
   size_t tmp = 0;
   auto make_tmp_consumer = [&tmp] {
     tmp = 0;
@@ -407,6 +402,8 @@ void copy_formatted(ParserState& ps, copy_state& cs) {
   }
   fin();
   // clang-format on
+  if (ps.code <= pec::trailing_character)
+    cs.fn = copy_verbatim<string_parser_state>;
 }
 
 // Copies the input verbatim to the output buffer until finding a format string.

--- a/libcaf_core/caf/detail/format.cpp
+++ b/libcaf_core/caf/detail/format.cpp
@@ -309,7 +309,7 @@ void copy_verbatim(ParserState& ps, copy_state& cs);
 template <class ParserState>
 void copy_formatted(ParserState& ps, copy_state& cs) {
   cs.reset();
-  auto guard = make_scope_guard([&] {
+  auto guard = make_scope_guard([&]() noexcept {
     if (ps.code <= pec::trailing_character)
       cs.fn = copy_verbatim<string_parser_state>;
   });

--- a/libcaf_core/caf/detail/json.cpp
+++ b/libcaf_core/caf/detail/json.cpp
@@ -215,7 +215,7 @@ template <class ParserState, class Consumer>
 void read_json_null_or_nan(ParserState& ps, Consumer consumer) {
   enum { nil, is_null, is_nan };
   auto res_type = nil;
-  auto g = make_scope_guard([&] {
+  auto g = make_scope_guard([&]() noexcept {
     if (ps.code <= pec::trailing_character) {
       CAF_ASSERT(res_type != nil);
       if (res_type == is_null)

--- a/libcaf_core/caf/detail/scope_guard.hpp
+++ b/libcaf_core/caf/detail/scope_guard.hpp
@@ -11,6 +11,8 @@ namespace caf::detail {
 /// A lightweight scope guard implementation.
 template <class Fun>
 class scope_guard {
+  static_assert(noexcept(std::declval<Fun>()()),
+                "Scope guard function must be declared noexcept");
   scope_guard() = delete;
   scope_guard(const scope_guard&) = delete;
   scope_guard& operator=(const scope_guard&) = delete;

--- a/libcaf_core/caf/execution_unit.hpp
+++ b/libcaf_core/caf/execution_unit.hpp
@@ -42,7 +42,7 @@ public:
   }
 
   /// Associated a new proxy factory to this unit.
-  void proxy_registry_ptr(proxy_registry* ptr) {
+  void proxy_registry_ptr(proxy_registry* ptr) noexcept {
     proxies_ = ptr;
   }
 

--- a/libcaf_core/caf/flow/op/from_resource.hpp
+++ b/libcaf_core/caf/flow/op/from_resource.hpp
@@ -125,7 +125,7 @@ private:
 
   void do_run() {
     CAF_LOG_TRACE("");
-    auto guard = detail::make_scope_guard([this] { running_ = false; });
+    auto guard = detail::scope_guard([this]() noexcept { running_ = false; });
     if (disposed_) {
       do_dispose();
       return;

--- a/libcaf_core/caf/flow/op/from_steps.hpp
+++ b/libcaf_core/caf/flow/op/from_steps.hpp
@@ -202,13 +202,14 @@ private:
     //       during the entire execution of do_run_impl. Otherwise, we might
     //       trigger a heap-use-after-free.
     ref();
-    auto guard = detail::make_scope_guard([this] { deref(); });
+    auto guard = detail::make_scope_guard([this]() noexcept { deref(); });
     running_ = true;
     do_run_impl();
   }
 
   void do_run_impl() {
-    auto guard = detail::make_scope_guard([this] { running_ = false; });
+    auto guard
+      = detail::make_scope_guard([this]() noexcept { running_ = false; });
     if (!disposed_) {
       CAF_ASSERT(out_);
       while (demand_ > 0 && !buf_.empty()) {

--- a/libcaf_core/caf/logger.cpp
+++ b/libcaf_core/caf/logger.cpp
@@ -677,7 +677,7 @@ actor_id logger::thread_local_aid() {
   return current_actor_id;
 }
 
-actor_id logger::thread_local_aid(actor_id aid) {
+actor_id logger::thread_local_aid(actor_id aid) noexcept {
   std::swap(current_actor_id, aid);
   return aid;
 }

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -247,7 +247,7 @@ public:
   static actor_id thread_local_aid();
 
   /// Associates an actor ID to the calling thread and returns the last value.
-  static actor_id thread_local_aid(actor_id aid);
+  static actor_id thread_local_aid(actor_id aid) noexcept;
 
   /// Returns whether the logger is configured to accept input for given
   /// component and log level.

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -353,8 +353,10 @@ private:
 #define CAF_PUSH_AID(aarg)                                                     \
   caf::actor_id CAF_PP_UNIFYN(caf_aid_tmp)                                     \
     = caf::logger::thread_local_aid(aarg);                                     \
-  auto CAF_PP_UNIFYN(caf_aid_tmp_guard) = caf::detail::make_scope_guard(       \
-    [=] { caf::logger::thread_local_aid(CAF_PP_UNIFYN(caf_aid_tmp)); })
+  auto CAF_PP_UNIFYN(caf_aid_tmp_guard)                                        \
+    = caf::detail::scope_guard([=]() noexcept {                                \
+        caf::logger::thread_local_aid(CAF_PP_UNIFYN(caf_aid_tmp));             \
+      })
 
 #define CAF_PUSH_AID_FROM_PTR(some_ptr)                                        \
   auto CAF_PP_UNIFYN(caf_aid_ptr) = some_ptr;                                  \

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -280,7 +280,7 @@ resumable::resume_result scheduled_actor::resume(execution_unit* ctx,
   if (!activate(ctx))
     return resumable::done;
   size_t consumed = 0;
-  auto guard = detail::make_scope_guard([this, &consumed] {
+  auto guard = detail::make_scope_guard([this, &consumed]() noexcept {
     CAF_LOG_DEBUG("resume consumed" << consumed << "messages");
     if (consumed > 0) {
       auto val = static_cast<int64_t>(consumed);

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -281,7 +281,6 @@ resumable::resume_result scheduled_actor::resume(execution_unit* ctx,
     return resumable::done;
   size_t consumed = 0;
   auto guard = detail::make_scope_guard([this, &consumed]() noexcept {
-    CAF_LOG_DEBUG("resume consumed" << consumed << "messages");
     if (consumed > 0) {
       auto val = static_cast<int64_t>(consumed);
       home_system().base_metrics().processed_messages->inc(val);

--- a/libcaf_core/tests/legacy/dsl.cpp
+++ b/libcaf_core/tests/legacy/dsl.cpp
@@ -252,7 +252,7 @@ SCENARIO("passing requirements increment the 'good' counter") {
       auto silent_expr = [&] {                                                 \
         auto bk = caf::test::logger::instance().make_quiet();                  \
         auto guard = caf::detail::make_scope_guard(                            \
-          [bk] { caf::test::logger::instance().levels(bk); });                 \
+          [bk]() noexcept { caf::test::logger::instance().levels(bk); });      \
         expr;                                                                  \
       };                                                                       \
       CHECK_THROWS_AS(silent_expr(), test::requirement_error);                 \

--- a/libcaf_io/caf/io/basp/remote_message_handler.hpp
+++ b/libcaf_io/caf/io/basp/remote_message_handler.hpp
@@ -42,8 +42,8 @@ public:
     auto mid = make_message_id(dref.hdr_.operation_data);
     binary_deserializer source{ctx, dref.payload_};
     // Make sure to drop the message in case we return abnormally.
-    auto guard
-      = detail::make_scope_guard([&] { dref.queue_->drop(ctx, dref.msg_id_); });
+    auto guard = detail::make_scope_guard(
+      [&]() noexcept { dref.queue_->drop(ctx, dref.msg_id_); });
     // Registry setup.
     dref.proxies_->set_last_hop(&dref.last_hop_);
     // Get the local receiver.

--- a/libcaf_io/caf/io/basp_broker.cpp
+++ b/libcaf_io/caf/io/basp_broker.cpp
@@ -427,7 +427,7 @@ proxy_registry* basp_broker::proxy_registry_ptr() {
 resumable::resume_result basp_broker::resume(execution_unit* ctx, size_t mt) {
   ctx->proxy_registry_ptr(&instance.proxies());
   auto guard
-    = detail::make_scope_guard([=] { ctx->proxy_registry_ptr(nullptr); });
+    = detail::scope_guard([=]() noexcept { ctx->proxy_registry_ptr(nullptr); });
   return super::resume(ctx, mt);
 }
 

--- a/libcaf_io/caf/io/basp_broker.cpp
+++ b/libcaf_io/caf/io/basp_broker.cpp
@@ -426,8 +426,8 @@ proxy_registry* basp_broker::proxy_registry_ptr() {
 
 resumable::resume_result basp_broker::resume(execution_unit* ctx, size_t mt) {
   ctx->proxy_registry_ptr(&instance.proxies());
-  auto guard
-    = detail::scope_guard([=]() noexcept { ctx->proxy_registry_ptr(nullptr); });
+  auto guard = detail::make_scope_guard(
+    [=]() noexcept { ctx->proxy_registry_ptr(nullptr); });
   return super::resume(ctx, mt);
 }
 

--- a/libcaf_io/caf/io/broker_servant.hpp
+++ b/libcaf_io/caf/io/broker_servant.hpp
@@ -65,7 +65,7 @@ protected:
     auto pfac = self->proxy_registry_ptr();
     if (pfac)
       ctx->proxy_registry_ptr(pfac);
-    auto guard = detail::make_scope_guard([=] {
+    auto guard = detail::make_scope_guard([=]() noexcept {
       if (pfac)
         ctx->proxy_registry_ptr(nullptr);
     });

--- a/libcaf_io/caf/io/network/native_socket.cpp
+++ b/libcaf_io/caf/io/network/native_socket.cpp
@@ -294,7 +294,7 @@ std::pair<native_socket, native_socket> create_pipe() {
   a.inaddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
   a.inaddr.sin_port = 0;
   // makes sure all sockets are closed in case of an error
-  auto guard = detail::make_scope_guard([&] {
+  auto guard = detail::make_scope_guard([&]() noexcept {
     auto e = WSAGetLastError();
     close_socket(listener);
     close_socket(socks[0]);

--- a/libcaf_net/caf/net/dsl/arg.hpp
+++ b/libcaf_net/caf/net/dsl/arg.hpp
@@ -56,7 +56,7 @@ public:
   /// @returns a pointer to the null-terminated string.
   const char* get() const noexcept {
     return std::visit(
-      [](auto& arg) -> const char* {
+      [](auto& arg) noexcept -> const char* {
         using T = std::decay_t<decltype(arg)>;
         if constexpr (std::is_same_v<T, const char*>) {
           return arg;

--- a/libcaf_net/caf/net/dsl/config_base.hpp
+++ b/libcaf_net/caf/net/dsl/config_base.hpp
@@ -115,7 +115,7 @@ public:
 
   /// Returns the name of the configuration type.
   std::string_view name() const noexcept override {
-    auto f = [](const auto& val) {
+    auto f = [](const auto& val) noexcept {
       using val_t = std::decay_t<decltype(val)>;
       return get_name<val_t>::value;
     };

--- a/libcaf_net/caf/net/pipe_socket.cpp
+++ b/libcaf_net/caf/net/pipe_socket.cpp
@@ -53,7 +53,7 @@ expected<std::pair<pipe_socket, pipe_socket>> make_pipe() {
   if (pipe(pipefds) != 0)
     return make_error(sec::network_syscall_failed, "pipe",
                       last_socket_error_as_string());
-  auto guard = detail::make_scope_guard([&] {
+  auto guard = detail::make_scope_guard([&]() noexcept {
     close(socket{pipefds[0]});
     close(socket{pipefds[1]});
   });

--- a/libcaf_net/caf/net/stream_socket.cpp
+++ b/libcaf_net/caf/net/stream_socket.cpp
@@ -69,7 +69,7 @@ expected<std::pair<stream_socket, stream_socket>> make_stream_socket_pair() {
   a.inaddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
   a.inaddr.sin_port = 0;
   // makes sure all sockets are closed in case of an error
-  auto guard = detail::make_scope_guard([&] {
+  auto guard = detail::make_scope_guard([&]() noexcept {
     auto e = WSAGetLastError();
     close(socket{listener});
     close(socket{socks[0]});

--- a/libcaf_net/tests/legacy/net/ssl/transport.cpp
+++ b/libcaf_net/tests/legacy/net/ssl/transport.cpp
@@ -109,7 +109,7 @@ void dummy_tls_server(stream_socket fd, const char* cert_file,
   namespace ssl = caf::net::ssl;
   multiplexer::block_sigpipe();
   // Make sure we close our socket.
-  auto guard = detail::make_scope_guard([fd] { close(fd); });
+  auto guard = detail::make_scope_guard([fd]() noexcept { close(fd); });
   // Get and configure our SSL context.
   auto ctx = unbox(ssl::context::make_server(ssl::tls::any));
   if (!ctx.use_certificate_file(cert_file, ssl::format::pem)) {
@@ -149,7 +149,7 @@ void dummy_tls_server(stream_socket fd, const char* cert_file,
 void dummy_tls_client(stream_socket fd) {
   multiplexer::block_sigpipe();
   // Make sure we close our socket.
-  auto guard = detail::make_scope_guard([fd] { close(fd); });
+  auto guard = detail::make_scope_guard([fd]() noexcept { close(fd); });
   // Perform SSL handshake.
   auto ctx = unbox(ssl::context::make_client(ssl::tls::any));
   auto conn = unbox(ctx.new_connection(fd));

--- a/libcaf_openssl/caf/openssl/session.cpp
+++ b/libcaf_openssl/caf/openssl/session.cpp
@@ -31,14 +31,15 @@ CAF_POP_WARNINGS
       perror("pthread_sigmask");                                               \
       exit(1);                                                                 \
     }                                                                          \
-    auto sigpipe_restore_guard = ::caf::detail::scope_guard([&]() noexcept {   \
-      struct timespec zerotime = {};                                           \
-      sigtimedwait(&sigpipe_mask, 0, &zerotime);                               \
-      if (pthread_sigmask(SIG_SETMASK, &saved_mask, 0) == -1) {                \
-        perror("pthread_sigmask");                                             \
-        exit(1);                                                               \
-      }                                                                        \
-    })
+    auto sigpipe_restore_guard                                                 \
+      = ::caf::detail::make_scope_guard([&]() noexcept {                       \
+          struct timespec zerotime = {};                                       \
+          sigtimedwait(&sigpipe_mask, 0, &zerotime);                           \
+          if (pthread_sigmask(SIG_SETMASK, &saved_mask, 0) == -1) {            \
+            perror("pthread_sigmask");                                         \
+            exit(1);                                                           \
+          }                                                                    \
+        })
 
 #else
 

--- a/libcaf_openssl/caf/openssl/session.cpp
+++ b/libcaf_openssl/caf/openssl/session.cpp
@@ -31,7 +31,7 @@ CAF_POP_WARNINGS
       perror("pthread_sigmask");                                               \
       exit(1);                                                                 \
     }                                                                          \
-    auto sigpipe_restore_guard = ::caf::detail::make_scope_guard([&] {         \
+    auto sigpipe_restore_guard = ::caf::detail::scope_guard([&]() noexcept {   \
       struct timespec zerotime = {};                                           \
       sigtimedwait(&sigpipe_mask, 0, &zerotime);                               \
       if (pthread_sigmask(SIG_SETMASK, &saved_mask, 0) == -1) {                \

--- a/libcaf_test/caf/test/outline.cpp
+++ b/libcaf_test/caf/test/outline.cpp
@@ -107,7 +107,7 @@ void outline::run() {
     }
   }
   ctx_->parameters = ctx_->example_parameters[ctx_->example_id];
-  auto guard = detail::make_scope_guard([this] {
+  auto guard = detail::make_scope_guard([this]() noexcept {
     auto& ptr = ctx_->steps[std::make_pair(0, ctx_->example_id)];
     if (!ptr->can_run()
         && ctx_->example_id + 1 < ctx_->example_parameters.size())

--- a/libcaf_test/caf/test/outline.cpp
+++ b/libcaf_test/caf/test/outline.cpp
@@ -107,8 +107,8 @@ void outline::run() {
     }
   }
   ctx_->parameters = ctx_->example_parameters[ctx_->example_id];
-  auto guard = detail::make_scope_guard([this]() noexcept {
-    auto& ptr = ctx_->steps[std::make_pair(0, ctx_->example_id)];
+  auto& ptr = ctx_->steps[std::make_pair(0, ctx_->example_id)];
+  auto guard = detail::make_scope_guard([this, &ptr]() noexcept {
     if (!ptr->can_run()
         && ctx_->example_id + 1 < ctx_->example_parameters.size())
       ++ctx_->example_id;

--- a/libcaf_test/caf/test/reporter.cpp
+++ b/libcaf_test/caf/test/reporter.cpp
@@ -406,7 +406,7 @@ public:
               ' ', indent_, self->name(), self->id(), msg);
   }
 
-  unsigned verbosity(unsigned level) override {
+  unsigned verbosity(unsigned level) noexcept override {
     auto result = level_;
     level_ = level;
     return result;

--- a/libcaf_test/caf/test/reporter.hpp
+++ b/libcaf_test/caf/test/reporter.hpp
@@ -91,7 +91,7 @@ public:
   virtual void print_actor_output(local_actor* self, std::string_view msg) = 0;
 
   /// Sets the verbosity level of the reporter and returns the previous value.
-  virtual unsigned verbosity(unsigned level) = 0;
+  virtual unsigned verbosity(unsigned level) noexcept = 0;
 
   /// returns the current verbosity level.
   virtual unsigned verbosity() const noexcept = 0;

--- a/libcaf_test/caf/test/runnable.cpp
+++ b/libcaf_test/caf/test/runnable.cpp
@@ -26,7 +26,8 @@ runnable::~runnable() {
 
 void runnable::run() {
   current_runnable = this;
-  auto guard = detail::make_scope_guard([] { current_runnable = nullptr; });
+  auto guard
+    = detail::make_scope_guard([]() noexcept { current_runnable = nullptr; });
   switch (root_type_) {
     case block_type::scenario:
       if (auto guard = ctx_->get<scenario>(0, description_, loc_)->commit()) {
@@ -51,7 +52,8 @@ void runnable::run() {
 
 void runnable::call_do_run() {
   current_runnable = this;
-  auto guard = detail::make_scope_guard([] { current_runnable = nullptr; });
+  auto guard
+    = detail::make_scope_guard([]() noexcept { current_runnable = nullptr; });
   do_run();
 }
 

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -250,7 +250,8 @@ public:
     auto lvl = rep.verbosity(CAF_LOG_LEVEL_QUIET);
     auto before = rep.test_stats();
     {
-      auto lvl_guard = detail::make_scope_guard([&] { rep.verbosity(lvl); });
+      auto lvl_guard
+        = detail::scope_guard([&]() noexcept { rep.verbosity(lvl); });
       expr();
     }
     auto after = rep.test_stats();

--- a/libcaf_test/caf/test/unit_test.hpp
+++ b/libcaf_test/caf/test/unit_test.hpp
@@ -330,15 +330,15 @@ public:
     level lvl_;
   };
 
-  auto levels() {
+  auto levels() noexcept {
     return std::make_pair(level_console_, level_file_);
   }
 
-  void levels(std::pair<level, level> values) {
+  void levels(std::pair<level, level> values) noexcept {
     std::tie(level_console_, level_file_) = values;
   }
 
-  void levels(level console_lvl, level file_lvl) {
+  void levels(level console_lvl, level file_lvl) noexcept {
     level_console_ = console_lvl;
     level_file_ = file_lvl;
   }


### PR DESCRIPTION
Like discussed before, this PR adds a static assert to the scope guard making sure the provided function is noexcept. 
I've also went and added `noexcept` to all lambdas so the solution compiles without issues, however clang tidy does complain a lot about some cases where the lambdas might throw under rare circumstances. 

Closes #1550.