### PR TITLE
Streamline logging and reporting APIs

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -144,6 +144,8 @@ caf_add_component(
     caf/detail/latch.cpp
     caf/detail/latch.test.cpp
     caf/detail/local_group_module.cpp
+    caf/detail/log_level_map.cpp
+    caf/detail/log_level_map.test.cpp
     caf/detail/mailbox_factory.cpp
     caf/detail/message_builder_element.cpp
     caf/detail/message_data.cpp

--- a/libcaf_core/caf/detail/format.hpp
+++ b/libcaf_core/caf/detail/format.hpp
@@ -114,32 +114,3 @@ std::string format(std::string_view fstr, Args&&... args) {
 } // namespace caf::detail
 
 #endif
-
-namespace caf::detail {
-
-/// Wraps a format string and its source location. Useful for logging functions
-/// that have a variadic list of arguments and thus cannot use the usual way of
-/// passing in a source location via default argument.
-struct format_string_with_location {
-  constexpr format_string_with_location(std::string_view str,
-                                        const source_location& loc
-                                        = source_location::current())
-    : value(str), location(loc) {
-    // nop
-  }
-
-  constexpr format_string_with_location(const char* str,
-                                        const source_location& loc
-                                        = source_location::current())
-    : value(str), location(loc) {
-    // nop
-  }
-
-  /// The format string.
-  std::string_view value;
-
-  /// The source location of the format string.
-  source_location location;
-};
-
-} // namespace caf::detail

--- a/libcaf_core/caf/detail/log_level_map.cpp
+++ b/libcaf_core/caf/detail/log_level_map.cpp
@@ -1,0 +1,65 @@
+#include "caf/detail/log_level_map.hpp"
+
+#include "caf/config.hpp"
+#include "caf/detail/log_level.hpp"
+#include "caf/string_algorithms.hpp"
+
+#include <algorithm>
+
+namespace caf::detail {
+
+namespace {
+
+/// The predicate for searching the log level map. This models `!(a < b)`, i.e.,
+/// the elements are sorted in *descending* order.
+struct predicate {
+  using kvp_t = std::pair<unsigned, std::string>;
+
+  bool operator()(unsigned lhs, const kvp_t& rhs) const noexcept {
+    return lhs > rhs.first;
+  }
+
+  bool operator()(const kvp_t& lhs, unsigned rhs) const noexcept {
+    return lhs.first > rhs;
+  }
+};
+
+} // namespace
+
+log_level_map::log_level_map() {
+  // Elements are sorted in descending order for efficient lookup.
+  mapping_.reserve(8);
+  mapping_.emplace_back(CAF_LOG_LEVEL_TRACE, "TRACE");
+  mapping_.emplace_back(CAF_LOG_LEVEL_DEBUG, "DEBUG");
+  mapping_.emplace_back(CAF_LOG_LEVEL_INFO, "INFO");
+  mapping_.emplace_back(CAF_LOG_LEVEL_WARNING, "WARNING");
+  mapping_.emplace_back(CAF_LOG_LEVEL_ERROR, "ERROR");
+}
+
+std::string_view log_level_map::operator[](unsigned level) const noexcept {
+  for (auto i = mapping_.begin(); i != mapping_.end(); ++i)
+    if (level >= i->first)
+      return i->second;
+  return "OFF";
+}
+
+unsigned log_level_map::by_name(std::string_view val) const noexcept {
+  auto& xs = mapping_;
+  auto i = std::find_if(xs.begin(), xs.end(), [val](auto& kvp) {
+    return icase_equal(kvp.second, val);
+  });
+  if (i != xs.end())
+    return i->first;
+  return 0;
+}
+
+void log_level_map::set(std::string name, unsigned level) {
+  predicate f;
+  auto i = std::lower_bound(mapping_.begin(), mapping_.end(), level, f);
+  if (i != mapping_.end() && i->first == level)
+    i->second = std::move(name);
+  else
+    mapping_.emplace(i, level, std::move(name));
+}
+
+} // namespace caf::detail

--- a/libcaf_core/caf/detail/log_level_map.hpp
+++ b/libcaf_core/caf/detail/log_level_map.hpp
@@ -1,0 +1,49 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/detail/core_export.hpp"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace caf::detail {
+
+/// Maps log levels to their names.
+class CAF_CORE_EXPORT log_level_map {
+public:
+  log_level_map();
+
+  log_level_map(const log_level_map&) = default;
+
+  log_level_map(log_level_map&&) noexcept = default;
+
+  log_level_map& operator=(const log_level_map&) = default;
+
+  log_level_map& operator=(log_level_map&&) noexcept = default;
+
+  /// Returns the name of the log level at `level`.
+  [[nodiscard]] std::string_view operator[](unsigned level) const noexcept;
+
+  /// Tries to find the key for `val` (case insensitive).
+  /// @returns the key associated to `val` or 0.
+  [[nodiscard]] unsigned by_name(std::string_view val) const noexcept;
+
+  /// Inserts or overwrites a custom log level name.
+  void set(std::string name, unsigned level);
+
+  /// Inserts or overwrites all custom log level names from `input`.
+  template <class Map>
+  void set(const Map& input) {
+    for (const auto& [name, level] : input)
+      set(name, level);
+  }
+
+private:
+  std::vector<std::pair<unsigned, std::string>> mapping_;
+};
+
+} // namespace caf::detail

