### PR TITLE
Add utils for spawning actors from state classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - The new class `caf::chunk` represents an immutable sequence of bytes with a
   fixed size. Unlike `std::span`, a `chunk` owns its data and can be (cheaply)
   copied and moved.
+- Users can now convert state classes with a `make_behavior` member function
+  into a "function-based actor" via the new `actor_from_state` utility. For
+  example, `sys.spawn(caf::actor_from_state<my_state>, args...)` creates a new
+  actor that initializes its state with `my_state{args...}` and then calls
+  `make_behavior()` on the state object to obtain the initial behavior.
 
 ### Fixed
 

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -80,6 +80,7 @@ caf_add_component(
     caf/actor_companion.test.cpp
     caf/actor_config.cpp
     caf/actor_control_block.cpp
+    caf/actor_from_state.test.cpp
     caf/actor_ostream.cpp
     caf/actor_pool.cpp
     caf/actor_profiler.cpp
@@ -195,14 +196,14 @@ caf_add_component(
     caf/flow/concat_map.test.cpp
     caf/flow/coordinated.cpp
     caf/flow/coordinator.cpp
-    caf/flow/for_each.test.cpp
     caf/flow/flat_map.test.cpp
+    caf/flow/for_each.test.cpp
     caf/flow/generation.test.cpp
     caf/flow/mixed.test.cpp
     caf/flow/multicaster.test.cpp
     caf/flow/observable.test.cpp
-    caf/flow/observe_on.test.cpp
     caf/flow/observable_builder.cpp
+    caf/flow/observe_on.test.cpp
     caf/flow/op/buffer.test.cpp
     caf/flow/op/cell.test.cpp
     caf/flow/op/concat.test.cpp
@@ -219,8 +220,8 @@ caf_add_component(
     caf/flow/op/ucast.test.cpp
     caf/flow/op/zip_with.test.cpp
     caf/flow/op/pullable.cpp
-    caf/flow/single.test.cpp
     caf/flow/scoped_coordinator.cpp
+    caf/flow/single.test.cpp
     caf/flow/step/ignore_elements.test.cpp
     caf/flow/step/skip_last.test.cpp
     caf/flow/step/take_last.test.cpp

--- a/libcaf_core/caf/actor_from_state.hpp
+++ b/libcaf_core/caf/actor_from_state.hpp
@@ -1,0 +1,101 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/detail/type_traits.hpp"
+#include "caf/event_based_actor.hpp"
+#include "caf/fwd.hpp"
+#include "caf/typed_event_based_actor.hpp"
+
+#include <new>
+#include <type_traits>
+#include <utility>
+
+namespace caf::detail {
+
+/// An event-based actor with managed state. The state is constructed separately
+/// and destroyed when the actor calls `quit`.
+template <class State, class Base>
+class actor_from_state_impl : public Base {
+public:
+  using super = Base;
+
+  friend actor_from_state_t<State>;
+
+  explicit actor_from_state_impl(actor_config& cfg) : super(cfg) {
+    // nop
+  }
+
+  void on_exit() override {
+    if (has_state_)
+      state.~State();
+  }
+
+  union {
+    State state;
+  };
+
+private:
+  bool has_state_ = false;
+};
+
+template <class T>
+struct actor_from_state_impl_base;
+
+template <>
+struct actor_from_state_impl_base<behavior> {
+  using type = event_based_actor;
+};
+
+template <class... Ts>
+struct actor_from_state_impl_base<typed_behavior<Ts...>> {
+  using type = typed_event_based_actor<Ts...>;
+};
+
+} // namespace caf::detail
+
+namespace caf {
+
+/// Helper class for automating the creation of an event-based actor with
+/// managed state.
+template <class State>
+struct actor_from_state_t {
+  /// The behavior type of the actor.
+  using behavior_type = decltype(std::declval<State*>()->make_behavior());
+
+  static_assert(detail::is_behavior_v<behavior_type>,
+                "State::make_behavior() must return a behavior");
+
+  /// The base class for the actor implementation. Either `event_based_actor`
+  /// or `typed_event_based_actor`.
+  using base_type =
+    typename detail::actor_from_state_impl_base<behavior_type>::type;
+
+  /// The actual actor implementation.
+  using impl_type = detail::actor_from_state_impl<State, base_type>;
+
+  /// Constructs the state from the given arguments and returns the initial
+  /// behavior for the actor.
+  template <class... Args>
+  behavior_type operator()(impl_type* self, Args&&... args) const {
+    if constexpr (std::is_constructible_v<State, Args...>) {
+      new (&self->state) State(std::forward<Args>(args)...);
+    } else {
+      static_assert(std::is_constructible_v<State, base_type*, Args...>,
+                    "cannot construct state from given arguments");
+      auto ptr = static_cast<base_type*>(self);
+      new (&self->state) State(ptr, std::forward<Args>(args)...);
+    }
+    self->has_state_ = true;
+    return self->state.make_behavior();
+  }
+};
+
+/// A function object that automates the creation of an event-based actor with
+/// managed state.
+template <class State>
+inline constexpr auto actor_from_state = actor_from_state_t<State>{};
+
+} // namespace caf

--- a/libcaf_core/caf/actor_from_state.test.cpp
+++ b/libcaf_core/caf/actor_from_state.test.cpp
@@ -1,0 +1,175 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/actor_from_state.hpp"
+
+#include "caf/test/fixture/deterministic.hpp"
+#include "caf/test/test.hpp"
+
+#include "caf/typed_actor.hpp"
+
+using namespace caf;
+
+namespace {
+
+behavior dummy_impl() {
+  return {
+    [](int) { return; },
+    [](uint64_t) { return; },
+  };
+}
+
+WITH_FIXTURE(test::fixture::deterministic) {
+
+struct cell_state {
+  cell_state() = default;
+
+  explicit cell_state(int init) : value(init) {
+    // nop
+  }
+
+  behavior make_behavior() {
+    return {
+      [this](get_atom) { return value; },
+      [this](put_atom, int new_value) { value = new_value; },
+    };
+  }
+
+  int value = 0;
+};
+
+using typed_cell_actor
+  = typed_actor<result<int>(get_atom), result<void>(put_atom, int)>;
+
+struct typed_cell_state {
+  typed_cell_state() = default;
+
+  explicit typed_cell_state(int init) : value(init) {
+    // nop
+  }
+
+  typed_cell_actor::behavior_type make_behavior() {
+    return {
+      [this](get_atom) { return value; },
+      [this](put_atom, int new_value) { value = new_value; },
+    };
+  }
+
+  int value = 0;
+};
+
+TEST("a default-constructed cell has value 0") {
+  auto dummy = sys.spawn(dummy_impl);
+  SECTION("dynamically typed") {
+    auto uut = sys.spawn(actor_from_state<cell_state>);
+    static_assert(std::is_same_v<decltype(uut), actor>);
+    inject().with(get_atom_v).from(dummy).to(uut);
+    expect<int>().with(0).from(uut).to(dummy);
+    inject().with(put_atom_v, 23).from(dummy).to(uut);
+    inject().with(get_atom_v).from(dummy).to(uut);
+    expect<int>().with(23).from(uut).to(dummy);
+  }
+  SECTION("statically typed") {
+    auto uut = sys.spawn(actor_from_state<typed_cell_state>);
+    static_assert(std::is_same_v<decltype(uut), typed_cell_actor>);
+    inject().with(get_atom_v).from(dummy).to(uut);
+    expect<int>().with(0).from(uut).to(dummy);
+    inject().with(put_atom_v, 23).from(dummy).to(uut);
+    inject().with(get_atom_v).from(dummy).to(uut);
+    expect<int>().with(23).from(uut).to(dummy);
+  }
+}
+
+TEST("passing a value to the cell constructor overrides the default value") {
+  auto dummy = sys.spawn(dummy_impl);
+  SECTION("dynamically typed") {
+    auto uut = sys.spawn(actor_from_state<cell_state>, 42);
+    static_assert(std::is_same_v<decltype(uut), actor>);
+    inject().with(get_atom_v).from(dummy).to(uut);
+    expect<int>().with(42).from(uut).to(dummy);
+    inject().with(put_atom_v, 23).from(dummy).to(uut);
+    inject().with(get_atom_v).from(dummy).to(uut);
+    expect<int>().with(23).from(uut).to(dummy);
+  }
+  SECTION("statically typed") {
+    auto uut = sys.spawn(actor_from_state<typed_cell_state>, 42);
+    static_assert(std::is_same_v<decltype(uut), typed_cell_actor>);
+    inject().with(get_atom_v).from(dummy).to(uut);
+    expect<int>().with(42).from(uut).to(dummy);
+    inject().with(put_atom_v, 23).from(dummy).to(uut);
+    inject().with(get_atom_v).from(dummy).to(uut);
+    expect<int>().with(23).from(uut).to(dummy);
+  }
+}
+
+struct id_cell_state {
+  explicit id_cell_state(event_based_actor* selfptr, uint64_t offset_init = 0)
+    : self(selfptr), offset(offset_init) {
+    // nop
+  }
+
+  behavior make_behavior() {
+    return {
+      [this](get_atom) { return self->id() + offset; },
+    };
+  }
+
+  event_based_actor* self;
+  uint64_t offset;
+};
+
+using typed_id_cell_actor = typed_actor<result<uint64_t>(get_atom)>;
+
+struct typed_id_cell_state {
+  explicit typed_id_cell_state(typed_id_cell_actor::pointer selfptr,
+                               uint64_t offset_init = 0)
+    : self(selfptr), offset(offset_init) {
+    // nop
+  }
+
+  typed_id_cell_actor::behavior_type make_behavior() {
+    return {
+      [this](get_atom) { return self->id() + offset; },
+    };
+  }
+
+  typed_id_cell_actor::pointer self;
+  uint64_t offset;
+};
+
+TEST("the state may take the self pointer as constructor argument") {
+  auto dummy = sys.spawn(dummy_impl);
+  SECTION("no additional constructor argument") {
+    SECTION("dynamically typed") {
+      auto uut = sys.spawn(actor_from_state<id_cell_state>);
+      static_assert(std::is_same_v<decltype(uut), actor>);
+      inject().with(get_atom_v).from(dummy).to(uut);
+      expect<uint64_t>().with(uut->id()).from(uut).to(dummy);
+    }
+    SECTION("statically typed") {
+      auto uut = sys.spawn(actor_from_state<typed_id_cell_state>);
+      static_assert(std::is_same_v<decltype(uut), typed_id_cell_actor>);
+      inject().with(get_atom_v).from(dummy).to(uut);
+      expect<uint64_t>().with(uut->id()).from(uut).to(dummy);
+    }
+  }
+  SECTION("with offset constructor argument") {
+    SECTION("dynamically typed") {
+      auto uut = sys.spawn(actor_from_state<id_cell_state>, 2u);
+      static_assert(std::is_same_v<decltype(uut), actor>);
+      inject().with(get_atom_v).from(dummy).to(uut);
+      expect<uint64_t>().with(uut->id() + 2).from(uut).to(dummy);
+    }
+    SECTION("statically typed") {
+      auto uut = sys.spawn(actor_from_state<typed_id_cell_state>, 2u);
+      static_assert(std::is_same_v<decltype(uut), typed_id_cell_actor>);
+      inject().with(get_atom_v).from(dummy).to(uut);
+      expect<uint64_t>().with(uut->id() + 2).from(uut).to(dummy);
+    }
+  }
+}
+
+} // WITH_FIXTURE(test::fixture::deterministic)
+
+} // namespace

--- a/libcaf_core/caf/behavior.hpp
+++ b/libcaf_core/caf/behavior.hpp
@@ -112,8 +112,12 @@ public:
     // nop
   }
 
-  behavior& unbox() {
+  behavior& unbox() & {
     return *this;
+  }
+
+  behavior&& unbox() && {
+    return std::move(*this);
   }
 
   /// @endcond

--- a/libcaf_core/caf/detail/type_traits.hpp
+++ b/libcaf_core/caf/detail/type_traits.hpp
@@ -76,6 +76,19 @@ struct is_stream<typed_stream<T>> : std::true_type {};
 template <class T>
 inline constexpr bool is_stream_v = is_stream<T>::value;
 
+/// Checks whether  `T` is a `behavior` or `typed_behavior`.
+template <class T>
+struct is_behavior : std::false_type {};
+
+template <>
+struct is_behavior<behavior> : std::true_type {};
+
+template <class... Ts>
+struct is_behavior<typed_behavior<Ts...>> : std::true_type {};
+
+template <class T>
+inline constexpr bool is_behavior_v = is_behavior<T>::value;
+
 /// Checks whether `T` is a `publisher`.
 template <class T>
 struct is_publisher : std::false_type {};

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -35,6 +35,7 @@ template <class> class span;
 template <class> class typed_stream;
 template <class> class weak_intrusive_ptr;
 
+template <class> struct actor_from_state_t;
 template <class> struct inspector_access;
 template <class> struct timeout_definition;
 template <class> struct type_id;
@@ -62,6 +63,7 @@ template <class...> class result;
 template <class...> class typed_actor;
 template <class...> class typed_actor_pointer;
 template <class...> class typed_actor_view;
+template <class...> class typed_behavior;
 template <class...> class typed_event_based_actor;
 template <class...> class typed_message_view;
 template <class...> class typed_response_promise;

--- a/libcaf_core/caf/typed_behavior.hpp
+++ b/libcaf_core/caf/typed_behavior.hpp
@@ -14,6 +14,8 @@
 #include "caf/timespan.hpp"
 #include "caf/unsafe_behavior_init.hpp"
 
+#include <utility>
+
 namespace caf ::detail {
 
 template <class Signature>
@@ -224,8 +226,12 @@ public:
 
   /// @cond PRIVATE
 
-  behavior& unbox() {
+  behavior& unbox() & {
     return bhvr_;
+  }
+
+  behavior&& unbox() && {
+    return std::move(bhvr_);
   }
 
   static typed_behavior make_empty_behavior() {


### PR DESCRIPTION
Prep work for #1702. Adding this feature now allows us to update the best practices with the next release and then deprecate the class-based `spawn` versions with 1.0.