### PR TITLE
Properly terminate test drivers on SIGTERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   enabled (#1669).
 - Calling `delay_for_fn` on a flow coordinator now returns a `disposable` in
   order to be consistent with `delay_for` and `delay_until`.
+- Calling `dispose` on a server (e.g. an HTTP server) now properly closes all
+  open connections.
 
 ### Changed
 

--- a/examples/http/rest.cpp
+++ b/examples/http/rest.cpp
@@ -15,7 +15,9 @@
 #include "caf/scheduled_actor/flow.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <cctype>
+#include <csignal>
 #include <iostream>
 #include <string>
 #include <utility>

--- a/examples/http/rest.cpp
+++ b/examples/http/rest.cpp
@@ -20,7 +20,7 @@
 #include <string>
 #include <utility>
 
-namespace http = caf::net::http;
+using namespace std::literals;
 
 // -- constants ----------------------------------------------------------------
 
@@ -89,9 +89,22 @@ std::string to_ascii(caf::span<const std::byte> buffer) {
 
 // -- main ---------------------------------------------------------------------
 
+namespace {
+
+std::atomic<bool> shutdown_flag;
+
+void set_shutdown_flag(int) {
+  shutdown_flag = true;
+}
+
+} // namespace
+
 int caf_main(caf::actor_system& sys, const config& cfg) {
-  using namespace std::literals;
   namespace ssl = caf::net::ssl;
+  namespace http = caf::net::http;
+  // Do a regular shutdown for CTRL+C and SIGTERM.
+  signal(SIGTERM, set_shutdown_flag);
+  signal(SIGINT, set_shutdown_flag);
   // Read the configuration.
   auto port = caf::get_or(cfg, "port", default_port);
   auto pem = ssl::format::pem;
@@ -188,8 +201,11 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
               << to_string(server.error()) << '\n';
     return EXIT_FAILURE;
   }
-  // Note: the actor system will keep the application running for as long as the
-  // kvs actor stays alive.
+  // Wait for CTRL+C or SIGTERM.
+  while (!shutdown_flag)
+    std::this_thread::sleep_for(250ms);
+  std::cerr << "*** shutting down\n";
+  server->dispose();
   return EXIT_SUCCESS;
 }
 

--- a/examples/web_socket/echo.cpp
+++ b/examples/web_socket/echo.cpp
@@ -9,6 +9,8 @@
 #include "caf/event_based_actor.hpp"
 #include "caf/scheduled_actor/flow.hpp"
 
+#include <atomic>
+#include <csignal>
 #include <iostream>
 #include <utility>
 

--- a/examples/web_socket/quote-server.cpp
+++ b/examples/web_socket/quote-server.cpp
@@ -17,7 +17,9 @@
 #include "caf/scheduled_actor/flow.hpp"
 #include "caf/span.hpp"
 
+#include <atomic>
 #include <cassert>
+#include <csignal>
 #include <iostream>
 #include <random>
 #include <utility>

--- a/robot/http/client-driver.cpp
+++ b/robot/http/client-driver.cpp
@@ -12,6 +12,7 @@
 #include "caf/detail/latch.hpp"
 #include "caf/ipv4_address.hpp"
 
+#include <csignal>
 #include <iostream>
 #include <memory>
 #include <utility>
@@ -104,7 +105,14 @@ private:
   std::shared_ptr<detail::latch> latch_;
 };
 
+namespace {
+
+std::atomic<bool> shutdown_flag;
+
+} // namespace
+
 int caf_main(caf::actor_system& sys, const config& cfg) {
+  signal(SIGTERM, [](int) { shutdown_flag = true; });
   auto maybe_resource = caf::get_as<uri>(cfg, "resource");
   if (!maybe_resource) {
     std::cerr << "*** missing mandatory option --resource" << std::endl;


### PR DESCRIPTION
Aside from the SIGTERM handling, I've also had to fix the behavior of disposing a server. Otherwise, the HTTP rest tests wouldn't shut down properly (it appears like the Robot HTTP client opens a single TCP connection and then keeps that alive).