--- a/libcaf_core/caf/detail/log_level_map.test.cpp
+++ b/libcaf_core/caf/detail/log_level_map.test.cpp
@@ -1,0 +1,125 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/detail/log_level_map.hpp"
+
+#include "caf/test/test.hpp"
+
+#include "caf/detail/log_level.hpp"
+
+#include <map>
+
+using namespace caf;
+using namespace std::literals;
+
+namespace {
+
+struct level {
+  static constexpr unsigned quiet = CAF_LOG_LEVEL_QUIET;
+
+  static constexpr unsigned error = CAF_LOG_LEVEL_ERROR;
+
+  static constexpr unsigned warning = CAF_LOG_LEVEL_WARNING;
+
+  static constexpr unsigned info = CAF_LOG_LEVEL_INFO;
+
+  static constexpr unsigned debug = CAF_LOG_LEVEL_DEBUG;
+
+  static constexpr unsigned trace = CAF_LOG_LEVEL_TRACE;
+};
+
+TEST("log level maps render the default log levels") {
+  detail::log_level_map uut;
+  check_eq(uut[level::quiet], "OFF");
+  check_eq(uut[level::quiet + 1], "OFF");
+  check_eq(uut[level::error - 1], "OFF");
+  check_eq(uut[level::error], "ERROR");
+  check_eq(uut[level::error + 1], "ERROR");
+  check_eq(uut[level::warning - 1], "ERROR");
+  check_eq(uut[level::warning], "WARNING");
+  check_eq(uut[level::warning + 1], "WARNING");
+  check_eq(uut[level::info - 1], "WARNING");
+  check_eq(uut[level::info], "INFO");
+  check_eq(uut[level::info + 1], "INFO");
+  check_eq(uut[level::debug - 1], "INFO");
+  check_eq(uut[level::debug], "DEBUG");
+  check_eq(uut[level::debug + 1], "DEBUG");
+  check_eq(uut[level::trace - 1], "DEBUG");
+  check_eq(uut[level::trace], "TRACE");
+  check_eq(uut[level::trace + 1], "TRACE");
+}
+
+TEST("log level maps allows custom log levels") {
+  std::map<std::string, unsigned> custom{{"NOTICE"s, CAF_LOG_LEVEL_WARNING + 1},
+                                         {"VERBOSE"s, CAF_LOG_LEVEL_INFO + 1}};
+  detail::log_level_map uut;
+  uut.set(custom);
+  check_eq(uut[level::quiet], "OFF");
+  check_eq(uut[level::quiet + 1], "OFF");
+  check_eq(uut[level::error - 1], "OFF");
+  check_eq(uut[level::error], "ERROR");
+  check_eq(uut[level::error + 1], "ERROR");
+  check_eq(uut[level::warning - 1], "ERROR");
+  check_eq(uut[level::warning], "WARNING");
+  check_eq(uut[level::warning + 1], "NOTICE");
+  check_eq(uut[level::info - 1], "NOTICE");
+  check_eq(uut[level::info], "INFO");
+  check_eq(uut[level::info + 1], "VERBOSE");
+  check_eq(uut[level::debug - 1], "VERBOSE");
+  check_eq(uut[level::debug], "DEBUG");
+  check_eq(uut[level::debug + 1], "DEBUG");
+  check_eq(uut[level::trace - 1], "DEBUG");
+  check_eq(uut[level::trace], "TRACE");
+  check_eq(uut[level::trace + 1], "TRACE");
+}
+
+TEST("log level maps allow overriding default log level names") {
+  std::map<std::string, unsigned> custom{{"my-quiet"s, CAF_LOG_LEVEL_QUIET},
+                                         {"my-info"s, CAF_LOG_LEVEL_INFO}};
+  detail::log_level_map uut;
+  uut.set(custom);
+  check_eq(uut[level::quiet], "my-quiet");
+  check_eq(uut[level::quiet + 1], "my-quiet");
+  check_eq(uut[level::error - 1], "my-quiet");
+  check_eq(uut[level::error], "ERROR");
+  check_eq(uut[level::error + 1], "ERROR");
+  check_eq(uut[level::warning - 1], "ERROR");
+  check_eq(uut[level::warning], "WARNING");
+  check_eq(uut[level::warning + 1], "WARNING");
+  check_eq(uut[level::info - 1], "WARNING");
+  check_eq(uut[level::info], "my-info");
+  check_eq(uut[level::info + 1], "my-info");
+  check_eq(uut[level::debug - 1], "my-info");
+  check_eq(uut[level::debug], "DEBUG");
+  check_eq(uut[level::debug + 1], "DEBUG");
+  check_eq(uut[level::trace - 1], "DEBUG");
+  check_eq(uut[level::trace], "TRACE");
+  check_eq(uut[level::trace + 1], "TRACE");
+}
+
+TEST("log level maps allow case-insensitive lookup by name") {
+  std::map<std::string, unsigned> custom{{"NOTICE"s, CAF_LOG_LEVEL_WARNING + 1},
+                                         {"VERBOSE"s, CAF_LOG_LEVEL_INFO + 1}};
+  detail::log_level_map uut;
+  uut.set(custom);
+  check_eq(uut.by_name("foo"), level::quiet); // default
+  check_eq(uut.by_name("OFF"), level::quiet);
+  check_eq(uut.by_name("off"), level::quiet);
+  check_eq(uut.by_name("ERROR"), level::error);
+  check_eq(uut.by_name("error"), level::error);
+  check_eq(uut.by_name("WARNING"), level::warning);
+  check_eq(uut.by_name("warning"), level::warning);
+  check_eq(uut.by_name("NOTICE"), level::warning + 1);
+  check_eq(uut.by_name("notice"), level::warning + 1);
+  check_eq(uut.by_name("INFO"), level::info);
+  check_eq(uut.by_name("info"), level::info);
+  check_eq(uut.by_name("VERBOSE"), level::info + 1);
+  check_eq(uut.by_name("verbose"), level::info + 1);
+  check_eq(uut.by_name("DEBUG"), level::debug);
+  check_eq(uut.by_name("debug"), level::debug);
+  check_eq(uut.by_name("TRACE"), level::trace);
+  check_eq(uut.by_name("trace"), level::trace);
+}
+
+} // namespace

