### PR TITLE
Make term inspectable and usable with FILE handles

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -62,6 +62,7 @@ caf_add_component(
     message_priority
     pec
     sec
+    term
     thread_owner
   HEADERS
     ${CAF_CORE_HEADERS}

--- a/libcaf_core/caf/term.hpp
+++ b/libcaf_core/caf/term.hpp
@@ -4,9 +4,14 @@
 
 #pragma once
 
+#include "caf/default_enum_inspect.hpp"
 #include "caf/detail/core_export.hpp"
 
+#include <cstdio>
 #include <iosfwd>
+#include <string>
+#include <string_view>
+#include <type_traits>
 
 namespace caf {
 
@@ -50,6 +55,31 @@ enum class term {
   bold_white
 };
 
+/// @relates term
+CAF_CORE_EXPORT std::string to_string(term);
+
+/// @relates term
+CAF_CORE_EXPORT bool from_string(std::string_view, term&);
+
+/// @relates term
+CAF_CORE_EXPORT bool from_integer(std::underlying_type_t<term>, term&);
+
 CAF_CORE_EXPORT std::ostream& operator<<(std::ostream& out, term x);
 
+/// @relates sec
+template <class Inspector>
+bool inspect(Inspector& f, term& x) {
+  return default_enum_inspect(f, x);
+}
+
 } // namespace caf
+
+namespace caf::detail {
+
+/// Checks whether `out` points to a TTY.
+CAF_CORE_EXPORT bool is_tty(FILE* out) noexcept;
+
+/// Sets the terminal color to `color` if `out` is a TTY.
+CAF_CORE_EXPORT void set_color(FILE* out, term color);
+
+} // namespace caf::detail


### PR DESCRIPTION
Make `caf::term` inspectable plus prep work for having the colors from `caf::term` work with `stdout` and `stderr`. Not really something that we can test automatically, unfortunately. If we run tests through Robot, it won't be a TTY. Tested manually, FWIW.