### PR TITLE
Fix subscribe implementations that emit errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Fix a minor bug in the deserialization of messages that caused CAF to allocate
   more storage than necessary (#1614).
 - Add missing `const` to `publisher<T>::observe_on`.
+- All `observable` implementations now properly call `on_subscribe` on their
+  subscriber before calling `on_error`.
 
 ### Changed
 

--- a/libcaf_core/caf/detail/stream_bridge.cpp
+++ b/libcaf_core/caf/detail/stream_bridge.cpp
@@ -147,8 +147,7 @@ stream_bridge::stream_bridge(scheduled_actor* self, strong_actor_ptr src,
 
 disposable stream_bridge::subscribe(flow::observer<async::batch> out) {
   if (!src_) {
-    out.on_error(make_error(sec::cannot_resubscribe_stream));
-    return {};
+    return fail_subscription(out, make_error(sec::cannot_resubscribe_stream));
   }
   auto self = self_ptr();
   auto local_id = self->new_u64_id();

--- a/libcaf_core/caf/flow/observable.test.cpp
+++ b/libcaf_core/caf/flow/observable.test.cpp
@@ -29,9 +29,9 @@ TEST("element_at(n) only takes the element with index n") {
       check_eq(collect(range(1, 3).element_at(0)), vector{1});
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 1)).element_at(0)), vector{1});
-      check_eq(collect(mat(range(1, 2)).element_at(0)), vector{1});
-      check_eq(collect(mat(range(1, 3)).element_at(0)), vector{1});
+      check_eq(collect(build(range(1, 1)).element_at(0)), vector{1});
+      check_eq(collect(build(range(1, 2)).element_at(0)), vector{1});
+      check_eq(collect(build(range(1, 3)).element_at(0)), vector{1});
     }
   }
   SECTION("element_at(1) picks the second element") {
@@ -40,8 +40,8 @@ TEST("element_at(n) only takes the element with index n") {
       check_eq(collect(range(1, 3).element_at(1)), vector{2});
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 2)).element_at(1)), vector{2});
-      check_eq(collect(mat(range(1, 3)).element_at(1)), vector{2});
+      check_eq(collect(build(range(1, 2)).element_at(1)), vector{2});
+      check_eq(collect(build(range(1, 3)).element_at(1)), vector{2});
     }
   }
   SECTION("element_at(n) does not pick any element if n >= m") {
@@ -51,19 +51,17 @@ TEST("element_at(n) only takes the element with index n") {
       check_eq(collect(range(1, 3).element_at(3)), nil);
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 1)).element_at(1)), nil);
-      check_eq(collect(mat(range(1, 2)).element_at(2)), nil);
-      check_eq(collect(mat(range(1, 3)).element_at(3)), nil);
+      check_eq(collect(build(range(1, 1)).element_at(1)), nil);
+      check_eq(collect(build(range(1, 2)).element_at(2)), nil);
+      check_eq(collect(build(range(1, 3)).element_at(3)), nil);
     }
   }
   SECTION("element_at(n) propagates errors") {
     SECTION("blueprint") {
-      check_eq(collect(obs_error(sec::runtime_error).element_at(1)),
-               sec::runtime_error);
+      check_eq(collect(obs_error().element_at(1)), sec::runtime_error);
     }
     SECTION("observable") {
-      check_eq(collect(mat(obs_error(sec::runtime_error)).element_at(1)),
-               sec::runtime_error);
+      check_eq(collect(build(obs_error()).element_at(1)), sec::runtime_error);
     }
   }
 }
@@ -77,9 +75,9 @@ TEST("reduce(init, fn) combines all items into one final value using fn") {
       check_eq(collect(range(1, 3).reduce(0, adder)), vector{6});
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 1)).reduce(0, adder)), vector{1});
-      check_eq(collect(mat(range(1, 2)).reduce(0, adder)), vector{3});
-      check_eq(collect(mat(range(1, 3)).reduce(0, adder)), vector{6});
+      check_eq(collect(build(range(1, 1)).reduce(0, adder)), vector{1});
+      check_eq(collect(build(range(1, 2)).reduce(0, adder)), vector{3});
+      check_eq(collect(build(range(1, 3)).reduce(0, adder)), vector{6});
     }
   }
   SECTION("reduce(init, fn) emits 0 for a range of size 0") {
@@ -87,7 +85,7 @@ TEST("reduce(init, fn) combines all items into one final value using fn") {
       check_eq(collect(range(1, 0).reduce(0, adder)), vector{0});
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 0)).reduce(0, adder)), vector{0});
+      check_eq(collect(build(range(1, 0)).reduce(0, adder)), vector{0});
     }
   }
   SECTION("reduce(init, fn) propagates errors") {
@@ -99,11 +97,12 @@ TEST("reduce(init, fn) combines all items into one final value using fn") {
       check_eq(collect(obs_error().reduce(0, adder)), sec::runtime_error);
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 1).concat(obs_error())).reduce(0, adder)),
+      check_eq(collect(build(range(1, 1).concat(obs_error())).reduce(0, adder)),
                sec::runtime_error);