--- a/libcaf_core/caf/format_string_with_location.hpp
+++ b/libcaf_core/caf/format_string_with_location.hpp
@@ -1,0 +1,38 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/detail/source_location.hpp"
+
+#include <string_view>
+
+namespace caf {
+
+/// Wraps a format string and its source location. Useful for logging functions
+/// that have a variadic list of arguments and thus cannot use the usual way of
+/// passing in a source location via default argument.
+struct format_string_with_location {
+  constexpr format_string_with_location(std::string_view str,
+                                        const detail::source_location& loc
+                                        = detail::source_location::current())
+    : value(str), location(loc) {
+    // nop
+  }
+
+  constexpr format_string_with_location(const char* str,
+                                        const detail::source_location& loc
+                                        = detail::source_location::current())
+    : value(str), location(loc) {
+    // nop
+  }
+
+  /// The format string.
+  std::string_view value;
+
+  /// The source location of the format string.
+  detail::source_location location;
+};
+
+} // namespace caf

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -14,6 +14,7 @@
 #include "caf/detail/pp.hpp"
 #include "caf/detail/pretty_type_name.hpp"
 #include "caf/detail/scope_guard.hpp"
+#include "caf/format_string_with_location.hpp"
 #include "caf/fwd.hpp"
 
 #include <cstring>
