### PR TITLE
Fix parsing of configs with dot-separated keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   implementation is correct and no longer relies on the order of elements.
 - When using `--dump-config`, CAF now properly renders nested dictionaries.
   Previously, dictionaries in lists missed surrounding braces.
+- CAF now parses `foo.bar = 42` in a config file as `foo { bar = 42 }`, just as
+  it does for CLI arguments.
 
 ### Changed
 

--- a/libcaf_core/caf/actor_system_config.cpp
+++ b/libcaf_core/caf/actor_system_config.cpp
@@ -327,14 +327,25 @@ private:
   void print_kvp(const config_value::dictionary::value_type& kvp) {
     const auto& [key, val] = kvp;
     if (auto* submap = get_if<config_value::dictionary>(&val)) {
-      std::cout << indent_ << key << " {\n";
+      std::cout << indent_;
+      print_key(key);
+      std::cout << " {\n";
       auto sub_printer = config_printer{indent_ + 2};
       sub_printer(*submap);
       std::cout << "\n" << indent_ << "}";
     } else {
-      std::cout << indent_ << key << " = ";
+      std::cout << indent_;
+      print_key(key);
+      std::cout << " = ";
       std::visit(*this, val.get_data());
     }
+  }
+
+  void print_key(const std::string& key) {
+    if (key.find('.') == std::string::npos)
+      std::cout << key;
+    else
+      detail::print_escaped(out_, key);
   }
 
   indentation indent_;

--- a/robot/config/options-test5.cfg
+++ b/robot/config/options-test5.cfg
@@ -1,0 +1,54 @@
+# Test 5: Test "nested key notation", e.g,. `foo.bar = "baz"`.
+
+my-obj.name = "FooBar"
+my-obj.some-attribute = "BarFoo"
+my-obj.sub-obj.name = "FooBar2"
+my-obj.sub-obj.some-attribute = "BarFoo"
+some.nested.key {
+  first: "Hello"
+  second: "World"
+}
+some.nested.key.third = "!"
+"key.with.dot" = "value.with.dot"
+mixed."category.with".some.dots = "foobar"
+
+# BEGIN ENV
+# END ENV
+
+# BEGIN CLI
+# END CLI
+
+# BEGIN BASELINE
+# -- member variables --
+# some-string = ""
+# some-int = 0
+# some-string-list = []
+# some-person = person("", 0)
+# some-person-list = []
+# -- config dump --
+# "key.with.dot" = "value.with.dot"
+# mixed {
+#   "category.with" {
+#     some {
+#       dots = "foobar"
+#     }
+#   }
+# }
+# my-obj {
+#   name = "FooBar"
+#   some-attribute = "BarFoo"
+#   sub-obj {
+#     name = "FooBar2"
+#     some-attribute = "BarFoo"
+#   }
+# }
+# some {
+#   nested {
+#     key {
+#       first = "Hello"
+#       second = "World"
+#       third = "!"
+#     }
+#   }
+# }
+# END BASELINE

--- a/robot/config/options.robot
+++ b/robot/config/options.robot
@@ -10,14 +10,14 @@ ${CONFIG_FILE_DIR}      /path/to/the/config/file/dir
 
 *** Test Cases ***
 Test Files
-    FOR  ${i}  IN RANGE  1  5
+    FOR  ${i}  IN RANGE  1  6
       Run Configuration File  ${CONFIG_FILE_DIR}/options-test${i}.cfg
     END
 
 Test Config File Path via Environment Variable
     # Our first config file has empty ENV nor CLI, so we can use it to test
     # the environment variable CONFIG_FILE.
-    ${file_path}=  Set Variable  ${CONFIG_FILE_DIR}/options-test1.cfg
+    ${file_path}=  Set Variable  ${CONFIG_FILE_DIR}/options-test2.cfg
     ${file_content}=    Get File    ${file_path}
     # Run the program with no CLI argument but CONFIG_FILE and HELP defined.
     # The latter checks that CAF will not accept this argument, i.e. CAF will


### PR DESCRIPTION
Parsing `foo.bar = 42` in a config file should be equivalent to `foo { bar = 42 }` in order to stay consistent with the syntax that we use on the CLI.