-      check_eq(collect(mat(range(1, 3).concat(obs_error())).reduce(0, adder)),
+      check_eq(collect(build(range(1, 3).concat(obs_error())).reduce(0, adder)),
                sec::runtime_error);
-      check_eq(collect(mat(obs_error()).reduce(0, adder)), sec::runtime_error);
+      check_eq(collect(build(obs_error()).reduce(0, adder)),
+               sec::runtime_error);
     }
   }
 }
@@ -117,9 +116,9 @@ TEST("scan(init, fn) creates successive reduced values using fn") {
       check_eq(collect(range(1, 3).scan(0, adder)), vector{1, 3, 6});
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 1)).scan(0, adder)), vector{1});
-      check_eq(collect(mat(range(1, 2)).scan(0, adder)), vector{1, 3});
-      check_eq(collect(mat(range(1, 3)).scan(0, adder)), vector{1, 3, 6});
+      check_eq(collect(build(range(1, 1)).scan(0, adder)), vector{1});
+      check_eq(collect(build(range(1, 2)).scan(0, adder)), vector{1, 3});
+      check_eq(collect(build(range(1, 3)).scan(0, adder)), vector{1, 3, 6});
     }
   }
   SECTION("scan(init, fn) emits 0 for a range of size 0") {
@@ -127,7 +126,7 @@ TEST("scan(init, fn) creates successive reduced values using fn") {
       check_eq(collect(range(1, 0).scan(0, adder)), nil);
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 0)).scan(0, adder)), nil);
+      check_eq(collect(build(range(1, 0)).scan(0, adder)), nil);
     }
   }
   SECTION("scan(init, fn) propagates errors") {
@@ -139,11 +138,11 @@ TEST("scan(init, fn) creates successive reduced values using fn") {
       check_eq(collect(obs_error().scan(0, adder)), sec::runtime_error);
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 1).concat(obs_error())).scan(0, adder)),
+      check_eq(collect(build(range(1, 1).concat(obs_error())).scan(0, adder)),
                sec::runtime_error);
-      check_eq(collect(mat(range(1, 3).concat(obs_error())).scan(0, adder)),
+      check_eq(collect(build(range(1, 3).concat(obs_error())).scan(0, adder)),
                sec::runtime_error);
-      check_eq(collect(mat(obs_error()).scan(0, adder)), sec::runtime_error);
+      check_eq(collect(build(obs_error()).scan(0, adder)), sec::runtime_error);
     }
   }
 }
@@ -157,10 +156,10 @@ TEST("skip(n) skips the first n elements in a range of size m") {
       check_eq(collect(range(1, 3).skip(0)), vector{1, 2, 3});
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 0)).skip(0)), nil);
-      check_eq(collect(mat(range(1, 1)).skip(0)), vector{1});
-      check_eq(collect(mat(range(1, 2)).skip(0)), vector{1, 2});
-      check_eq(collect(mat(range(1, 3)).skip(0)), vector{1, 2, 3});
+      check_eq(collect(build(range(1, 0)).skip(0)), nil);
+      check_eq(collect(build(range(1, 1)).skip(0)), vector{1});
+      check_eq(collect(build(range(1, 2)).skip(0)), vector{1, 2});
+      check_eq(collect(build(range(1, 3)).skip(0)), vector{1, 2, 3});
     }
   }
   SECTION("skip(n) truncates the first n elements if n < m") {
@@ -169,8 +168,8 @@ TEST("skip(n) skips the first n elements in a range of size m") {
       check_eq(collect(range(1, 3).skip(2)), vector{3});
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 3)).skip(1)), vector{2, 3});
-      check_eq(collect(mat(range(1, 3)).skip(2)), vector{3});
+      check_eq(collect(build(range(1, 3)).skip(1)), vector{2, 3});
+      check_eq(collect(build(range(1, 3)).skip(2)), vector{3});
     }
   }
   SECTION("skip(n) drops all elements if n >= m") {
@@ -179,8 +178,8 @@ TEST("skip(n) skips the first n elements in a range of size m") {
       check_eq(collect(range(1, 3).skip(4)), nil);
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 3)).skip(3)), nil);
-      check_eq(collect(mat(range(1, 3)).skip(4)), nil);
+      check_eq(collect(build(range(1, 3)).skip(3)), nil);
+      check_eq(collect(build(range(1, 3)).skip(4)), nil);
     }
   }
   SECTION("skip(n) stops early when the next operator stops early") {
@@ -192,11 +191,11 @@ TEST("skip(n) skips the first n elements in a range of size m") {
       check_eq(collect(range(1, 5).skip(2).take(4)), vector{3, 4, 5});
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 5)).skip(2).take(0)), nil);
-      check_eq(collect(mat(range(1, 5)).skip(2).take(1)), vector{3});
-      check_eq(collect(mat(range(1, 5)).skip(2).take(2)), vector{3, 4});
-      check_eq(collect(mat(range(1, 5)).skip(2).take(3)), vector{3, 4, 5});
-      check_eq(collect(mat(range(1, 5)).skip(2).take(4)), vector{3, 4, 5});
+      check_eq(collect(build(range(1, 5)).skip(2).take(0)), nil);
+      check_eq(collect(build(range(1, 5)).skip(2).take(1)), vector{3});
+      check_eq(collect(build(range(1, 5)).skip(2).take(2)), vector{3, 4});
+      check_eq(collect(build(range(1, 5)).skip(2).take(3)), vector{3, 4, 5});
+      check_eq(collect(build(range(1, 5)).skip(2).take(4)), vector{3, 4, 5});
     }
   }
   SECTION("skip(n) forwards errors") {
@@ -205,8 +204,8 @@ TEST("skip(n) skips the first n elements in a range of size m") {
       check_eq(collect(obs_error().skip(1)), sec::runtime_error);
     }
     SECTION("observable") {
-      check_eq(collect(mat(obs_error()).skip(0)), sec::runtime_error);
-      check_eq(collect(mat(obs_error()).skip(1)), sec::runtime_error);
+      check_eq(collect(build(obs_error()).skip(0)), sec::runtime_error);
+      check_eq(collect(build(obs_error()).skip(1)), sec::runtime_error);
     }
   }
 }
