### PR TITLE
Relax assertion in telemetry::counter::inc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   fully qualified name).
 - Log format strings no longer support `%C`. CAF still recognizes this option
   but it will always print `null`.
+- The function `caf::telemetry::counter::inc` now allows passing 0 as an
+  argument. Previously, passing 0 triggered an assertion when building CAF with
+  runtime checks enabled.
 
 ### Deprecated
 

--- a/libcaf_core/caf/telemetry/counter.hpp
+++ b/libcaf_core/caf/telemetry/counter.hpp
@@ -50,9 +50,9 @@ public:
   }
 
   /// Increments the counter by `amount`.
-  /// @pre `amount > 0`
+  /// @pre `amount >= 0`
   void inc(value_type amount) noexcept {
-    CAF_ASSERT(amount > 0);
+    CAF_ASSERT(amount >= 0);
     gauge_.inc(amount);
   }
 


### PR DESCRIPTION
The assertion in telemetry::counter::inc is meant to ensure that a counter can only increase. Hence, prohibiting 0 is a bit overzealous since applications might pass something like a container size to the function and currently cannot (at least with runtime checks enabled) do so without special-casing.