### PR TITLE
Limit request size in HTTP high level API

### DIFF
--- a/examples/http/rest.cpp
+++ b/examples/http/rest.cpp
@@ -10,6 +10,7 @@
 #include "caf/actor_system_config.hpp"
 #include "caf/caf_main.hpp"
 #include "caf/deep_to_string.hpp"
+#include "caf/defaults.hpp"
 #include "caf/event_based_actor.hpp"
 #include "caf/scheduled_actor/flow.hpp"
 
@@ -26,9 +27,6 @@ namespace http = caf::net::http;
 static constexpr uint16_t default_port = 8080;
 
 static constexpr size_t default_max_connections = 128;
-
-static constexpr size_t default_max_request_size
-  = caf::net::http::server::default_max_request_size;
 
 // -- configuration ------------------------------------------------------------
 
@@ -47,7 +45,8 @@ struct config : caf::actor_system_config {
     auto result = actor_system_config::dump_content();
     caf::put_missing(result, "port", default_port);
     caf::put_missing(result, "max-connections", default_max_connections);
-    caf::put_missing(result, "max-request-size", default_max_request_size);
+    caf::put_missing(result, "max-request-size",
+                     caf::defaults::net::http_max_request_size);
     return result;
   }
 };
@@ -100,8 +99,8 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
   auto cert_file = caf::get_as<std::string>(cfg, "tls.cert-file");
   auto max_connections = caf::get_or(cfg, "max-connections",
                                      default_max_connections);
-  auto max_request_size = caf::get_or(cfg, "max-request-size",
-                                      default_max_request_size);
+  auto max_request_size = caf::get_or(
+    cfg, "max-request-size", caf::defaults::net::http_max_request_size);
   if (!key_file != !cert_file) {
     std::cerr << "*** inconsistent TLS config: declare neither file or both\n";
     return EXIT_FAILURE;

--- a/libcaf_core/caf/defaults.hpp
+++ b/libcaf_core/caf/defaults.hpp
@@ -164,10 +164,13 @@ namespace caf::defaults::net {
 /// previous connection has been closed.
 constexpr auto max_connections = make_parameter("max-connections", size_t{64});
 
+/// Default maximum size for incoming HTTP requests: 64KiB.
+constexpr auto http_max_request_size = uint32_t{65'536};
+
 /// The default port for HTTP servers.
-constexpr uint16_t http_default_port = 80;
+constexpr auto http_default_port = uint16_t{80};
 
 /// The default port for HTTPS servers.
-constexpr uint16_t https_default_port = 443;
+constexpr auto https_default_port = uint16_t{443};
 
 } // namespace caf::defaults::net

--- a/libcaf_net/caf/net/http/config.hpp
+++ b/libcaf_net/caf/net/http/config.hpp
@@ -44,6 +44,9 @@ public:
 
   /// Store actors that the server should monitor.
   std::vector<strong_actor_ptr> monitored_actors;
+
+  /// Store the maximum request size.
+  size_t max_request_size = 0;
 };
 
 } // namespace caf::net::http

--- a/libcaf_net/caf/net/http/config.hpp
+++ b/libcaf_net/caf/net/http/config.hpp
@@ -45,7 +45,7 @@ public:
   /// Store actors that the server should monitor.
   std::vector<strong_actor_ptr> monitored_actors;
 
-  /// Store the maximum request size.
+  /// Store the maximum request size with 0 meaning "default".
   size_t max_request_size = 0;
 };
 

--- a/libcaf_net/caf/net/http/server.hpp
+++ b/libcaf_net/caf/net/http/server.hpp
@@ -16,6 +16,7 @@
 #include "caf/net/socket_manager.hpp"
 
 #include "caf/byte_span.hpp"
+#include "caf/defaults.hpp"
 #include "caf/detail/append_hex.hpp"
 #include "caf/detail/message_flow_bridge.hpp"
 #include "caf/detail/net_export.hpp"
@@ -43,11 +44,6 @@ public:
 
   using upper_layer_ptr = std::unique_ptr<http::upper_layer::server>;
 
