### PR TITLE
Simplify implementation of chunked_string

### DIFF
--- a/libcaf_core/caf/chunked_string.cpp
+++ b/libcaf_core/caf/chunked_string.cpp
@@ -6,6 +6,8 @@
 
 #include "caf/detail/monotonic_buffer_resource.hpp"
 
+#include <numeric>
+
 namespace caf {
 
 namespace {
@@ -15,43 +17,40 @@ using allocator_t = detail::monotonic_buffer_resource::allocator<T>;
 
 } // namespace
 
-std::string to_string(const chunked_string& str) {
-  std::string result;
-  for (auto* chunk = str.head; chunk != nullptr; chunk = chunk->next)
-    result.insert(result.end(), chunk->content.begin(), chunk->content.end());
-  return result;
+size_t chunked_string::size() const noexcept {
+  auto fn = [](size_t acc, std::string_view chunk) {
+    return acc + chunk.size();
+  };
+  return std::accumulate(begin(), end(), size_t{0}, fn);
 }
 
-chunked_string_builder::chunked_string_builder(
-  detail::monotonic_buffer_resource* resource)
-  : resource_(resource) {
-  auto* buf = allocator_t<chunked_string::node>{resource_}.allocate(1);
-  first_chunk_ = new (buf) chunked_string::node();
-  last_chunk_ = first_chunk_;
+std::string to_string(const chunked_string& str) {
+  std::string result;
+  result.reserve(str.size());
+  for (auto chunk : str)
+    result.insert(result.end(), chunk.begin(), chunk.end());
+  return result;
 }
 
 void chunked_string_builder::chunked_string_builder::append(char ch) {
   if (current_block_ == nullptr) { // Lazy initialization.
-    current_block_ = allocator_t<char>{resource_}.allocate(chunk_size);
+    current_block_ = allocator_t<char>{resource()}.allocate(chunk_size);
     write_pos_ = 0;
   } else if (write_pos_ == chunk_size) { // Flush current block if necessary.
-    last_chunk_->content = std::string_view{current_block_, chunk_size};
-    auto* buf = allocator_t<chunked_string::node>{resource_}.allocate(1);
-    auto* next = new (buf) chunked_string::node();
-    last_chunk_->next = next;
-    last_chunk_ = next;
-    current_block_ = allocator_t<char>{resource_}.allocate(chunk_size);
+    auto& back = chunks_.emplace_back();
+    back = std::string_view{current_block_, chunk_size};
+    current_block_ = allocator_t<char>{resource()}.allocate(chunk_size);
     write_pos_ = 0;
   }
   current_block_[write_pos_++] = ch;
 }
 
-chunked_string chunked_string_builder::seal() {
-  if (current_block_ == nullptr)
-    return chunked_string{first_chunk_};
-  last_chunk_->content = std::string_view{current_block_, write_pos_};
-  current_block_ = nullptr;
-  return chunked_string{first_chunk_};
+chunked_string chunked_string_builder::build() {
+  if (current_block_ != nullptr) {
+    auto& back = chunks_.emplace_back();
+    back = std::string_view{current_block_, write_pos_};
+  }
+  return chunked_string{chunks_.head()};
 }
 
 } // namespace caf

--- a/libcaf_core/caf/chunked_string.test.cpp
+++ b/libcaf_core/caf/chunked_string.test.cpp
@@ -13,27 +13,31 @@ using namespace std::literals;
 
 namespace {
 
-auto str(chunked_string::node& node) {
-  return chunked_string{&node};
+using list_type = detail::json::linked_list<std::string_view>;
+
+using node_type = list_type::node_type;
+
+auto str(const node_type& head) {
+  return chunked_string{&head};
 }
 
 TEST("to_string") {
-  auto world = chunked_string::node{"World!", nullptr};
+  auto world = node_type{"World!", nullptr};
   check_eq(to_string(str(world)), "World!");
-  auto hello = chunked_string::node{"Hello, ", &world};
+  auto hello = node_type{"Hello, ", &world};
   check_eq(to_string(str(hello)), "Hello, World!");
 }
 
 TEST("format") {
-  auto world = chunked_string::node{"World!", nullptr};
+  auto world = node_type{"World!", nullptr};
   check_eq(detail::format("{}", str(world)), "World!");
   check_eq(detail::format("{:?}", str(world)), R"_("World!")_");
   check_eq(detail::format("{:?} {}", str(world), str(world)),
            R"_("World!" World!)_");
-  auto hello = chunked_string::node{"Hello, ", &world};
+  auto hello = node_type{"Hello, ", &world};
   check_eq(detail::format("{}", str(hello)), "Hello, World!");
   check_eq(detail::format("{:?}", str(hello)), R"_("Hello, World!")_");
-  auto prefix = chunked_string::node{"\"Jon\":\t", &hello};
+  auto prefix = node_type{"\"Jon\":\t", &hello};
   check_eq(detail::format("{}", str(prefix)), "\"Jon\":\tHello, World!");
   check_eq(detail::format("{:?}", str(prefix)),
            R"_("\"Jon\":\tHello, World!")_");
@@ -44,7 +48,7 @@ TEST("builder") {
   auto builder = chunked_string_builder{&resource};
   auto out = chunked_string_builder_output_iterator{&builder};
   SECTION("empty") {
-    check_eq(to_string(builder.seal()), "");
+    check_eq(to_string(builder.build()), "");
   }
   SECTION("iterator interface") {
     out = 'h';
@@ -54,12 +58,12 @@ TEST("builder") {
     *out++ = 'l';
     *out++ = 'l';
     *out = 'o';
-    check_eq(to_string(builder.seal()), "hello");
+    check_eq(to_string(builder.build()), "hello");
   }
   SECTION("single chunk") {
     auto hello = "Hello, World!"s;
     std::copy(hello.begin(), hello.end(), out);
-    check_eq(to_string(builder.seal()), hello);
+    check_eq(to_string(builder.build()), hello);
   }
   SECTION("multiple chunks") {
     auto next = [ch = '1']() mutable {
@@ -75,11 +79,11 @@ TEST("builder") {
     for (size_t i = 0; i < 513; ++i)
       str += next();
     std::copy(str.begin(), str.end(), out);
-    auto res = builder.seal();
+    auto res = builder.build();
     check_eq(to_string(res), str);
     auto sizes = std::vector<size_t>{};
-    for (auto chunk = res.head; chunk != nullptr; chunk = chunk->next)
-      sizes.push_back(chunk->content.size());
+    for (auto chunk : res)
+      sizes.push_back(chunk.size());
     check_eq(sizes, std::vector<size_t>{128, 128, 128, 128, 1});
   }
 }

--- a/libcaf_core/caf/detail/json.hpp
+++ b/libcaf_core/caf/detail/json.hpp
@@ -140,6 +140,9 @@ operator!=(linked_list_iterator<T> lhs, linked_list_iterator<T> rhs) {
 //
 // The default-constructed list object is an empty list that does not allow
 // push_back.
+//
+// TODO: should not be part of the json namespace. Probably should be merged
+//       into intrusive::linked_list.
 template <class T>
 class linked_list {
 public:
@@ -158,6 +161,8 @@ public:
   using const_pointer = const value_type*;
 
   using node_pointer = node_type*;
+
+  using const_node_pointer = const node_type*;
 
   using iterator = linked_list_iterator<value_type>;
 
@@ -179,6 +184,11 @@ public:
 
   explicit linked_list(allocator_type allocator) noexcept
     : allocator_(allocator) {
+    // nop
+  }
+
+  explicit linked_list(monotonic_buffer_resource* resource) noexcept
+    : allocator_(resource) {
     // nop
   }
 
@@ -259,7 +269,7 @@ public:
 
   void push_back(T value) {
     ++size_;
-    auto new_node = allocator_->allocate(1);
+    auto new_node = allocator_.allocate(1);
     new (new_node) node_type{std::move(value), nullptr};
     if (head_ == nullptr) {
       head_ = tail_ = new_node;
@@ -281,6 +291,14 @@ public:
       tail_ = new_node;
     }
     return new_node->value;
+  }
+
+  node_pointer head() noexcept {
+    return head_;
+  }
+
+  const_node_pointer head() const noexcept {
+    return head_;
   }
 
 private:

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -94,6 +94,7 @@ class binary_deserializer;
 class binary_serializer;
 class blocking_actor;
 class chunk;
+class chunked_string;
 class config_option;
 class config_option_adder;
 class config_option_set;
@@ -150,7 +151,6 @@ class stateful_actor;
 
 // -- structs ------------------------------------------------------------------
 
-struct chunked_string;
 struct down_msg;
 struct exit_msg;
 struct group_down_msg;


### PR DESCRIPTION
I was about to implement something similar to the chunked string builder again. So I looked for ways to make parts of the implementation re-usable or re-use something else that already exists. Turns out we already have a `linked_list` with a custom allocator: `detail::json::linked_list`. We'll definitely have to move this somewhere else (see #1692), but it's still the right tool for the job.