### PR TITLE
Restructure the logging API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,18 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   on the observer. Previously, CAF would simply call `on_complete()` on the
   observer, making it impossible to distinguish between a normal completion and
   disposal.
+- The `caf::logger` received a complete overhaul and became an interface class.
+  By turning the class into an interface, users can now install custom logger
+  implementations. CAF uses the previous implementation as the default logger if
+  no custom logger is configured. To install a logger, users can call
+  `cfg.logger_factory(my_logger_factory)` on the `actor_system_config` before
+  constructing the `actor_system`. The logger factory is a function object with
+  signature `caf::intrusive_ptr<caf::logger>(caf::actor_system&)`. Furthermore,
+  log messages are now formatted using `std::format` when compiling CAF with
+  C++20 or later. Otherwise, CAF will fall back to a minimal formatting
+  implementation with compatible syntax. The logging API will also automatically
+  convert any type with a suitable `inspect` overload to a string if the type is
+  not recognized by `format`.
 
 ### Deprecated
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,15 @@ endfunction()
 
 # -- convenience function for automating our component setup -------------------
 
+function(caf_add_log_component name)
+  set(CAF_COMPONENT_NAME ${name})
+  configure_file("${PROJECT_SOURCE_DIR}/cmake/log.hpp.in"
+                 "${CMAKE_CURRENT_BINARY_DIR}/caf/log/${name}.hpp"
+                 @ONLY)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/caf/log/${name}.hpp"
+          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/caf/log/")
+endfunction()
+
 # Usage:
 # caf_add_component(
 #   foo
@@ -283,6 +292,7 @@ function(caf_add_component name)
                              $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                              $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
                              $<INSTALL_INTERFACE:include>)
