### PR TITLE
Block codecov/patch from failing builds

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,3 +17,6 @@ coverage:
       default:
         threshold: 1% # we have some fluctuation from nondeterminism alone
         informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
We still see the `codecov/patch` check failing builds. This change sets it to `informational`. If that doesn't help, we'll have to turn off the `patch` check.