### PR TITLE
Allow checking for custom logger factories

### DIFF
--- a/libcaf_core/caf/actor_system.cpp
+++ b/libcaf_core/caf/actor_system.cpp
@@ -268,7 +268,7 @@ actor_system::actor_system(actor_system_config& cfg)
     ids_(0),
     metrics_(cfg),
     base_metrics_(make_base_metrics(metrics_)),
-    logger_(cfg.logger_factory_(*this)),
+    logger_(cfg.make_logger(*this)),
     registry_(*this),
     groups_(*this),
     dummy_execution_unit_(this),

--- a/libcaf_core/caf/actor_system_config.cpp
+++ b/libcaf_core/caf/actor_system_config.cpp
@@ -33,6 +33,8 @@ constexpr std::string_view default_config_file = "caf-application.conf";
 
 } // namespace
 
+// -- constructors, destructors, and assignment operators ----------------------
+
 actor_system_config::~actor_system_config() {
   // nop
 }
@@ -42,8 +44,6 @@ actor_system_config::~actor_system_config() {
 
 actor_system_config::actor_system_config()
   : program_name(default_program_name), config_file_path(default_config_file) {
-  // Set default factories.
-  logger_factory_ = +[](actor_system& sys) { return logger::make(sys); };
   // Fill our options vector for creating config file and CLI parsers.
   using std::string;
   using string_list = std::vector<string>;
@@ -88,6 +88,8 @@ actor_system_config::actor_system_config()
     .add<string_list>("excludes", "excludes actors from run-time metrics");
 }
 
+// -- properties ---------------------------------------------------------------
+
 settings actor_system_config::dump_content() const {
   settings result = content;
   // Hide options that make no sense in a config file.
@@ -131,6 +133,8 @@ settings actor_system_config::dump_content() const {
   put_missing(console_group, "excluded-components", std::vector<std::string>{});
   return result;
 }
+
+// -- modifiers ----------------------------------------------------------------
 
 error actor_system_config::parse(int argc, char** argv) {
   string_list args;
@@ -486,6 +490,15 @@ detail::mailbox_factory* actor_system_config::mailbox_factory() {
 
 const settings& content(const actor_system_config& cfg) {
   return cfg.content;
+}
+
+// -- factories ----------------------------------------------------------------
+
+intrusive_ptr<logger>
+actor_system_config::make_logger(actor_system& sys) const {
+  if (logger_factory_)
+    return logger_factory_(sys);
+  return logger::make(sys);
 }
 
 } // namespace caf

--- a/libcaf_core/caf/actor_system_config.hpp
+++ b/libcaf_core/caf/actor_system_config.hpp
@@ -173,11 +173,20 @@ public:
   /// Overrides the default logger factory.
   /// @pre `new_factory != nullptr`
   actor_system_config& logger_factory(logger_factory_t new_factory) {
-    if (new_factory == nullptr)
-      CAF_RAISE_ERROR(std::invalid_argument, "logger factory may not be null");
     logger_factory_ = std::move(new_factory);
     return *this;
   }
+
+  /// Checks whether this config contains a custom logger factory.
+  bool has_logger_factory() const noexcept {
+    return logger_factory_ != nullptr;
+  }
+
+  // -- factories --------------------------------------------------------------
+
+  /// Creates a new logger for `sys`. Either uses the user-defined logger
+  /// factory or the default logger factory.
+  intrusive_ptr<logger> make_logger(actor_system& sys) const;
 
   // -- parser and CLI state ---------------------------------------------------
 


### PR DESCRIPTION
Currently, it's not possible to check whether a custom logger factory has been installed. This prevents use cases where a module (or library on top of CAF) wants to provide it's own default logger factory that should be installed only if the user didn't already install a custom logger.