### PR TITLE
Implement new log event type for logging

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -232,6 +232,8 @@ caf_add_component(
     caf/json_writer.cpp
     caf/load_inspector.cpp
     caf/local_actor.cpp
+    caf/log_event.cpp
+    caf/log_event.test.cpp
     caf/logger.cpp
     caf/mailbox_element.cpp
     caf/make_config_option.cpp

--- a/libcaf_core/caf/chunked_string.cpp
+++ b/libcaf_core/caf/chunked_string.cpp
@@ -6,6 +6,7 @@
 
 #include "caf/detail/monotonic_buffer_resource.hpp"
 
+#include <new>
 #include <numeric>
 
 namespace caf {
@@ -30,6 +31,11 @@ std::string to_string(const chunked_string& str) {
   for (auto chunk : str)
     result.insert(result.end(), chunk.begin(), chunk.end());
   return result;
+}
+
+chunked_string_builder::chunked_string_builder(
+  resource_type* resource) noexcept {
+  new (&chunks_) list_type(resource);
 }
 
 void chunked_string_builder::chunked_string_builder::append(char ch) {

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -119,6 +119,9 @@ class json_reader;
 class json_value;
 class json_writer;
 class local_actor;
+class log_event;
+class log_event_builder;
+class log_event_fields;
 class logger;
 class mailbox_element;
 class message;
@@ -366,6 +369,10 @@ intrusive_cow_ptr_unshare(dynamic_message_data*&);
 using global_meta_objects_guard_type = intrusive_ptr<ref_counted>;
 
 } // namespace detail
+
+// -- intrusive pointer aliases ------------------------------------------------
+
+using log_event_ptr = intrusive_ptr<log_event>;
 
 // -- weak pointer aliases -----------------------------------------------------
 

--- a/libcaf_core/caf/log_event.cpp
+++ b/libcaf_core/caf/log_event.cpp
@@ -1,0 +1,60 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/log_event.hpp"
+
+#include "caf/make_counted.hpp"
+
+#include <new>
+
+namespace caf {
+
+namespace {
+
+template <class T>
+using allocator_t = detail::monotonic_buffer_resource::allocator<T>;
+
+std::string_view deep_copy_impl(detail::monotonic_buffer_resource* resource,
+                                std::string_view str) {
+  auto* buf = allocator_t<char>{resource}.allocate(str.size());
+  memcpy(buf, str.data(), str.size());
+  return std::string_view{buf, str.size()};
+}
+
+} // namespace
+
+log_event_ptr log_event::make(unsigned level, std::string_view component,
+                              const detail::source_location& loc,
+                              std::string_view msg) {
+  using chunk_node = chunked_string::node_type;
+  auto event = make(level, component, loc);
+  auto* res = &event->resource_;
+  auto* buf = allocator_t<chunk_node>{res}.allocate(1);
+  auto* node = new (buf) chunk_node{deep_copy_impl(res, msg), nullptr};
+  event->message_ = chunked_string{node};
+  return event;
+}
+
+log_event_ptr log_event::make(unsigned level, std::string_view component,
+                              const detail::source_location& loc) {
+  return make_counted<log_event>(level, component, loc);
+}
+
+log_event_fields_builder::log_event_fields_builder(
+  resource_type* resource) noexcept {
+  new (&fields_) list_type(resource);
+}
+
+std::string_view log_event_fields_builder::deep_copy(std::string_view str) {
+  auto* buf = allocator_t<char>{resource()}.allocate(str.size());
+  memcpy(buf, str.data(), str.size());
+  return std::string_view{buf, str.size()};
+}
+
+intrusive_ptr<log_event> log_event_builder::build() && {
+  event_->first_field_ = fields_.build().head;
+  return std::move(event_);
+}
+
+} // namespace caf

--- a/libcaf_core/caf/log_event.cpp
+++ b/libcaf_core/caf/log_event.cpp
@@ -47,9 +47,7 @@ log_event_fields_builder::log_event_fields_builder(
 }
 
 std::string_view log_event_fields_builder::deep_copy(std::string_view str) {
-  auto* buf = allocator_t<char>{resource()}.allocate(str.size());
-  memcpy(buf, str.data(), str.size());
-  return std::string_view{buf, str.size()};
+  return deep_copy_impl(resource(), str);
 }
 
 intrusive_ptr<log_event> log_event_builder::build() && {

--- a/libcaf_core/caf/log_event.hpp
+++ b/libcaf_core/caf/log_event.hpp
@@ -1,0 +1,335 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/chunked_string.hpp"
+#include "caf/detail/core_export.hpp"
+#include "caf/detail/format.hpp"
+#include "caf/detail/json.hpp"
+#include "caf/detail/monotonic_buffer_resource.hpp"
+#include "caf/detail/source_location.hpp"
+#include "caf/fwd.hpp"
+#include "caf/intrusive_ptr.hpp"
+#include "caf/ref_counted.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
+#include <variant>
+
+namespace caf {
+
+// -- log_event ----------------------------------------------------------------
+
+/// Captures a single event for a logger.
+class CAF_CORE_EXPORT log_event : public ref_counted {
+public:
+  // -- member types -----------------------------------------------------------
+
+  friend class log_event_builder;
+
+  struct field;
+
+  using field_node = detail::json::linked_list_node<field>;
+
+  /// A list of user-defined fields.
+  struct field_list {
+    const field_node* head;
+    auto begin() const noexcept {
+      return detail::json::linked_list_iterator<const field>{head};
+    }
+    auto end() const noexcept {
+      return detail::json::linked_list_iterator<const field>{};
+    }
+  };
+
+  /// A single, user-defined field.
+  struct field {
+    using value_t
+      = std::variant<std::nullopt_t, bool, int64_t, uint64_t, double,
+                     std::string_view, chunked_string, field_list>;
+
+    /// The key (name) of the field.
+    std::string_view key;
+
+    /// The value of the field.
+    value_t value;
+  };
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  log_event(unsigned level, std::string_view component,
+            const detail::source_location& loc) noexcept
+    : level_(level),
+      component_(component),
+      line_number_(loc.line()),
+      file_name_(loc.file_name()),
+      function_name_(loc.function_name()) {
+    // nop
+  }
+
+  log_event(const log_event&) = delete;
+
+  log_event& operator=(const log_event&) = delete;
+
+  // -- factory functions ------------------------------------------------------
+
+  template <class Arg, class... Args>
+  static log_event_ptr make(unsigned level, std::string_view component,
+                            const detail::source_location& loc,
+                            std::string_view fmt, Arg&& arg, Args&&... args) {
+    auto event = make(level, component, loc);
+    chunked_string_builder cs_builder{&event->resource_};
+    chunked_string_builder_output_iterator out{&cs_builder};
+    detail::format_to(out, fmt, std::forward<Arg>(arg),
+                      std::forward<Args>(args)...);
+    event->message_ = cs_builder.build();
+    return event;
+  }
+
+  static log_event_ptr make(unsigned level, std::string_view component,
+                            const detail::source_location& loc,
+                            std::string_view msg);
+
+  // -- properties -------------------------------------------------------------
+
+  /// Returns the severity level of the event.
+  [[nodiscard]] unsigned level() const noexcept {
+    return level_;
+  }
+
+  /// Returns the name of the component that generated the event.
+  [[nodiscard]] std::string_view component() const noexcept {
+    return component_;
+  }
+
+  /// Returns the line number at which the event was generated.
+  [[nodiscard]] uint_least32_t line_number() const noexcept {
+    return line_number_;
+  }
+
+  /// Returns the name of the file in which the event was generated.
+  [[nodiscard]] const char* file_name() const noexcept {
+    return file_name_;
+  }
+
+  /// Returns the name of the function in which the event was generated.
+  [[nodiscard]] const char* function_name() const noexcept {
+    return function_name_;
+  }
+
+  /// Returns the user-defined message of the event.
+  [[nodiscard]] chunked_string message() const noexcept {
+    return message_;
+  }
+
+  /// Returns the user-defined fields of the event.
+  [[nodiscard]] field_list fields() const noexcept {
+    return field_list{first_field_};
+  }
+
+private:
+  static log_event_ptr make(unsigned level, std::string_view component,
+                            const detail::source_location& loc);
+
+  /// The severity level of the event.
+  unsigned level_;
+
+  /// The name of the component that generated the event.
+  std::string_view component_;
+
+  /// The line number at which the event was generated.
+  uint_least32_t line_number_;
+
+  /// The name of the file in which the event was generated.
+  const char* file_name_;
+
+  /// The name of the function in which the event was generated.
+  const char* function_name_;
+
+  /// The user-defined message of the event.
+  chunked_string message_;
+
+  /// Pointer to the first user-defined field of the event.
+  const field_node* first_field_ = nullptr;
+
+  /// Storage for string chunks and fields.
+  detail::monotonic_buffer_resource resource_;
+};
+
+/// Builds list of user-defined fields for a log event.
+class CAF_CORE_EXPORT log_event_fields_builder {
+private:
+  template <class T>
+  static auto lift_integral(T value) {
+    if constexpr (std::is_same_v<T, bool>)
+      return value;
+    else if constexpr (std::is_signed_v<T>)
+      return static_cast<int64_t>(value);
+    else
+      return static_cast<uint64_t>(value);
+  }
+
+public:
+  // -- member types -----------------------------------------------------------
+
+  using list_type = detail::json::linked_list<log_event::field>;
+
+  using resource_type = detail::monotonic_buffer_resource;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  explicit log_event_fields_builder(resource_type* resource) noexcept;
+
+  ~log_event_fields_builder() noexcept {
+    // nop
+  }
+
+  // -- add fields -------------------------------------------------------------
+
+  /// Adds a boolean or integer field.
+  template <class T>
+  std::enable_if_t<std::is_integral_v<T>>
+  add_field(std::string_view key, T value) {
+    auto& field = fields_.emplace_back(std::string_view{},
+                                       lift_integral(value));
+    field.key = deep_copy(key);
+  }
+
+  /// Adds a floating point field.
+  void add_field(std::string_view key, double value) {
+    auto& field = fields_.emplace_back(std::string_view{}, value);
+    field.key = deep_copy(key);
+  }
+
+  /// Adds a string field.
+  void add_field(std::string_view key, std::string_view value) {
+    auto& field = fields_.emplace_back(std::string_view{}, std::nullopt);
+    field.key = deep_copy(key);
+    field.value = deep_copy(value);
+  }
+
+  /// Adds a formatted string field.
+  template <class Arg, class... Args>
+  void add_field(std::string_view key, std::string_view fmt, Arg&& arg,
+                 Args&&... args) {
+    auto& field = fields_.emplace_back(std::string_view{}, std::nullopt);
+    field.key = deep_copy(key);
+    chunked_string_builder cs_builder{resource()};
+    chunked_string_builder_output_iterator out{&cs_builder};
+    detail::format_to(out, fmt, std::forward<Arg>(arg),
+                      std::forward<Args>(args)...);
+    field.value = cs_builder.build();
+  }
+
+  /// Adds nested fields.
+  template <class SubFieldsInitializer>
+  auto add_field(std::string_view key, SubFieldsInitializer&& init)
+    -> std::enable_if_t<std::is_same_v<
+      decltype(init(std::declval<log_event_fields_builder&>())), void>> {
+    auto& field = fields_.emplace_back(std::string_view{}, std::nullopt);
+    field.key = deep_copy(key);
+    log_event_fields_builder nested_builder{resource()};
+    init(nested_builder);
+    field.value = nested_builder.build();
+  }
+
+  // -- build ------------------------------------------------------------------
+
+  /// Seals the list and returns it.
+  [[nodiscard]] log_event::field_list build() {
+    return log_event::field_list{fields_.head()};
+  }
+
+private:
+  [[nodiscard]] resource_type* resource() noexcept {
+    return fields_.get_allocator().resource();
+  }
+
+  [[nodiscard]] std::string_view deep_copy(std::string_view str);
+
+  union { // Suppress the dtor call for fields_.
+    list_type fields_;
+  };
+};
+
+/// Builds a chunked string by allocating each chunk on a monotonic buffer.
+class CAF_CORE_EXPORT log_event_builder {
+public:
+  // -- member types -----------------------------------------------------------
+
+  using resource_type = detail::monotonic_buffer_resource;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  template <class... Args>
+  log_event_builder(unsigned level, std::string_view component,
+                    const detail::source_location& loc, std::string_view fmt,
+                    Args&&... args)
+    : event_(
+      log_event::make(level, component, loc, fmt, std::forward<Args>(args)...)),
+      fields_(&event_->resource_) {
+    // nop
+  }
+
+  // -- add fields -------------------------------------------------------------
+
+  /// Adds a boolean or integer field.
+  template <class T>
+  std::enable_if_t<std::is_integral_v<T>, log_event_builder&&>
+  add_field(std::string_view key, T value) && {
+    fields_.add_field(key, value);
+    return std::move(*this);
+  }
+
+  /// Adds a floating point field.
+  log_event_builder&& add_field(std::string_view key, double value) && {
+    fields_.add_field(key, value);
+    return std::move(*this);
+  }
+
+  /// Adds a string field.
+  log_event_builder&& add_field(std::string_view key,
+                                std::string_view value) && {
+    fields_.add_field(key, value);
+    return std::move(*this);
+  }
+
+  /// Adds a formatted string field.
+  template <class Arg, class... Args>
+  log_event_builder&& add_field(std::string_view key, std::string_view fmt,
+                                Arg&& arg, Args&&... args) && {
+    fields_.add_field(key, fmt, std::forward<Arg>(arg),
+                      std::forward<Args>(args)...);
+    return std::move(*this);
+  }
+
+  /// Adds nested fields.
+  template <class SubFieldsInitializer>
+  auto add_field(std::string_view key, SubFieldsInitializer&& init)
+    -> std::enable_if_t<
+      std::is_same_v<decltype(init(std::declval<log_event_fields_builder&>())),
+                     void>,
+      log_event_builder&&> {
+    fields_.add_field(key, std::forward<SubFieldsInitializer>(init));
+    return std::move(*this);
+  }
+
+  // -- build ------------------------------------------------------------------
+
+  /// Seals the event and returns it.
+  [[nodiscard]] log_event_ptr build() &&;
+
+private:
+  [[nodiscard]] resource_type* resource() noexcept {
+    return &event_->resource_;
+  }
+
+  log_event_ptr event_;
+
+  log_event_fields_builder fields_;
+};
+
+} // namespace caf

--- a/libcaf_core/caf/log_event.hpp
+++ b/libcaf_core/caf/log_event.hpp
@@ -21,8 +21,6 @@
 
 namespace caf {
 
-// -- log_event ----------------------------------------------------------------
-
 /// Captures a single event for a logger.
 class CAF_CORE_EXPORT log_event : public ref_counted {
 public:
@@ -36,7 +34,7 @@ public:
 
   /// A list of user-defined fields.
   struct field_list {
-    const field_node* head;
+    const field_node* head = nullptr;
     auto begin() const noexcept {
       return detail::json::linked_list_iterator<const field>{head};
     }
@@ -255,7 +253,7 @@ private:
   };
 };
 
-/// Builds a chunked string by allocating each chunk on a monotonic buffer.
+/// Builds a log event by allocating each field on a monotonic buffer.
 class CAF_CORE_EXPORT log_event_builder {
 public:
   // -- member types -----------------------------------------------------------

--- a/libcaf_core/caf/log_event.test.cpp
+++ b/libcaf_core/caf/log_event.test.cpp
@@ -1,0 +1,108 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/log_event.hpp"
+
+#include "caf/test/test.hpp"
+
+using namespace caf;
+using namespace std::literals;
+
+namespace {
+
+template <class T>
+std::pair<std::string_view, T>
+get_at(size_t index, const log_event::field_list& fields) {
+  auto i = fields.begin();
+  if (i == fields.end())
+    CAF_RAISE_ERROR(std::logic_error, "fields list is empty");
+  for (size_t j = 0; j < index; ++j)
+    if (++i == fields.end())
+      CAF_RAISE_ERROR(std::logic_error, "index out of range");
+  return {i->key, std::get<T>(i->value)};
+}
+
+std::pair<std::string_view, std::string>
+de_chunk(const std::pair<std::string_view, chunked_string>& x) {
+  return {x.first, to_string(x.second)};
+}
+
+TEST("fields builder") {
+  auto init_sub_fields = [](auto& builder) {
+    auto init_sub_sub_fields = [](auto& builder) {
+      builder.add_field("foo-7-3-1", 3);
+      builder.add_field("foo-7-3-2", 4);
+    };
+    builder.add_field("foo-7-1", 1);
+    builder.add_field("foo-7-2", 2);
+    builder.add_field("foo-7-3", init_sub_sub_fields);
+  };
+  auto resource = detail::monotonic_buffer_resource{};
+  auto builder = log_event_fields_builder{&resource};
+  builder.add_field("foo-1", true);
+  builder.add_field("foo-2", 23);
+  builder.add_field("foo-3", 42u);
+  builder.add_field("foo-4", 2.0);
+  builder.add_field("foo-5", "bar");
+  builder.add_field("foo-6", "{}, {}!", "Hello", "World");
+  builder.add_field("foo-7", init_sub_fields);
+  auto fields = builder.build();
+  check_eq(get_at<bool>(0, fields), std::pair{"foo-1"sv, true});
+  check_eq(get_at<int64_t>(1, fields), std::pair{"foo-2"sv, int64_t{23}});
+  check_eq(get_at<uint64_t>(2, fields), std::pair{"foo-3"sv, uint64_t{42}});
+  check_eq(get_at<double>(3, fields), std::pair{"foo-4"sv, 2.0});
+  check_eq(get_at<std::string_view>(4, fields), std::pair{"foo-5"sv, "bar"sv});
+  check_eq(de_chunk(get_at<chunked_string>(5, fields)),
+           std::pair{"foo-6"sv, "Hello, World!"s});
+  auto [foo_7, foo_7_fields] = get_at<log_event::field_list>(6, fields);
+  check_eq(foo_7, "foo-7"sv);
+  check_eq(get_at<int64_t>(0, foo_7_fields),
+           std::pair{"foo-7-1"sv, int64_t{1}});
+  check_eq(get_at<int64_t>(1, foo_7_fields),
+           std::pair{"foo-7-2"sv, int64_t{2}});
+  auto [foo_7_3, foo_7_3_fields] = get_at<log_event::field_list>(2,
+                                                                 foo_7_fields);
+  check_eq(foo_7_3, "foo-7-3"sv);
+  check_eq(get_at<int64_t>(0, foo_7_3_fields),
+           std::pair{"foo-7-3-1"sv, int64_t{3}});
+  check_eq(get_at<int64_t>(1, foo_7_3_fields),
+           std::pair{"foo-7-3-2"sv, int64_t{4}});
+}
+
+TEST("log event builder") {
+  auto loc = detail::source_location::current();
+  SECTION("trivial message") {
+    auto event = log_event_builder(CAF_LOG_LEVEL_DEBUG, "foo", loc, "hello")
+                   .add_field("foo", 42)
+                   .add_field("bar", "baz")
+                   .build();
+    check_eq(event->level(), unsigned{CAF_LOG_LEVEL_DEBUG});
+    check_eq(event->component(), "foo"sv);
+    check_eq(event->line_number(), loc.line());
+    check_eq(event->file_name(), loc.file_name());
+    check_eq(event->function_name(), loc.function_name());
+    check_eq(to_string(event->message()), "hello"sv);
+    auto fields = event->fields();
+    check_eq(get_at<int64_t>(0, fields), std::pair{"foo"sv, int64_t{42}});
+    check_eq(get_at<std::string_view>(1, fields), std::pair{"bar"sv, "baz"sv});
+  }
+  SECTION("formatted message") {
+    auto event = log_event_builder(CAF_LOG_LEVEL_DEBUG, "foo", loc, "{}, {}!",
+                                   "Hello", "World")
+                   .add_field("foo", 42)
+                   .add_field("bar", "baz")
+                   .build();
+    check_eq(event->level(), unsigned{CAF_LOG_LEVEL_DEBUG});
+    check_eq(event->component(), "foo"sv);
+    check_eq(event->line_number(), loc.line());
+    check_eq(event->file_name(), loc.file_name());
+    check_eq(event->function_name(), loc.function_name());
+    check_eq(to_string(event->message()), "Hello, World!"sv);
+    auto fields = event->fields();
+    check_eq(get_at<int64_t>(0, fields), std::pair{"foo"sv, int64_t{42}});
+    check_eq(get_at<std::string_view>(1, fields), std::pair{"bar"sv, "baz"sv});
+  }
+}
+
+} // namespace


### PR DESCRIPTION
More prep work for https://github.com/actor-framework/actor-framework/issues/1652. The new `log_event` is going to be used for the `logger` once this has landed.