@@ -219,9 +218,9 @@ TEST("first() returns the first element in a range of size m") {
       check_eq(collect(range(1, 3).first()), vector{1});
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 1)).first()), vector{1});
-      check_eq(collect(mat(range(1, 2)).first()), vector{1});
-      check_eq(collect(mat(range(1, 3)).first()), vector{1});
+      check_eq(collect(build(range(1, 1)).first()), vector{1});
+      check_eq(collect(build(range(1, 2)).first()), vector{1});
+      check_eq(collect(build(range(1, 3)).first()), vector{1});
     }
   }
   SECTION("first() returns an empty range if the input is empty") {
@@ -229,7 +228,7 @@ TEST("first() returns the first element in a range of size m") {
       check_eq(collect(range(1, 0).first()), nil);
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 0)).first()), nil);
+      check_eq(collect(build(range(1, 0)).first()), nil);
     }
   }
 }
@@ -242,9 +241,9 @@ TEST("last() returns the last element in a range of size m") {
       check_eq(collect(range(1, 3).last()), vector{3});
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 1)).last()), vector{1});
-      check_eq(collect(mat(range(1, 2)).last()), vector{2});
-      check_eq(collect(mat(range(1, 3)).last()), vector{3});
+      check_eq(collect(build(range(1, 1)).last()), vector{1});
+      check_eq(collect(build(range(1, 2)).last()), vector{2});
+      check_eq(collect(build(range(1, 3)).last()), vector{3});
     }
   }
   SECTION("last() returns an empty range if the input is empty") {
@@ -252,7 +251,7 @@ TEST("last() returns the last element in a range of size m") {
       check_eq(collect(range(1, 0).last()), nil);
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 0)).last()), nil);
+      check_eq(collect(build(range(1, 0)).last()), nil);
     }
   }
 }
@@ -266,65 +265,57 @@ TEST("on_error_complete() suppresses errors") {
       check_eq(collect(range(1, 0).on_error_complete()), nil);
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 1)).on_error_complete()), vector{1});
-      check_eq(collect(mat(range(1, 2)).on_error_complete()), vector{1, 2});
-      check_eq(collect(mat(range(1, 3)).on_error_complete()), vector{1, 2, 3});
-      check_eq(collect(mat(range(1, 0)).on_error_complete()), nil);
+      check_eq(collect(build(range(1, 1)).on_error_complete()), vector{1});
+      check_eq(collect(build(range(1, 2)).on_error_complete()), vector{1, 2});
+      check_eq(collect(build(range(1, 3)).on_error_complete()),
+               vector{1, 2, 3});
+      check_eq(collect(build(range(1, 0)).on_error_complete()), nil);
     }
   }
   SECTION("on_error_complete() does not propagate errors") {
     SECTION("blueprint") {
-      check_eq(collect(range(1, 1)
-                         .concat(obs_error(sec::runtime_error))
-                         .on_error_complete()),
+      check_eq(collect(range(1, 1).concat(obs_error()).on_error_complete()),
                vector{1});
-      check_eq(collect(range(1, 2)
-                         .concat(obs_error(sec::runtime_error))
-                         .on_error_complete()),
+      check_eq(collect(range(1, 2).concat(obs_error()).on_error_complete()),
                vector{1, 2});
-      check_eq(collect(range(1, 3)
-                         .concat(obs_error(sec::runtime_error))
-                         .on_error_complete()),
+      check_eq(collect(range(1, 3).concat(obs_error()).on_error_complete()),
                vector{1, 2, 3});
-      check_eq(collect(obs_error(sec::runtime_error).on_error_complete()), nil);
+      check_eq(collect(obs_error().on_error_complete()), nil);
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 1).concat(obs_error(sec::runtime_error)))
-                         .on_error_complete()),
+      check_eq(collect(
+                 build(range(1, 1).concat(obs_error())).on_error_complete()),
                vector{1});
-      check_eq(collect(mat(range(1, 2).concat(obs_error(sec::runtime_error)))
-                         .on_error_complete()),
+      check_eq(collect(
+                 build(range(1, 2).concat(obs_error())).on_error_complete()),
                vector{1, 2});
-      check_eq(collect(mat(range(1, 3).concat(obs_error(sec::runtime_error)))
-                         .on_error_complete()),
+      check_eq(collect(
+                 build(range(1, 3).concat(obs_error())).on_error_complete()),
                vector{1, 2, 3});
-      check_eq(collect(mat(obs_error(sec::runtime_error)).on_error_complete()),
-               nil);
+      check_eq(collect(build(obs_error()).on_error_complete()), nil);
     }
   }
   SECTION("on_error_complete() completes on error") {
     SECTION("blueprint") {
       check_eq(collect(range(1, 2)
-                         .concat(obs_error(sec::runtime_error))
+                         .concat(obs_error())
                          .concat(range(1, 2))
                          .on_error_complete()),
                vector{1, 2});
       check_eq(collect(range(1, 3)
-                         .concat(obs_error(sec::runtime_error))
+                         .concat(obs_error())
                          .concat(range(1, 3))
                          .on_error_complete()),
                vector{1, 2, 3});
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 2)
-                             .concat(obs_error(sec::runtime_error))
-                             .concat(range(1, 2)))
-                         .on_error_complete()),
+      check_eq(collect(
+                 build(range(1, 2).concat(obs_error()).concat(range(1, 2)))
+                   .on_error_complete()),
                vector{1, 2});
-      check_eq(collect(mat(range(1, 3)
-                             .concat(obs_error(sec::runtime_error))
-                             .concat(range(1, 3)))
-                         .on_error_complete()),
+      check_eq(collect(
+                 build(range(1, 3).concat(obs_error()).concat(range(1, 3)))
+                   .on_error_complete()),
                vector{1, 2, 3});
     }
   }