@@ -150,7 +151,7 @@ public:
   /// @param args Arguments for the format string.
   template <class... Ts>
   static void log(unsigned level, std::string_view component,
-                  detail::format_string_with_location fmt_str, Ts&&... args) {
+                  format_string_with_location fmt_str, Ts&&... args) {
     auto* instance = current_logger();
     if (instance && instance->accepts(level, component)) {
       auto& loc = fmt_str.location;
@@ -167,7 +168,7 @@ public:
   /// @param args Arguments for the format string.
   template <class... Ts>
   [[nodiscard]] static trace_exit_guard
-  trace(std::string_view component, detail::format_string_with_location fmt_str,
+  trace(std::string_view component, format_string_with_location fmt_str,
         Ts&&... args) {
     auto* instance = current_logger();
     if (instance && instance->accepts(CAF_LOG_LEVEL_TRACE, component)) {
@@ -189,7 +190,7 @@ public:
   /// @param args Arguments for the format string.
   template <class... Ts>
   static void debug(std::string_view component,
-                    detail::format_string_with_location fmt_str, Ts&&... args) {
+                    format_string_with_location fmt_str, Ts&&... args) {
     log(CAF_LOG_LEVEL_DEBUG, component, fmt_str, std::forward<Ts>(args)...);
   }
 
@@ -199,7 +200,7 @@ public:
   /// @param args Arguments for the format string.
   template <class... Ts>
   static void info(std::string_view component,
-                   detail::format_string_with_location fmt_str, Ts&&... args) {
+                   format_string_with_location fmt_str, Ts&&... args) {
     log(CAF_LOG_LEVEL_INFO, component, fmt_str, std::forward<Ts>(args)...);
   }
 
@@ -209,8 +210,7 @@ public:
   /// @param args Arguments for the format string.
   template <class... Ts>
   static void warning(std::string_view component,
-                      detail::format_string_with_location fmt_str,
-                      Ts&&... args) {
+                      format_string_with_location fmt_str, Ts&&... args) {
     log(CAF_LOG_LEVEL_WARNING, component, fmt_str, std::forward<Ts>(args)...);
   }
 
@@ -220,7 +220,7 @@ public:
   /// @param args Arguments for the format string.
   template <class... Ts>
   static void error(std::string_view component,
-                    detail::format_string_with_location fmt_str, Ts&&... args) {
+                    format_string_with_location fmt_str, Ts&&... args) {
     log(CAF_LOG_LEVEL_ERROR, component, fmt_str, std::forward<Ts>(args)...);
   }
 

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -69,6 +69,12 @@ public:
 
     /// Name of the current function.
     const char* function_name;
+
+    static context make(unsigned level, std::string_view component,
+                        const detail::source_location& location) {
+      return {level, component, location.line(), location.file_name(),
+              location.function_name()};
+    }
   };
 
   /// Helper class to print exit trace messages on scope exit.

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -20,6 +20,7 @@
 #include "caf/detail/source_location.hpp"
 #include "caf/detail/test_export.hpp"
 #include "caf/expected.hpp"
+#include "caf/format_string_with_location.hpp"
 #include "caf/raise_error.hpp"
 
 #include <string_view>
@@ -51,7 +52,7 @@ public:
 
   /// Generates a message with the INFO severity level.
   template <class... Ts>
-  [[noreturn]] void fail(detail::format_string_with_location fwl, Ts&&... xs) {
+  [[noreturn]] void fail(format_string_with_location fwl, Ts&&... xs) {
     auto msg = detail::format(fwl.value, std::forward<Ts>(xs)...);
     reporter::instance().fail(msg, fwl.location);
     requirement_failed::raise(fwl.location);
@@ -59,28 +60,28 @@ public:
 
   /// Generates a message with the INFO severity level.
   template <class... Ts>
-  void print_info(detail::format_string_with_location fwl, Ts&&... xs) {
+  void print_info(format_string_with_location fwl, Ts&&... xs) {
     auto msg = detail::format(fwl.value, std::forward<Ts>(xs)...);
     reporter::instance().print_info(msg, fwl.location);
   }
 
   /// Generates a message with the DEBUG severity level.
   template <class... Ts>
-  void print_debug(detail::format_string_with_location fwl, Ts&&... xs) {
+  void print_debug(format_string_with_location fwl, Ts&&... xs) {
     auto msg = detail::format(fwl.value, std::forward<Ts>(xs)...);
     reporter::instance().print_debug(msg, fwl.location);
   }
 
   /// Generates a message with the WARNING severity level.
   template <class... Ts>
-  void print_warning(detail::format_string_with_location fwl, Ts&&... xs) {
+  void print_warning(format_string_with_location fwl, Ts&&... xs) {
     auto msg = detail::format(fwl.value, std::forward<Ts>(xs)...);
     reporter::instance().print_warning(msg, fwl.location);
   }
 
   /// Generates a message with the ERROR severity level.
   template <class... Ts>
-  void print_error(detail::format_string_with_location fwl, Ts&&... xs) {
+  void print_error(format_string_with_location fwl, Ts&&... xs) {
     auto msg = detail::format(fwl.value, std::forward<Ts>(xs)...);
     reporter::instance().print_error(msg, fwl.location);
   }

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -58,32 +58,28 @@ public:
     requirement_failed::raise(fwl.location);
   }
 
-  /// Generates a message with the INFO severity level.
-  template <class... Ts>
-  void print_info(format_string_with_location fwl, Ts&&... xs) {
-    auto msg = detail::format(fwl.value, std::forward<Ts>(xs)...);
-    reporter::instance().print_info(msg, fwl.location);
-  }
-
   /// Generates a message with the DEBUG severity level.
   template <class... Ts>
   void print_debug(format_string_with_location fwl, Ts&&... xs) {
-    auto msg = detail::format(fwl.value, std::forward<Ts>(xs)...);
-    reporter::instance().print_debug(msg, fwl.location);
+    reporter::instance().print_debug(fwl, std::forward<Ts>(xs)...);
+  }
+
+  /// Generates a message with the INFO severity level.
+  template <class... Ts>
+  void print_info(format_string_with_location fwl, Ts&&... xs) {
+    reporter::instance().print_info(fwl, std::forward<Ts>(xs)...);
   }
 
   /// Generates a message with the WARNING severity level.
   template <class... Ts>
   void print_warning(format_string_with_location fwl, Ts&&... xs) {
-    auto msg = detail::format(fwl.value, std::forward<Ts>(xs)...);
-    reporter::instance().print_warning(msg, fwl.location);
+    reporter::instance().print_warning(fwl, std::forward<Ts>(xs)...);
   }
 
   /// Generates a message with the ERROR severity level.
   template <class... Ts>
   void print_error(format_string_with_location fwl, Ts&&... xs) {
-    auto msg = detail::format(fwl.value, std::forward<Ts>(xs)...);
-    reporter::instance().print_error(msg, fwl.location);
+    reporter::instance().print_error(fwl, std::forward<Ts>(xs)...);
   }
 
   /// Checks whether `lhs` and `rhs` are equal.

--- a/libcaf_test/caf/test/runner.cpp
+++ b/libcaf_test/caf/test/runner.cpp
@@ -172,7 +172,9 @@ int runner::run(int argc, char** argv) {
         default_reporter->unhandled_exception(ex.message(), ex.location());
         default_reporter->end_test();
       } catch (const requirement_failed& ex) {
-        default_reporter->print_error(ex.message(), ex.location());
+        auto ctx = logger::context::make(CAF_LOG_LEVEL_ERROR, "caf.test",
+                                         ex.location());
+        default_reporter->print(ctx, ex.message());
         default_reporter->end_test();
       } catch (const std::exception& ex) {
         default_reporter->unhandled_exception(ex.what());


### PR DESCRIPTION
- `format_string_with_location` is used in public API functions and thus should be a public type
- mapping from the logger to the reporter felt overly brittle, so I've reworked the latter to use `logger::context`
- we had multiple places where we resolved log levels to names or vice versa, so I've implemented a new class `log_level_map ` to solve this once