### PR TITLE
Add start_with step for observables

### DIFF
--- a/libcaf_core/caf/flow/observable.hpp
+++ b/libcaf_core/caf/flow/observable.hpp
@@ -377,9 +377,9 @@ public:
   }
 
   /// @copydoc observable::start_with
-  template <class F>
-  auto start_with(F fn) && {
-    return materialize().start_with(std::forward<F>(fn));
+  template <class Input>
+  auto start_with(Input&& value) && {
+    return materialize().start_with(std::forward<Input>(value));
   }
 
   /// @copydoc observable::flat_map

--- a/libcaf_core/caf/flow/observable.hpp
+++ b/libcaf_core/caf/flow/observable.hpp
@@ -376,6 +376,12 @@ public:
     return materialize().concat(std::forward<Inputs>(xs)...);
   }
 
+  /// @copydoc observable::start_with
+  template <class F>
+  auto start_with(F fn) && {
+    return materialize().start_with(std::forward<F>(fn));
+  }
+
   /// @copydoc observable::flat_map
   template <class F>
   auto flat_map(F f) && {

--- a/libcaf_core/caf/flow/observable.test.cpp
+++ b/libcaf_core/caf/flow/observable.test.cpp
@@ -543,29 +543,58 @@ TEST("on_error_return() replaces an error with a value") {
   }
 }
 
