### PR TITLE
Implement new release semantics for flow handles

### DIFF
--- a/libcaf_core/caf/async/blocking_consumer.hpp
+++ b/libcaf_core/caf/async/blocking_consumer.hpp
@@ -69,6 +69,7 @@ public:
     }
 
     void on_complete() {
+      // nop
     }
 
     void on_error(const caf::error& abort_reason) {

--- a/libcaf_core/caf/async/spsc_buffer.hpp
+++ b/libcaf_core/caf/async/spsc_buffer.hpp
@@ -260,10 +260,10 @@ public:
       return {true, consumed};
     } else {
       consumer_ = nullptr;
-      if (err_)
-        dst.on_error(err_);
-      else
+      if (!err_)
         dst.on_complete();
+      else
+        dst.on_error(err_);
       return {false, consumed};
     }
   }

--- a/libcaf_core/caf/detail/stream_bridge.hpp
+++ b/libcaf_core/caf/detail/stream_bridge.hpp
@@ -43,6 +43,8 @@ public:
 
   // -- implementation of subscription -----------------------------------------
 
+  flow::coordinator* parent() const noexcept override;
+
   bool disposed() const noexcept override;
 
   void dispose() override;

--- a/libcaf_core/caf/expected.hpp
+++ b/libcaf_core/caf/expected.hpp
@@ -203,7 +203,7 @@ public:
     return value_;
   }
 
-  void swap(expected& other) noexcept(nothrow_move&& nothrow_swap) {
+  void swap(expected& other) noexcept(nothrow_move && nothrow_swap) {
     expected tmp{std::move(other)};
     other = std::move(*this);
     *this = std::move(tmp);

--- a/libcaf_core/caf/flow/coordinated.hpp
+++ b/libcaf_core/caf/flow/coordinated.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "caf/detail/core_export.hpp"
+#include "caf/flow/fwd.hpp"
 
 namespace caf::flow {
 
@@ -14,6 +15,11 @@ public:
   // -- constructors, destructors, and assignment operators --------------------
 
   virtual ~coordinated();
+
+  // -- properties -------------------------------------------------------------
+
+  /// Returns the @ref coordinator this object lives on.
+  virtual coordinator* parent() const noexcept = 0;
 
   // -- reference counting -----------------------------------------------------
 
@@ -32,5 +38,8 @@ public:
     ptr->deref_coordinated();
   }
 };
+
+/// @relates coordinated
+using coordinated_ptr = intrusive_ptr<coordinated>;
 
 } // namespace caf::flow

--- a/libcaf_core/caf/flow/coordinator.hpp
+++ b/libcaf_core/caf/flow/coordinator.hpp
@@ -10,12 +10,14 @@
 #include "caf/cow_string.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/flow/fwd.hpp"
-#include "caf/flow/subscription.hpp"
 #include "caf/intrusive_ptr.hpp"
+#include "caf/make_counted.hpp"
 #include "caf/timespan.hpp"
 
 #include <chrono>
 #include <tuple>