@@ -339,60 +330,52 @@ TEST("on_error_return_item() replaces an error with a value") {
       check_eq(collect(range(1, 0).on_error_return_item(42)), nil);
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 1)).on_error_return_item(42)), vector{1});
-      check_eq(collect(mat(range(1, 2)).on_error_return_item(42)),
+      check_eq(collect(build(range(1, 1)).on_error_return_item(42)), vector{1});
+      check_eq(collect(build(range(1, 2)).on_error_return_item(42)),
                vector{1, 2});
-      check_eq(collect(mat(range(1, 3)).on_error_return_item(42)),
+      check_eq(collect(build(range(1, 3)).on_error_return_item(42)),
                vector{1, 2, 3});
-      check_eq(collect(mat(range(1, 0)).on_error_return_item(42)), nil);
+      check_eq(collect(build(range(1, 0)).on_error_return_item(42)), nil);
     }
   }
   SECTION("on_error_return_item() returns the item when an error occurs") {
     SECTION("blueprint") {
-      check_eq(collect(range(1, 0)
-                         .concat(obs_error(sec::runtime_error))
-                         .on_error_return_item(42)),
-               vector{42});
+      check_eq(collect(obs_error().on_error_return_item(42)), vector{42});
       check_eq(collect(range(1, 2)
-                         .concat(obs_error(sec::runtime_error))
+                         .concat(obs_error())
                          .concat(range(1, 2))
                          .on_error_return_item(42)),
                vector{1, 2, 42});
       check_eq(collect(range(1, 3)
-                         .concat(obs_error(sec::runtime_error))
+                         .concat(obs_error())
                          .concat(range(1, 3))
                          .on_error_return_item(42)),
                vector{1, 2, 3, 42});
-      check_eq(collect(range(1, 2)
-                         .concat(obs_error(sec::runtime_error))
-                         .on_error_return_item(42)
-                         .take(2)),
-               vector{1, 2});
-      check_eq(collect(range(1, 3)
-                         .concat(obs_error(sec::runtime_error))
-                         .on_error_return_item(42)
-                         .take(3)),
-               vector{1, 2, 3});
+      check_eq(
+        collect(
+          range(1, 2).concat(obs_error()).on_error_return_item(42).take(2)),
+        vector{1, 2});
+      check_eq(
+        collect(
+          range(1, 3).concat(obs_error()).on_error_return_item(42).take(3)),
+        vector{1, 2, 3});
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 0).concat(obs_error(sec::runtime_error)))
-                         .on_error_return_item(42)),
+      check_eq(collect(build(obs_error()).on_error_return_item(42)),
                vector{42});
