### PR TITLE
Simplify interface of detail::sync_ring_buffer

### DIFF
--- a/libcaf_core/caf/detail/sync_ring_buffer.hpp
+++ b/libcaf_core/caf/detail/sync_ring_buffer.hpp
@@ -7,9 +7,9 @@
 #include "caf/config.hpp"
 
 #include <array>
-#include <atomic>
 #include <condition_variable>
 #include <mutex>
+#include <optional>
 
 namespace caf::detail {
 
@@ -24,81 +24,58 @@ public:
     // nop
   }
 
-  void wait_nonempty() {
-    // Double-checked locking to reduce contention on mtx_.
-    if (!empty())
-      return;
-    guard_type guard{mtx_};
-    while (empty())
-      cv_empty_.wait(guard);
-  }
-
-  template <class TimePoint>
-  bool wait_nonempty(TimePoint timeout) {
-    if (!empty())
-      return true;
-    auto pred = [&] { return !empty(); };
-    guard_type guard{mtx_};
-    return cv_empty_.wait_until(guard, timeout, pred);
-  }
-
-  T& front() {
-    // Safe to access without lock, because we assume a single consumer.
-    return buf_[rd_pos_];
-  }
-
-  void pop_front() {
-    guard_type guard{mtx_};
-    auto rp = rd_pos_.load();
-    rd_pos_ = next(rp);
-    // Wakeup a waiting producers if the queue became non-full.
-    if (rp == next(wr_pos_))
-      cv_full_.notify_all();
-  }
-
-  template <class OutputIterator>
-  OutputIterator get_all(OutputIterator i) {
-    // No lock needed, again because of single-consumer assumption.
-    auto first = rd_pos_.load();
-    auto last = wr_pos_.load();
-    size_t n;
-    CAF_ASSERT(first != last);
-    // Move buffer content to the output iterator.
-    if (first < last) {
-      n = last - first;
-      for (auto j = first; j != last; ++j)
-        *i++ = std::move(buf_[j]);
-    } else {
-      n = (Size - first) + last;
-      for (size_t j = first; j != Size; ++j)
-        *i++ = std::move(buf_[j]);
-      for (size_t j = 0; j != last; ++j)
-        *i++ = std::move(buf_[j]);
-    }
-    guard_type guard{mtx_};
-    rd_pos_ = (first + n) % Size;
-    // Wakeup a waiting producers if the queue became non-full.
-    if (first == next(wr_pos_))
-      cv_full_.notify_all();
-    return i;
-  }
-
-  void push_back(T&& x) {
+  /// Enqueues a new element at the end of the queue. If the queue is full,
+  /// this function blocks until space becomes available.
+  void push(T&& value) {
     guard_type guard{mtx_};
     while (full())
       cv_full_.wait(guard);
-    auto wp = wr_pos_.load();
-    buf_[wp] = std::move(x);
-    wr_pos_ = next(wp);
-    if (rd_pos_ == wp)
+    auto was_empty = empty();
+    buf_[wr_pos_] = std::move(value);
+    wr_pos_ = next(wr_pos_);
+    if (was_empty)
       cv_empty_.notify_all();
   }
 
-  template <class... Us>
-  void emplace_back(Us&&... xs) {
-    push_back(T{std::forward<Us>(xs)...});
+  /// Checks whether the queue currently has at least one element.
+  bool can_push() const {
+    guard_type guard{mtx_};
+    return !full();
   }
 
+  /// Dequeues the next element from the queue. If the queue is empty, this
+  /// function blocks until an element is available.
+  T pop() {
+    guard_type guard{mtx_};
+    while (empty())
+      cv_empty_.wait(guard);
+    auto was_full = full();
+    auto result = std::move(buf_[rd_pos_]);
+    rd_pos_ = next(rd_pos_);
+    if (was_full)
+      cv_full_.notify_all();
+    return result;
+  }
+
+  /// Dequeues the next element from the queue. If the queue is empty, this
+  /// function blocks until an element is available or the timeout expires.
+  template <class TimePoint>
+  std::optional<T> try_pop(TimePoint timeout) {
+    guard_type guard{mtx_};
+    if (empty()) {
+      auto pred = [this] { return !empty(); };
+      if (!cv_empty_.wait_until(guard, timeout, pred))
+        return std::nullopt;
+    }
+    auto was_full = full();
+    auto result = std::move(buf_[rd_pos_]);
+    rd_pos_ = next(rd_pos_);
+    if (was_full)
+      cv_full_.notify_all();
+    return result;
+  }
+
+private:
   bool empty() const noexcept {
     return rd_pos_ == wr_pos_;
   }
@@ -107,17 +84,6 @@ public:
     return rd_pos_ == next(wr_pos_);
   }
 
-  size_t size() const noexcept {
-    auto rp = rd_pos_.load();
-    auto wp = wr_pos_.load();
-    if (rp == wp)
-      return 0;
-    if (rp < wp)
-      return wp - rp;
-    return Size - rp + wp;
-  }
-
-private:
   static size_t next(size_t pos) {
     return (pos + 1) % Size;
   }
@@ -132,10 +98,10 @@ private:
   std::condition_variable cv_full_;
 
   // Stores the current write position in the ringbuffer.
-  std::atomic<size_t> wr_pos_;
+  size_t wr_pos_;
 
   // Stores the current read position in the ringbuffer.
-  std::atomic<size_t> rd_pos_;
+  size_t rd_pos_;
 
   // Stores events in a circular ringbuffer.
   std::array<T, Size> buf_;

--- a/libcaf_core/caf/detail/sync_ring_buffer.test.cpp
+++ b/libcaf_core/caf/detail/sync_ring_buffer.test.cpp
@@ -11,102 +11,54 @@
 #include <vector>
 
 using namespace caf;
+using namespace std::literals;
 
 namespace {
 
 constexpr size_t int_buffer_size = 64;
 
-using int_buffer = detail::sync_ring_buffer<int, int_buffer_size>;
+using string_queue = detail::sync_ring_buffer<std::string, int_buffer_size>;
 
-std::vector<int> consumer(int_buffer& buf, size_t num) {
+std::vector<int> consumer(string_queue* queue, size_t num) {
   std::vector<int> result;
   for (size_t i = 0; i < num; ++i) {
-    buf.wait_nonempty();
-    result.emplace_back(buf.front());
-    buf.pop_front();
+    result.emplace_back(atoi(queue->pop().c_str()));
   }
   return result;
 }
 
-void producer(int_buffer& buf, int first, int last) {
-  for (auto i = first; i != last; ++i) // NOLINT(bugprone-use-after-move)
-    buf.push_back(std::move(i));
+void producer(string_queue* queue, int first, int last) {
+  for (auto i = first; i != last; ++i)
+    queue->push(std::to_string(i));
 }
 
 TEST("a default-constructed ring buffer is empty") {
-  int_buffer buf;
-  check(buf.empty());
-  check(!buf.full());
-  check_eq(buf.size(), 0u);
+  string_queue queue;
+  auto now = std::chrono::steady_clock::now();
+  check_eq(queue.try_pop(now), std::nullopt);
 }
 
-TEST("push_back adds one element to the ring buffer") {
-  int_buffer buf;
-  print_debug("add one element");
-  buf.push_back(42);
-  check(!buf.empty());
-  check(!buf.full());
-  check_eq(buf.size(), 1u);
-  check_eq(buf.front(), 42);
-  print_debug("remove element");
-  buf.pop_front();
-  check(buf.empty());
-  check(!buf.full());
-  check_eq(buf.size(), 0u);
-  print_debug("fill buffer");
-  // NOLINTNEXTLINE(bugprone-use-after-move)
-  for (int i = 0; i < static_cast<int>(int_buffer_size - 1); ++i)
-    buf.push_back(std::move(i));
-  check(!buf.empty());
-  check(buf.full());
-  check_eq(buf.size(), int_buffer_size - 1);
-  check_eq(buf.front(), 0);
-}
-
-TEST("get_all returns all elements from the ring buffer") {
-  int_buffer buf;
-  using array_type = std::array<int, int_buffer_size>;
-  using vector_type = std::vector<int>;
-  array_type tmp;
-  auto fetch_all = [&] {
-    auto i = tmp.begin();
-    auto e = buf.get_all(i);
-    return vector_type(i, e);
-  };
-  print_debug("add five element");
-  for (int i = 0; i < 5; ++i) // NOLINT(bugprone-use-after-move)
-    buf.push_back(std::move(i));
-  check(!buf.empty());
-  check(!buf.full());
-  check_eq(buf.size(), 5u);
-  check_eq(buf.front(), 0);
-  print_debug("drain elements");
-  check_eq(fetch_all(), vector_type({0, 1, 2, 3, 4}));
-  check(buf.empty());
-  check(!buf.full());
-  check_eq(buf.size(), 0u);
-  print_debug("add 60 elements (wraps around)");
-  vector_type expected;
-  for (int i = 0; i < 60; ++i) { // NOLINT(bugprone-use-after-move)
-    expected.push_back(i);
-    buf.push_back(std::move(i));
-  }
-  check_eq(buf.size(), 60u);
-  check_eq(fetch_all(), expected);
-  check(buf.empty());
-  check(!buf.full());
-  check_eq(buf.size(), 0u);
+TEST("push adds one element to the ring buffer") {
+  string_queue queue;
+  queue.push("hello");
+  auto now = std::chrono::steady_clock::now();
+  check_eq(queue.try_pop(now), "hello"s);
+  check_eq(queue.try_pop(now), std::nullopt);
 }
 
 TEST("sync_ring_buffer can be used with multiple producers") {
-  int_buffer buf;
+  string_queue queue;
   std::vector<std::thread> producers;
-  producers.emplace_back(producer, std::ref(buf), 0, 100);
-  producers.emplace_back(producer, std::ref(buf), 100, 200);
-  producers.emplace_back(producer, std::ref(buf), 200, 300);
-  auto vec = consumer(buf, 300);
+  // Start three producers that push 100 elements each.
+  producers.emplace_back(producer, &queue, 0, 100);
+  producers.emplace_back(producer, &queue, 100, 200);
+  producers.emplace_back(producer, &queue, 200, 300);
+  // Wait until the queue is full to his the blocking paths in push.
+  while (queue.can_push())
+    std::this_thread::sleep_for(1ms);
+  // Consume all elements and check whether we got all of them.
+  auto vec = consumer(&queue, 300);
   std::sort(vec.begin(), vec.end());
-  check(std::is_sorted(vec.begin(), vec.end()));
   check_eq(vec.size(), 300u);
   check_eq(vec.front(), 0);
   check_eq(vec.back(), 299);

--- a/libcaf_core/caf/detail/thread_safe_actor_clock.cpp
+++ b/libcaf_core/caf/detail/thread_safe_actor_clock.cpp
@@ -13,52 +13,55 @@
 
 namespace caf::detail {
 
-thread_safe_actor_clock::thread_safe_actor_clock() {
-  tbl_.reserve(buffer_size * 2);
-}
-
 disposable thread_safe_actor_clock::schedule(time_point abs_time, action f) {
-  queue_.emplace_back(schedule_entry_ptr{new schedule_entry{abs_time, f}});
+  queue_.push(schedule_entry_ptr{new schedule_entry{abs_time, f}});
   return std::move(f).as_disposable();
 }
 
-void thread_safe_actor_clock::run() {
+void thread_safe_actor_clock::run(queue_type* queue) {
   CAF_LOG_TRACE("");
+  std::vector<schedule_entry_ptr> tbl;
+  tbl.reserve(buffer_size * 2);
   auto is_disposed = [](auto& x) { return !x || x->f.disposed(); };
   auto by_timeout = [](auto& x, auto& y) { return x->t < y->t; };
-  while (running_) {
+
+  for (;;) {
     // Fetch additional scheduling requests from the queue.
-    if (tbl_.empty()) {
-      queue_.wait_nonempty();
-      queue_.get_all(std::back_inserter(tbl_));
-      std::sort(tbl_.begin(), tbl_.end(), by_timeout);
+    if (tbl.empty()) {
+      auto ptr = queue->pop();
+      if (!ptr)
+        return;
+      tbl.emplace_back(std::move(ptr));
     } else {
-      auto next_timeout = (*tbl_.begin())->t;
-      if (queue_.wait_nonempty(next_timeout)) {
-        queue_.get_all(std::back_inserter(tbl_));
-        std::sort(tbl_.begin(), tbl_.end(), by_timeout);
+      auto next_timeout = (*tbl.begin())->t;
+      if (auto maybe_ptr = queue->try_pop(next_timeout)) {
+        if (!*maybe_ptr)
+          return;
+        auto insert_pos = std::upper_bound(tbl.begin(), tbl.end(), *maybe_ptr,
+                                           by_timeout);
+        tbl.insert(insert_pos, std::move(*maybe_ptr));
       }
     }
     // Run all actions that timed out.
-    auto n = now();
-    auto i = tbl_.begin();
-    for (; i != tbl_.end() && (*i)->t <= n; ++i)
+    auto n = clock_type::now();
+    auto i = tbl.begin();
+    for (; i != tbl.end() && (*i)->t <= n; ++i)
       (*i)->f.run();
     // Here, we have [begin, i) be the actions that were executed. Move any
     // already disposed action also to the beginning so that we can erase them
     // at once.
-    i = std::stable_partition(i, tbl_.end(), is_disposed);
-    tbl_.erase(tbl_.begin(), i);
+    i = std::stable_partition(i, tbl.end(), is_disposed);
+    tbl.erase(tbl.begin(), i);
   }
 }
 
 void thread_safe_actor_clock::start_dispatch_loop(caf::actor_system& sys) {
   dispatcher_ = sys.launch_thread("caf.clock", thread_owner::system,
-                                  [this] { run(); });
+                                  [qptr = &queue_] { run(qptr); });
 }
 
 void thread_safe_actor_clock::stop_dispatch_loop() {
-  schedule(make_action([this] { running_ = false; }));
+  queue_.push(nullptr);
   dispatcher_.join();
 }
 

--- a/libcaf_core/caf/detail/thread_safe_actor_clock.hpp
+++ b/libcaf_core/caf/detail/thread_safe_actor_clock.hpp
@@ -36,10 +36,6 @@ public:
   /// @relates schedule_entry
   using schedule_entry_ptr = std::unique_ptr<schedule_entry>;
 
-  // -- constructors, destructors, and assignment operators --------------------
-
-  thread_safe_actor_clock();
-
   // -- overrides --------------------------------------------------------------
 
   using super::schedule;
@@ -53,7 +49,12 @@ public:
   void stop_dispatch_loop();
 
 private:
-  void run();
+  // -- member types -----------------------------------------------------------
+  using queue_type = detail::sync_ring_buffer<schedule_entry_ptr, buffer_size>;
+
+  // -- internal API -----------------------------------------------------------
+
+  static void run(queue_type* queue);
 
   // -- member variables -------------------------------------------------------
 
@@ -62,12 +63,6 @@ private:
 
   /// Handle to the dispatcher thread.
   std::thread dispatcher_;
-
-  /// Internal data of the dispatcher.
-  bool running_ = true;
-
-  /// Internal data of the dispatcher.
-  std::vector<schedule_entry_ptr> tbl_;
 };
 
 } // namespace caf::detail


### PR DESCRIPTION
We use the sync ring buffer in the logger as well as in the actor clock. The interface made it hard and error-prone to use, which bugged me for a while now. The new API is much more simple, consisting of just `push`, `pop` and `try_pop`.