+  caf_add_log_component(${name})
   if(BUILD_SHARED_LIBS)
     set_target_properties(${lib_target} PROPERTIES
                           CXX_VISIBILITY_PRESET hidden

--- a/cmake/log.hpp.in
+++ b/cmake/log.hpp.in
@@ -1,0 +1,73 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/log/level.hpp"
+#include "caf/logger.hpp"
+
+#include <string_view>
+
+namespace caf::log::@CAF_COMPONENT_NAME@ {
+
+/// The name of this component in log events.
+constexpr std::string_view component = "caf.@CAF_COMPONENT_NAME@";
+
+/// Logs a message with `debug` severity.
+/// @param fmt_str The format string (with source location) for the message.
+/// @param args Arguments for the format string.
+template <class... Ts>
+void debug(format_string_with_location fmt_str, Ts&&... args) {
+  logger::log(level::debug, component, fmt_str,
+              std::forward<Ts>(args)...);
+}
+
+/// Starts a new log event with `debug` severity.
+inline auto debug() {
+  return logger::log(level::debug, component);
+}
+
+/// Logs a message with `info` severity.
+/// @param fmt_str The format string (with source location) for the message.
+/// @param args Arguments for the format string.
+template <class... Ts>
+void info(format_string_with_location fmt_str, Ts&&... args) {
+  logger::log(level::info, component, fmt_str,
+              std::forward<Ts>(args)...);
+}
+
+/// Starts a new log event with `info` severity.
+inline auto info() {
+  return logger::log(level::info, component);
+}
+
+/// Logs a message with `warning` severity.
+/// @param fmt_str The format string (with source location) for the message.
+/// @param args Arguments for the format string.
+template <class... Ts>
+void warning(format_string_with_location fmt_str, Ts&&... args) {
+  logger::log(level::warning, component, fmt_str,
+              std::forward<Ts>(args)...);
+}
+
+/// Starts a new log event with `warning` severity.
+inline auto warning() {
+  return logger::log(level::warning, component);
+}
+
+/// Logs a message with `error` severity.
+/// @param fmt_str The format string (with source location) for the message.
+/// @param args Arguments for the format string.
+template <class... Ts>
+void error(format_string_with_location fmt_str, Ts&&... args) {
+  logger::log(level::error, component, fmt_str,
+              std::forward<Ts>(args)...);
+}
+
+/// Starts a new log event with `error` severity.
+inline auto error() {
+  return logger::log(level::error, component);
+}
+
+} // namespace caf::log::@CAF_COMPONENT_NAME@

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -241,8 +241,8 @@ caf_add_component(
     caf/json_writer.cpp
     caf/load_inspector.cpp
     caf/local_actor.cpp
-    caf/log_event.cpp
-    caf/log_event.test.cpp
+    caf/log/event.cpp
+    caf/log/event.test.cpp
     caf/logger.cpp
     caf/mailbox_element.cpp
     caf/make_config_option.cpp
@@ -401,6 +401,9 @@ caf_add_component(
     unit
     uri
     uuid)
+
+# Additional log component for (potentially critical) system-wide events.
+caf_add_log_component(system)
 
 if(NOT CAF_USE_STD_FORMAT)
   target_sources(libcaf_core PRIVATE caf/detail/format.cpp)

--- a/libcaf_core/caf/chrono.test.cpp
+++ b/libcaf_core/caf/chrono.test.cpp
@@ -7,6 +7,8 @@
 #include "caf/test/scenario.hpp"
 #include "caf/test/test.hpp"
 
+#include "caf/log/test.hpp"
+
 using namespace caf;
 
 namespace {
@@ -355,12 +357,12 @@ TEST("chrono::to_string generates valid input for datetime::parse") {
   // can only check that the string is valid by parsing it again.
   SECTION("std::chrono time point") {
     auto str = chrono::to_string(std::chrono::system_clock::now());
-    print_debug("str = {}", str);
+    log::test::debug("str = {}", str);
     check(datetime::from_string(str).has_value());
   }
   SECTION("caf::timestamp") {
     auto str = chrono::to_string(make_timestamp());
-    print_debug("str = {}", str);
+    log::test::debug("str = {}", str);
     check(datetime::from_string(str).has_value());
   }
 }

--- a/libcaf_core/caf/config_option.test.cpp
+++ b/libcaf_core/caf/config_option.test.cpp
@@ -10,6 +10,7 @@
 
 #include "caf/config_value.hpp"
 #include "caf/expected.hpp"
+#include "caf/log/test.hpp"
 #include "caf/make_config_option.hpp"
 
 #include <sstream>
@@ -51,7 +52,7 @@ OUTLINE("config options parse their parameters for long, short and env names") {
         check_eq(full_name, uut.full_name());
         check_eq(flat, uut.has_flat_cli_name());
         check_eq(ename, uut.env_var_name_cstr());
-        print_debug("copying the config option must produce an equal object");
+        log::test::debug("copying config options must return equal objects");
         auto equal_to_uut = [&uut, this](const config_option& other,
                                          const detail::source_location& loc
                                          = detail::source_location::current()) {
@@ -65,12 +66,12 @@ OUTLINE("config options parse their parameters for long, short and env names") {
           check(strcmp(uut.env_var_name_cstr(), other.env_var_name_cstr()) == 0,
                 loc);
         };
-        print_debug("copy and move construction must produce an equal object");
+        log::test::debug("copy and move construct must return equal objects");
         auto cpy = uut;
         equal_to_uut(cpy);
         auto mv = std::move(cpy);
         equal_to_uut(mv);
-        print_debug("copy and move assignment must produce an equal object");
+        log::test::debug("copy and move assignment must return equal objects");
         auto cpy2 = config_option{"abc", "def", "ghi", &dummy};
         cpy2 = uut;
         equal_to_uut(cpy2);

--- a/libcaf_core/caf/detail/config_consumer.test.cpp
+++ b/libcaf_core/caf/detail/config_consumer.test.cpp
@@ -7,6 +7,7 @@
 #include "caf/test/test.hpp"
 
 #include "caf/detail/parser/read_config.hpp"
+#include "caf/log/test.hpp"
 
 using std::string;
 
@@ -72,15 +73,15 @@ TEST("config_consumer") {
 }
 
 TEST("simplified syntax") {
-  print_debug("read test_config");
+  log::test::debug("read test_config");
   {
     detail::config_consumer consumer{options, config};
     string_parser_state res{test_config1.begin(), test_config1.end()};
     detail::parser::read_config(res, consumer);
     check_eq(res.code, pec::success);
-    print_debug("read test_config2");
   }
   settings config2;
+  log::test::debug("read test_config2");
   {
     detail::config_consumer consumer{options, config2};
     string_parser_state res{test_config2.begin(), test_config2.end()};

--- a/libcaf_core/caf/detail/log_level_map.cpp
+++ b/libcaf_core/caf/detail/log_level_map.cpp
@@ -1,7 +1,7 @@
 #include "caf/detail/log_level_map.hpp"
 
 #include "caf/config.hpp"
-#include "caf/detail/log_level.hpp"
+#include "caf/log/level.hpp"
 #include "caf/string_algorithms.hpp"
 
 #include <algorithm>
@@ -29,11 +29,11 @@ struct predicate {
 log_level_map::log_level_map() {
   // Elements are sorted in descending order for efficient lookup.
   mapping_.reserve(8);
-  mapping_.emplace_back(CAF_LOG_LEVEL_TRACE, "TRACE");
-  mapping_.emplace_back(CAF_LOG_LEVEL_DEBUG, "DEBUG");
-  mapping_.emplace_back(CAF_LOG_LEVEL_INFO, "INFO");
-  mapping_.emplace_back(CAF_LOG_LEVEL_WARNING, "WARNING");
-  mapping_.emplace_back(CAF_LOG_LEVEL_ERROR, "ERROR");
+  mapping_.emplace_back(log::level::trace, "TRACE");
+  mapping_.emplace_back(log::level::debug, "DEBUG");
+  mapping_.emplace_back(log::level::info, "INFO");
+  mapping_.emplace_back(log::level::warning, "WARNING");
+  mapping_.emplace_back(log::level::error, "ERROR");
 }
 
 std::string_view log_level_map::operator[](unsigned level) const noexcept {

--- a/libcaf_core/caf/detail/log_level_map.test.cpp
+++ b/libcaf_core/caf/detail/log_level_map.test.cpp
@@ -6,28 +6,16 @@
 
 #include "caf/test/test.hpp"
 
-#include "caf/detail/log_level.hpp"
+#include "caf/log/level.hpp"
 
 #include <map>
 
 using namespace caf;
 using namespace std::literals;
 
+using caf::log::level;
+
 namespace {
-
-struct level {
-  static constexpr unsigned quiet = CAF_LOG_LEVEL_QUIET;
-
-  static constexpr unsigned error = CAF_LOG_LEVEL_ERROR;
-
-  static constexpr unsigned warning = CAF_LOG_LEVEL_WARNING;
-
-  static constexpr unsigned info = CAF_LOG_LEVEL_INFO;
-
-  static constexpr unsigned debug = CAF_LOG_LEVEL_DEBUG;
-
-  static constexpr unsigned trace = CAF_LOG_LEVEL_TRACE;
-};
 
 TEST("log level maps render the default log levels") {
   detail::log_level_map uut;

--- a/libcaf_core/caf/detail/meta_object.test.cpp
+++ b/libcaf_core/caf/detail/meta_object.test.cpp
@@ -11,6 +11,7 @@
 #include "caf/binary_serializer.hpp"
 #include "caf/detail/make_meta_object.hpp"
 #include "caf/init_global_meta_objects.hpp"
+#include "caf/log/test.hpp"
 
 #include <tuple>
 #include <type_traits>
@@ -113,7 +114,7 @@ TEST("init_global_meta_objects takes care of creating a meta object table") {
   check_eq(type_name_by_id_v<type_id_v<i64_wrapper>>, "i64_wrapper"s);
   check_eq(xs[type_id_v<i32_wrapper>].type_name, "i32_wrapper"s);
   check_eq(xs[type_id_v<i64_wrapper>].type_name, "i64_wrapper"s);
-  print_debug("calling init_global_meta_objects again is a no-op");
+  log::test::debug("calling init_global_meta_objects again is a no-op");
   init_global_meta_objects<id_block::meta_object_test>();
   auto ys = global_meta_objects();
   auto same = [](const auto& x, const auto& y) {

--- a/libcaf_core/caf/detail/monotonic_buffer_resource.test.cpp
+++ b/libcaf_core/caf/detail/monotonic_buffer_resource.test.cpp
@@ -6,6 +6,8 @@
 
 #include "caf/test/scenario.hpp"
 
+#include "caf/log/test.hpp"
+
 #include <list>
 #include <map>
 #include <vector>
@@ -35,22 +37,24 @@ SCENARIO("monotonic buffers group allocations") {
       THEN("the resource puts allocations into buckets") {
         void* unused = nullptr; // For silencing nodiscard warnings.
         check_eq(mbr.blocks(), 0u);
-        print_debug("perform small allocations");
+        log::test::debug("perform small allocations");
         unused = mbr.allocate(64);
         check_eq(mbr.blocks(), 1u);
         unused = mbr.allocate(64);
         check_eq(mbr.blocks(), 1u);
-        print_debug("perform medium allocations");
+        log::test::debug("perform medium allocations");
         unused = mbr.allocate(65);
         check_eq(mbr.blocks(), 2u);
         unused = mbr.allocate(512);
         check_eq(mbr.blocks(), 2u);
-        print_debug("perform large allocations <= 1 MB (pools allocations)");
+        log::test::debug("perform large allocations <= 1 MB "
+                         "(pools allocations)");
         unused = mbr.allocate(513);
         check_eq(mbr.blocks(), 3u);
         unused = mbr.allocate(1023);
         check_eq(mbr.blocks(), 3u);
-        print_debug("perform large allocations > 1 MB (individual allocation)");
+        log::test::debug("perform large allocations > 1 MB "
+                         "(individual allocation)");
         unused = mbr.allocate(1'048'577);
         check_eq(mbr.blocks(), 4u);
         unused = mbr.allocate(1'048'577);

--- a/libcaf_core/caf/detail/parser/read_config.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_config.test.cpp
@@ -7,6 +7,7 @@
 #include "caf/test/test.hpp"
 
 #include "caf/config_value.hpp"
+#include "caf/log/test.hpp"
 #include "caf/parser_state.hpp"
 #include "caf/pec.hpp"
 
@@ -69,10 +70,8 @@ struct fixture {
     string_parser_state res{str.begin(), str.end()};
     detail::parser::read_config(res, f);
     if ((res.code == pec::success) != expect_success) {
-      auto& this_test = test::runnable::current();
-      this_test.print_error("unexpected parser result state: {}",
-                            to_string(res.code));
-      this_test.print_error("input remainder: {}", std::string(res.i, res.e));
+      log::test::error("unexpected parser result state: {}", res.code);
+      log::test::error("input remainder: {}", std::string{res.i, res.e});
     }
     return std::move(f.log);
   }

--- a/libcaf_core/caf/detail/ring_buffer.test.cpp
+++ b/libcaf_core/caf/detail/ring_buffer.test.cpp
@@ -6,6 +6,8 @@
 
 #include "caf/test/test.hpp"
 
+#include "caf/log/test.hpp"
+
 using namespace caf;
 
 using detail::ring_buffer;
@@ -20,14 +22,14 @@ int pop(ring_buffer<int>& buf) {
 
 TEST("push_back adds element") {
   ring_buffer<int> buf{3};
-  print_debug("full capacity of ring buffer");
+  log::test::debug("full capacity of ring buffer");
   for (int i = 1; i <= 3; ++i) {
     buf.push_back(i);
   }
   check_eq(buf.full(), true);
   check_eq(buf.empty(), false);
   check_eq(buf.front(), 1);
-  print_debug("additional element after full capacity");
+  log::test::debug("additional element after full capacity");
   buf.push_back(4);
   check_eq(buf.full(), true);
   check_eq(buf.empty(), false);
@@ -44,14 +46,14 @@ TEST("push_back adds element") {
 
 TEST("pop_front removes the oldest element") {
   ring_buffer<int> buf{3};
-  print_debug("full capacity of ring buffer");
+  log::test::debug("full capacity of ring buffer");
   for (int i = 1; i <= 3; ++i) {
     buf.push_back(i);
   }
   check_eq(buf.full(), true);
   check_eq(buf.empty(), false);
   check_eq(buf.front(), 1);
-  print_debug("remove element from buffer");
+  log::test::debug("remove element from buffer");
   buf.pop_front();
   check_eq(buf.full(), false);
   check_eq(buf.empty(), false);
@@ -66,14 +68,14 @@ TEST("pop_front removes the oldest element") {
 
 TEST("circular buffer overwrites oldest element after it is full") {
   ring_buffer<int> buf{5};
-  print_debug("full capacity of ring buffer");
+  log::test::debug("full capacity of ring buffer");
   for (int i = 1; i <= 5; ++i) {
     buf.push_back(i);
   }
   check_eq(buf.full(), true);
   check_eq(buf.empty(), false);
   check_eq(buf.front(), 1);
-  print_debug("add some elements into buffer");
+  log::test::debug("add some elements into buffer");
   buf.push_back(6);
   buf.push_back(7);
   check_eq(buf.full(), true);
@@ -91,14 +93,14 @@ TEST("circular buffer overwrites oldest element after it is full") {
 
 TEST("pop_front removes the oldest element from the buffer") {
   ring_buffer<int> buf{5};
-  print_debug("full capacity of ring buffer");
+  log::test::debug("full capacity of ring buffer");
   for (int i = 1; i <= 5; ++i) {
     buf.push_back(i);
   }
   check_eq(buf.full(), true);
   check_eq(buf.empty(), false);
   check_eq(buf.front(), 1);
-  print_debug("remove some element from buffer");
+  log::test::debug("remove some element from buffer");
   buf.pop_front();
   check_eq(buf.full(), false);
   check_eq(buf.empty(), false);
@@ -106,7 +108,7 @@ TEST("pop_front removes the oldest element from the buffer") {
   buf.pop_front();
   check_eq(buf.full(), false);
   check_eq(buf.front(), 3);
-  print_debug("add some elements into buffer");
+  log::test::debug("add some elements into buffer");
   buf.push_back(6);
   buf.push_back(7);
   check_eq(buf.full(), true);
@@ -124,29 +126,29 @@ TEST("pop_front removes the oldest element from the buffer") {
 
 TEST("push_back does nothing for ring buffer with a capacity of 0") {
   ring_buffer<int> buf{0};
-  print_debug("empty buffer is initialized");
+  log::test::debug("empty buffer is initialized");
   check_eq(buf.size(), 0u);
   for (int i = 1; i <= 3; ++i) {
     buf.push_back(i);
   }
-  print_debug("buffer size after adding some elements");
+  log::test::debug("buffer size after adding some elements");
   check_eq(buf.size(), 0u);
 }
 
 TEST("size() returns the number of elements in a buffer") {
   ring_buffer<int> buf{5};
-  print_debug("empty buffer is initialized");
+  log::test::debug("empty buffer is initialized");
   check_eq(buf.size(), 0u);
   for (int i = 1; i <= 3; ++i) {
     buf.push_back(i);
   }
-  print_debug("buffer size after adding some elements");
+  log::test::debug("buffer size after adding some elements");
   check_eq(buf.size(), 3u);
 }
 
 TEST("ring-buffers are copiable") {
   ring_buffer<int> buf{5};
-  print_debug("empty buffer is initialized");
+  log::test::debug("empty buffer is initialized");
   check_eq(buf.size(), 0u);
   for (int i = 1; i <= 3; ++i) {
     buf.push_back(i);
@@ -155,7 +157,8 @@ TEST("ring-buffers are copiable") {
   SECTION("copy-assignment") {
     ring_buffer<int> new_buf{0};
     new_buf = buf;
-    print_debug("check size and elements of new_buf after copy-assignment");
+    log::test::debug(
+      "check size and elements of new_buf after copy-assignment");
     check_eq(new_buf.size(), 3u);
     check_eq(pop(new_buf), 1);
     check_eq(pop(new_buf), 2);
@@ -164,14 +167,15 @@ TEST("ring-buffers are copiable") {
   }
   SECTION("copy constructor") {
     ring_buffer<int> new_buf{buf};
-    print_debug("check size and elements of new_buf after copy constructor");
+    log::test::debug(
+      "check size and elements of new_buf after copy constructor");
     check_eq(new_buf.size(), 3u);
     check_eq(pop(new_buf), 1);
     check_eq(pop(new_buf), 2);
     check_eq(pop(new_buf), 3);
     check_eq(new_buf.empty(), true);
   }
-  print_debug("check size and elements of buf after copy");
+  log::test::debug("check size and elements of buf after copy");
   check_eq(buf.size(), 3u);
   check_eq(pop(buf), 1);
   check_eq(pop(buf), 2);

--- a/libcaf_core/caf/detail/stream_bridge.cpp
+++ b/libcaf_core/caf/detail/stream_bridge.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/detail/stream_bridge.hpp"
 
+#include "caf/log/system.hpp"
 #include "caf/scheduled_actor.hpp"
 
 namespace caf::detail {
@@ -25,7 +26,7 @@ void stream_bridge_sub::ack(uint64_t src_flow_id,
   CAF_LOG_TRACE(CAF_ARG(src_flow_id) << CAF_ARG(max_items_per_batch));
   // Sanity checking.
   if (max_items_per_batch == 0) {
-    CAF_LOG_ERROR("stream ACK announced a batch size of 0");
+    log::system::error("stream ACK announced a batch size of 0");
     do_abort(make_error(sec::protocol_error));
     return;
   }
@@ -72,7 +73,7 @@ void stream_bridge_sub::push(const async::batch& input) {
   CAF_LOG_TRACE(CAF_ARG2("input.size", input.size()));
   // Sanity checking.
   if (in_flight_batches_ == 0) {
-    CAF_LOG_ERROR("source exceeded its allowed credit!");
+    log::system::error("source exceeded its allowed credit!");
     do_abort(make_error(sec::protocol_error));
     return;
   }

--- a/libcaf_core/caf/flow/op/buffer.test.cpp
+++ b/libcaf_core/caf/flow/op/buffer.test.cpp
@@ -9,7 +9,9 @@
 #include "caf/test/scenario.hpp"
 #include "caf/test/test.hpp"
 
-#include "caf/all.hpp"
+#include "caf/event_based_actor.hpp"
+#include "caf/flow/multicaster.hpp"
+#include "caf/log/test.hpp"
 
 using namespace caf;
 using namespace std::literals;
@@ -104,23 +106,23 @@ SCENARIO("the buffer operator forces items at regular intervals") {
             });
         });
         dispatch_messages();
-        print_debug("emit the first six items");
+        log::test::debug("emit the first six items");
         pub.push({1, 2, 4, 8, 16, 32});
         run_flows();
         dispatch_messages();
-        print_debug("force an empty buffer");
+        log::test::debug("force an empty buffer");
         advance_time(1s);
         dispatch_messages();
-        print_debug("force a buffer with a single element");
+        log::test::debug("force a buffer with a single element");
         pub.push(64);
         run_flows();
         dispatch_messages();
         advance_time(1s);
         dispatch_messages();
-        print_debug("force an empty buffer");
+        log::test::debug("force an empty buffer");
         advance_time(1s);
         dispatch_messages();
-        print_debug("emit the last items and close the source");
+        log::test::debug("emit the last items and close the source");
         pub.push({128, 256, 512});
         pub.close();
         run_flows();

--- a/libcaf_core/caf/flow/op/from_resource.hpp
+++ b/libcaf_core/caf/flow/op/from_resource.hpp
@@ -11,6 +11,7 @@
 #include "caf/flow/observer.hpp"
 #include "caf/flow/op/hot.hpp"
 #include "caf/flow/subscription.hpp"
+#include "caf/logger.hpp"
 #include "caf/sec.hpp"
 
 #include <utility>

--- a/libcaf_core/caf/flow/op/mcast.test.cpp
+++ b/libcaf_core/caf/flow/op/mcast.test.cpp
@@ -10,6 +10,7 @@
 
 #include "caf/flow/observable.hpp"
 #include "caf/flow/scoped_coordinator.hpp"
+#include "caf/log/test.hpp"
 
 using namespace caf;
 
@@ -65,7 +66,7 @@ SCENARIO("mcast operators buffer items that they cannot ship immediately") {
   GIVEN("an mcast operator with three observers") {
     WHEN("pushing more data than the observers have requested") {
       THEN("items are buffered individually") {
-        print_debug("subscribe three observers to a fresh mcast operator");
+        log::test::debug("subscribe three observers to a fresh mcast operator");
         auto uut = make_mcast();
         check(!uut->has_observers());
         check_eq(uut->observer_count(), 0u);
@@ -88,7 +89,7 @@ SCENARIO("mcast operators buffer items that they cannot ship immediately") {
         check_eq(uut->min_demand(), 0u);
         check_eq(uut->max_buffered(), 0u);
         check_eq(uut->min_buffered(), 0u);
-        print_debug("trigger request for items");
+        log::test::debug("trigger request for items");
         o1->request(3);
         o2->request(5);
         o3->request(7);
@@ -97,14 +98,14 @@ SCENARIO("mcast operators buffer items that they cannot ship immediately") {
         check_eq(uut->min_demand(), 3u);
         check_eq(uut->max_buffered(), 0u);
         check_eq(uut->min_buffered(), 0u);
-        print_debug("push more items than we have demand for");
+        log::test::debug("push more items than we have demand for");
         for (auto i = 0; i < 8; ++i)
           uut->push_all(i);
         check_eq(uut->max_demand(), 0u);
         check_eq(uut->min_demand(), 0u);
         check_eq(uut->max_buffered(), 5u);
         check_eq(uut->min_buffered(), 1u);
-        print_debug("drop the subscriber with the largest buffer");
+        log::test::debug("drop the subscriber with the largest buffer");
         sub1.dispose();
         run_flows();
         check_eq(uut->max_demand(), 0u);

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -119,9 +119,6 @@ class json_reader;
 class json_value;
 class json_writer;
 class local_actor;
-class log_event;
-class log_event_fields;
-class log_event_sender;
 class logger;
 class mailbox_element;
 class message;
@@ -336,6 +333,18 @@ class abstract_coordinator;
 
 } // namespace scheduler
 
+// -- log classes --------------------------------------------------------------
+
+namespace log {
+
+class event;
+class event_fields;
+class event_sender;
+
+using event_ptr = intrusive_ptr<event>;
+
+} // namespace log
+
 // -- OpenSSL classes ----------------------------------------------------------
 
 namespace openssl {
@@ -369,10 +378,6 @@ intrusive_cow_ptr_unshare(dynamic_message_data*&);
 using global_meta_objects_guard_type = intrusive_ptr<ref_counted>;
 
 } // namespace detail
-
-// -- intrusive pointer aliases ------------------------------------------------
-
-using log_event_ptr = intrusive_ptr<log_event>;
 
 // -- weak pointer aliases -----------------------------------------------------
 

--- a/libcaf_core/caf/log/event.cpp
+++ b/libcaf_core/caf/log/event.cpp
@@ -2,14 +2,14 @@
 // the main distribution directory for license terms and copyright or visit
 // https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
 
-#include "caf/log_event.hpp"
+#include "caf/log/event.hpp"
 
 #include "caf/logger.hpp"
 #include "caf/make_counted.hpp"
 
 #include <new>
 
-namespace caf {
+namespace caf::log {
 
 namespace {
 
@@ -51,10 +51,9 @@ chunked_string deep_copy_impl(detail::monotonic_buffer_resource* resource,
 
 } // namespace
 
-log_event_ptr log_event::with_message(std::string_view msg,
-                                      keep_timestamp_t) const {
+event_ptr event::with_message(std::string_view msg, keep_timestamp_t) const {
   // Note: can't use make_counted here because the constructor is private.
-  auto copy = log_event_ptr{new log_event, false};
+  auto copy = event_ptr{new event, false};
   auto* resource = &copy->resource_;
   copy->level_ = level_;
   copy->component_ = component_;
@@ -65,7 +64,7 @@ log_event_ptr log_event::with_message(std::string_view msg,
   copy->timestamp_ = timestamp_;
   copy->tid_ = tid_;
   copy->message_ = chunked_string{deep_copy_to_node(resource, msg)};
-  auto fields_builder = log_event_fields_builder{resource};
+  auto fields_builder = event_fields_builder{resource};
   for (auto field : fields()) {
     auto add = [&fields_builder, key = field.key](const auto& val) {
       fields_builder.field(key, val);
@@ -76,15 +75,15 @@ log_event_ptr log_event::with_message(std::string_view msg,
   return copy;
 }
 
-log_event_ptr log_event::with_message(std::string_view msg) const {
+event_ptr event::with_message(std::string_view msg) const {
   auto copy = with_message(msg, keep_timestamp);
   copy->timestamp_ = make_timestamp();
   return copy;
 }
 
-log_event_ptr log_event::make(unsigned level, std::string_view component,
-                              const detail::source_location& loc,
-                              caf::actor_id aid, std::string_view msg) {
+event_ptr event::make(unsigned level, std::string_view component,
+                      const detail::source_location& loc, caf::actor_id aid,
+                      std::string_view msg) {
   using chunk_node = chunked_string::node_type;
   auto event = make(level, component, loc, aid);
   auto* res = &event->resource_;
@@ -94,29 +93,26 @@ log_event_ptr log_event::make(unsigned level, std::string_view component,
   return event;
 }
 
-log_event_ptr log_event::make(unsigned level, std::string_view component,
-                              const detail::source_location& loc,
-                              caf::actor_id aid) {
-  return make_counted<log_event>(level, component, loc, aid);
+event_ptr event::make(unsigned level, std::string_view component,
+                      const detail::source_location& loc, caf::actor_id aid) {
+  return make_counted<event>(level, component, loc, aid);
 }
 
-log_event_fields_builder::log_event_fields_builder(
-  resource_type* resource) noexcept {
+event_fields_builder::event_fields_builder(resource_type* resource) noexcept {
   if (resource)
     new (&fields_) list_type(resource);
 }
 
-void log_event_fields_builder::field(std::string_view key, chunked_string str) {
+void event_fields_builder::field(std::string_view key, chunked_string str) {
   auto& field = fields_.emplace_back(std::string_view{}, std::nullopt);
   field.key = deep_copy(key);
   field.value = deep_copy_impl(resource(), str);
 }
 
-void log_event_fields_builder::field(std::string_view key,
-                                     log_event::field_list list) {
+void event_fields_builder::field(std::string_view key, event::field_list list) {
   auto& field = fields_.emplace_back(std::string_view{}, std::nullopt);
   field.key = deep_copy(key);
-  auto nested = log_event_fields_builder{resource()};
+  auto nested = event_fields_builder{resource()};
   for (auto field : list) {
     auto add = [&nested, key = field.key](const auto& val) {
       nested.field(key, val);
@@ -126,15 +122,15 @@ void log_event_fields_builder::field(std::string_view key,
   field.value = nested.build();
 }
 
-std::string_view log_event_fields_builder::deep_copy(std::string_view str) {
+std::string_view event_fields_builder::deep_copy(std::string_view str) {
   return deep_copy_impl(resource(), str);
 }
 
-void log_event_sender::send() && {
+void event_sender::send() && {
   if (logger_) {
     event_->first_field_ = fields_.build().head;
     logger_->do_log(std::move(event_));
   }
 }
 
-} // namespace caf
+} // namespace caf::log

--- a/libcaf_core/caf/log/level.hpp
+++ b/libcaf_core/caf/log/level.hpp
@@ -1,0 +1,32 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/detail/log_level.hpp"
+
+namespace caf::log {
+
+/// Provides integer constants for the predefined log levels.
+struct level {
+  /// Integer value for the 'quiet' log level.
+  static constexpr unsigned quiet = CAF_LOG_LEVEL_QUIET;
+
+  /// Integer value for the 'error' log level.
+  static constexpr unsigned error = CAF_LOG_LEVEL_ERROR;
+
+  /// Integer value for the 'warning' log level.
+  static constexpr unsigned warning = CAF_LOG_LEVEL_WARNING;
+
+  /// Integer value for the 'info' log level.
+  static constexpr unsigned info = CAF_LOG_LEVEL_INFO;
+
+  /// Integer value for the 'debug' log level.
+  static constexpr unsigned debug = CAF_LOG_LEVEL_DEBUG;
+
+  /// Integer value for the 'trace' log level.
+  static constexpr unsigned trace = CAF_LOG_LEVEL_TRACE;
+};
+
+} // namespace caf::log

--- a/libcaf_core/caf/message.cpp
+++ b/libcaf_core/caf/message.cpp
@@ -276,6 +276,11 @@ bool message::save(binary_serializer& sink) const {
   return save_data(sink, data_);
 }
 
+bool message::save(detail::stringification_inspector& sink) const {
+  auto str = to_string(*this);
+  return sink.value(str);
+}
+
 // -- related non-members ------------------------------------------------------
 
 std::string to_string(const message& msg) {

--- a/libcaf_core/caf/message.hpp
+++ b/libcaf_core/caf/message.hpp
@@ -17,6 +17,12 @@
 #include <tuple>
 #include <type_traits>
 
+namespace caf::detail {
+
+class stringification_inspector;
+
+} // namespace caf::detail
+
 namespace caf {
 
 /// Describes a fixed-length, copy-on-write, type-erased
@@ -124,6 +130,8 @@ public:
   bool save(serializer& sink) const;
 
   bool save(binary_serializer& sink) const;
+
+  bool save(detail::stringification_inspector& sink) const;
 
   bool load(deserializer& source);
 

--- a/libcaf_core/caf/message_builder.test.cpp
+++ b/libcaf_core/caf/message_builder.test.cpp
@@ -7,6 +7,7 @@
 #include "caf/test/test.hpp"
 
 #include "caf/init_global_meta_objects.hpp"
+#include "caf/log/test.hpp"
 #include "caf/type_id.hpp"
 
 using namespace caf;
@@ -72,7 +73,7 @@ TEST("message_builder can build messages incrementally") {
     check_eq(builder.size(), 0u);
   }
   SECTION("append() adds values to a builder") {
-    print_debug("after adding 1, the message is (1)");
+    log::test::debug("after adding 1, the message is (1)");
     {
       builder.append(int32_t{1});
       auto msg = builder.to_message();
@@ -80,7 +81,7 @@ TEST("message_builder can build messages incrementally") {
       check_eq(msg.types(), make_type_id_list<int32_t>());
       check_eq(msg.get_as<int32_t>(0), 1);
     }
-    print_debug("after adding [2, 3], the message is (1, 2, 3)");
+    log::test::debug("after adding [2, 3], the message is (1, 2, 3)");
     {
       std::vector<int32_t> xs{2, 3};
       builder.append(xs.begin(), xs.end());

--- a/libcaf_core/caf/node_id.cpp
+++ b/libcaf_core/caf/node_id.cpp
@@ -13,7 +13,7 @@
 #include "caf/detail/parse.hpp"
 #include "caf/detail/parser/ascii_to_int.hpp"
 #include "caf/expected.hpp"
-#include "caf/logger.hpp"
+#include "caf/log/core.hpp"
 #include "caf/make_counted.hpp"
 #include "caf/parser_state.hpp"
 #include "caf/sec.hpp"
@@ -212,7 +212,7 @@ error parse(std::string_view str, node_id& dest) {
       dest = std::move(*nid);
       return none;
     }
-    CAF_LOG_ERROR("make_node_id failed after can_parse returned true");
+    log::core::error("make_node_id failed after can_parse returned true");
     return sec::invalid_argument;
   }
   if (auto nid_uri = make_uri(str)) {

--- a/libcaf_core/caf/raise_error.cpp
+++ b/libcaf_core/caf/raise_error.cpp
@@ -8,9 +8,8 @@
 
 namespace caf::detail {
 
-void log_cstring_error(const char* cstring) {
-  CAF_IGNORE_UNUSED(cstring);
-  CAF_LOG_ERROR(cstring);
+void log_cstring_error(const char*) {
+  // TODO: remove with 1.0.
 }
 
 } // namespace caf::detail

--- a/libcaf_core/caf/scoped_actor.cpp
+++ b/libcaf_core/caf/scoped_actor.cpp
@@ -5,6 +5,7 @@
 #include "caf/scoped_actor.hpp"
 
 #include "caf/actor_registry.hpp"
+#include "caf/log/system.hpp"
 #include "caf/scoped_execution_unit.hpp"
 #include "caf/spawn_options.hpp"
 
@@ -19,7 +20,7 @@ public:
   }
 
   void act() override {
-    CAF_LOG_ERROR("act() of scoped_actor impl called");
+    log::system::error("act() of scoped_actor impl called");
   }
 
   const char* name() const override {

--- a/libcaf_core/caf/stream.test.cpp
+++ b/libcaf_core/caf/stream.test.cpp
@@ -11,6 +11,7 @@
 #include "caf/binary_deserializer.hpp"
 #include "caf/binary_serializer.hpp"
 #include "caf/event_based_actor.hpp"
+#include "caf/log/test.hpp"
 #include "caf/scheduled_actor/flow.hpp"
 
 using namespace caf;
@@ -21,14 +22,14 @@ namespace {
 using ivec = std::vector<int>;
 
 behavior int_sink(event_based_actor* self, std::shared_ptr<ivec> results) {
-  caf::logger::debug("stream.test", "started sink with ID {}", self->id());
+  log::test::debug("stream.test", "started sink with ID {}", self->id());
   return {
     [self, results](const stream& input) {
       self //
         ->observe_as<int>(input, 30, 10)
         .do_finally([self] {
-          caf::logger::debug("stream.test", "sink with ID {} shuts down",
-                             self->id());
+          log::test::debug("stream.test", "sink with ID {} shuts down",
+                           self->id());
           self->quit();
         })
         .for_each([results](int x) { results->push_back(x); });

--- a/libcaf_core/caf/telemetry/collector/prometheus.test.cpp
+++ b/libcaf_core/caf/telemetry/collector/prometheus.test.cpp
@@ -6,6 +6,7 @@
 
 #include "caf/test/test.hpp"
 
+#include "caf/log/test.hpp"
 #include "caf/telemetry/metric_registry.hpp"
 #include "caf/telemetry/metric_type.hpp"
 
@@ -60,7 +61,8 @@ some_request_duration_seconds_bucket{x="get",le="+Inf"} 3 42000
 some_request_duration_seconds_sum{x="get"} 14 42000
 some_request_duration_seconds_count{x="get"} 3 42000
 )"sv);
-  print_debug("multiple runs with the same timestamp generate the same output");
+  log::test::debug("multiple runs with the same timestamp produce "
+                   "the same output");
   auto ts = make_timestamp();
   std::string res1;
   {

--- a/libcaf_core/caf/telemetry/importer/process.cpp
+++ b/libcaf_core/caf/telemetry/importer/process.cpp
@@ -4,7 +4,7 @@
 
 #include "caf/telemetry/importer/process.hpp"
 
-#include "caf/logger.hpp"
+#include "caf/log/system.hpp"
 #include "caf/telemetry/gauge.hpp"
 #include "caf/telemetry/metric_registry.hpp"
 
@@ -172,7 +172,7 @@ bool load_system_setting(std::atomic<long>& cache_var, long& var, int name,
     case 0:
       var = sysconf(name);
       if (var <= 0) {
-        CAF_LOG_ERROR("failed to read" << pretty_name << "from sysconf");
+        caf::log::system::error("failed to read {} from sysconf", pretty_name);
         var = -1;
         cache_var = var;
         return false;
@@ -244,7 +244,7 @@ sys_stats read_sys_stats() {
                      &utime_ticks, &stime_ticks, &vmsize_bytes, &rss_pages);
     fclose(f);
     if (rd != 4) {
-      CAF_LOG_ERROR("failed to read content of /proc/self/stat");
+      caf::log::system::warning("failed to read /proc/self/stat");
       global_ticks_per_second = -1;
       global_page_size = -1;
       return result;
@@ -283,7 +283,7 @@ sys_stats read_sys_stats() {
   if (!TRY_LOAD(page_size, _SC_PAGE_SIZE))
     return result;
   if (sysctl(mib, 6, &kip2, &kip2_size, nullptr, size_t{0}) != 0) {
-    CAF_LOG_ERROR("failed to call sysctl in read_sys_stats");
+    caf::log::system::error("failed to call sysctl in read_sys_stats");
     global_page_size = -1;
     return result;
   }

--- a/libcaf_io/caf/io/middleman.cpp
+++ b/libcaf_io/caf/io/middleman.cpp
@@ -24,6 +24,7 @@
 #include "caf/function_view.hpp"
 #include "caf/group_module.hpp"
 #include "caf/init_global_meta_objects.hpp"
+#include "caf/log/system.hpp"
 #include "caf/logger.hpp"
 #include "caf/make_counted.hpp"
 #include "caf/node_id.hpp"
@@ -132,7 +133,7 @@ public:
       dptr = std::move(*maybe_dptr);
     } else {
       auto& err = maybe_dptr.error();
-      CAF_LOG_ERROR("failed to expose Prometheus metrics:" << err);
+      log::system::error("failed to expose Prometheus metrics: {}", err);
       return std::move(err);
     }
     auto actual_port = dptr->port();
@@ -412,8 +413,7 @@ strong_actor_ptr middleman::remote_lookup(std::string name,
   self->receive(
     [&](strong_actor_ptr& addr) { result = std::move(addr); },
     others >> []([[maybe_unused]] message& msg) -> skippable_result {
-      CAF_LOG_ERROR(
-        "middleman received unexpected remote_lookup result:" << msg);
+      log::system::error("received unexpected remote_lookup result: {}", msg);
       return message{};
     },
     after(std::chrono::minutes(5)) >>

--- a/libcaf_io/caf/io/network/ip_endpoint.cpp
+++ b/libcaf_io/caf/io/network/ip_endpoint.cpp
@@ -7,7 +7,7 @@
 #include "caf/io/network/native_socket.hpp"
 
 #include "caf/hash/fnv.hpp"
-#include "caf/logger.hpp"
+#include "caf/log/system.hpp"
 #include "caf/sec.hpp"
 
 // clang-format off
@@ -96,7 +96,8 @@ size_t ep_hash::operator()(const sockaddr& sa) const noexcept {
     case AF_INET6:
       return hash(reinterpret_cast<const struct sockaddr_in6*>(&sa));
     default:
-      CAF_LOG_ERROR("Only IPv4 and IPv6 are supported.");
+      log::system::error("failed to hash socket address: "
+                         "only IPv4 and IPv6 are supported");
       return 0;
   }
 }

--- a/libcaf_net/caf/net/lp/default_trait.cpp
+++ b/libcaf_net/caf/net/lp/default_trait.cpp
@@ -7,7 +7,7 @@
 #include "caf/net/lp/frame.hpp"
 
 #include "caf/error.hpp"
-#include "caf/logger.hpp"
+#include "caf/log/system.hpp"
 #include "caf/sec.hpp"
 
 namespace caf::net::lp {
@@ -24,7 +24,7 @@ bool default_trait::convert(const_byte_span bytes, input_type& x) {
 }
 
 error default_trait::last_error() {
-  CAF_LOG_ERROR("lp::default_trait::last_error called");
+  log::system::error("lp::default_trait::last_error called");
   return {sec::logic_error};
 }
 

--- a/libcaf_net/caf/net/middleman.cpp
+++ b/libcaf_net/caf/net/middleman.cpp
@@ -14,6 +14,7 @@
 #include "caf/actor_system_config.hpp"
 #include "caf/detail/set_thread_name.hpp"
 #include "caf/expected.hpp"
+#include "caf/log/system.hpp"
 #include "caf/raise_error.hpp"
 #include "caf/sec.hpp"
 #include "caf/send.hpp"
@@ -97,7 +98,7 @@ void middleman::stop() {
 
 void middleman::init(actor_system_config&) {
   if (auto err = mpx_->init()) {
-    CAF_LOG_ERROR("mpx_->init() failed: " << err);
+    log::system::error("failed to initialize multiplexer: {}", err);
     CAF_RAISE_ERROR("mpx_->init() failed");
   }
 }

--- a/libcaf_net/caf/net/multiplexer.cpp
+++ b/libcaf_net/caf/net/multiplexer.cpp
@@ -20,6 +20,7 @@
 #include "caf/detail/net_export.hpp"
 #include "caf/error.hpp"
 #include "caf/expected.hpp"
+#include "caf/log/system.hpp"
 #include "caf/logger.hpp"
 #include "caf/make_counted.hpp"
 #include "caf/ref_counted.hpp"
@@ -311,7 +312,7 @@ public:
             break;
           }
           case std::errc::not_enough_memory: {
-            CAF_LOG_ERROR("poll() failed due to insufficient memory");
+            log::system::error("poll() failed due to insufficient memory");
             // There's not much we can do other than try again in hope someone
             // else releases memory.
             break;
@@ -607,7 +608,7 @@ void pollset_updater::handle_read_event() {
             mpx_->do_shutdown();
             break;
           default:
-            CAF_LOG_ERROR("opcode not recognized: " << CAF_ARG(opcode));
+            log::system::error("invalid opcode in pollset updater: {}", opcode);
             break;
         }
       }
@@ -618,7 +619,7 @@ void pollset_updater::handle_read_event() {
     } else if (last_socket_error_is_temporary()) {
       return;
     } else {
-      CAF_LOG_ERROR("pollset updater failed to read from the pipe");
+      log::system::error("pollset updater failed to read from its pipe");
       owner_->deregister();
       return;
     }

--- a/libcaf_net/caf/net/web_socket/default_trait.cpp
+++ b/libcaf_net/caf/net/web_socket/default_trait.cpp
@@ -7,6 +7,7 @@
 #include "caf/net/web_socket/frame.hpp"
 
 #include "caf/error.hpp"
+#include "caf/log/system.hpp"
 #include "caf/logger.hpp"
 #include "caf/sec.hpp"
 
@@ -39,7 +40,7 @@ bool default_trait::convert(std::string_view text, input_type& x) {
 }
 
 error default_trait::last_error() {
-  CAF_LOG_ERROR("default_trait::last_error called");
+  log::system::error("web_socket::default_trait::last_error called");
   return {sec::logic_error};
 }
 

--- a/libcaf_openssl/caf/openssl/middleman_actor.cpp
+++ b/libcaf_openssl/caf/openssl/middleman_actor.cpp
@@ -24,6 +24,7 @@
 #include "caf/actor_proxy.hpp"
 #include "caf/actor_system_config.hpp"
 #include "caf/detail/socket_guard.hpp"
+#include "caf/log/system.hpp"
 #include "caf/logger.hpp"
 #include "caf/node_id.hpp"
 #include "caf/sec.hpp"
@@ -214,7 +215,7 @@ public:
     io::network::nonblocking(fd, true);
     auto sssn = make_session(parent()->system(), fd, true);
     if (sssn == nullptr) {
-      CAF_LOG_ERROR("Unable to create SSL session for accepted socket");
+      log::system::error("unable to create SSL session for accepted socket");
       return false;
     }
     auto scrb = make_counted<scribe_impl>(dm, fd, std::move(sssn));
@@ -246,7 +247,7 @@ protected:
     io::network::nonblocking(*fd, true);
     auto sssn = make_session(system(), *fd, false);
     if (!sssn) {
-      CAF_LOG_ERROR("Unable to create SSL session for connection");
+      log::system::error("unable to create SSL session for connection");
       return sec::cannot_connect_to_node;
     }
     CAF_LOG_DEBUG("successfully created an SSL session for:" << CAF_ARG(host)

--- a/libcaf_openssl/caf/openssl/session.cpp
+++ b/libcaf_openssl/caf/openssl/session.cpp
@@ -13,6 +13,7 @@ CAF_POP_WARNINGS
 #include "caf/openssl/manager.hpp"
 
 #include "caf/actor_system_config.hpp"
+#include "caf/log/system.hpp"
 
 // On Linux we need to block SIGPIPE whenever we access OpenSSL functions.
 // Unfortunately there's no sane way to configure OpenSSL properly.
@@ -75,7 +76,7 @@ bool session::init() {
   ctx_ = create_ssl_context();
   ssl_ = SSL_new(ctx_);
   if (ssl_ == nullptr) {
-    CAF_LOG_ERROR("cannot create SSL session");
+    log::system::error("cannot create SSL session");
     return false;
   }
   return true;

--- a/libcaf_test/caf/test/outline.test.cpp
+++ b/libcaf_test/caf/test/outline.test.cpp
@@ -4,6 +4,8 @@
 
 #include "caf/test/outline.hpp"
 
+#include "caf/log/test.hpp"
+
 #include <numeric>
 
 namespace {
@@ -12,11 +14,11 @@ OUTLINE("eating cucumbers") {
   GIVEN("there are <start> cucumbers") {
     auto start = block_parameters<int>();
     auto cucumbers = start;
-    print_debug("cucumbers: {}", cucumbers);
+    caf::log::test::debug("cucumbers: {}", cucumbers);
     WHEN("I eat <eat> cucumbers") {
       auto eat = block_parameters<int>();
       cucumbers -= eat;
-      print_debug("cucumbers: {}", cucumbers);
+      caf::log::test::debug("cucumbers: {}", cucumbers);
       THEN("I should have <left> cucumbers") {
         auto left = block_parameters<int>();
         check_eq(cucumbers, left);

--- a/libcaf_test/caf/test/reporter.hpp
+++ b/libcaf_test/caf/test/reporter.hpp
@@ -76,45 +76,27 @@ public:
     = 0;
 
   /// Prints a message to the output stream if `verbosity() >= level`.
-  virtual void print(const log_event& event) = 0;
+  virtual void print(const log::event& event) = 0;
 
   /// Prints a message to the output stream if `verbosity() >= level`.
-  virtual void print(const log_event_ptr& event) {
+  virtual void print(const log::event_ptr& event) {
     if (event != nullptr)
       print(*event);
   }
 
-  /// Generates a message with the DEBUG severity level.
-  template <class... Ts>
-  void print_debug(format_string_with_location fwl, Ts&&... xs) {
-    do_print(CAF_LOG_LEVEL_DEBUG, fwl, std::forward<Ts>(xs)...);
-  }
-
-  /// Generates a message with the INFO severity level.
-  template <class... Ts>
-  void print_info(format_string_with_location fwl, Ts&&... xs) {
-    do_print(CAF_LOG_LEVEL_INFO, fwl, std::forward<Ts>(xs)...);
-  }
-
-  /// Generates a message with the WARNING severity level.
-  template <class... Ts>
-  void print_warning(format_string_with_location fwl, Ts&&... xs) {
-    do_print(CAF_LOG_LEVEL_WARNING, fwl, std::forward<Ts>(xs)...);
-  }
-
-  /// Generates a message with the ERROR severity level.
-  template <class... Ts>
-  void print_error(format_string_with_location fwl, Ts&&... xs) {
-    do_print(CAF_LOG_LEVEL_ERROR, fwl, std::forward<Ts>(xs)...);
-  }
-
   virtual void print_actor_output(local_actor* self, std::string_view msg) = 0;
+
+  /// Returns the current verbosity level.
+  virtual unsigned verbosity() const noexcept = 0;
 
   /// Sets the verbosity level of the reporter and returns the previous value.
   virtual unsigned verbosity(unsigned level) noexcept = 0;
 
-  /// returns the current verbosity level.
-  virtual unsigned verbosity() const noexcept = 0;
+  /// Returns the current filter for log messages.
+  virtual std::vector<std::string> log_component_filter() const = 0;
+
+  /// Sets the filter for log messages.
+  virtual void log_component_filter(std::vector<std::string> new_filter) = 0;
 
   /// Sets whether the reporter disables colored output even when writing to a
   /// TTY.
@@ -140,14 +122,6 @@ public:
 
   /// Creates a default reporter that writes to the standard output.
   static std::unique_ptr<reporter> make_default();
-
-private:
-  template <class... Ts>
-  void do_print(unsigned level, format_string_with_location fwl, Ts&&... xs) {
-    print(log_event::make(level, "caf.test", fwl.location,
-                          logger::thread_local_aid(), fwl.value,
-                          std::forward<Ts>(xs)...));
-  }
 };
 
 } // namespace caf::test

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -21,6 +21,7 @@
 #include "caf/detail/test_export.hpp"
 #include "caf/expected.hpp"
 #include "caf/format_string_with_location.hpp"
+#include "caf/log/level.hpp"
 #include "caf/raise_error.hpp"
 
 #include <string_view>
@@ -56,30 +57,6 @@ public:
     auto msg = detail::format(fwl.value, std::forward<Ts>(xs)...);
     reporter::instance().fail(msg, fwl.location);
     requirement_failed::raise(fwl.location);
-  }
-
-  /// Generates a message with the DEBUG severity level.
-  template <class... Ts>
-  void print_debug(format_string_with_location fwl, Ts&&... xs) {
-    reporter::instance().print_debug(fwl, std::forward<Ts>(xs)...);
-  }
-
-  /// Generates a message with the INFO severity level.
-  template <class... Ts>
-  void print_info(format_string_with_location fwl, Ts&&... xs) {
-    reporter::instance().print_info(fwl, std::forward<Ts>(xs)...);
-  }
-
-  /// Generates a message with the WARNING severity level.
-  template <class... Ts>
-  void print_warning(format_string_with_location fwl, Ts&&... xs) {
-    reporter::instance().print_warning(fwl, std::forward<Ts>(xs)...);
-  }
-
-  /// Generates a message with the ERROR severity level.
-  template <class... Ts>
-  void print_error(format_string_with_location fwl, Ts&&... xs) {
-    reporter::instance().print_error(fwl, std::forward<Ts>(xs)...);
   }
 
   /// Checks whether `lhs` and `rhs` are equal.
@@ -244,7 +221,7 @@ public:
   void should_fail(Expr&& expr, const caf::detail::source_location& location
                                 = caf::detail::source_location::current()) {
     auto& rep = reporter::instance();
-    auto lvl = rep.verbosity(CAF_LOG_LEVEL_QUIET);
+    auto lvl = rep.verbosity(log::level::quiet);
     auto before = rep.test_stats();
     {
       auto lvl_guard
@@ -321,7 +298,7 @@ public:
                                   = caf::detail::source_location::current()) {
     auto& rep = reporter::instance();
     auto before = rep.test_stats();
-    auto lvl = rep.verbosity(CAF_LOG_LEVEL_QUIET);
+    auto lvl = rep.verbosity(log::level::quiet);
     auto caught = false;
     if constexpr (std::is_same_v<Exception, void>) {
       try {

--- a/libcaf_test/caf/test/test.test.cpp
+++ b/libcaf_test/caf/test/test.test.cpp
@@ -5,6 +5,8 @@
 
 #include "caf/test/requirement_failed.hpp"
 
+#include "caf/log/test.hpp"
+
 using caf::test::block_type;
 
 namespace {
@@ -39,7 +41,7 @@ TEST("tests can contain different types of checks") {
     should_fail([this]() { check_lt(1, 1); });
     should_fail([this]() { check_lt(2, 1); });
   }
-  print_debug("this test had {} checks", rep.test_stats().total());
+  caf::log::test::debug("this test had {} checks", rep.test_stats().total());
 }
 
 #ifdef CAF_ENABLE_EXCEPTIONS
@@ -83,7 +85,7 @@ TEST("tests fail when requirement errors occur") {
       [this]() { require_gt(1, 2); });
     require_gt(2, 1);
   }
-  print_debug("this test had {} checks", rep.test_stats().total());
+  caf::log::test::debug("this test had {} checks", rep.test_stats().total());
 }
 
 #endif // CAF_ENABLE_EXCEPTIONS
@@ -93,7 +95,7 @@ TEST("failed checks increment the failed counter") {
   auto stats = caf::test::reporter::instance().test_stats();
   check_eq(stats.passed, 0u);
   check_eq(stats.failed, 1u);
-  print_debug("reset error count to not fail the test");
+  caf::log::test::debug("reset error count to not fail the test");
   caf::test::reporter::instance().test_stats({2, 0});
 }
 

--- a/robot/logging/base.cfg
+++ b/robot/logging/base.cfg
@@ -2,12 +2,12 @@ caf {
   logger {
     console {
       format = "%p %c %m"
-      excluded-components = ["caf", "caf_flow"]
+      excluded-components = ["caf", "caf_flow", "caf.core"]
     }
     file {
       path = "app.log"
       format = "%p %c %m%n"
-      excluded-components = ["caf", "caf_flow"]
+      excluded-components = ["caf", "caf_flow", "caf.core"]
     }
   }
 }

--- a/robot/logging/driver.cpp
+++ b/robot/logging/driver.cpp
@@ -19,58 +19,42 @@ namespace app {
 
 constexpr std::string_view component = "app";
 
-/// Logs a message for the `caf.core` component with `debug` severity.
-/// @param fmt_str The format string (with source location) for the message.
-/// @param args Arguments for the format string.
 template <class... Ts>
 void debug(caf::format_string_with_location fmt_str, Ts&&... args) {
   caf::logger::log(caf::log::level::debug, component, fmt_str,
                    std::forward<Ts>(args)...);
 }
 
-/// Starts a new log event for the `caf.core` component with `debug` severity.
 inline auto debug() {
   return caf::logger::log(caf::log::level::debug, component);
 }
 
-/// Logs a message for the `caf.core` component with `info` severity.
-/// @param fmt_str The format string (with source location) for the message.
-/// @param args Arguments for the format string.
 template <class... Ts>
 void info(caf::format_string_with_location fmt_str, Ts&&... args) {
   caf::logger::log(caf::log::level::info, component, fmt_str,
                    std::forward<Ts>(args)...);
 }
 
-/// Starts a new log event for the `caf.core` component with `info` severity.
 inline auto info() {
   return caf::logger::log(caf::log::level::info, component);
 }
 
-/// Logs a message for the `caf.core` component with `warning` severity.
-/// @param fmt_str The format string (with source location) for the message.
-/// @param args Arguments for the format string.
 template <class... Ts>
 void warning(caf::format_string_with_location fmt_str, Ts&&... args) {
   caf::logger::log(caf::log::level::warning, component, fmt_str,
                    std::forward<Ts>(args)...);
 }
 
-/// Starts a new log event for the `caf.core` component with `warning` severity.
 inline auto warning() {
   return caf::logger::log(caf::log::level::warning, component);
 }
 
-/// Logs a message for the `caf.core` component with `error` severity.
-/// @param fmt_str The format string (with source location) for the message.
-/// @param args Arguments for the format string.
 template <class... Ts>
 void error(caf::format_string_with_location fmt_str, Ts&&... args) {
   caf::logger::log(caf::log::level::error, component, fmt_str,
                    std::forward<Ts>(args)...);
 }
 
-/// Starts a new log event for the `caf.core` component with `error` severity.
 inline auto error() {
   return caf::logger::log(caf::log::level::error, component);
 }
@@ -138,5 +122,4 @@ void caf_main(caf::actor_system&, const config& cfg) {
   foo(42, get_or(cfg, "api", "default") == "legacy");
 }
 
-// creates a main function for us that calls our caf_main
 CAF_MAIN(caf::id_block::driver)

--- a/robot/logging/driver.cpp
+++ b/robot/logging/driver.cpp
@@ -1,7 +1,8 @@
 #define CAF_LOG_COMPONENT "app"
 
 #include "caf/caf_main.hpp"
-#include "caf/logger.hpp"
+#include "caf/log/core.hpp"
+#include "caf/log/level.hpp"
 #include "caf/type_id.hpp"
 
 #include <string_view>
@@ -14,7 +15,67 @@ CAF_BEGIN_TYPE_ID_BLOCK(driver, caf::first_custom_type_id)
 
 CAF_END_TYPE_ID_BLOCK(driver)
 
+namespace app {
+
 constexpr std::string_view component = "app";
+
+/// Logs a message for the `caf.core` component with `debug` severity.
+/// @param fmt_str The format string (with source location) for the message.
+/// @param args Arguments for the format string.
+template <class... Ts>
+void debug(caf::format_string_with_location fmt_str, Ts&&... args) {
+  caf::logger::log(caf::log::level::debug, component, fmt_str,
+                   std::forward<Ts>(args)...);
+}
+
+/// Starts a new log event for the `caf.core` component with `debug` severity.
+inline auto debug() {
+  return caf::logger::log(caf::log::level::debug, component);
+}
+
+/// Logs a message for the `caf.core` component with `info` severity.
+/// @param fmt_str The format string (with source location) for the message.
+/// @param args Arguments for the format string.
+template <class... Ts>
+void info(caf::format_string_with_location fmt_str, Ts&&... args) {
+  caf::logger::log(caf::log::level::info, component, fmt_str,
+                   std::forward<Ts>(args)...);
+}
+
+/// Starts a new log event for the `caf.core` component with `info` severity.
+inline auto info() {
+  return caf::logger::log(caf::log::level::info, component);
+}
+
+/// Logs a message for the `caf.core` component with `warning` severity.
+/// @param fmt_str The format string (with source location) for the message.
+/// @param args Arguments for the format string.
+template <class... Ts>
+void warning(caf::format_string_with_location fmt_str, Ts&&... args) {
+  caf::logger::log(caf::log::level::warning, component, fmt_str,
+                   std::forward<Ts>(args)...);
+}
+
+/// Starts a new log event for the `caf.core` component with `warning` severity.
+inline auto warning() {
+  return caf::logger::log(caf::log::level::warning, component);
+}
+
+/// Logs a message for the `caf.core` component with `error` severity.
+/// @param fmt_str The format string (with source location) for the message.
+/// @param args Arguments for the format string.
+template <class... Ts>
+void error(caf::format_string_with_location fmt_str, Ts&&... args) {
+  caf::logger::log(caf::log::level::error, component, fmt_str,
+                   std::forward<Ts>(args)...);
+}
+
+/// Starts a new log event for the `caf.core` component with `error` severity.
+inline auto error() {
+  return caf::logger::log(caf::log::level::error, component);
+}
+
+} // namespace app
 
 struct foobar {
   std::string foo;
@@ -40,25 +101,25 @@ void foo([[maybe_unused]] int value, bool use_legacy_api) {
     CAF_LOG_ERROR("this is another error message ; foo = bar");
   } else {
     using caf::logger;
-    auto trace_guard = logger::trace(component, "value = {}", value);
-    logger::debug(component, "this is a debug message");
-    logger::debug(component)
+    auto trace_guard = logger::trace(app::component, "value = {}", value);
+    app::debug("this is a debug message");
+    app::debug()
       .message("this is {} with {}", "another debug message",
                foobar{"one", "two"})
       .field("field", "{}", foobar{"three", "four"})
       .send();
-    logger::info(component, "this is an info message");
-    logger::info(component)
+    app::info("this is an info message");
+    app::info()
       .message("this is {}", "another info message")
       .field("foo", "bar")
       .send();
-    logger::warning(component, "this is a warning message");
-    logger::warning(component)
+    app::warning("this is a warning message");
+    app::warning()
       .message("this is {}", "another warning message")
       .field("foo", "bar")
       .send();
-    logger::error(component, "this is an error message");
-    logger::error(component)
+    app::error("this is an error message");
+    app::error()
       .message("this is {}", "another error message")
       .field("foo", "bar")
       .send();


### PR DESCRIPTION
- Rename `caf::{log_event => log::event}`
- Add new `caf::log::level` class with properly typed constants for the existing log level macros.
- Remove member functions such as `logger::debug` that require a component argument.
- Implement new logging API under `caf::log` with one header (and namespace) per component: `system`, `core`, `io`, `net`, `openssl`, and `test`.
- Remove the `print_<level>` functions from the test reporter and instead simply use the new `log::test::<level>` functions.
- Drop automatic logging from `CAF_RAISE_ERROR`, because it cannot log with the appropriate component.
- Use the new `log::system` logging API throughout CAF wherever an event might impact the operation of the entire system.
- Implement log component filtering on the unit test binaries. This enables CAF developers to print log messages as part of the test execution when using the deterministic fixture.