### PR TITLE
Fix UB in actor clock action decorator

### DIFF
--- a/libcaf_core/caf/actor_clock.cpp
+++ b/libcaf_core/caf/actor_clock.cpp
@@ -49,11 +49,10 @@ public:
 
   void run() override {
     CAF_ASSERT(decorated_ != nullptr);
-    CAF_ASSERT(worker_ != nullptr);
     WorkerPtr tmp;
     {
       std::unique_lock guard(mtx_);
-      tmp = std::move(worker_);
+      tmp.swap(worker_);
     }
     if constexpr (std::is_same_v<WorkerPtr, weak_actor_ptr>) {
       if (auto ptr = actor_cast<strong_actor_ptr>(tmp)) {
@@ -62,7 +61,8 @@ public:
         decorated_->dispose();
       }
     } else {
-      do_run(tmp);
+      if (tmp)
+        do_run(tmp);
     }
   }
 


### PR DESCRIPTION
That `CAF_ASSERT` was unsafe, because it accessed `worker_` without the mutex. Furthermore, `run()` might well read `worker_` as `nullptr` if the action has been disposed. Consequently, the decorator must check for `null` before calling `do_run`.

Closes #1667.