### PR TITLE
Get rid of make_scope_guard

### DIFF
--- a/libcaf_core/caf/blocking_actor.cpp
+++ b/libcaf_core/caf/blocking_actor.cpp
@@ -279,8 +279,8 @@ void blocking_actor::receive_impl(receive_cond& rcc, message_id mid,
     // Blocking actors can nest receives => push/pop `current_element_`
     auto prev_element = current_element_;
     current_element_ = ptr.get();
-    auto g = detail::make_scope_guard(
-      [&]() noexcept { current_element_ = prev_element; });
+    auto g = detail::scope_guard{
+      [&]() noexcept { current_element_ = prev_element; }};
     // Dispatch on the current mailbox element.
     if (consume()) {
       unstash();

--- a/libcaf_core/caf/config_value.cpp
+++ b/libcaf_core/caf/config_value.cpp
@@ -198,12 +198,11 @@ error_code<sec> config_value::default_construct(type_id_t id) {
       return sec::none;
     default:
       if (auto meta = detail::global_meta_object_or_null(id)) {
-        using detail::make_scope_guard;
         auto ptr = malloc(meta->padded_size);
-        auto free_guard = make_scope_guard([ptr]() noexcept { free(ptr); });
+        auto free_guard = detail::scope_guard{[ptr]() noexcept { free(ptr); }};
         meta->default_construct(ptr);
         auto destroy_guard
-          = make_scope_guard([=]() noexcept { meta->destroy(ptr); });
+          = detail::scope_guard{[=]() noexcept { meta->destroy(ptr); }};
         config_value_writer writer{this};
         if (meta->save(writer, ptr)) {
           return sec::none;

--- a/libcaf_core/caf/flow/op/from_steps.hpp
+++ b/libcaf_core/caf/flow/op/from_steps.hpp
@@ -202,14 +202,13 @@ private:
     //       during the entire execution of do_run_impl. Otherwise, we might
     //       trigger a heap-use-after-free.
     ref();
-    auto guard = detail::make_scope_guard([this]() noexcept { deref(); });
+    auto guard = detail::scope_guard{[this]() noexcept { deref(); }};
     running_ = true;
     do_run_impl();
   }
 
   void do_run_impl() {
-    auto guard
-      = detail::make_scope_guard([this]() noexcept { running_ = false; });
+    auto guard = detail::scope_guard{[this]() noexcept { running_ = false; }};
     if (!disposed_) {
       CAF_ASSERT(out_);
       while (demand_ > 0 && !buf_.empty()) {

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -280,12 +280,12 @@ resumable::resume_result scheduled_actor::resume(execution_unit* ctx,
   if (!activate(ctx))
     return resumable::done;
   size_t consumed = 0;
-  auto guard = detail::make_scope_guard([this, &consumed]() noexcept {
+  auto guard = detail::scope_guard{[this, &consumed]() noexcept {
     if (consumed > 0) {
       auto val = static_cast<int64_t>(consumed);
       home_system().base_metrics().processed_messages->inc(val);
     }
-  });
+  }};
   auto reset_timeouts_if_needed = [&] {
     // Set a new receive timeout if we called our behavior at least once.
     if (consumed > 0)

--- a/libcaf_core/tests/legacy/dsl.cpp
+++ b/libcaf_core/tests/legacy/dsl.cpp
@@ -251,8 +251,8 @@ SCENARIO("passing requirements increment the 'good' counter") {
     if (true) {                                                                \
       auto silent_expr = [&] {                                                 \
         auto bk = caf::test::logger::instance().make_quiet();                  \
-        auto guard = caf::detail::make_scope_guard(                            \
-          [bk]() noexcept { caf::test::logger::instance().levels(bk); });      \
+        auto guard = caf::detail::scope_guard{                                 \
+          [bk]() noexcept { caf::test::logger::instance().levels(bk); }};      \
         expr;                                                                  \
       };                                                                       \
       CHECK_THROWS_AS(silent_expr(), test::requirement_error);                 \

--- a/libcaf_io/caf/io/basp/remote_message_handler.hpp
+++ b/libcaf_io/caf/io/basp/remote_message_handler.hpp
@@ -42,8 +42,8 @@ public:
     auto mid = make_message_id(dref.hdr_.operation_data);
     binary_deserializer source{ctx, dref.payload_};
     // Make sure to drop the message in case we return abnormally.
-    auto guard = detail::make_scope_guard(
-      [&]() noexcept { dref.queue_->drop(ctx, dref.msg_id_); });
+    auto guard = detail::scope_guard{
+      [&]() noexcept { dref.queue_->drop(ctx, dref.msg_id_); }};
     // Registry setup.
     dref.proxies_->set_last_hop(&dref.last_hop_);
     // Get the local receiver.

--- a/libcaf_io/caf/io/basp_broker.cpp
+++ b/libcaf_io/caf/io/basp_broker.cpp
@@ -426,8 +426,8 @@ proxy_registry* basp_broker::proxy_registry_ptr() {
 
 resumable::resume_result basp_broker::resume(execution_unit* ctx, size_t mt) {
   ctx->proxy_registry_ptr(&instance.proxies());
-  auto guard = detail::make_scope_guard(
-    [=]() noexcept { ctx->proxy_registry_ptr(nullptr); });
+  auto guard
+    = detail::scope_guard{[=]() noexcept { ctx->proxy_registry_ptr(nullptr); }};
   return super::resume(ctx, mt);
 }
 

--- a/libcaf_io/caf/io/broker_servant.hpp
+++ b/libcaf_io/caf/io/broker_servant.hpp
@@ -65,10 +65,10 @@ protected:
     auto pfac = self->proxy_registry_ptr();
     if (pfac)
       ctx->proxy_registry_ptr(pfac);
-    auto guard = detail::make_scope_guard([=]() noexcept {
+    auto guard = detail::scope_guard{[=]() noexcept {
       if (pfac)
         ctx->proxy_registry_ptr(nullptr);
-    });
+    }};
     self->activate(ctx, x);
   }
 

--- a/libcaf_io/caf/io/network/native_socket.cpp
+++ b/libcaf_io/caf/io/network/native_socket.cpp
@@ -294,13 +294,13 @@ std::pair<native_socket, native_socket> create_pipe() {
   a.inaddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
   a.inaddr.sin_port = 0;
   // makes sure all sockets are closed in case of an error
-  auto guard = detail::make_scope_guard([&]() noexcept {
+  auto guard = detail::scope_guard{[&]() noexcept {
     auto e = WSAGetLastError();
     close_socket(listener);
     close_socket(socks[0]);
     close_socket(socks[1]);
     WSASetLastError(e);
-  });
+  }};
   // bind listener to a local port
   int reuse = 1;
   CALL_CRITICAL_CFUN(tmp1, detail::cc_zero, "setsockopt",

--- a/libcaf_net/caf/net/pipe_socket.cpp
+++ b/libcaf_net/caf/net/pipe_socket.cpp
@@ -53,10 +53,10 @@ expected<std::pair<pipe_socket, pipe_socket>> make_pipe() {
   if (pipe(pipefds) != 0)
     return make_error(sec::network_syscall_failed, "pipe",
                       last_socket_error_as_string());
-  auto guard = detail::make_scope_guard([&]() noexcept {
+  auto guard = detail::scope_guard{[&]() noexcept {
     close(socket{pipefds[0]});
     close(socket{pipefds[1]});
-  });
+  }};
   // Note: for pipe2 it is better to avoid races by setting CLOEXEC (but not on
   // POSIX).
   if (auto err = child_process_inherit(socket{pipefds[0]}, false))

--- a/libcaf_net/caf/net/stream_socket.cpp
+++ b/libcaf_net/caf/net/stream_socket.cpp
@@ -69,13 +69,13 @@ expected<std::pair<stream_socket, stream_socket>> make_stream_socket_pair() {
   a.inaddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
   a.inaddr.sin_port = 0;
   // makes sure all sockets are closed in case of an error
-  auto guard = detail::make_scope_guard([&]() noexcept {
+  auto guard = detail::scope_guard{[&]() noexcept {
     auto e = WSAGetLastError();
     close(socket{listener});
     close(socket{socks[0]});
     close(socket{socks[1]});
     WSASetLastError(e);
-  });
+  }};
   // bind listener to a local port
   int reuse = 1;
   CAF_NET_SYSCALL("setsockopt", tmp1, !=, 0,

--- a/libcaf_net/tests/legacy/net/ssl/transport.cpp
+++ b/libcaf_net/tests/legacy/net/ssl/transport.cpp
@@ -109,7 +109,7 @@ void dummy_tls_server(stream_socket fd, const char* cert_file,
   namespace ssl = caf::net::ssl;
   multiplexer::block_sigpipe();
   // Make sure we close our socket.
-  auto guard = detail::make_scope_guard([fd]() noexcept { close(fd); });
+  auto guard = detail::scope_guard{[fd]() noexcept { close(fd); }};
   // Get and configure our SSL context.
   auto ctx = unbox(ssl::context::make_server(ssl::tls::any));
   if (!ctx.use_certificate_file(cert_file, ssl::format::pem)) {
@@ -149,7 +149,7 @@ void dummy_tls_server(stream_socket fd, const char* cert_file,
 void dummy_tls_client(stream_socket fd) {
   multiplexer::block_sigpipe();
   // Make sure we close our socket.
-  auto guard = detail::make_scope_guard([fd]() noexcept { close(fd); });
+  auto guard = detail::scope_guard{[fd]() noexcept { close(fd); }};
   // Perform SSL handshake.
   auto ctx = unbox(ssl::context::make_client(ssl::tls::any));
   auto conn = unbox(ctx.new_connection(fd));

--- a/libcaf_openssl/caf/openssl/session.cpp
+++ b/libcaf_openssl/caf/openssl/session.cpp
@@ -31,15 +31,16 @@ CAF_POP_WARNINGS
       perror("pthread_sigmask");                                               \
       exit(1);                                                                 \
     }                                                                          \
-    auto sigpipe_restore_guard                                                 \
-      = ::caf::detail::make_scope_guard([&]() noexcept {                       \
-          struct timespec zerotime = {};                                       \
-          sigtimedwait(&sigpipe_mask, 0, &zerotime);                           \
-          if (pthread_sigmask(SIG_SETMASK, &saved_mask, 0) == -1) {            \
-            perror("pthread_sigmask");                                         \
-            exit(1);                                                           \
-          }                                                                    \
-        })
+    auto sigpipe_restore_guard = ::caf::detail::scope_guard {                  \
+      [&]() noexcept {                                                         \
+        struct timespec zerotime = {};                                         \
+        sigtimedwait(&sigpipe_mask, 0, &zerotime);                             \
+        if (pthread_sigmask(SIG_SETMASK, &saved_mask, 0) == -1) {              \
+          perror("pthread_sigmask");                                           \
+          exit(1);                                                             \
+        }                                                                      \
+      }                                                                        \
+    }
 
 #else
 

--- a/libcaf_test/caf/test/outline.cpp
+++ b/libcaf_test/caf/test/outline.cpp
@@ -108,11 +108,11 @@ void outline::run() {
   }
   ctx_->parameters = ctx_->example_parameters[ctx_->example_id];
   auto& ptr = ctx_->steps[std::make_pair(0, ctx_->example_id)];
-  auto guard = detail::make_scope_guard([this, &ptr]() noexcept {
+  auto guard = detail::scope_guard{[this, &ptr]() noexcept {
     if (!ptr->can_run()
         && ctx_->example_id + 1 < ctx_->example_parameters.size())
       ++ctx_->example_id;
-  });
+  }};
   super::run();
 }
 

--- a/libcaf_test/caf/test/runnable.cpp
+++ b/libcaf_test/caf/test/runnable.cpp
@@ -27,7 +27,7 @@ runnable::~runnable() {
 void runnable::run() {
   current_runnable = this;
   auto guard
-    = detail::make_scope_guard([]() noexcept { current_runnable = nullptr; });
+    = detail::scope_guard{[]() noexcept { current_runnable = nullptr; }};
   switch (root_type_) {
     case block_type::scenario:
       if (auto guard = ctx_->get<scenario>(0, description_, loc_)->commit()) {
@@ -53,7 +53,7 @@ void runnable::run() {
 void runnable::call_do_run() {
   current_runnable = this;
   auto guard
-    = detail::make_scope_guard([]() noexcept { current_runnable = nullptr; });
+    = detail::scope_guard{[]() noexcept { current_runnable = nullptr; }};
   do_run();
 }
 


### PR DESCRIPTION
C++17 made `make_scope_guard` superfluous by introducing class template argument deduction.

@riemass just a quick followup on your recent PR to modernize the scope guard implementation while we're at it. 🙂