### PR TITLE
Fix behavior of caf::net::make_pipe on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   open connections.
 - Fix static assert in `expected` when calling `transform` on an rvalue with a
   function object that only accepts an rvalue.
+- The function `caf::net::make_pipe` no longer closes read/write channels of the
+  connected socket pair on Windows. This fixes a bug where the pipe would close
+  after two minutes of inactivity.
 
 ### Changed
 

--- a/libcaf_net/caf/net/pipe_socket.cpp
+++ b/libcaf_net/caf/net/pipe_socket.cpp
@@ -24,11 +24,9 @@ namespace caf::net {
 #ifdef CAF_WINDOWS
 
 expected<std::pair<pipe_socket, pipe_socket>> make_pipe() {
-  // Windows has no support for unidirectional pipes. Emulate pipes by using a
-  // pair of regular TCP sockets with read/write channels closed appropriately.
+  // Windows has no support for unidirectional pipes. Hence, we emulate pipes by
+  // using a regular connected socket pair.
   if (auto result = make_stream_socket_pair()) {
-    shutdown_write(result->first);
-    shutdown_read(result->second);
     return std::make_pair(socket_cast<pipe_socket>(result->first),
                           socket_cast<pipe_socket>(result->second));
   } else {


### PR DESCRIPTION
Fixes a bug when using `make_pipe` on Windows where the OS would close the pipe after two minutes. Since there is no `pipe()` equivalent on Windows, we use a connected socket pair (of TCP sockets). The function used to close the read/write ends to turn the sockets into a unidirectional communication mode. However, closing the write channel on a TCP socket sets the socket into the state FIN_WAIT, which waits two minutes before closing the socket. So we can't use it that way.

Original bug report / context: https://github.com/zeek/broker/issues/316.