### PR TITLE
Add new actor_ostream::println utility function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   example, `sys.spawn(caf::actor_from_state<my_state>, args...)` creates a new
   actor that initializes its state with `my_state{args...}` and then calls
   `make_behavior()` on the state object to obtain the initial behavior.
+- The `aout` utility received a `println` member function that adds a formatted
+  line to the output stream. The function uses the same formatting backend as
+  the logging API.
 
 ### Fixed
 

--- a/examples/aout.cpp
+++ b/examples/aout.cpp
@@ -11,20 +11,20 @@
 using namespace caf;
 
 behavior printer(event_based_actor* self, int32_t num, int32_t delay) {
-  aout(self) << "Hi there! This is actor nr. " << num << "!" << std::endl;
-  std::chrono::milliseconds timeout{delay};
+  aout(self).println("Hi there! This is actor nr. {}!", num);
+  auto timeout = std::chrono::milliseconds{delay};
   self->delayed_send(self, timeout, timeout_atom_v);
   return {
     [=](timeout_atom) {
-      aout(self) << "Actor nr. " << num << " says goodbye after waiting for "
-                 << delay << "ms!" << std::endl;
+      aout(self).println("Actor nr. {} says goodbye after waiting for {}ms!",
+                         num, delay);
     },
   };
 }
 
 void caf_main(actor_system& sys) {
   std::random_device rd;
-  std::minstd_rand re(rd());
+  std::minstd_rand re{rd()};
   std::uniform_int_distribution<int32_t> dis{1, 99};
   for (int32_t i = 1; i <= 50; ++i)
     sys.spawn(printer, i, dis(re));

--- a/examples/custom_type/custom_types_1.cpp
+++ b/examples/custom_type/custom_types_1.cpp
@@ -74,12 +74,12 @@ struct testee_state {
       // note: we sent a foo_pair2, but match on foo_pair
       // that works because both are aliases for std::pair<int, int>
       [this](const foo_pair& val) {
-        aout(self) << "foo_pair" << deep_to_string(val) << endl;
+        aout(self).println("foo_pair{}", val);
         if (--remaining == 0)
           self->quit();
       },
       [this](const foo& val) {
-        aout(self) << deep_to_string(val) << endl;
+        aout(self).println("{}", val);
         if (--remaining == 0)
           self->quit();
       },

--- a/examples/custom_type/custom_types_2.cpp
+++ b/examples/custom_type/custom_types_2.cpp
@@ -58,7 +58,7 @@ private:
 
 behavior testee(event_based_actor* self) {
   return {
-    [self](const foo& x) { aout(self) << deep_to_string(x) << endl; },
+    [self](const foo& x) { aout(self).println("{}", x); },
   };
 }
 

--- a/examples/custom_type/custom_types_3.cpp
+++ b/examples/custom_type/custom_types_3.cpp
@@ -74,7 +74,7 @@ bool inspect(Inspector& f, foo& x) {
 
 behavior testee(event_based_actor* self) {
   return {
-    [self](const foo& x) { aout(self) << deep_to_string(x) << endl; },
+    [self](const foo& x) { aout(self).println("{}", x); },
   };
 }
 

--- a/examples/custom_type/custom_types_4.cpp
+++ b/examples/custom_type/custom_types_4.cpp
@@ -1,6 +1,10 @@
 // Showcases custom message types with a sealed class hierarchy.
 
-#include "caf/all.hpp"
+#include "caf/actor_ostream.hpp"
+#include "caf/actor_system.hpp"
+#include "caf/caf_main.hpp"
+#include "caf/scoped_actor.hpp"
+#include "caf/type_id.hpp"
 
 #include <cassert>
 #include <iostream>
@@ -228,17 +232,18 @@ shape_ptr serialization_roundtrip(const shape_ptr& in) {
   return out;
 }
 
-void caf_main(caf::actor_system&) {
+void caf_main(caf::actor_system& sys) {
+  caf::scoped_actor self{sys};
   std::vector<shape_ptr> shapes;
   shapes.emplace_back(nullptr);
   shapes.emplace_back(rectangle::make({10, 10}, {20, 20}));
   shapes.emplace_back(circle::make({15, 15}, 5));
-  std::cout << "shapes:\n";
+  aout(self).println("shapes:");
   for (auto& ptr : shapes) {
-    std::cout << "  shape: " << caf::deep_to_string(ptr) << '\n';
+    aout(self).println("- value: {}", ptr);
     auto copy = serialization_roundtrip(ptr);
     assert(!ptr || ptr.get() != copy.get());
-    std::cout << "   copy: " << caf::deep_to_string(copy) << '\n';
+    aout(self).println("-  copy: {}", copy);
   }
 }
 

--- a/examples/dynamic_behavior/dining_philosophers.cpp
+++ b/examples/dynamic_behavior/dining_philosophers.cpp
@@ -118,9 +118,9 @@ public:
     // philosopher was able to obtain the first chopstick
     granted.assign([this](taken_atom, bool result) {
       if (result) {
-        aout(self) << name << " has picked up chopsticks with IDs "
-                   << left->id() << " and " << right->id()
-                   << " and starts to eat\n";
+        aout(self).println("{} has picked up chopsticks with "
+                           "IDs {} and {} and starts to eat",
+                           name, left->id(), right->id());
         // eat some time
         self->delayed_send(self, 5s, think_atom_v);
         self->become(eating);
@@ -142,7 +142,8 @@ public:
       self->send(left, put_atom_v);
       self->send(right, put_atom_v);
       self->delayed_send(self, 5s, eat_atom_v);
-      aout(self) << name << " puts down his chopsticks and starts to think\n";
+      aout(self).println("{} puts down his chopsticks and starts to think",
+                         name);
       self->become(thinking);
     });
   }
@@ -153,7 +154,7 @@ public:
     // philosophers start to think after receiving {think}
     return {
       [this](think_atom) {
-        aout(self) << name << " starts to think\n";
+        aout(self).println("{} starts to think", name);
         self->delayed_send(self, 5s, eat_atom_v);
         self->become(thinking);
       },
@@ -174,13 +175,12 @@ public:
 void caf_main(actor_system& sys) {
   scoped_actor self{sys};
   // create five chopsticks
-  aout(self) << "chopstick ids are:";
+  aout(self).println("chopstick ids are:");
   auto chopsticks = std::vector<chopstick>{};
   for (size_t i = 0; i < 5; ++i) {
     chopsticks.push_back(self->spawn(actor_from_state<chopstick_state>));
-    aout(self) << " " << chopsticks.back()->id();
+    aout(self).println("- {}", chopsticks.back()->id());
   }
-  aout(self) << endl;
   // spawn five philosophers
   auto names = std::vector{"Plato"s, "Hume"s, "Kant"s, "Nietzsche"s,
                            "Descartes"s};

--- a/examples/dynamic_behavior/skip_messages.cpp
+++ b/examples/dynamic_behavior/skip_messages.cpp
@@ -1,12 +1,27 @@
-#include "caf/all.hpp"
+// This example illustrates how to use the `skip` default handler to keep
+// messages in the mailbox until an actor switches to another behavior that can
+// handle them.
+
+#include "caf/actor_ostream.hpp"
+#include "caf/actor_system.hpp"
+#include "caf/caf_main.hpp"
+#include "caf/event_based_actor.hpp"
+#include "caf/scoped_actor.hpp"
 
 using namespace caf;
+using namespace std::literals;
 
 behavior server(event_based_actor* self) {
+  // Setting the default handler to `skip` will keep all unmatched messages in
+  // the mailbox until we switch to another behavior that handles them. This
+  // allows us to receive idle and ping messages in any order but process them
+  // in alternating order.
   self->set_default_handler(skip);
   return {
     [self](idle_atom, const actor& worker) {
-      self->become(keep_behavior, [=](ping_atom atm) {
+      // Passing keep_behavior allows us to return to this behavior later on by
+      // calling `self->unbecome()`.
+      self->become(keep_behavior, [self, worker](ping_atom atm) {
         self->delegate(worker, atm);
         self->unbecome();
       });
@@ -25,21 +40,21 @@ behavior client(event_based_actor* self, const actor& serv) {
   };
 }
 
-void caf_main(actor_system& system) {
-  auto serv = system.spawn(server);
-  auto worker = system.spawn(client, serv);
-  scoped_actor self{system};
-  self->request(serv, std::chrono::seconds(10), ping_atom_v)
+void caf_main(actor_system& sys) {
+  auto serv = sys.spawn(server);
+  auto worker = sys.spawn(client, serv);
+  scoped_actor self{sys};
+  self->request(serv, 10s, ping_atom_v)
     .receive(
       [&self, worker](pong_atom) {
-        aout(self) << "received response from "
-                   << (self->current_sender() == worker ? "worker\n"
-                                                        : "server\n");
+        aout(self).println("received response from {}",
+                           self->current_sender() == worker ? "worker"
+                                                            : "server");
       },
       [&self, worker](error& err) {
-        aout(self) << "received error " << to_string(err) << " from "
-                   << (self->current_sender() == worker ? "worker\n"
-                                                        : "server\n");
+        aout(self).println("received error {} from {}", err,
+                           self->current_sender() == worker ? "worker"
+                                                            : "server");
       });
   self->send_exit(serv, exit_reason::user_shutdown);
 }

--- a/examples/flow/iota.cpp
+++ b/examples/flow/iota.cpp
@@ -1,4 +1,4 @@
-// Non-interactive example to showcase `from_callable`.
+// Non-interactive example to showcase the `iota` generator.
 
 #include "caf/actor_system.hpp"
 #include "caf/caf_main.hpp"

--- a/examples/flow/spsc-buffer-resource.cpp
+++ b/examples/flow/spsc-buffer-resource.cpp
@@ -58,10 +58,10 @@ struct config : caf::actor_system_config {
 
 // --(rst-main-begin)--
 void caf_main(caf::actor_system& sys, const config& cfg) {
-  auto [snk_res, src_res] = caf::async::make_spsc_buffer_resource<int>();
+  auto [pull, push] = caf::async::make_spsc_buffer_resource<int>();
   auto n = get_or(cfg, "num-values", default_num_values);
-  sys.spawn(sink, std::move(snk_res));
-  sys.spawn(source, std::move(src_res), n);
+  sys.spawn(sink, std::move(pull));
+  sys.spawn(source, std::move(push), n);
 }
 // --(rst-main-end)--
 

--- a/examples/hello_world.cpp
+++ b/examples/hello_world.cpp
@@ -16,9 +16,9 @@ behavior mirror(event_based_actor* self) {
   return {
     // a handler for messages containing a single string
     // that replies with a string
-    [=](const std::string& what) -> std::string {
+    [self](const std::string& what) -> std::string {
       // prints "Hello World!" via aout (thread-safe cout wrapper)
-      aout(self) << what << std::endl;
+      aout(self).println("{}", what);
       // reply "!dlroW olleH"
       return std::string{what.rbegin(), what.rend()};
     },
@@ -30,9 +30,9 @@ void hello_world(event_based_actor* self, const actor& buddy) {
   self->request(buddy, 10s, "Hello World!")
     .then(
       // ... wait up to 10s for a response ...
-      [=](const std::string& what) {
+      [self](const std::string& what) {
         // ... and print it
-        aout(self) << what << std::endl;
+        aout(self).println("{}", what);
       });
 }
 

--- a/examples/message_passing/calculator.cpp
+++ b/examples/message_passing/calculator.cpp
@@ -81,12 +81,11 @@ void tester(scoped_actor& self, const Handle& hdl, int32_t x, int32_t y,
   // test: x + y = z
   self->request(hdl, infinite, add_atom_v, x, y)
     .receive(
-      [&self, x, y](int32_t z) {
-        aout(self) << x << " + " << y << " = " << z << endl;
+      [&self, x, y](int32_t z) { //
+        aout(self).println("{} + {} = {}", x, y, z);
       },
       [&self](const error& err) {
-        aout(self) << "AUT (actor under test) failed: " << to_string(err)
-                   << endl;
+        aout(self).println("AUT (actor under test) failed: {}", err);
       });
   tester(self, std::forward<Ts>(xs)...);
 }

--- a/examples/message_passing/delegating.cpp
+++ b/examples/message_passing/delegating.cpp
@@ -31,7 +31,7 @@ adder_actor::behavior_type server_impl(adder_actor::pointer self,
 void client_impl(event_based_actor* self, adder_actor adder, int32_t x,
                  int32_t y) {
   self->request(adder, 10s, add_atom_v, x, y).then([=](int32_t result) {
-    aout(self) << x << " + " << y << " = " << result << std::endl;
+    aout(self).println("{} + {} = {}", x, y, result);
   });
 }
 

--- a/examples/message_passing/divider.cpp
+++ b/examples/message_passing/divider.cpp
@@ -88,12 +88,11 @@ void caf_main(actor_system& system) {
   auto div = system.spawn(divider_impl);
   scoped_actor self{system};
   self->request(div, std::chrono::seconds(10), div_atom_v, x, y)
-    .receive(
-      [&](double z) { aout(self) << x << " / " << y << " = " << z << endl; },
-      [&](const error& err) {
-        aout(self) << "*** cannot compute " << x << " / " << y << " => "
-                   << to_string(err) << endl;
-      });
+    .receive([&](double z) { aout(self).println("{} / {} = {}", x, y, z); },
+             [&](const error& err) {
+               aout(self).println("*** cannot compute {} / {} => {}", x, y,
+                                  err);
+             });
   // --(rst-request-end)--
 }
 

--- a/examples/message_passing/promises.cpp
+++ b/examples/message_passing/promises.cpp
@@ -35,7 +35,7 @@ void client_impl(event_based_actor* self, adder_actor adder, int32_t x,
                  int32_t y) {
   using namespace std::literals::chrono_literals;
   self->request(adder, 10s, add_atom_v, x, y).then([=](int32_t result) {
-    aout(self) << x << " + " << y << " = " << result << std::endl;
+    aout(self).println("{} + {} = {}", x, y, result);
   });
 }
 

--- a/examples/remoting/distributed_calculator.cpp
+++ b/examples/remoting/distributed_calculator.cpp
@@ -83,7 +83,7 @@ struct client_state {
     // transition to `unconnected` on server failure
     self->set_down_handler([this](const down_msg& dm) {
       if (dm.source == current_server) {
-        aout(self) << "*** lost connection to server" << endl;
+        aout(self).println("*** lost connection to server");
         current_server = nullptr;
         self->become(unconnected());
       }
@@ -118,24 +118,24 @@ struct client_state {
         [this, host, port](const node_id&, strong_actor_ptr serv,
                            const std::set<std::string>& ifs) {
           if (!serv) {
-            aout(self) << R"(*** no server found at ")" << host << R"(":)"
-                       << port << endl;
+            aout(self).println("*** no server found at {}:{}", host, port);
             return;
           }
           if (!ifs.empty()) {
-            aout(self) << R"(*** typed actor found at ")" << host << R"(":)"
-                       << port << ", but expected an untyped actor " << endl;
+            aout(self).println(
+              "*** typed actor found at {}:{}, but expected an untyped actor",
+              host, port);
             return;
           }
-          aout(self) << "*** successfully connected to server" << endl;
+          aout(self).println("*** successfully connected to server");
           current_server = serv;
           auto hdl = actor_cast<actor>(serv);
           self->monitor(hdl);
           self->become(running(hdl));
         },
         [this, host, port](const error& err) {
-          aout(self) << R"(*** cannot connect to ")" << host << R"(":)" << port
-                     << " => " << to_string(err) << endl;
+          aout(self).println("*** cannot connect to {}:{} => {}", host, port,
+                             err);
           self->become(unconnected());
         });
   }
@@ -145,12 +145,12 @@ struct client_state {
       self->request(calculator, task_timeout, op, x, y)
         .then(
           [this, x, y](int result) {
-            const char* op_str;
+            char op_ch;
             if constexpr (std::is_same_v<add_atom, decltype(op)>)
-              op_str = " + ";
+              op_ch = '+';
             else
-              op_str = " - ";
-            aout(self) << x << op_str << y << " = " << result << endl;
+              op_ch = '-';
+            aout(self).println("{} {} {} = {}", x, op_ch, y, result);
           },
           [this, op, x, y](const error&) {
             // simply try again by enqueueing the task to the mailbox again

--- a/examples/remoting/remote_spawn.cpp
+++ b/examples/remoting/remote_spawn.cpp
@@ -46,11 +46,11 @@ using namespace caf;
 calculator::behavior_type calculator_fun(calculator::pointer self) {
   return {
     [self](add_atom, int32_t a, int32_t b) {
-      aout(self) << "received task from a remote node" << endl;
+      aout(self).println("received task from a remote node");
       return a + b;
     },
     [self](sub_atom, int32_t a, int32_t b) {
-      aout(self) << "received task from a remote node" << endl;
+      aout(self).println("received task from a remote node");
       return a - b;
     },
   };
@@ -77,6 +77,7 @@ void client_repl(actor_system& sys, calculator hdl) {
   };
   usage();
   scoped_actor self{sys};
+  self->link_to(hdl);
   // read next line, split it, and evaluate user input
   string line;
   while (std::getline(std::cin, line)) {
@@ -106,7 +107,9 @@ void client_repl(actor_system& sys, calculator hdl) {
       self->send(hdl, add_atom_v, *x, *y);
     else
       self->send(hdl, sub_atom_v, *x, *y);
-    self->receive([](int32_t result) { cout << " = " << result << std::endl; });
+    self->receive([&self, x = *x, y = *y, op = words[1][0]](int32_t result) {
+      aout(self).println("{} {} {} = {}", x, op, y, result);
+    });
   }
 }
 

--- a/libcaf_core/caf/actor_ostream.hpp
+++ b/libcaf_core/caf/actor_ostream.hpp
@@ -8,7 +8,11 @@
 #include "caf/deep_to_string.hpp"
 #include "caf/detail/actor_local_printer.hpp"
 #include "caf/detail/core_export.hpp"
+#include "caf/detail/format.hpp"
 #include "caf/typed_actor_pointer.hpp"
+
+#include <string>
+#include <string_view>
 
 namespace caf {
 
@@ -37,6 +41,15 @@ public:
   explicit actor_ostream(const typed_actor_pointer<Sigs...>& ptr)
     : actor_ostream(ptr.internal_ptr()) {
     // nop
+  }
+
+  /// Adds a new line to the actor output stream.
+  template <class... Args>
+  actor_ostream& println(std::string_view fmt, Args&&... args) {
+    auto buf = detail::format(fmt, std::forward<Args>(args)...);
+    buf.push_back('\n');
+    printer_->write(std::move(buf));
+    return *this;
   }
 
   /// Writes `arg` to the buffer allocated for the calling actor.

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -42,9 +42,8 @@ skippable_result reflect_and_quit(scheduled_actor* ptr, message& msg) {
 skippable_result print_and_drop(scheduled_actor* ptr, message& msg) {
   log::system::warning("discarded unexpected message (id: {}, name: {}): {}",
                        ptr->id(), ptr->name(), msg);
-  aout(ptr) << "*** unexpected message [id: " << ptr->id()
-            << ", name: " << ptr->name() << "]: " << to_string(msg)
-            << std::endl;
+  aout(ptr).println("*** unexpected message [id: {}, name: {}]: {}", ptr->id(),
+                    ptr->name(), msg);
   return make_error(sec::unexpected_message);
 }
 
@@ -76,16 +75,14 @@ void scheduled_actor::default_error_handler(scheduled_actor* ptr, error& x) {
 }
 
 void scheduled_actor::default_down_handler(scheduled_actor* ptr, down_msg& x) {
-  aout(ptr) << "*** unhandled down message [id: " << ptr->id()
-            << ", name: " << ptr->name() << "]: " << deep_to_string(x)
-            << std::endl;
+  aout(ptr).println("*** unhandled down message [id: {}, name: {}]: {}",
+                    ptr->id(), ptr->name(), x);
 }
 
 void scheduled_actor::default_node_down_handler(scheduled_actor* ptr,
                                                 node_down_msg& x) {
-  aout(ptr) << "*** unhandled node down message [id: " << ptr->id()
-            << ", name: " << ptr->name() << "]: " << deep_to_string(x)
-            << std::endl;
+  aout(ptr).println("*** unhandled node down message [id: {} , name: {}]: {}",
+                    ptr->id(), ptr->name(), x);
 }
 
 void scheduled_actor::default_exit_handler(scheduled_actor* ptr, exit_msg& x) {
@@ -101,15 +98,14 @@ error scheduled_actor::default_exception_handler(local_actor* ptr,
     std::rethrow_exception(x);
   } catch (std::exception& e) {
     auto pretty_type = detail::pretty_type_name(typeid(e));
-    aout(ptr) << "*** unhandled exception: [id: " << ptr->id()
-              << ", name: " << ptr->name()
-              << ", exception typeid: " << pretty_type << "]: " << e.what()
-              << std::endl;
+    aout(ptr).println(
+      "*** unhandled exception: [id: {}, name: {}, exception typeid {}]: {}",
+      ptr->id(), ptr->name(), pretty_type, e.what());
     return make_error(sec::runtime_error, std::move(pretty_type), e.what());
   } catch (...) {
-    aout(ptr) << "*** unhandled exception: [id: " << ptr->id()
-              << ", name: " << ptr->name() << "]: unknown exception"
-              << std::endl;
+    aout(ptr).println(
+      "*** unhandled exception: [id: {}, name: {}]: unknown exception",
+      ptr->id(), ptr->name());
     return sec::runtime_error;
   }
 }

--- a/manual/Actors.rst
+++ b/manual/Actors.rst
@@ -521,7 +521,7 @@ loops.
      [&](int value1) {
        self->receive (
          [&](float value2) {
-           aout(self) << value1 << " => " << value2 << endl;
+           aout(self).println("{} => {}", value1, value2);
          }
        );
      },


### PR DESCRIPTION
The new `println` integrates our new formatting backend into the `actor_ostream` class. I'm not super keen on `actor_ostream`, so maybe we will end up removing it eventually. However, we do use it in several examples and it should be at least nice to use and properly integrated while we have it.