-  // -- constants --------------------------------------------------------------
-
-  /// Default maximum size for incoming HTTP requests: 64KiB.
-  static constexpr uint32_t default_max_request_size = 65'536;
-
   // -- constructors, destructors, and assignment operators --------------------
 
   explicit server(upper_layer_ptr up) : up_(std::move(up)) {
@@ -73,7 +69,8 @@ public:
   }
 
   void max_request_size(size_t value) noexcept {
-    max_request_size_ = value;
+    if (value > 0)
+      max_request_size_ = value;
   }
 
   // -- http::lower_layer implementation ---------------------------------------
@@ -141,7 +138,7 @@ private:
   size_t payload_len_ = 0;
 
   /// Maximum size for incoming HTTP requests.
-  size_t max_request_size_ = default_max_request_size;
+  size_t max_request_size_ = caf::defaults::net::http_max_request_size;
 };
 
 } // namespace caf::net::http

--- a/libcaf_net/caf/net/http/server_factory.hpp
+++ b/libcaf_net/caf/net/http/server_factory.hpp
@@ -84,8 +84,7 @@ public:
                                connection_handle conn) override {
     auto app = net::http::router::make(routes_);
     auto serv = net::http::server::make(std::move(app));
-    if (max_request_size_ > 0)
-      serv->max_request_size(max_request_size_);
+    serv->max_request_size(max_request_size_);
     auto transport = Transport::make(std::move(conn), std::move(serv));
     transport->max_consecutive_reads(max_consecutive_reads_);
     transport->active_policy().accept();

--- a/libcaf_net/caf/net/http/server_factory.hpp
+++ b/libcaf_net/caf/net/http/server_factory.hpp
@@ -73,9 +73,10 @@ public:
   using connection_handle = typename Transport::connection_handle;
 
   http_conn_factory(std::vector<net::http::route_ptr> routes,
-                    size_t max_consecutive_reads)
+                    size_t max_consecutive_reads, size_t max_request_size)
     : routes_(std::move(routes)),
-      max_consecutive_reads_(max_consecutive_reads) {
+      max_consecutive_reads_(max_consecutive_reads),
+      max_request_size_(max_request_size) {
     // nop
   }
 
@@ -83,6 +84,8 @@ public:
                                connection_handle conn) override {
     auto app = net::http::router::make(routes_);
     auto serv = net::http::server::make(std::move(app));
+    if (max_request_size_ > 0)
+      serv->max_request_size(max_request_size_);
     auto transport = Transport::make(std::move(conn), std::move(serv));
     transport->max_consecutive_reads(max_consecutive_reads_);
     transport->active_policy().accept();
@@ -94,6 +97,7 @@ public:
 private:
   std::vector<net::http::route_ptr> routes_;
   size_t max_consecutive_reads_;
+  size_t max_request_size_;
   action monitor_;
 };
 
@@ -110,6 +114,12 @@ public:
   using config_type = typename super::config_type;
 
   using super::super;
+
+  /// Sets the maximum request size to @p value.
+  server_factory& max_request_size(size_t value) noexcept {
+    super::config().max_request_size = value;
+    return *this;
+  }
 
   /// Monitors the actor handle @p hdl and stops the server if the monitored
   /// actor terminates.
@@ -196,7 +206,8 @@ private:
     using factory_t = detail::http_conn_factory<transport_t>;
     using impl_t = detail::accept_handler<Acceptor>;
     auto factory = std::make_unique<factory_t>(cfg.routes,
-                                               cfg.max_consecutive_reads);
+                                               cfg.max_consecutive_reads,
+                                               cfg.max_request_size);
     auto impl = impl_t::make(std::move(acc), std::move(factory),
                              cfg.max_connections, cfg.monitored_actors);
     auto impl_ptr = impl.get();


### PR DESCRIPTION
Followup from our meeting, and I wanted to read the server factory code a bit more. 
We could make this more generic, however I'd wait for the refactoring we plan, since `lp` has `max_message_length`, which is the length excluding the length prefix, and `websocket` has `max_frame_size` which applies to both server and client.