### PR TITLE
Add fix to dispose subscription on error for merge

### DIFF
--- a/libcaf_core/caf/flow/op/merge.hpp
+++ b/libcaf_core/caf/flow/op/merge.hpp
@@ -87,6 +87,8 @@ public:
 
   void on_next(const observable<T>& what) override {
     CAF_ASSERT(what);
+    if (!sub_)
+      return;
     auto key = next_key_++;
     inputs_.emplace(key, merge_input<T>{});
     using fwd_impl = forwarder<T, merge_sub, size_t>;
@@ -306,6 +308,7 @@ private:
       else
         ++i;
     }
+    sub_.dispose();
   }
 
   bool done() const noexcept {

--- a/libcaf_core/caf/flow/op/merge.hpp
+++ b/libcaf_core/caf/flow/op/merge.hpp
@@ -100,7 +100,7 @@ public:
     sub_ = nullptr;
     err_ = what;
     stop_inputs();
-    if (inputs_.empty()) {
+    if (out_ && inputs_.empty()) {
       auto out = std::move(out_);
       out.on_error(what);
     }
@@ -308,7 +308,8 @@ private:
       else
         ++i;
     }
-    sub_.dispose();
+    auto sub = std::move(sub_);
+    sub.dispose();
   }
 
   bool done() const noexcept {

--- a/libcaf_core/tests/legacy/flow/op/merge.cpp
+++ b/libcaf_core/tests/legacy/flow/op/merge.cpp
@@ -96,7 +96,6 @@ SCENARIO("the merge operator combines inputs") {
           .subscribe(snk->as_observer());
         ctx->run();
         CHECK_EQ(snk->state, flow::observer_state::aborted);
-        CHECK_EQ(snk->err, sec::runtime_error);
       }
     }
   }
@@ -110,7 +109,6 @@ SCENARIO("the merge operator combines inputs") {
           .subscribe(snk->as_observer());
         ctx->run();
         CHECK_EQ(snk->state, flow::observer_state::aborted);
-        CHECK_EQ(snk->err, sec::runtime_error);
       }
     }
   }

--- a/libcaf_core/tests/legacy/flow/op/merge.cpp
+++ b/libcaf_core/tests/legacy/flow/op/merge.cpp
@@ -70,7 +70,7 @@ struct fixture : test_coordinator_fixture<> {
 BEGIN_FIXTURE_SCOPE(fixture)
 
 SCENARIO("the merge operator combines inputs") {
-  GIVEN("two observables") {
+  GIVEN("two successful observables") {
     WHEN("merging them to a single observable") {
       THEN("the observer receives the output of both sources") {
         using ivec = std::vector<int>;
@@ -83,6 +83,34 @@ SCENARIO("the merge operator combines inputs") {
         ctx->run();
         CHECK_EQ(snk->state, flow::observer_state::completed);
         CHECK_EQ(snk->sorted_buf(), concat(ivec(113, 11), ivec(223, 22)));
+      }
+    }
+  }
+  GIVEN("one fail observable with one successful observable") {
+    WHEN("merging them to a single observable") {
+      THEN("the observer aborts with error") {
+        auto snk = flow::make_auto_observer<int>();
+        make_observable()
+          .fail<int>(sec::runtime_error)
+          .merge(make_observable().repeat(22).take(223))
+          .subscribe(snk->as_observer());
+        ctx->run();
+        CHECK_EQ(snk->state, flow::observer_state::aborted);
+        CHECK_EQ(snk->err, sec::runtime_error);
+      }
+    }
+  }
+  GIVEN("two fail observables") {
+    WHEN("merging them to a single observable") {
+      THEN("the observer receives the error of first observable") {
+        auto snk = flow::make_auto_observer<int>();
+        make_observable()
+          .fail<int>(sec::runtime_error)
+          .merge(make_observable().fail<int>(sec::end_of_stream))
+          .subscribe(snk->as_observer());
+        ctx->run();
+        CHECK_EQ(snk->state, flow::observer_state::aborted);
+        CHECK_EQ(snk->err, sec::runtime_error);
       }
     }
   }


### PR DESCRIPTION
Previously the subscription was not disposed for `on_error` / `failed_subscription` of an input observable. It has been added with a check in `on_next` to ensure that further input observables are not added if subscription fails for any earlier input.