### PR TITLE
Tweak Codecov configuration

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -22,9 +22,8 @@ jobs:
           -S . \
           -B build \
           -DCAF_ENABLE_ROBOT_TESTS:BOOL=ON \
-          -DCAF_ENABLE_EXCEPTIONS:BOOL=OFF \
           -DCAF_LOG_LEVEL:STRING=TRACE \
-          -DCMAKE_CXX_FLAGS:STRING="-fno-exceptions --coverage -O0" \
+          -DCMAKE_CXX_FLAGS:STRING="--coverage -O0" \
           -DCMAKE_BUILD_TYPE:STRING=Debug \
           -DBUILD_SHARED_LIBS:BOOL=OFF
     - name: build
@@ -36,4 +35,5 @@ jobs:
       with:
         fail_ci_if_error: true
         gcov: true
+        gcov_args: --exclude-throw-branches
         token: ${{ secrets.CODECOV_TOKEN  }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,3 +16,4 @@ coverage:
     project:
       default:
         threshold: 1% # we have some fluctuation from nondeterminism alone
+        informational: true


### PR DESCRIPTION
- Measure coverage with exceptions enabled.
- Enable "informational" mode to stop Codecov from failing PRs.