-      check_eq(collect(mat(range(1, 2)
-                             .concat(obs_error(sec::runtime_error))
-                             .concat(range(1, 2)))
-                         .on_error_return_item(42)),
+      check_eq(collect(
+                 build(range(1, 2).concat(obs_error()).concat(range(1, 2)))
+                   .on_error_return_item(42)),
                vector{1, 2, 42});
-      check_eq(collect(mat(range(1, 3)
-                             .concat(obs_error(sec::runtime_error))
-                             .concat(range(1, 3)))
-                         .on_error_return_item(42)),
+      check_eq(collect(
+                 build(range(1, 3).concat(obs_error()).concat(range(1, 3)))
+                   .on_error_return_item(42)),
                vector{1, 2, 3, 42});
-      check_eq(collect(mat(range(1, 2).concat(obs_error(sec::runtime_error)))
+      check_eq(collect(build(range(1, 2).concat(obs_error()))
                          .on_error_return_item(42)
                          .take(2)),
                vector{1, 2});
-      check_eq(collect(mat(range(1, 3).concat(obs_error(sec::runtime_error)))
+      check_eq(collect(build(range(1, 3).concat(obs_error()))
                          .on_error_return_item(42)
                          .take(3)),
                vector{1, 2, 3});
@@ -417,19 +400,19 @@ TEST("on_error_return() replaces an error with a value") {
                nil);
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 1)).on_error_return([](const error&) {
+      check_eq(collect(build(range(1, 1)).on_error_return([](const error&) {
                  return expected<int>{42};
                })),
                vector{1});
-      check_eq(collect(mat(range(1, 2)).on_error_return([](const error&) {
+      check_eq(collect(build(range(1, 2)).on_error_return([](const error&) {
                  return expected<int>{42};
                })),
                vector{1, 2});
-      check_eq(collect(mat(range(1, 3)).on_error_return([](const error&) {
+      check_eq(collect(build(range(1, 3)).on_error_return([](const error&) {
                  return expected<int>{42};
                })),
                vector{1, 2, 3});
-      check_eq(collect(mat(range(1, 0)).on_error_return([](const error&) {
+      check_eq(collect(build(range(1, 0)).on_error_return([](const error&) {
                  return expected<int>{42};
                })),
                nil);
@@ -438,50 +421,46 @@ TEST("on_error_return() replaces an error with a value") {
   SECTION("on_error_return() replaces an error with a value from the handler") {
     auto return_42 = [](const error&) { return expected<int>{42}; };
     SECTION("blueprint") {
-      check_eq(collect(range(1, 0)
-                         .concat(obs_error(sec::runtime_error))
-                         .on_error_return(return_42)),
+      check_eq(collect(
+                 range(1, 0).concat(obs_error()).on_error_return(return_42)),
                vector{42});
       check_eq(collect(range(1, 2)
-                         .concat(obs_error(sec::runtime_error))
+                         .concat(obs_error())
                          .concat(range(1, 2))
                          .on_error_return(return_42)),
                vector{1, 2, 42});
       check_eq(collect(range(1, 3)
-                         .concat(obs_error(sec::runtime_error))
+                         .concat(obs_error())
                          .concat(range(1, 3))
                          .on_error_return(return_42)),
                vector{1, 2, 3, 42});
-      check_eq(collect(range(1, 2)
-                         .concat(obs_error(sec::runtime_error))
-                         .on_error_return(return_42)
-                         .take(2)),
-               vector{1, 2});
-      check_eq(collect(range(1, 3)
-                         .concat(obs_error(sec::runtime_error))
-                         .on_error_return(return_42)
-                         .take(3)),
-               vector{1, 2, 3});
+      check_eq(
+        collect(
+          range(1, 2).concat(obs_error()).on_error_return(return_42).take(2)),
+        vector{1, 2});
+      check_eq(
+        collect(
+          range(1, 3).concat(obs_error()).on_error_return(return_42).take(3)),
+        vector{1, 2, 3});
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 0).concat(obs_error(sec::runtime_error)))
-                         .on_error_return(return_42)),
-               vector{42});
-      check_eq(collect(mat(range(1, 2)
-                             .concat(obs_error(sec::runtime_error))
-                             .concat(range(1, 2)))
-                         .on_error_return(return_42)),
+      check_eq(
+        collect(
+          build(range(1, 0).concat(obs_error())).on_error_return(return_42)),
+        vector{42});
+      check_eq(collect(
+                 build(range(1, 2).concat(obs_error()).concat(range(1, 2)))
+                   .on_error_return(return_42)),
                vector{1, 2, 42});
-      check_eq(collect(mat(range(1, 3)
-                             .concat(obs_error(sec::runtime_error))
-                             .concat(range(1, 3)))
-                         .on_error_return(return_42)),
+      check_eq(collect(
+                 build(range(1, 3).concat(obs_error()).concat(range(1, 3)))
+                   .on_error_return(return_42)),
                vector{1, 2, 3, 42});
-      check_eq(collect(mat(range(1, 2).concat(obs_error(sec::runtime_error)))
+      check_eq(collect(build(range(1, 2).concat(obs_error()))
                          .on_error_return(return_42)
                          .take(2)),
                vector{1, 2});
-      check_eq(collect(mat(range(1, 3).concat(obs_error(sec::runtime_error)))
+      check_eq(collect(build(range(1, 3).concat(obs_error()))
                          .on_error_return(return_42)
                          .take(3)),
                vector{1, 2, 3});
@@ -493,47 +472,42 @@ TEST("on_error_return() replaces an error with a value") {
     };
     auto return_err = [](const error& err) { return expected<int>{err}; };
     SECTION("blueprint") {
-      check_eq(collect(range(1, 0)
-                         .concat(obs_error(sec::runtime_error))
-                         .on_error_return(return_unexpected)),
+      check_eq(collect(obs_error().on_error_return(return_unexpected)),
                sec::unexpected_message);
       check_eq(collect(range(1, 2)
-                         .concat(obs_error(sec::runtime_error))
+                         .concat(obs_error())
                          .concat(range(1, 2))
                          .on_error_return(return_unexpected)),
                sec::unexpected_message);
       check_eq(collect(range(1, 3)
-                         .concat(obs_error(sec::runtime_error))
+                         .concat(obs_error())
                          .concat(range(1, 3))
                          .on_error_return(return_err)),
                sec::runtime_error);
-      check_eq(collect(range(1, 2)
-                         .concat(obs_error(sec::runtime_error))
-                         .on_error_return(return_err)),
+      check_eq(collect(
+                 range(1, 2).concat(obs_error()).on_error_return(return_err)),
                sec::runtime_error);
-      check_eq(collect(range(1, 3)
-                         .concat(obs_error(sec::runtime_error))
-                         .on_error_return(return_unexpected)),
-               sec::unexpected_message);
+      check_eq(
+        collect(
+          range(1, 3).concat(obs_error()).on_error_return(return_unexpected)),
+        sec::unexpected_message);
     }
     SECTION("observable") {
-      check_eq(collect(mat(range(1, 0).concat(obs_error(sec::runtime_error)))
-                         .on_error_return(return_unexpected)),
+      check_eq(collect(build(obs_error()).on_error_return(return_unexpected)),
                sec::unexpected_message);
-      check_eq(collect(mat(range(1, 2)
-                             .concat(obs_error(sec::runtime_error))
-                             .concat(range(1, 2)))
-                         .on_error_return(return_unexpected)),
+      check_eq(collect(
+                 build(range(1, 2).concat(obs_error()).concat(range(1, 2)))
+                   .on_error_return(return_unexpected)),
                sec::unexpected_message);
-      check_eq(collect(mat(range(1, 3)
-                             .concat(obs_error(sec::runtime_error))
-                             .concat(range(1, 3)))
-                         .on_error_return(return_err)),
+      check_eq(collect(
+                 build(range(1, 3).concat(obs_error()).concat(range(1, 3)))
+                   .on_error_return(return_err)),
                sec::runtime_error);
-      check_eq(collect(mat(range(1, 2).concat(obs_error(sec::runtime_error)))
-                         .on_error_return(return_err)),
-               sec::runtime_error);
-      check_eq(collect(mat(range(1, 3).concat(obs_error(sec::runtime_error)))
+      check_eq(
+        collect(
+          build(range(1, 2).concat(obs_error())).on_error_return(return_err)),
+        sec::runtime_error);
+      check_eq(collect(build(range(1, 3).concat(obs_error()))
                          .on_error_return(return_unexpected)),
                sec::unexpected_message);
     }

--- a/libcaf_core/caf/flow/observable.test.cpp
+++ b/libcaf_core/caf/flow/observable.test.cpp
@@ -384,46 +384,28 @@ TEST("on_error_return_item() replaces an error with a value") {
 }
 
 TEST("on_error_return() replaces an error with a value") {
+  auto return_42 = [](const error&) { return expected<int>{42}; };
   SECTION("on_error_return() does nothing if no error occurs") {
     SECTION("blueprint") {
-      check_eq(collect(range(1, 1).on_error_return(
-                 [](const error&) { return expected<int>{42}; })),
-               vector{1});
-      check_eq(collect(range(1, 2).on_error_return(
-                 [](const error&) { return expected<int>{42}; })),
-               vector{1, 2});
-      check_eq(collect(range(1, 3).on_error_return(
-                 [](const error&) { return expected<int>{42}; })),
+      check_eq(collect(range(1, 1).on_error_return(return_42)), vector{1});
+      check_eq(collect(range(1, 2).on_error_return(return_42)), vector{1, 2});
+      check_eq(collect(range(1, 3).on_error_return(return_42)),
                vector{1, 2, 3});
-      check_eq(collect(range(1, 0).on_error_return(
-                 [](const error&) { return expected<int>{42}; })),
-               nil);
+      check_eq(collect(range(1, 0).on_error_return(return_42)), nil);
     }
     SECTION("observable") {
-      check_eq(collect(build(range(1, 1)).on_error_return([](const error&) {
-                 return expected<int>{42};
-               })),
+      check_eq(collect(build(range(1, 1)).on_error_return(return_42)),
                vector{1});
-      check_eq(collect(build(range(1, 2)).on_error_return([](const error&) {
-                 return expected<int>{42};
-               })),
+      check_eq(collect(build(range(1, 2)).on_error_return(return_42)),
                vector{1, 2});
-      check_eq(collect(build(range(1, 3)).on_error_return([](const error&) {
-                 return expected<int>{42};
-               })),
+      check_eq(collect(build(range(1, 3)).on_error_return(return_42)),
                vector{1, 2, 3});
-      check_eq(collect(build(range(1, 0)).on_error_return([](const error&) {
-                 return expected<int>{42};
-               })),
-               nil);
+      check_eq(collect(build(range(1, 0)).on_error_return(return_42)), nil);
     }
   }
   SECTION("on_error_return() replaces an error with a value from the handler") {
-    auto return_42 = [](const error&) { return expected<int>{42}; };
     SECTION("blueprint") {
-      check_eq(collect(
-                 range(1, 0).concat(obs_error()).on_error_return(return_42)),
-               vector{42});
+      check_eq(collect(obs_error().on_error_return(return_42)), vector{42});
       check_eq(collect(range(1, 2)
                          .concat(obs_error())
                          .concat(range(1, 2))
@@ -444,10 +426,8 @@ TEST("on_error_return() replaces an error with a value") {
         vector{1, 2, 3});
     }
     SECTION("observable") {
-      check_eq(
-        collect(
-          build(range(1, 0).concat(obs_error())).on_error_return(return_42)),
-        vector{42});
+      check_eq(collect(build(obs_error()).on_error_return(return_42)),
+               vector{42});
       check_eq(collect(
                  build(range(1, 2).concat(obs_error()).concat(range(1, 2)))
                    .on_error_return(return_42)),

--- a/libcaf_core/caf/flow/observer.hpp
+++ b/libcaf_core/caf/flow/observer.hpp
@@ -116,6 +116,30 @@ private:
 template <class T>
 using observer_impl = typename observer<T>::impl;
 
+/// Calls `on_subscribe` and `on_error` on `out` to immediately fail a
+/// subscription.
+/// @relates observer
+template <class T>
+disposable fail_subscription(observer<T>& out, const error& err) {
+  auto sub = subscription::make_trivial();
+  out.on_subscribe(sub);
+  if (!sub.disposed())
+    out.on_error(err);
+  return sub.as_disposable();
+}
+
+/// Calls `on_subscribe` and `on_complete` on `out` to immediately complete a
+/// subscription.
+/// @relates observer
+template <class T>
+disposable empty_subscription(observer<T>& out) {
+  auto sub = subscription::make_trivial();
+  out.on_subscribe(sub);
+  if (!sub.disposed())
+    out.on_complete();
+  return sub.as_disposable();
+}
+
 /// Simple base type observer implementations that implements the reference
 /// counting member functions with a plain (i.e., not thread-safe) reference
 /// count.

--- a/libcaf_core/caf/flow/op/buffer.hpp
+++ b/libcaf_core/caf/flow/op/buffer.hpp
@@ -321,10 +321,9 @@ public:
     auto ptr = make_counted<buffer_sub<Trait>>(super::ctx_, max_items_, out);
     ptr->init(in_, select_);
     if (!ptr->running()) {
-      auto err = ptr->err().or_else(sec::runtime_error,
-                                    "failed to initialize buffer subscription");
-      out.on_error(err);
-      return {};
+      return fail_subscription(
+        out, ptr->err().or_else(sec::runtime_error,
+                                "failed to initialize buffer subscription"));
     }
     out.on_subscribe(subscription{ptr});
     return ptr->as_disposable();

--- a/libcaf_core/caf/flow/op/concat.hpp
+++ b/libcaf_core/caf/flow/op/concat.hpp
@@ -219,12 +219,11 @@ public:
 
   disposable subscribe(observer<T> out) override {
     if (inputs() == 0) {
-      return make_counted<empty<T>>(super::ctx_)->subscribe(std::move(out));
-    } else {
-      auto ptr = make_counted<concat_sub<T>>(super::ctx_, out, inputs_);
-      out.on_subscribe(subscription{ptr});
-      return ptr->as_disposable();
+      return empty_subscription(out);
     }
+    auto ptr = make_counted<concat_sub<T>>(super::ctx_, out, inputs_);
+    out.on_subscribe(subscription{ptr});
+    return ptr->as_disposable();
   }
 
 private:

--- a/libcaf_core/caf/flow/op/empty.hpp
+++ b/libcaf_core/caf/flow/op/empty.hpp
@@ -12,39 +12,6 @@
 
 namespace caf::flow::op {
 
-template <class T>
-class empty_sub : public subscription::impl_base {
-public:
-  // -- constructors, destructors, and assignment operators --------------------
-
-  empty_sub(coordinator* ctx, observer<T> out)
-    : ctx_(ctx), out_(std::move(out)) {
-    // nop
-  }
-
-  // -- implementation of subscription -----------------------------------------
-
-  bool disposed() const noexcept override {
-    return !out_;
-  }
-
-  void dispose() override {
-    if (out_)
-      ctx_->delay_fn([out = std::move(out_)]() mutable { out.on_complete(); });
-  }
-
-  void request(size_t) override {
-    dispose();
-  }
-
-private:
-  /// Stores the context (coordinator) that runs this flow.
-  coordinator* ctx_;
-
-  /// Stores a handle to the subscribed observer.
-  observer<T> out_;
-};
-
 /// An observable that represents an empty range. As soon as an observer
 /// requests values from this observable, it calls `on_complete`.
 template <class T>
@@ -65,9 +32,7 @@ public:
   // -- implementation of observable<T>::impl ----------------------------------
 
   disposable subscribe(observer<output_type> out) override {
-    auto ptr = make_counted<empty_sub<T>>(super::ctx_, out);
-    out.on_subscribe(subscription{ptr});
-    return disposable{std::move(ptr)};
+    return empty_subscription(out);
   }
 };
 

--- a/libcaf_core/caf/flow/op/fail.hpp
+++ b/libcaf_core/caf/flow/op/fail.hpp
@@ -12,6 +12,7 @@
 
 namespace caf::flow::op {
 
+/// Emits an error to the subscriber immediately after subscribing.
 template <class T>
 class fail : public cold<T> {
 public:
@@ -28,8 +29,7 @@ public:
   // -- implementation of observable_impl<T> -----------------------------------
 
   disposable subscribe(observer<T> out) override {
-    out.on_error(err_);
-    return {};
+    return fail_subscription(out, err_);
   }
 
 private:

--- a/libcaf_core/caf/flow/op/from_resource.hpp
+++ b/libcaf_core/caf/flow/op/from_resource.hpp
@@ -208,21 +208,17 @@ public:
         super::ctx_->watch(ptr->as_disposable());
         out.on_subscribe(subscription{ptr});
         return ptr->as_disposable();
-      } else {
-        resource_ = nullptr;
-        CAF_LOG_WARNING("failed to open an async resource");
-        auto err = make_error(sec::cannot_open_resource,
-                              "failed to open an async resource");
-        out.on_error(err);
-        return disposable{};
       }
-    } else {
-      CAF_LOG_WARNING("may only subscribe once to an async resource");
-      auto err = make_error(sec::too_many_observers,
-                            "may only subscribe once to an async resource");
-      out.on_error(err);
-      return disposable{};
+      resource_ = nullptr;
+      CAF_LOG_WARNING("failed to open an async resource");
+      return fail_subscription(out,
+                               make_error(sec::cannot_open_resource,
+                                          "failed to open an async resource"));
     }
+    CAF_LOG_WARNING("may only subscribe once to an async resource");
+    return fail_subscription(
+      out, make_error(sec::too_many_observers,
+                      "may only subscribe once to an async resource"));
   }
 
 private:

--- a/libcaf_core/caf/flow/op/mcast.hpp
+++ b/libcaf_core/caf/flow/op/mcast.hpp
@@ -196,12 +196,11 @@ public:
       auto ptr = make_counted<mcast_sub<T>>(super::ctx_, add_state(out));
       out.on_subscribe(subscription{ptr});
       return disposable{std::move(ptr)};
-    } else if (!err_) {
-      return make_counted<op::empty<T>>(super::ctx_)->subscribe(out);
-    } else {
-      out.on_error(err_);
-      return disposable{};
     }
+    if (!err_) {
+      return empty_subscription(out);
+    }
+    return fail_subscription(out, err_);
   }
 
   // -- implementation of ucast_sub_state_listener -----------------------------

--- a/libcaf_core/caf/flow/op/prefix_and_tail.hpp
+++ b/libcaf_core/caf/flow/op/prefix_and_tail.hpp
@@ -242,8 +242,8 @@ public:
   disposable subscribe(observer<tuple_t> out) override {
     using impl_t = prefix_and_tail_sub<T>;
     auto obs = make_counted<impl_t>(super::ctx(), out, prefix_size_);
-    decorated_.subscribe(observer<T>{obs});
     out.on_subscribe(subscription{obs});
+    decorated_.subscribe(observer<T>{obs});
     return obs->as_disposable();
   }
 

--- a/libcaf_core/caf/flow/subscription.cpp
+++ b/libcaf_core/caf/flow/subscription.cpp
@@ -45,4 +45,30 @@ void subscription::fwd_impl::dispose() {
   }
 }
 
+namespace {
+
+class trivial_subscription : public subscription::impl_base {
+public:
+  bool disposed() const noexcept override {
+    return disposed_;
+  }
+
+  void request(size_t) override {
+    // nop
+  }
+
+  void dispose() override {
+    disposed_ = true;
+  }
+
+private:
+  bool disposed_ = false;
+};
+
+} // namespace
+
+subscription subscription::make_trivial() {
+  return subscription{make_counted<trivial_subscription>()};
+}
+
 } // namespace caf::flow

--- a/libcaf_core/caf/flow/subscription.hpp
+++ b/libcaf_core/caf/flow/subscription.hpp
@@ -117,6 +117,12 @@ public:
   subscription& operator=(subscription&&) noexcept = default;
   subscription& operator=(const subscription&) noexcept = default;
 
+  // -- factory functions ------------------------------------------------------
+
+  /// Creates a trivial subscription that simply wraps a boolean flag and
+  /// ignores all requests.
+  static subscription make_trivial();
+
   // -- demand signaling -------------------------------------------------------
 
   /// Causes the publisher to stop producing items for the subscriber. Any

--- a/libcaf_test/caf/test/fixture/flow.hpp
+++ b/libcaf_test/caf/test/fixture/flow.hpp
@@ -211,9 +211,9 @@ public:
 
   // -- conversion functions ---------------------------------------------------
 
-  /// Materializes an observable by calling `as_observable` on it.
+  /// Builds a blueprint by calling `as_observable` on it.
   template <class Observable>
-  [[nodiscard]] static auto mat(Observable&& x) {
+  [[nodiscard]] static auto build(Observable&& x) {
     return std::forward<Observable>(x).as_observable();
   }
 


### PR DESCRIPTION
Observables must call on_subscribe before calling any other member function on an observer.

@shariarriday thanks for reporting this the other day. I finally found the time to look into this. I've also replaced several places in the `observables` test where we've concatenated an empty range with the `fail` operator to work around this bug previously. I've also renamed `mat` to `build` in the fixture. We'll probably implement https://reactivex.io/documentation/operators/materialize-dematerialize.html at some point, so we should not use "materialize" for something else. I'll also send a followup to rename the materializers in the flow API to builders.