-TEST("start_with(fn) makes an observable that emits output of fn()") {
-  const auto fn = [] { return 1; };
-  SECTION("start_with(fn) adds fn() as first element") {
+TEST("start_with(value) builds observable that emits value first") {
+  const auto value = 1;
+  SECTION("start_with(value) adds value as first element") {
     SECTION("blueprint") {
-      check_eq(collect(range(2, 3).start_with(fn)), vector{1, 2, 3, 4});
-      check_eq(collect(range(2, 3).start_with(fn).take(3)), vector{1, 2, 3});
-      check_eq(collect(range(2, 3).start_with(fn).first()), vector{1});
-      check_eq(collect(range(2, 3).start_with(fn).last()), vector{4});
+      check_eq(collect(range(2, 3).start_with(value)), vector{1, 2, 3, 4});
+      check_eq(collect(range(2, 3).start_with(value).take(3)), vector{1, 2, 3});
+      check_eq(collect(range(2, 3).start_with(value).first()), vector{1});
+      check_eq(collect(range(2, 3).start_with(value).last()), vector{4});
     }
     SECTION("observable") {
-      check_eq(collect(build(range(2, 3).start_with(fn))), vector{1, 2, 3, 4});
-      check_eq(collect(build(range(2, 3).start_with(fn).take(3))),
+      check_eq(collect(build(range(2, 3).start_with(value))),
+               vector{1, 2, 3, 4});
+      check_eq(collect(build(range(2, 3).start_with(value).take(3))),
                vector{1, 2, 3});
-      check_eq(collect(build(range(2, 3).start_with(fn).first())), vector{1});
-      check_eq(collect(build(range(2, 3).start_with(fn).last())), vector{4});
+      check_eq(collect(build(range(2, 3).start_with(value).first())),
+               vector{1});
+      check_eq(collect(build(range(2, 3).start_with(value).last())), vector{4});
     }
   }
-  SECTION("start_with(fn) forwards error)") {
+  SECTION("start_with(value) adds observable as first element") {
     SECTION("blueprint") {
-      check_eq(collect(obs_error().start_with(fn)), sec::runtime_error);
+      check_eq(collect(range(2, 3).start_with(range(1, 2))),
+               vector{1, 2, 2, 3, 4});
+      check_eq(collect(range(2, 3).start_with(make_observable().empty<int>())),
+               vector{2, 3, 4});
+      check_eq(collect(range(2, 3).start_with(range(1, 0))), vector{2, 3, 4});
     }
     SECTION("observable") {
-      check_eq(collect(build(obs_error().start_with(fn))), sec::runtime_error);
+      check_eq(collect(build(range(2, 3).start_with(range(1, 2)))),
+               vector{1, 2, 2, 3, 4});
+      check_eq(collect(
+                 build(range(2, 3).start_with(make_observable().empty<int>()))),
+               vector{2, 3, 4});
+      check_eq(collect(build(range(2, 3).start_with(range(1, 0)))),
+               vector{2, 3, 4});
+    }
+  }
+  SECTION("start_with(value) forwards error)") {
+    SECTION("blueprint") {
+      check_eq(collect(obs_error().start_with(value)), sec::runtime_error);
+      check_eq(collect(obs_error().start_with(range(1, 2))),
+               sec::runtime_error);
+      check_eq(collect(range(1, 2).start_with(obs_error())),
+               sec::runtime_error);
+    }
+    SECTION("observable") {
+      check_eq(collect(build(obs_error().start_with(value))),
+               sec::runtime_error);
+      check_eq(collect(build(obs_error().start_with(range(1, 2)))),
+               sec::runtime_error);
+      check_eq(collect(build(range(1, 2).start_with(obs_error()))),
+               sec::runtime_error);
     }
   }
 }

--- a/libcaf_core/caf/flow/observable.test.cpp
+++ b/libcaf_core/caf/flow/observable.test.cpp
@@ -545,22 +545,28 @@ TEST("on_error_return() replaces an error with a value") {
 
 TEST("start_with(fn) makes an observable that emits output of fn()") {
   const auto fn = [] { return 1; };
-  const auto make_start_with = [&](auto fn) {
-    return make_observable().start_with(fn);
-  };
-  SECTION("blueprint") {
-    check_eq(collect(make_start_with(fn)), vector{1});
-    check_eq(collect(make_start_with(fn).concat(range(2, 3))),
-             vector{1, 2, 3, 4});
-    check_eq(collect(make_start_with(fn).concat(range(2, 3)).take(3)),
-             vector{1, 2, 3});
+  SECTION("start_with(fn) adds fn() as first element") {
+    SECTION("blueprint") {
+      check_eq(collect(range(2, 3).start_with(fn)), vector{1, 2, 3, 4});
+      check_eq(collect(range(2, 3).start_with(fn).take(3)), vector{1, 2, 3});
+      check_eq(collect(range(2, 3).start_with(fn).first()), vector{1});
+      check_eq(collect(range(2, 3).start_with(fn).last()), vector{4});
+    }
+    SECTION("observable") {
+      check_eq(collect(build(range(2, 3).start_with(fn))), vector{1, 2, 3, 4});
+      check_eq(collect(build(range(2, 3).start_with(fn).take(3))),
+               vector{1, 2, 3});
+      check_eq(collect(build(range(2, 3).start_with(fn).first())), vector{1});
+      check_eq(collect(build(range(2, 3).start_with(fn).last())), vector{4});
+    }
   }
-  SECTION("observable") {
-    check_eq(collect(build(make_start_with(fn))), vector{1});
-    check_eq(collect(build(make_start_with(fn).concat(range(2, 3)))),
-             vector{1, 2, 3, 4});
-    check_eq(collect(build(make_start_with(fn).concat(range(2, 3)).take(3))),
-             vector{1, 2, 3});
+  SECTION("start_with(fn) forwards error)") {
+    SECTION("blueprint") {
+      check_eq(collect(obs_error().start_with(fn)), sec::runtime_error);
+    }
+    SECTION("observable") {
+      check_eq(collect(build(obs_error().start_with(fn))), sec::runtime_error);
+    }
   }
 }
 

--- a/libcaf_core/caf/flow/observable.test.cpp
+++ b/libcaf_core/caf/flow/observable.test.cpp
@@ -543,6 +543,27 @@ TEST("on_error_return() replaces an error with a value") {
   }
 }
 
+TEST("start_with(fn) makes an observable that emits output of fn()") {
+  const auto fn = [] { return 1; };
+  const auto make_start_with = [&](auto fn) {
+    return make_observable().start_with(fn);
+  };
+  SECTION("blueprint") {
+    check_eq(collect(make_start_with(fn)), vector{1});
+    check_eq(collect(make_start_with(fn).concat(range(2, 3))),
+             vector{1, 2, 3, 4});
+    check_eq(collect(make_start_with(fn).concat(range(2, 3)).take(3)),
+             vector{1, 2, 3});
+  }
+  SECTION("observable") {
+    check_eq(collect(build(make_start_with(fn))), vector{1});
+    check_eq(collect(build(make_start_with(fn).concat(range(2, 3)))),
+             vector{1, 2, 3, 4});
+    check_eq(collect(build(make_start_with(fn).concat(range(2, 3)).take(3))),
+             vector{1, 2, 3});
+  }
+}
+
 } // WITH_FIXTURE(test::fixture::flow)
 
 } // namespace

--- a/libcaf_core/caf/flow/observable_builder.hpp
+++ b/libcaf_core/caf/flow/observable_builder.hpp
@@ -136,12 +136,6 @@ public:
     return iota(init).take(num);
   }
 
-  /// Creates a @ref generation that emits `value` once by invoking fn.
-  template <class F>
-  auto start_with(F fn) const {
-    return just(fn());
-  }
-
   /// Creates an @ref observable that reads and emits all values from `res`.
   template <class T>
   observable<T> from_resource(async::consumer_resource<T> res) const {

--- a/libcaf_core/caf/flow/observable_builder.hpp
+++ b/libcaf_core/caf/flow/observable_builder.hpp
@@ -136,6 +136,12 @@ public:
     return iota(init).take(num);
   }
 
+  /// Creates a @ref generation that emits `value` once by invoking fn.
+  template <class F>
+  auto start_with(F fn) const {
+    return just(fn());
+  }
+
   /// Creates an @ref observable that reads and emits all values from `res`.
   template <class T>
   observable<T> from_resource(async::consumer_resource<T> res) const {

--- a/libcaf_core/caf/flow/observable_decl.hpp
+++ b/libcaf_core/caf/flow/observable_decl.hpp
@@ -178,6 +178,12 @@ public:
     return reduce(T{}, [](T x, T y) { return x + y; });
   }
 
+  /// Adds the output of fn() to the beginning of current observable.
+  template <class F>
+  auto start_with(F fn) {
+    return ctx()->make_observable().just(fn()).concat(*this);
+  }
+
   /// Collects all values and emits all values at once in a @ref cow_vector.
   auto to_vector() {
     using vector_type = cow_vector<output_type>;

--- a/libcaf_core/caf/flow/observable_decl.hpp
+++ b/libcaf_core/caf/flow/observable_decl.hpp
@@ -178,7 +178,7 @@ public:
     return reduce(T{}, [](T x, T y) { return x + y; });
   }
 
-  /// Adds the output of fn() to the beginning of current observable.
+  /// Adds a value or observable to the beginning of current observable.
   template <class Input>
   auto start_with(Input value) {
     if constexpr (is_observable_v<Input>)

--- a/libcaf_core/caf/flow/observable_decl.hpp
+++ b/libcaf_core/caf/flow/observable_decl.hpp
@@ -179,9 +179,12 @@ public:
   }
 
   /// Adds the output of fn() to the beginning of current observable.
-  template <class F>
-  auto start_with(F fn) {
-    return ctx()->make_observable().just(fn()).concat(*this);
+  template <class Input>
+  auto start_with(Input value) {
+    if constexpr (is_observable_v<Input>)
+      return std::move(value).concat(*this);
+    else
+      return parent()->make_observable().just(std::move(value)).concat(*this);
   }
 
   /// Collects all values and emits all values at once in a @ref cow_vector.


### PR DESCRIPTION
@Neverlord you had mentioned that this can be implemented as `just(x).concat(*this)`. But, upon reading the documentation for this step it looks that the only difference between `just()` and `start_with()` is that `start_with` expects a function that outputs `x`.

Relates https://github.com/actor-framework/actor-framework/issues/1389