+#include <type_traits>
+#include <utility>
 
 namespace caf::flow {
 
@@ -42,6 +44,51 @@ public:
 
   /// Returns a factory object for new observable objects on this coordinator.
   [[nodiscard]] observable_builder make_observable();
+
+  /// Creates a new @ref coordinated object on this coordinator.
+  template <class Impl, class... Args>
+  [[nodiscard]] std::enable_if_t<std::is_base_of_v<coordinated, Impl>,
+                                 intrusive_ptr<Impl>>
+  add_child(std::in_place_type_t<Impl>, Args&&... args) {
+    return make_counted<Impl>(this, std::forward<Args>(args)...);
+  }
+
+  /// Like @ref add_child, but wraps the result in a handle type. The handle
+  /// type depends on the @ref coordinated object and usually one of
+  /// `observer<T>`, `observable<T>`, or `subscription`.
+  template <class Impl, class... Args>
+  [[nodiscard]] std::enable_if_t<std::is_base_of_v<coordinated, Impl>,
+                                 typename Impl::handle_type>
+  add_child_hdl(std::in_place_type_t<Impl> token, Args&&... args) {
+    using handle_type = typename Impl::handle_type;
+    return handle_type{add_child(token, std::forward<Args>(args)...)};
+  }
+
+  // -- lifetime management ----------------------------------------------------
+
+  /// Resets `child` and releases the reference count of the @ref coordinated
+  /// object at the end of the current cycle.
+  /// @post `child == nullptr`
+  virtual void release_later(coordinated_ptr& child) = 0;
+
+  /// Resets `child` and releases the reference count of the @ref coordinated
+  /// object at the end of the current cycle.
+  /// @post `child == nullptr`
+  template <class T>
+  std::enable_if_t<std::is_base_of_v<coordinated, T>>
+  release_later(intrusive_ptr<T>& child) {
+    auto ptr = coordinated_ptr{child.release(), false};
+    release_later(ptr);
+  }
+
+  /// Resets `hdl` and releases the reference count of the @ref coordinated
+  /// object at the end of the current cycle.
+  /// @post `child == nullptr`
+  template <class Handle>
+  std::enable_if<Handle::holds_coordinated> release_later(Handle& hdl) {
+    auto ptr = coordinated_ptr{hdl.as_intrusive_ptr().release(), false};
+    release_later(ptr);
+  }
 
   // -- time -------------------------------------------------------------------
 

--- a/libcaf_core/caf/flow/fwd.hpp
+++ b/libcaf_core/caf/flow/fwd.hpp
@@ -27,6 +27,12 @@ namespace caf::flow {
 
 class coordinator;
 
+using coordinator_ptr = intrusive_ptr<coordinator>;
+
+class coordinated;
+
+using coordinated_ptr = intrusive_ptr<coordinated>;
+
 class subscription;
 
 template <class T>

--- a/libcaf_core/caf/flow/multicaster.hpp
+++ b/libcaf_core/caf/flow/multicaster.hpp
@@ -8,7 +8,6 @@
 #include "caf/flow/observable_decl.hpp"
 #include "caf/flow/op/mcast.hpp"
 #include "caf/intrusive_ptr.hpp"
-#include "caf/make_counted.hpp"
 
 #include <cstdint>
 
@@ -20,8 +19,8 @@ class multicaster {
 public:
   using impl_ptr = intrusive_ptr<op::mcast<T>>;
 
-  explicit multicaster(coordinator* ctx) {
-    pimpl_ = make_counted<op::mcast<T>>(ctx);
+  explicit multicaster(coordinator* parent) {
+    pimpl_ = parent->add_child(std::in_place_type<op::mcast<T>>);
   }
 
   explicit multicaster(impl_ptr ptr) noexcept : pimpl_(std::move(ptr)) {

--- a/libcaf_core/caf/flow/observable_decl.hpp
+++ b/libcaf_core/caf/flow/observable_decl.hpp
@@ -70,12 +70,17 @@ public:
   /// Creates a new observer that pushes all observed items to the resource.
   disposable subscribe(async::producer_resource<T> resource);
 
-  /// Subscribes a new observer to the items emitted by this observable.
+  /// Subscribes a new observer that discards all items it receives.
   disposable subscribe(ignore_t);
 
   /// Calls `on_next` for each item emitted by this observable.
   template <class OnNext>
   disposable for_each(OnNext on_next);
+
+  /// Calls `on_next` for each item emitted by this observable and `on_error` in
+  /// case of an error.
+  template <class OnNext, class OnError>
+  disposable for_each(OnNext on_next, OnError on_error);
 
   // -- transforming -----------------------------------------------------------
 
@@ -363,8 +368,8 @@ public:
   }
 
   /// @pre `valid()`
-  coordinator* ctx() const {
-    return pimpl_->ctx();
+  coordinator* parent() const {
+    return pimpl_->parent();
   }
 
   // -- swapping ---------------------------------------------------------------
@@ -378,18 +383,6 @@ private:
 
   pimpl_type pimpl_;
 };
-
-/// Convenience function for creating an @ref observable from a concrete
-/// operator type.
-/// @relates observable
-template <class Operator, class CoordinatorType, class... Ts>
-observable<typename Operator::output_type>
-make_observable(CoordinatorType* ctx, Ts&&... xs) {
-  using out_t = typename Operator::output_type;
-  using ptr_t = intrusive_ptr<op::base<out_t>>;
-  ptr_t ptr{new Operator(ctx, std::forward<Ts>(xs)...), false};
-  return observable<out_t>{std::move(ptr)};
-}
 
 // Note: the definition of all member functions is in observable.hpp.
 

--- a/libcaf_core/caf/flow/op/base.hpp
+++ b/libcaf_core/caf/flow/op/base.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "caf/flow/coordinated.hpp"
+#include "caf/flow/fwd.hpp"
 #include "caf/flow/observer.hpp"
 #include "caf/flow/subscription.hpp"
 
@@ -14,14 +16,43 @@ namespace caf::flow::op {
 template <class T>
 class base : public coordinated {
 public:
+  // -- member types -----------------------------------------------------------
+
+  /// The derived type.
+  using super = coordinated;
+
   /// The type of observed values.
   using output_type = T;
 
-  /// Returns the @ref coordinator that executes this flow operator.
-  virtual coordinator* ctx() const noexcept = 0;
+  /// The proper type for holding a type-erased handle to object instances.
+  using handle_type = observable<T>;
 
   /// Subscribes a new observer to the operator.
   virtual disposable subscribe(observer<T> what) = 0;
+
+  /// Calls `on_subscribe` and `on_error` on `out` to immediately fail a
+  /// subscription.
+  /// @relates observer
+  disposable fail_subscription(observer<T>& out, const error& err) {
+    using sub_t = subscription::trivial_impl;
+    auto sub = parent()->add_child(std::in_place_type<sub_t>);
+    out.on_subscribe(subscription{sub});
+    if (!sub->disposed())
+      out.on_error(err);
+    return sub->as_disposable();
+  }
+
+  /// Calls `on_subscribe` and `on_complete` on `out` to immediately complete a
+  /// subscription.
+  /// @relates observer
+  disposable empty_subscription(observer<T>& out) {
+    using sub_t = subscription::trivial_impl;
+    auto sub = parent()->add_child(std::in_place_type<sub_t>);
+    out.on_subscribe(subscription{sub});
+    if (!sub->disposed())
+      out.on_complete();
+    return sub->as_disposable();
+  }
 };
 
 } // namespace caf::flow::op

--- a/libcaf_core/caf/flow/op/buffer.hpp
+++ b/libcaf_core/caf/flow/op/buffer.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "caf/cow_vector.hpp"
+#include "caf/flow/coordinator.hpp"
 #include "caf/flow/observable_decl.hpp"
 #include "caf/flow/observer.hpp"
 #include "caf/flow/op/cold.hpp"
@@ -64,12 +65,17 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  buffer_sub(coordinator* ctx, size_t max_buf_size, observer<output_type> out)
-    : ctx_(ctx), max_buf_size_(max_buf_size), out_(std::move(out)) {
+  buffer_sub(coordinator* parent, size_t max_buf_size,
+             observer<output_type> out)
+    : parent_(parent), max_buf_size_(max_buf_size), out_(std::move(out)) {
     // nop
   }
 
   // -- properties -------------------------------------------------------------
+
+  coordinator* parent() const noexcept override {
+    return parent_;
+  }
 
   bool running() const noexcept {
     return state_ == state::running;
@@ -92,13 +98,14 @@ public:
   void init(observable<input_type> vals, observable<select_token_type> ctrl) {
     using val_fwd_t = forwarder<input_type, buffer_sub, buffer_input_t>;
     using ctrl_fwd_t = forwarder<select_token_type, buffer_sub, buffer_emit_t>;
-    vals.subscribe(
-      make_counted<val_fwd_t>(this, buffer_input_t{})->as_observer());
+    auto fwd = parent_->add_child(std::in_place_type<val_fwd_t>, this,
+                                  buffer_input_t{});
+    vals.subscribe(fwd->as_observer());
     // Note: the previous subscribe might call on_error, in which case we don't
     // need to try to subscribe to the control observable.
     if (running())
-      ctrl.subscribe(
-        make_counted<ctrl_fwd_t>(this, buffer_emit_t{})->as_observer());
+      ctrl.subscribe(parent_->add_child_hdl(std::in_place_type<ctrl_fwd_t>,
+                                            this, buffer_emit_t{}));
   }
 
   // -- callbacks for the forwarders -------------------------------------------
@@ -113,12 +120,12 @@ public:
   }
 
   void fwd_on_complete(buffer_input_t) {
-    value_sub_ = nullptr;
+    value_sub_.release_later();
     shutdown();
   }
 
   void fwd_on_error(buffer_input_t, const error& what) {
-    value_sub_ = nullptr;
+    value_sub_.release_later();
     err_ = what;
     shutdown();
   }
@@ -141,7 +148,7 @@ public:
   }
 
   void fwd_on_complete(buffer_emit_t) {
-    control_sub_ = nullptr;
+    control_sub_.release_later();
     if (state_ == state::running)
       err_ = make_error(sec::end_of_stream,
                         "buffer: unexpected end of the control stream");
@@ -149,7 +156,7 @@ public:
   }
 
   void fwd_on_error(buffer_emit_t, const error& what) {
-    control_sub_ = nullptr;
+    control_sub_.release_later();
     err_ = what;
     shutdown();
   }
@@ -172,7 +179,7 @@ public:
 
   void dispose() override {
     if (out_) {
-      ctx_->delay_fn([strong_this = intrusive_ptr<buffer_sub>{this}] {
+      parent_->delay_fn([strong_this = intrusive_ptr<buffer_sub>{this}] {
         strong_this->do_dispose();
       });
     }
@@ -183,7 +190,7 @@ public:
     demand_ += n;
     // If we can ship a batch, schedule an event to do so.
     if (demand_ == n && can_emit()) {
-      ctx_->delay_fn([strong_this = intrusive_ptr<buffer_sub>{this}] {
+      parent_->delay_fn([strong_this = intrusive_ptr<buffer_sub>{this}] {
         strong_this->on_request();
       });
     }
@@ -204,11 +211,10 @@ private:
           out_.on_next(f(buf_));
           buf_.clear();
         }
-        auto tmp = std::move(out_);
-        if (err_)
-          tmp.on_error(err_);
+        if (!err_)
+          out_.on_complete();
         else
-          tmp.on_complete();
+          out_.on_error(err_);
         state_ = state::disposed;
         break;
       }
@@ -227,11 +233,10 @@ private:
     }
     if (!buf_.empty())
       do_emit();
-    auto tmp = std::move(out_);
-    if (err_)
-      tmp.on_error(err_);
+    if (!err_)
+      out_.on_complete();
     else
-      tmp.on_complete();
+      out_.on_error(err_);
   }
 
   void do_emit() {
@@ -247,17 +252,15 @@ private:
   }
 
   void do_dispose() {
+    state_ = state::disposed;
     value_sub_.dispose();
     control_sub_.dispose();
-    if (out_) {
-      auto tmp = std::move(out_);
-      tmp.on_complete();
-    }
-    state_ = state::disposed;
+    if (out_)
+      out_.on_complete();
   }
 
   /// Stores the context (coordinator) that runs this flow.
-  coordinator* ctx_;
+  coordinator* parent_;
 
   /// Stores the maximum buffer size before forcing a batch.
   size_t max_buf_size_;
@@ -307,8 +310,8 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  buffer(coordinator* ctx, size_t max_items, input in, selector select)
-    : super(ctx),
+  buffer(coordinator* parent, size_t max_items, input in, selector select)
+    : super(parent),
       max_items_(max_items),
       in_(std::move(in)),
       select_(std::move(select)) {
@@ -318,10 +321,11 @@ public:
   // -- implementation of observable<T> -----------------------------------
 
   disposable subscribe(observer<output_type> out) override {
-    auto ptr = make_counted<buffer_sub<Trait>>(super::ctx_, max_items_, out);
+    auto ptr = super::parent_->add_child(std::in_place_type<buffer_sub<Trait>>,
+                                         max_items_, out);
     ptr->init(in_, select_);
     if (!ptr->running()) {
-      return fail_subscription(
+      return super::fail_subscription(
         out, ptr->err().or_else(sec::runtime_error,
                                 "failed to initialize buffer subscription"));
     }

--- a/libcaf_core/caf/flow/op/cold.hpp
+++ b/libcaf_core/caf/flow/op/cold.hpp
@@ -15,13 +15,9 @@ namespace caf::flow::op {
 template <class T>
 class cold : public detail::atomic_ref_counted, public base<T> {
 public:
-  // -- member types -----------------------------------------------------------
-
-  using output_type = T;
-
   // -- constructors, destructors, and assignment operators --------------------
 
-  explicit cold(coordinator* ctx) : ctx_(ctx) {
+  explicit cold(coordinator* parent) : parent_(parent) {
     // nop
   }
 
@@ -37,14 +33,14 @@ public:
 
   // -- implementation of observable_impl<T> -----------------------------------
 
-  coordinator* ctx() const noexcept override {
-    return ctx_;
+  coordinator* parent() const noexcept override {
+    return parent_;
   }
 
 protected:
   // -- member variables -------------------------------------------------------
 
-  coordinator* ctx_;
+  coordinator* parent_;
 };
 
 } // namespace caf::flow::op

--- a/libcaf_core/caf/flow/op/defer.hpp
+++ b/libcaf_core/caf/flow/op/defer.hpp
@@ -33,7 +33,7 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  defer(coordinator* ctx, Factory fn) : super(ctx), fn_(std::move(fn)) {
+  defer(coordinator* parent, Factory fn) : super(parent), fn_(std::move(fn)) {
     // nop
   }
 

--- a/libcaf_core/caf/flow/op/empty.hpp
+++ b/libcaf_core/caf/flow/op/empty.hpp
@@ -21,18 +21,16 @@ public:
 
   using super = cold<T>;
 
-  using output_type = T;
-
   // -- constructors, destructors, and assignment operators --------------------
 
-  explicit empty(coordinator* ctx) : super(ctx) {
+  explicit empty(coordinator* parent) : super(parent) {
     // nop
   }
 
   // -- implementation of observable<T>::impl ----------------------------------
 
-  disposable subscribe(observer<output_type> out) override {
-    return empty_subscription(out);
+  disposable subscribe(observer<T> out) override {
+    return super::empty_subscription(out);
   }
 };
 

--- a/libcaf_core/caf/flow/op/fail.hpp
+++ b/libcaf_core/caf/flow/op/fail.hpp
@@ -22,14 +22,14 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  fail(coordinator* ctx, error err) : super(ctx), err_(std::move(err)) {
+  fail(coordinator* parent, error err) : super(parent), err_(std::move(err)) {
     // nop
   }
 
   // -- implementation of observable_impl<T> -----------------------------------
 
   disposable subscribe(observer<T> out) override {
-    return fail_subscription(out, err_);
+    return super::fail_subscription(out, err_);
   }
 
 private:

--- a/libcaf_core/caf/flow/op/hot.hpp
+++ b/libcaf_core/caf/flow/op/hot.hpp
@@ -15,13 +15,9 @@ namespace caf::flow::op {
 template <class T>
 class hot : public detail::atomic_ref_counted, public base<T> {
 public:
-  // -- member types -----------------------------------------------------------
-
-  using output_type = T;
-
   // -- constructors, destructors, and assignment operators --------------------
 
-  explicit hot(coordinator* ctx) : ctx_(ctx) {
+  explicit hot(coordinator* parent) : parent_(parent) {
     // nop
   }
 
@@ -37,14 +33,14 @@ public:
 
   // -- implementation of observable_impl<T> -----------------------------------
 
-  coordinator* ctx() const noexcept override {
-    return ctx_;
+  coordinator* parent() const noexcept override {
+    return parent_;
   }
 
 protected:
   // -- member variables -------------------------------------------------------
 
-  coordinator* ctx_;
+  coordinator* parent_;
 };
 
 } // namespace caf::flow::op

--- a/libcaf_core/caf/flow/op/interval.hpp
+++ b/libcaf_core/caf/flow/op/interval.hpp
@@ -21,9 +21,9 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  interval(coordinator* ctx, timespan initial_delay, timespan period);
+  interval(coordinator* parent, timespan initial_delay, timespan period);
 
-  interval(coordinator* ctx, timespan initial_delay, timespan period,
+  interval(coordinator* parent, timespan initial_delay, timespan period,
            int64_t max_val);
 
   // -- implementation of observable_impl<T> -----------------------------------

--- a/libcaf_core/caf/flow/op/mcast.test.cpp
+++ b/libcaf_core/caf/flow/op/mcast.test.cpp
@@ -21,7 +21,7 @@ using int_mcast_ptr = intrusive_ptr<int_mcast>;
 
 struct fixture : test::fixture::flow {
   int_mcast_ptr make_mcast() {
-    return make_counted<int_mcast>(coordinator());
+    return coordinator()->add_child(std::in_place_type<int_mcast>);
   }
 
   auto lift(int_mcast_ptr mcast) {

--- a/libcaf_core/caf/flow/op/never.hpp
+++ b/libcaf_core/caf/flow/op/never.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "caf/config.hpp"
 #include "caf/flow/observer.hpp"
 #include "caf/flow/op/cold.hpp"
 #include "caf/flow/subscription.hpp"
@@ -17,12 +18,16 @@ class never_sub : public subscription::impl_base {
 public:
   // -- constructors, destructors, and assignment operators --------------------
 
-  never_sub(coordinator* ctx, observer<T> out)
-    : ctx_(ctx), out_(std::move(out)) {
+  never_sub(coordinator* parent, observer<T> out)
+    : parent_(parent), out_(std::move(out)) {
     // nop
   }
 
   // -- implementation of subscription -----------------------------------------
+
+  coordinator* parent() const noexcept override {
+    return parent_;
+  }
 
   bool disposed() const noexcept override {
     return !out_;
@@ -30,7 +35,9 @@ public:
 
   void dispose() override {
     if (out_)
-      ctx_->delay_fn([out = std::move(out_)]() mutable { out.on_complete(); });
+      parent_->delay_fn([out = std::move(out_)]() mutable { //
+        out.on_complete();
+      });
   }
 
   void request(size_t) override {
@@ -39,7 +46,7 @@ public:
 
 private:
   /// Stores the context (coordinator) that runs this flow.
-  coordinator* ctx_;
+  coordinator* parent_;
 
   /// Stores a handle to the subscribed observer.
   observer<T> out_;
@@ -53,20 +60,20 @@ public:
 
   using super = cold<T>;
 
-  using output_type = T;
-
   // -- constructors, destructors, and assignment operators --------------------
 
-  explicit never(coordinator* ctx) : super(ctx) {
+  explicit never(coordinator* parent) : super(parent) {
     // nop
   }
 
   // -- implementation of observable_impl<T> -----------------------------------
 
-  disposable subscribe(observer<output_type> out) override {
-    auto ptr = make_counted<never_sub<T>>(super::ctx_, out);
-    out.on_subscribe(subscription{ptr});
-    return disposable{std::move(ptr)};
+  disposable subscribe(observer<T> out) override {
+    CAF_ASSERT(out.valid());
+    auto sub = super::parent_->add_child_hdl(std::in_place_type<never_sub<T>>,
+                                             out);
+    out.on_subscribe(sub);
+    return disposable{std::move(sub).as_disposable()};
   }
 };
 

--- a/libcaf_core/caf/flow/op/publish.hpp
+++ b/libcaf_core/caf/flow/op/publish.hpp
@@ -27,9 +27,9 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  publish(coordinator* ctx, src_ptr src,
+  publish(coordinator* parent, src_ptr src,
           size_t max_buf_size = defaults::flow::buffer_size)
-    : super(ctx), max_buf_size_(max_buf_size), source_(std::move(src)) {
+    : super(parent), max_buf_size_(max_buf_size), source_(std::move(src)) {
     try_request_more_ = make_action([this] { this->try_request_more(); });
   }
 
@@ -38,6 +38,10 @@ public:
   }
 
   // -- ref counting (and disambiguation due to multiple base types) -----------
+
+  coordinator* parent() const noexcept override {
+    return super::parent_;
+  }
 
   void ref_coordinated() const noexcept override {
     this->ref();
@@ -127,7 +131,7 @@ public:
   void on_consumed_some(state_type*, size_t, size_t) override {
     if (!try_request_more_pending_) {
       try_request_more_pending_ = true;
-      super::ctx_->delay(try_request_more_);
+      super::parent_->delay(try_request_more_);
     }
   }
 

--- a/libcaf_core/caf/flow/op/pullable.cpp
+++ b/libcaf_core/caf/flow/op/pullable.cpp
@@ -24,10 +24,10 @@ pullable::~pullable() {
   pull_cb_.dispose();
 }
 
-void pullable::pull(flow::coordinator* ctx, size_t n) {
+void pullable::pull(flow::coordinator* parent, size_t n) {
   CAF_ASSERT(n > 0);
   if (in_flight_demand_ == 0)
-    ctx->delay(pull_cb_);
+    parent->delay(pull_cb_);
   in_flight_demand_ += n;
 }
 

--- a/libcaf_core/caf/flow/op/pullable.hpp
+++ b/libcaf_core/caf/flow/op/pullable.hpp
@@ -29,7 +29,7 @@ public:
   }
 
 protected:
-  void pull(flow::coordinator* ctx, size_t n);
+  void pull(flow::coordinator* parent, size_t n);
 
 private:
   virtual void do_pull(size_t in_flight_demand) = 0;

--- a/libcaf_core/caf/flow/op/zip_with.hpp
+++ b/libcaf_core/caf/flow/op/zip_with.hpp
@@ -8,6 +8,7 @@
 #include "caf/flow/observer.hpp"
 #include "caf/flow/op/cold.hpp"
 #include "caf/flow/subscription.hpp"
+#include "caf/make_counted.hpp"
 
 #include <algorithm>
 #include <deque>
@@ -60,19 +61,23 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  zip_with_sub(coordinator* ctx, F fn, observer<output_type> out,
+  zip_with_sub(coordinator* parent, F fn, observer<output_type> out,
                std::tuple<observable<Ts>...>& srcs)
-    : ctx_(ctx), fn_(std::move(fn)), out_(std::move(out)) {
+    : parent_(parent), fn_(std::move(fn)), out_(std::move(out)) {
     for_each_input([this, &srcs](auto index, auto& input) {
       using index_type = decltype(index);
       using value_type = typename std::decay_t<decltype(input)>::value_type;
       using fwd_impl = forwarder<value_type, zip_with_sub, index_type>;
-      auto fwd = make_counted<fwd_impl>(this, index);
+      auto fwd = parent_->add_child(std::in_place_type<fwd_impl>, this, index);
       std::get<index_type::value>(srcs).subscribe(fwd->as_observer());
     });
   }
 
   // -- implementation of subscription -----------------------------------------
+
+  coordinator* parent() const noexcept override {
+    return parent_;
+  }
 
   bool disposed() const noexcept override {
     return !out_;
@@ -157,7 +162,7 @@ public:
     if (out_) {
       auto& input = at(index);
       if (input.sub)
-        input.sub = nullptr;
+        input.sub.release_later();
       if (input.buf.empty())
         fin();
     }
@@ -170,7 +175,7 @@ public:
         err_ = what;
       auto& input = at(index);
       if (input.sub)
-        input.sub = nullptr;
+        input.sub.release_later();
       if (input.buf.empty())
         fin();
     }
@@ -202,20 +207,19 @@ private:
     for_each_input([](auto, auto& input) {
       if (input.sub) {
         input.sub.dispose();
-        input.sub = nullptr;
+        input.sub.release_later();
       }
       input.buf.clear();
     });
     // Set out_ to null and emit the final event.
-    auto out = std::move(out_);
-    if (err_)
-      out.on_error(err_);
+    if (!err_)
+      out_.on_complete();
     else
-      out.on_complete();
+      out_.on_error(err_);
   }
 
   /// Stores the context (coordinator) that runs this flow.
-  coordinator* ctx_;
+  coordinator* parent_;
 
   /// Reduces n inputs to 1 output.
   F fn_;
@@ -245,16 +249,17 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  zip_with(coordinator* ctx, F fn, observable<Ts>... inputs)
-    : super(ctx), fn_(std::move(fn)), inputs_(inputs...) {
+  zip_with(coordinator* parent, F fn, observable<Ts>... inputs)
+    : super(parent), fn_(std::move(fn)), inputs_(inputs...) {
     // nop
   }
 
   // -- implementation of observable<T>::impl ----------------------------------
 
   disposable subscribe(observer<output_type> out) override {
-    auto ptr = make_counted<zip_with_sub<F, Ts...>>(super::ctx_, fn_, out,
-                                                    inputs_);
+    using sub_t = zip_with_sub<F, Ts...>;
+    auto ptr = super::parent_->add_child(std::in_place_type<sub_t>, fn_, out,
+                                         inputs_);
     out.on_subscribe(subscription{ptr});
     return ptr->as_disposable();
   }
@@ -269,7 +274,8 @@ private:
 
 /// Creates a new zip-with operator from given inputs.
 template <class F, class T0, class T1, class... Ts>
-auto make_zip_with(coordinator* ctx, F fn, T0 input0, T1 input1, Ts... inputs) {
+auto make_zip_with(coordinator* parent, F fn, T0 input0, T1 input1,
+                   Ts... inputs) {
   using output_type = zip_with_output_t<F,                        //
                                         typename T0::output_type, //
                                         typename T1::output_type, //
@@ -279,10 +285,10 @@ auto make_zip_with(coordinator* ctx, F fn, T0 input0, T1 input1, Ts... inputs) {
                           typename T1::output_type, //
                           typename Ts::output_type...>;
   if (input0.valid() && input1.valid() && (inputs.valid() && ...)) {
-    auto ptr = make_counted<impl_t>(ctx, std::move(fn),
-                                    std::move(input0).as_observable(),
-                                    std::move(input1).as_observable(),
-                                    std::move(inputs).as_observable()...);
+    auto ptr = parent->add_child(std::in_place_type<impl_t>, std::move(fn),
+                                 std::move(input0).as_observable(),
+                                 std::move(input1).as_observable(),
+                                 std::move(inputs).as_observable()...);
     return observable<output_type>{std::move(ptr)};
   }
   return observable<output_type>{};

--- a/libcaf_core/caf/flow/scoped_coordinator.hpp
+++ b/libcaf_core/caf/flow/scoped_coordinator.hpp
@@ -4,8 +4,9 @@
 
 #pragma once
 
+#include "caf/flow/coordinated.hpp"
 #include "caf/flow/coordinator.hpp"
-#include "caf/make_counted.hpp"
+#include "caf/intrusive_ptr.hpp"
 #include "caf/ref_counted.hpp"
 
 #include <condition_variable>
@@ -43,6 +44,8 @@ public:
 
   // -- lifetime management ----------------------------------------------------
 
+  void release_later(coordinated_ptr& child) override;
+
   void watch(disposable what) override;
 
   // -- time -------------------------------------------------------------------
@@ -64,8 +67,13 @@ private:
 
   void drop_disposed_flows();
 
+  /// Stores objects that need to be disposed before returning from `run`.
   std::vector<disposable> watched_disposables_;
 
+  /// Stores children that were marked for release while running an action.
+  std::vector<coordinated_ptr> released_;
+
+  /// Stores delayed actions until they are due.
   std::multimap<steady_time_point, action> delayed_;
 
   mutable std::mutex mtx_;

--- a/libcaf_core/caf/flow/single.hpp
+++ b/libcaf_core/caf/flow/single.hpp
@@ -36,33 +36,40 @@ class single_observer_impl
 public:
   using input_type = on_success_arg_t<OnSuccess>;
 
-  single_observer_impl(OnSuccess on_success, OnError on_error)
-    : on_success_(std::move(on_success)), on_error_(std::move(on_error)) {
+  single_observer_impl(coordinator* parent, OnSuccess on_success,
+                       OnError on_error)
+    : parent_(parent),
+      on_success_(std::move(on_success)),
+      on_error_(std::move(on_error)) {
     // nop
   }
 
-  void on_subscribe(subscription sub) {
+  coordinator* parent() const noexcept override {
+    return parent_;
+  }
+
+  void on_subscribe(subscription sub) override {
     // Request one additional item to detect whether the observable emits more
     // than one item.
     sub.request(2);
     sub_ = std::move(sub);
   }
 
-  void on_next(const input_type& item) {
+  void on_next(const input_type& item) override {
     if (!result_) {
       result_.emplace(item);
     } else {
       sub_.dispose();
-      sub_ = nullptr;
+      sub_.release_later();
       auto err = make_error(sec::runtime_error,
                             "single emitted more than one item");
       on_error_(err);
     }
   }
 
-  void on_complete() {
+  void on_complete() override {
     if (sub_) {
-      sub_ = nullptr;
+      sub_.release_later();
       if (result_) {
         on_success_(*result_);
         result_ = std::nullopt;
@@ -74,14 +81,15 @@ public:
     }
   }
 
-  void on_error(const error& what) {
+  void on_error(const error& what) override {
     if (sub_) {
-      sub_ = nullptr;
+      sub_.release_later();
       on_error_(what);
     }
   }
 
 private:
+  coordinator* parent_;
   OnSuccess on_success_;
   OnError on_error_;
   std::optional<input_type> result_;
@@ -123,8 +131,10 @@ public:
     static_assert(std::is_invocable_v<OnSuccess, const T&>);
     static_assert(std::is_invocable_v<OnError, const error&>);
     using impl_t = single_observer_impl<OnSuccess, OnError>;
-    auto ptr = make_counted<impl_t>(std::move(on_success), std::move(on_error));
-    return pimpl_->subscribe(observer<T>{ptr});
+    auto hdl = pimpl_->parent()->add_child_hdl(std::in_place_type<impl_t>,
+                                               std::move(on_success),
+                                               std::move(on_error));
+    return pimpl_->subscribe(std::move(hdl));
   }
 
   bool valid() const noexcept {

--- a/libcaf_core/caf/flow/step/ignore_elements.test.cpp
+++ b/libcaf_core/caf/flow/step/ignore_elements.test.cpp
@@ -14,8 +14,6 @@
 
 using namespace caf;
 
-using caf::flow::make_observer;
-
 namespace {
 
 WITH_FIXTURE(test::fixture::flow) {

--- a/libcaf_core/caf/flow/step/skip_last.test.cpp
+++ b/libcaf_core/caf/flow/step/skip_last.test.cpp
@@ -14,8 +14,6 @@
 
 using namespace caf;
 
-using caf::flow::make_observer;
-
 namespace {
 
 WITH_FIXTURE(test::fixture::flow) {

--- a/libcaf_core/caf/flow/step/take_last.test.cpp
+++ b/libcaf_core/caf/flow/step/take_last.test.cpp
@@ -14,8 +14,6 @@
 
 using namespace caf;
 
-using caf::flow::make_observer;
-
 namespace {
 
 WITH_FIXTURE(test::fixture::flow) {

--- a/libcaf_core/caf/flow/subscription.hpp
+++ b/libcaf_core/caf/flow/subscription.hpp
@@ -8,6 +8,7 @@
 #include "caf/detail/plain_ref_counted.hpp"
 #include "caf/disposable.hpp"
 #include "caf/flow/coordinated.hpp"
+#include "caf/flow/coordinator.hpp"
 #include "caf/flow/fwd.hpp"
 #include "caf/intrusive_ptr.hpp"
 #include "caf/ref_counted.hpp"
@@ -23,12 +24,22 @@ public:
   // -- nested types -----------------------------------------------------------
 
   /// Internal interface of a `subscription`.
-  class CAF_CORE_EXPORT impl : public disposable::impl {
+  class CAF_CORE_EXPORT impl : public coordinated, public disposable::impl {
   public:
+    using handle_type = subscription;
+
     ~impl() override;
 
     /// Signals demand for `n` more items.
     virtual void request(size_t n) = 0;
+
+    friend void intrusive_ptr_add_ref(const impl* ptr) noexcept {
+      ptr->ref_disposable();
+    }
+
+    friend void intrusive_ptr_release(const impl* ptr) noexcept {
+      ptr->deref_disposable();
+    }
   };
 
   /// Simple base type for all subscription implementations that implements the
@@ -39,6 +50,10 @@ public:
     void ref_disposable() const noexcept final;
 
     void deref_disposable() const noexcept final;
+
+    void ref_coordinated() const noexcept final;
+
+    void deref_coordinated() const noexcept final;
   };
 
   /// Describes a listener to the subscription that will receive an event
@@ -56,8 +71,8 @@ public:
   /// `cancel` to a @ref listener.
   class CAF_CORE_EXPORT fwd_impl final : public impl_base {
   public:
-    fwd_impl(coordinator* ctx, listener* src, coordinated* snk)
-      : ctx_(ctx), src_(src), snk_(snk) {
+    fwd_impl(coordinator* parent, listener* src, coordinated* snk)
+      : parent_(parent), src_(src), snk_(snk) {
       // nop
     }
 
@@ -67,36 +82,56 @@ public:
 
     void dispose() override;
 
-    auto* ctx() const noexcept {
-      return ctx_;
+    coordinator* parent() const noexcept override {
+      return parent_;
     }
 
     /// Creates a new subscription object.
-    /// @param ctx The owner of @p src and @p snk.
+    /// @param parent The owner of @p src and @p snk.
     /// @param src The @ref observable that emits items.
     /// @param snk the @ref observer that consumes items.
     /// @returns an instance of @ref fwd_impl in a @ref subscription handle.
     template <class Observable, class Observer>
-    static subscription make(coordinator* ctx, Observable* src, Observer* snk) {
+    static subscription
+    make(coordinator* parent, Observable* src, Observer* snk) {
       static_assert(std::is_base_of_v<listener, Observable>);
       static_assert(std::is_base_of_v<coordinated, Observer>);
       static_assert(std::is_same_v<typename Observable::output_type,
                                    typename Observer::input_type>);
-      intrusive_ptr<impl> ptr{new fwd_impl(ctx, src, snk), false};
+      auto ptr = parent->template add_child<fwd_impl>(src, snk);
       return subscription{std::move(ptr)};
     }
 
     /// Like @ref make but without any type checking.
-    static subscription make_unsafe(coordinator* ctx, listener* src,
+    static subscription make_unsafe(coordinator* parent, listener* src,
                                     coordinated* snk) {
-      intrusive_ptr<impl> ptr{new fwd_impl(ctx, src, snk), false};
+      intrusive_ptr<impl> ptr{new fwd_impl(parent, src, snk), false};
       return subscription{std::move(ptr)};
     }
 
   private:
-    coordinator* ctx_;
+    coordinator* parent_;
     intrusive_ptr<listener> src_;
     intrusive_ptr<coordinated> snk_;
+  };
+
+  class CAF_CORE_EXPORT trivial_impl final : public subscription::impl_base {
+  public:
+    explicit trivial_impl(coordinator* parent) : parent_(parent) {
+      // nop
+    }
+
+    coordinator* parent() const noexcept override;
+
+    bool disposed() const noexcept override;
+
+    void request(size_t) override;
+
+    void dispose() override;
+
+  private:
+    coordinator* parent_;
+    bool disposed_ = false;
   };
 
   // -- constructors, destructors, and assignment operators --------------------
@@ -106,31 +141,38 @@ public:
     // nop
   }
 
-  subscription& operator=(std::nullptr_t) noexcept {
-    pimpl_.reset();
-    return *this;
-  }
-
   subscription() noexcept = default;
   subscription(subscription&&) noexcept = default;
   subscription(const subscription&) noexcept = default;
   subscription& operator=(subscription&&) noexcept = default;
   subscription& operator=(const subscription&) noexcept = default;
 
-  // -- factory functions ------------------------------------------------------
+  // -- mutators ---------------------------------------------------------------
 
-  /// Creates a trivial subscription that simply wraps a boolean flag and
-  /// ignores all requests.
-  static subscription make_trivial();
+  /// Resets this handle but releases the reference count after the current
+  /// coordinator cycle.
+  /// @post `!valid()`
+  void release_later() {
+    if (pimpl_) {
+      auto* parent = pimpl_->parent();
+      parent->release_later(pimpl_);
+      CAF_ASSERT(pimpl_ == nullptr);
+    }
+  }
 
   // -- demand signaling -------------------------------------------------------
 
   /// Causes the publisher to stop producing items for the subscriber. Any
   /// in-flight items may still get dispatched.
+  /// @post `!valid()`
   void dispose() {
     if (pimpl_) {
-      pimpl_->dispose();
-      pimpl_ = nullptr;
+      // Defend against impl::dispose() indirectly calling member functions on
+      // this object again.
+      auto ptr = intrusive_ptr<impl>{pimpl_.release(), false};
+      auto* parent = ptr->parent();
+      ptr->dispose();
+      parent->release_later(ptr);
     }
   }
 

--- a/libcaf_core/caf/optional.hpp
+++ b/libcaf_core/caf/optional.hpp
@@ -67,7 +67,7 @@ public:
   }
 
   optional& operator=(optional&& other) noexcept(
-    std::is_nothrow_destructible_v<T>&& std::is_nothrow_move_assignable_v<T>) {
+    std::is_nothrow_destructible_v<T> && std::is_nothrow_move_assignable_v<T>) {
     if (m_valid) {
       if (other.m_valid)
         m_value = std::move(other.m_value);

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -436,6 +436,8 @@ public:
 
   void delay(action what) override;
 
+  void release_later(flow::coordinated_ptr& child) override;
+
   disposable delay_until(steady_time_point abs_time, action what) override;
 
   void watch(disposable what) override;
@@ -818,6 +820,9 @@ private:
   /// Stores actions that the actor executes after processing the current
   /// message.
   std::vector<action> actions_;
+
+  /// Stores children that were marked for release while running an action.
+  std::vector<flow::coordinated_ptr> released_;
 
   /// Counter for scheduled_actor::delay to make sure
   /// scheduled_actor::run_actions does not end up in a busy loop that might

--- a/libcaf_core/tests/legacy/core-test.cpp
+++ b/libcaf_core/tests/legacy/core-test.cpp
@@ -101,6 +101,10 @@ disposable make_trivial_disposable() {
   return disposable{make_counted<trivial_impl>()};
 }
 
+coordinator* passive_subscription_impl::parent() const noexcept {
+  return parent_;
+}
+
 void passive_subscription_impl::request(size_t n) {
   demand += n;
 }

--- a/libcaf_core/tests/legacy/flow/mixed.cpp
+++ b/libcaf_core/tests/legacy/flow/mixed.cpp
@@ -16,8 +16,6 @@
 
 using namespace caf;
 
-using caf::flow::make_observer;
-
 namespace {
 
 struct fixture : test_coordinator_fixture<> {
@@ -39,7 +37,8 @@ BEGIN_FIXTURE_SCOPE(fixture)
 
 SCENARIO("sum up all the multiples of 3 or 5 below 1000") {
   SUB_CASE("solution 1") {
-    auto snk = flow::make_auto_observer<int>();
+    using snk_t = flow::auto_observer<int>;
+    auto snk = ctx->add_child(std::in_place_type<snk_t>);
     ctx->make_observable()
       .range(1, 999)
       .filter([](int x) { return x % 3 == 0 || x % 5 == 0; })
@@ -50,7 +49,8 @@ SCENARIO("sum up all the multiples of 3 or 5 below 1000") {
     CHECK_EQ(snk->buf, ls(233'168));
   }
   SUB_CASE("solution 2") {
-    auto snk = flow::make_auto_observer<int>();
+    using snk_t = flow::auto_observer<int>;
+    auto snk = ctx->add_child(std::in_place_type<snk_t>);
     ctx->make_observable()
       .merge(ctx->make_observable()
                .iota(1)

--- a/libcaf_core/tests/legacy/flow/multicaster.cpp
+++ b/libcaf_core/tests/legacy/flow/multicaster.cpp
@@ -32,8 +32,8 @@ BEGIN_FIXTURE_SCOPE(fixture)
 SCENARIO("a multicaster pushes items to all subscribers") {
   GIVEN("a multicaster with two subscribers") {
     auto uut = flow::multicaster<int>{ctx.get()};
-    auto snk1 = flow::make_passive_observer<int>();
-    auto snk2 = flow::make_passive_observer<int>();
+    auto snk1 = ctx->add_child(std::in_place_type<flow::passive_observer<int>>);
+    auto snk2 = ctx->add_child(std::in_place_type<flow::passive_observer<int>>);
     uut.subscribe(snk1->as_observer());
     uut.subscribe(snk2->as_observer());
     CHECK(uut.impl().has_observers());
@@ -121,9 +121,10 @@ SCENARIO("a multicaster pushes items to all subscribers") {
 SCENARIO("a multicaster discards items that arrive before a subscriber") {
   WHEN("pushing items") {
     THEN("observers see only items that were pushed after subscribing") {
+      using snk_t = flow::auto_observer<int>;
       auto uut = flow::multicaster<int>{ctx.get()};
       uut.push({1, 2, 3});
-      auto snk = flow::make_auto_observer<int>();
+      auto snk = ctx->add_child(std::in_place_type<snk_t>);
       uut.subscribe(snk->as_observer());
       ctx->run();
       uut.push({4, 5, 6});

--- a/libcaf_core/tests/legacy/flow/op/buffer.cpp
+++ b/libcaf_core/tests/legacy/flow/op/buffer.cpp
@@ -68,9 +68,10 @@ struct fixture : test_coordinator_fixture<> {
 
   template <class Impl>
   void add_subs(intrusive_ptr<Impl> uut) {
-    auto data_sub = make_counted<flow::passive_subscription_impl>();
+    using sub_t = flow::passive_subscription_impl;
+    auto data_sub = ctx->add_child(std::in_place_type<sub_t>);
     uut->fwd_on_subscribe(fwd_data, flow::subscription{std::move(data_sub)});
-    auto ctrl_sub = make_counted<flow::passive_subscription_impl>();
+    auto ctrl_sub = ctx->add_child(std::in_place_type<sub_t>);
     uut->fwd_on_subscribe(fwd_ctrl, flow::subscription{std::move(ctrl_sub)});
   }
 
@@ -214,12 +215,14 @@ SCENARIO("buffers start to emit items once subscribed") {
   GIVEN("a buffer operator") {
     WHEN("the selector never calls on_subscribe") {
       THEN("the buffer still emits batches") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        using snk_t = flow::passive_observer<cow_vector<int>>;
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto grd = make_unsubscribe_guard(snk);
         auto uut = raw_sub(3, flow::make_nil_observable<int>(ctx.get()),
                            flow::make_nil_observable<int64_t>(ctx.get()),
                            snk->as_observer());
-        auto data_sub = make_counted<flow::passive_subscription_impl>();
+        using sub_t = flow::passive_subscription_impl;
+        auto data_sub = ctx->add_child(std::in_place_type<sub_t>);
         uut->fwd_on_subscribe(fwd_data, flow::subscription{data_sub});
         ctx->run();
         REQUIRE_GE(data_sub->demand, 3u);
@@ -240,7 +243,8 @@ SCENARIO("buffers never subscribe to their control observable on error") {
   GIVEN("a buffer operator") {
     WHEN("the data observable calls on_error on subscribing it") {
       THEN("the buffer never tries to subscribe to their control observable") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        using snk_t = flow::passive_observer<cow_vector<int>>;
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto cnt = std::make_shared<size_t>(0);
         auto uut = raw_sub(3,
                            ctx->make_observable().fail<int>(sec::runtime_error),
@@ -258,18 +262,20 @@ SCENARIO("buffers dispose unexpected subscriptions") {
   GIVEN("an initialized buffer operator") {
     WHEN("calling on_subscribe with unexpected subscriptions") {
       THEN("the buffer disposes them immediately") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        using snk_t = flow::passive_observer<cow_vector<int>>;
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto grd = make_unsubscribe_guard(snk);
         auto uut = raw_sub(3, flow::make_nil_observable<int>(ctx.get()),
                            flow::make_nil_observable<int64_t>(ctx.get()),
                            snk->as_observer());
-        auto data_sub = make_counted<flow::passive_subscription_impl>();
-        auto ctrl_sub = make_counted<flow::passive_subscription_impl>();
+        using sub_t = flow::passive_subscription_impl;
+        auto data_sub = ctx->add_child(std::in_place_type<sub_t>);
+        auto ctrl_sub = ctx->add_child(std::in_place_type<sub_t>);
         uut->fwd_on_subscribe(fwd_data, flow::subscription{data_sub});
         uut->fwd_on_subscribe(fwd_ctrl, flow::subscription{ctrl_sub});
         ctx->run();
-        auto data_sub_2 = make_counted<flow::passive_subscription_impl>();
-        auto ctrl_sub_2 = make_counted<flow::passive_subscription_impl>();
+        auto data_sub_2 = ctx->add_child(std::in_place_type<sub_t>);
+        auto ctrl_sub_2 = ctx->add_child(std::in_place_type<sub_t>);
         uut->fwd_on_subscribe(fwd_data, flow::subscription{data_sub_2});
         uut->fwd_on_subscribe(fwd_ctrl, flow::subscription{ctrl_sub_2});
         ctx->run();
@@ -284,10 +290,11 @@ SCENARIO("buffers dispose unexpected subscriptions") {
 }
 
 SCENARIO("buffers emit final items after an on_error event") {
+  using snk_t = flow::passive_observer<cow_vector<int>>;
   GIVEN("an initialized buffer operator") {
     WHEN("calling on_error(data) on a buffer without pending data") {
       THEN("the buffer forward on_error immediately") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = raw_sub(3, trivial_obs<int>(), trivial_obs<int64_t>(),
                            snk->as_observer());
         snk->request(42);
@@ -303,7 +310,7 @@ SCENARIO("buffers emit final items after an on_error event") {
     }
     WHEN("calling on_error(data) on a buffer with pending data") {
       THEN("the buffer still emits pending data before closing") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = raw_sub(3, trivial_obs<int>(), trivial_obs<int64_t>(),
                            snk->as_observer());
         ctx->run();
@@ -321,7 +328,7 @@ SCENARIO("buffers emit final items after an on_error event") {
     }
     WHEN("calling on_error(control) on a buffer without pending data") {
       THEN("the buffer forward on_error immediately") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = raw_sub(3, trivial_obs<int>(), trivial_obs<int64_t>(),
                            snk->as_observer());
         snk->request(42);
@@ -337,7 +344,7 @@ SCENARIO("buffers emit final items after an on_error event") {
     }
     WHEN("calling on_error(control) on a buffer with pending data") {
       THEN("the buffer still emits pending data before closing") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = raw_sub(3, trivial_obs<int>(), trivial_obs<int64_t>(),
                            snk->as_observer());
         ctx->run();
@@ -357,10 +364,11 @@ SCENARIO("buffers emit final items after an on_error event") {
 }
 
 SCENARIO("buffers emit final items after an on_complete event") {
+  using snk_t = flow::passive_observer<cow_vector<int>>;
   GIVEN("an initialized buffer operator") {
     WHEN("calling on_complete(data) on a buffer without pending data") {
       THEN("the buffer forward on_complete immediately") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = raw_sub(3, trivial_obs<int>(), trivial_obs<int64_t>(),
                            snk->as_observer());
         snk->request(42);
@@ -376,7 +384,7 @@ SCENARIO("buffers emit final items after an on_complete event") {
     }
     WHEN("calling on_complete(data) on a buffer with pending data") {
       THEN("the buffer still emits pending data before closing") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = raw_sub(3, trivial_obs<int>(), trivial_obs<int64_t>(),
                            snk->as_observer());
         ctx->run();
@@ -394,7 +402,7 @@ SCENARIO("buffers emit final items after an on_complete event") {
     }
     WHEN("calling on_complete(control) on a buffer without pending data") {
       THEN("the buffer raises an error immediately") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = raw_sub(3, trivial_obs<int>(), trivial_obs<int64_t>(),
                            snk->as_observer());
         snk->request(42);
@@ -410,7 +418,7 @@ SCENARIO("buffers emit final items after an on_complete event") {
     }
     WHEN("calling on_complete(control) on a buffer with pending data") {
       THEN("the buffer raises an error after shipping pending items") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = raw_sub(3, trivial_obs<int>(), trivial_obs<int64_t>(),
                            snk->as_observer());
         ctx->run();
@@ -430,10 +438,11 @@ SCENARIO("buffers emit final items after an on_complete event") {
 }
 
 SCENARIO("skip policies suppress empty batches") {
+  using snk_t = flow::passive_observer<cow_vector<int>>;
   GIVEN("a buffer operator") {
     WHEN("the control observable fires with no pending data") {
       THEN("the operator omits the batch") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto grd = make_unsubscribe_guard(snk);
         auto uut = raw_sub<skip_trait>(3, trivial_obs<int>(),
                                        trivial_obs<int64_t>(),
@@ -448,7 +457,7 @@ SCENARIO("skip policies suppress empty batches") {
     }
     WHEN("the control observable fires with pending data") {
       THEN("the operator emits a partial batch") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto grd = make_unsubscribe_guard(snk);
         auto uut = raw_sub<skip_trait>(3, trivial_obs<int>(),
                                        trivial_obs<int64_t>(),
@@ -466,10 +475,11 @@ SCENARIO("skip policies suppress empty batches") {
 }
 
 SCENARIO("no-skip policies emit empty batches") {
+  using snk_t = flow::passive_observer<cow_vector<int>>;
   GIVEN("a buffer operator") {
     WHEN("the control observable fires with no pending data") {
       THEN("the operator emits an empty batch") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto grd = make_unsubscribe_guard(snk);
         auto uut = raw_sub<noskip_trait>(3, trivial_obs<int>(),
                                          trivial_obs<int64_t>(),
@@ -484,7 +494,7 @@ SCENARIO("no-skip policies emit empty batches") {
     }
     WHEN("the control observable fires with pending data") {
       THEN("the operator emits a partial batch") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto grd = make_unsubscribe_guard(snk);
         auto uut = raw_sub<noskip_trait>(3, trivial_obs<int>(),
                                          trivial_obs<int64_t>(),
@@ -505,7 +515,8 @@ SCENARIO("disposing a buffer operator completes the flow") {
   GIVEN("a buffer operator") {
     WHEN("disposing the subscription operator of the operator") {
       THEN("the observer receives an on_complete event") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        using snk_t = flow::passive_observer<cow_vector<int>>;
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = raw_sub<skip_trait>(3, trivial_obs<int>(),
                                        trivial_obs<int64_t>(),
                                        snk->as_observer());
@@ -524,7 +535,8 @@ SCENARIO("on_request actions can turn into no-ops") {
   GIVEN("a buffer operator") {
     WHEN("the sink requests more data right before a timeout triggers") {
       THEN("the batch gets shipped and the on_request action does nothing") {
-        auto snk = flow::make_passive_observer<cow_vector<int>>();
+        using snk_t = flow::passive_observer<cow_vector<int>>;
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto grd = make_unsubscribe_guard(snk);
         auto uut = raw_sub<skip_trait>(3, trivial_obs<int>(),
                                        trivial_obs<int64_t>(),

--- a/libcaf_core/tests/legacy/flow/op/cell.cpp
+++ b/libcaf_core/tests/legacy/flow/op/cell.cpp
@@ -39,8 +39,9 @@ SCENARIO("a null cell emits zero items") {
   GIVEN("an integer cell with an observer") {
     WHEN("calling set_null on the cell") {
       THEN("the observer receives the completed event") {
+        using snk_t = flow::passive_observer<int>;
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = make_cell();
-        auto snk = flow::make_passive_observer<int>();
         lift(uut).subscribe(snk->as_observer());
         REQUIRE(snk->subscribed());
         snk->sub.request(128);
@@ -56,9 +57,10 @@ SCENARIO("a null cell emits zero items") {
   GIVEN("an integer cell without on bserver") {
     WHEN("calling set_null on the cell") {
       THEN("observers receive completed events immediately after subscribing") {
+        using snk_t = flow::passive_observer<int>;
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = make_cell();
         uut->set_null();
-        auto snk = flow::make_passive_observer<int>();
         lift(uut).subscribe(snk->as_observer());
         REQUIRE(snk->subscribed());
         snk->sub.request(128);
@@ -74,8 +76,9 @@ SCENARIO("a cell with a value emits exactly one item") {
   GIVEN("an integer cell with an observer") {
     WHEN("calling set_value on the cell") {
       THEN("the observer receives on_next and then on_complete") {
+        using snk_t = flow::passive_observer<int>;
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = make_cell();
-        auto snk = flow::make_passive_observer<int>();
         lift(uut).subscribe(snk->as_observer());
         REQUIRE(snk->subscribed());
         snk->sub.request(128);
@@ -89,8 +92,9 @@ SCENARIO("a cell with a value emits exactly one item") {
     }
     WHEN("disposing the subscription before calling set_value on the cell") {
       THEN("the observer does not receive the item") {
+        using snk_t = flow::passive_observer<int>;
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = make_cell();
-        auto snk = flow::make_passive_observer<int>();
         lift(uut).subscribe(snk->as_observer());
         REQUIRE(snk->subscribed());
         snk->request(128);
@@ -113,9 +117,10 @@ SCENARIO("a cell with a value emits exactly one item") {
   GIVEN("an integer cell without on bserver") {
     WHEN("calling set_null on the cell") {
       THEN("the observer receives on_next and then on_complete immediately") {
+        using snk_t = flow::passive_observer<int>;
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = make_cell();
         uut->set_value(42);
-        auto snk = flow::make_passive_observer<int>();
         lift(uut).subscribe(snk->as_observer());
         REQUIRE(snk->subscribed());
         snk->sub.request(128);
@@ -131,8 +136,9 @@ SCENARIO("a failed cell emits zero item") {
   GIVEN("an integer cell with an observer") {
     WHEN("calling set_error on the cell") {
       THEN("the observer receives on_error") {
+        using snk_t = flow::passive_observer<int>;
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = make_cell();
-        auto snk = flow::make_passive_observer<int>();
         lift(uut).subscribe(snk->as_observer());
         REQUIRE(snk->subscribed());
         snk->sub.request(128);
@@ -149,9 +155,10 @@ SCENARIO("a failed cell emits zero item") {
   GIVEN("an integer cell without on bserver") {
     WHEN("calling set_error on the cell") {
       THEN("the observer receives on_error immediately when subscribing") {
+        using snk_t = flow::passive_observer<int>;
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = make_cell();
         uut->set_error(sec::runtime_error);
-        auto snk = flow::make_passive_observer<int>();
         lift(uut).subscribe(snk->as_observer());
         REQUIRE(snk->subscribed());
         snk->sub.request(128);

--- a/libcaf_core/tests/legacy/flow/op/defer.cpp
+++ b/libcaf_core/tests/legacy/flow/op/defer.cpp
@@ -28,14 +28,15 @@ SCENARIO("the defer operator produces a fresh observable for each observer") {
     WHEN("two observers subscribes") {
       THEN("each observer subscribes to a fresh observable") {
         using ivec = std::vector<int>;
+        using snk_t = flow::passive_observer<int>;
         size_t factory_calls = 0;
         auto factory = [this, &factory_calls] {
           ++factory_calls;
           return ctx->make_observable().iota(1).take(5);
         };
         auto uut = ctx->make_observable().defer(factory);
-        auto snk1 = flow::make_passive_observer<int>();
-        auto snk2 = flow::make_passive_observer<int>();
+        auto snk1 = ctx->add_child(std::in_place_type<snk_t>);
+        auto snk2 = ctx->add_child(std::in_place_type<snk_t>);
         uut.subscribe(snk1->as_observer());
         CHECK_EQ(factory_calls, 1u);
         REQUIRE(snk1->sub);

--- a/libcaf_core/tests/legacy/flow/op/empty.cpp
+++ b/libcaf_core/tests/legacy/flow/op/empty.cpp
@@ -27,7 +27,8 @@ SCENARIO("an empty observable terminates normally") {
   GIVEN("an empty<int32>") {
     WHEN("an observer subscribes") {
       THEN("the observer receives on_complete") {
-        auto snk = flow::make_passive_observer<int32_t>();
+        using snk_t = flow::passive_observer<int32_t>;
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         ctx->make_observable().empty<int32_t>().subscribe(snk->as_observer());
         ctx->run();
         CHECK(snk->subscribed());

--- a/libcaf_core/tests/legacy/flow/op/fail.cpp
+++ b/libcaf_core/tests/legacy/flow/op/fail.cpp
@@ -25,8 +25,9 @@ SCENARIO("the fail operator immediately calls on_error on any subscriber") {
   GIVEN("a fail<int32> operator") {
     WHEN("an observer subscribes") {
       THEN("the observer receives on_error") {
+        using snk_t = flow::passive_observer<int32_t>;
+        auto snk = ctx->add_child(std::in_place_type<snk_t>);
         auto uut = ctx->make_observable().fail<int32_t>(sec::runtime_error);
-        auto snk = flow::make_auto_observer<int32_t>();
         uut.subscribe(snk->as_observer());
         ctx->run();
         CHECK(!snk->sub);

--- a/libcaf_core/tests/legacy/flow/op/never.cpp
+++ b/libcaf_core/tests/legacy/flow/op/never.cpp
@@ -27,9 +27,10 @@ SCENARIO("the never operator never invokes callbacks except when disposed") {
   GIVEN("a never operator") {
     WHEN("an observer subscribes and disposing the subscription") {
       THEN("the observer receives on_complete") {
+        using snk_t = flow::auto_observer<int32_t>;
         auto uut = ctx->make_observable().never<int32_t>();
-        auto snk1 = flow::make_auto_observer<int32_t>();
-        auto snk2 = flow::make_auto_observer<int32_t>();
+        auto snk1 = ctx->add_child(std::in_place_type<snk_t>);
+        auto snk2 = ctx->add_child(std::in_place_type<snk_t>);
         auto sub1 = uut.subscribe(snk1->as_observer());
         ctx->run();
         CHECK(snk1->buf.empty());

--- a/libcaf_net/caf/detail/message_flow_bridge.hpp
+++ b/libcaf_net/caf/detail/message_flow_bridge.hpp
@@ -152,7 +152,7 @@ private:
   action do_cancel_cb() {
     return make_action([this] {
       if (out_) {
-        out_ = nullptr;
+        out_.release_later();
         down_->shutdown();
       }
     });


### PR DESCRIPTION
The subscription and the observer hold mutual references, which makes it very easy to accidentally destroy the current object when disposing objects. The `release_later` functions delay releasing the reference count of discarded objects until all actions have completed. This makes it safe to discard a subscription or observer, even if both objects end up discard each other by delaying the destruction of the objects.