### PR TITLE
Allow actors to send messages during cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   setting the configuration option `caf.net.prometheus-http`. The option has the
   following fields: `port`, `address`, `tls.key-file`, and `tls.cert-file`. When
   setting the TLS options, the server will use HTTPS instead of HTTP.
+- Sending messages from cleanup code (e.g., the destructor of a state class) is
+  now safe. Previously, doing so could cause undefined behavior by forming a
+  strong reference to a destroyed actor.
 
 ## [0.19.5] - 2024-01-08
 

--- a/libcaf_core/caf/abstract_actor.hpp
+++ b/libcaf_core/caf/abstract_actor.hpp
@@ -35,6 +35,8 @@ class remote_message_handler;
 
 namespace caf {
 
+void intrusive_ptr_release(actor_control_block*);
+
 /// A unique actor ID.
 /// @relates abstract_actor
 using actor_id = uint64_t;
@@ -52,6 +54,8 @@ public:
 
   template <class>
   friend class caf::io::basp::remote_message_handler;
+
+  friend void intrusive_ptr_release(actor_control_block*);
 
   // -- constructors, destructors, and assignment operators --------------------
 
@@ -155,25 +159,42 @@ public:
   /// This member function is thread-safe, and if the actor has already exited
   /// upon invocation, nothing is done. The return value of this member
   /// function is ignored by scheduled actors.
-  virtual bool cleanup(error&& reason, execution_unit* host);
+  bool cleanup(error&& reason, execution_unit* host);
 
   // -- here be dragons: end of public interface -------------------------------
 
   /// @cond PRIVATE
 
-  // flags storing runtime information                    used by ...
-  static constexpr int is_hidden_flag = 0x0004;        // scheduled_actor
-  static constexpr int is_registered_flag = 0x0008;    // (several actors)
-  static constexpr int is_initialized_flag = 0x0010;   // event-based actors
-  static constexpr int is_blocking_flag = 0x0020;      // blocking_actor
-  static constexpr int is_detached_flag = 0x0040;      // local_actor
-  static constexpr int collects_metrics_flag = 0x0080; // local_actor
-  static constexpr int is_serializable_flag = 0x0100;  // local_actor
-  static constexpr int is_migrated_from_flag = 0x0200; // local_actor
-  static constexpr int has_used_aout_flag = 0x0400;    // local_actor
-  static constexpr int is_terminated_flag = 0x0800;    // local_actor
-  static constexpr int is_cleaned_up_flag = 0x1000;    // monitorable_actor
-  static constexpr int is_shutting_down_flag = 0x2000; // scheduled_actor
+  /// Indicates that the actor system shall not wait for this actor to
+  /// finish execution on shutdown.
+  static constexpr int is_hidden_flag = 0b0000'0000'0001;
+
+  /// Indicates that the actor is registered at the actor system.
+  static constexpr int is_registered_flag = 0b0000'0000'0010;
+
+  /// Indicates that the actor has been initialized.
+  static constexpr int is_initialized_flag = 0b0000'0000'0100;
+
+  /// Indicates that the actor uses blocking message handlers.
+  static constexpr int is_blocking_flag = 0b0000'0000'1000;
+
+  /// Indicates that the actor runs in its own thread.
+  static constexpr int is_detached_flag = 0b0000'0001'0000;
+
+  /// Indicates that the actor collects metrics.
+  static constexpr int collects_metrics_flag = 0b0000'0010'0000;
+
+  /// Indicates that the actor has used aout at least once and thus needs to
+  /// call `flush` when shutting down.
+  static constexpr int has_used_aout_flag = 0b0000'0100'0000;
+
+  /// Indicates that the actor has terminated and waits for its destructor to
+  /// run.
+  static constexpr int is_terminated_flag = 0b0000'1000'0000;
+
+  /// Indicates that the actor is currently shutting down and thus may no longer
+  /// set a new behavior.
+  static constexpr int is_shutting_down_flag = 0b0001'0000'0000;
 
   void setf(int flag) {
     auto x = flags();
@@ -234,16 +255,13 @@ public:
 protected:
   // -- callbacks --------------------------------------------------------------
 
-  /// Cleans up any remaining state before the destructor is called.
-  /// This function makes sure it is safe to call virtual functions
-  /// in sub classes before destroying the object, because calling
-  /// virtual function in the destructor itself is not safe. Any override
-  /// implementation is required to call `super::destroy()` at the end.
-  virtual void on_destroy();
+  /// Called on actor if the last strong reference to it expired without
+  /// a prior call to `quit(exit_reason::not_exited)`.
+  /// @pre `getf(is_terminated_flag) == false`
+  /// @post `getf(is_terminated_flag) == true`
+  virtual void on_unreachable();
 
-  /// Allows subclasses to add additional cleanup code to the
-  /// critical section in `cleanup`. This member function is
-  /// called inside of a critical section.
+  /// Called from `cleanup` to perform extra cleanup actions for this actor.
   virtual void on_cleanup(const error& reason);
 
   // -- properties -------------------------------------------------------------
@@ -260,6 +278,11 @@ protected:
 
   void flags(int new_value) {
     flags_.store(new_value, std::memory_order_relaxed);
+  }
+
+  /// Checks whether this actor has terminated.
+  bool is_terminated() const noexcept {
+    return getf(is_terminated_flag);
   }
 
   // -- constructors, destructors, and assignment operators --------------------

--- a/libcaf_core/caf/abstract_actor.hpp
+++ b/libcaf_core/caf/abstract_actor.hpp
@@ -35,7 +35,7 @@ class remote_message_handler;
 
 namespace caf {
 
-void intrusive_ptr_release(actor_control_block*);
+CAF_CORE_EXPORT void intrusive_ptr_release(actor_control_block*);
 
 /// A unique actor ID.
 /// @relates abstract_actor
@@ -55,7 +55,7 @@ public:
   template <class>
   friend class caf::io::basp::remote_message_handler;
 
-  friend void intrusive_ptr_release(actor_control_block*);
+  friend CAF_CORE_EXPORT void intrusive_ptr_release(actor_control_block*);
 
   // -- constructors, destructors, and assignment operators --------------------
 

--- a/libcaf_core/caf/abstract_actor.hpp
+++ b/libcaf_core/caf/abstract_actor.hpp
@@ -333,6 +333,13 @@ protected:
 
   /// Points to the first attachable in the linked list of attachables (if any).
   attachable_ptr attachables_head_;
+
+private:
+  /// Forces the actor to close its mailbox and drop all messages. The only
+  /// place calling this member function is
+  /// `intrusive_ptr_release(actor_control_block*)` before calling
+  /// `on_unreachable`.
+  virtual void force_close_mailbox() = 0;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/actor_control_block.cpp
+++ b/libcaf_core/caf/actor_control_block.cpp
@@ -46,6 +46,9 @@ void intrusive_ptr_release(actor_control_block* x) {
     // in turn reference this actor.
     auto* ptr = x->get();
     if (!ptr->is_terminated()) {
+      // First, make sure that other actors can no longer send messages to this
+      // actor. Then bump the reference count and do the regular cleanup.
+      ptr->force_close_mailbox();
       x->strong_refs.fetch_add(1, std::memory_order_relaxed);
       ptr->on_unreachable();
       CAF_ASSERT(ptr->is_terminated());

--- a/libcaf_core/caf/actor_control_block.cpp
+++ b/libcaf_core/caf/actor_control_block.cpp
@@ -39,10 +39,24 @@ void intrusive_ptr_release_weak(actor_control_block* x) {
 }
 
 void intrusive_ptr_release(actor_control_block* x) {
-  // release implicit weak pointer if the last strong ref expires
-  // and destroy the data block
   if (x->strong_refs.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+    // When hitting 0, we need to allow the actor to clean up its state in case
+    // it is not terminated yet. For this, we need to bump the ref count to 1
+    // again, because the cleanup code might send messages to other actors that
+    // in turn reference this actor.
+    auto* ptr = x->get();
+    if (!ptr->is_terminated()) {
+      x->strong_refs.fetch_add(1, std::memory_order_relaxed);
+      ptr->on_unreachable();
+      CAF_ASSERT(ptr->is_terminated());
+      if (x->strong_refs.fetch_sub(1, std::memory_order_acq_rel) != 1) {
+        // Another strong reference was added while we were cleaning up.
+        return;
+      }
+    }
     x->data_dtor(x->get());
+    // We release the implicit weak pointer if the last strong ref expires and
+    // destroy the data block.
     intrusive_ptr_release_weak(x);
   }
 }

--- a/libcaf_core/caf/actor_pool.cpp
+++ b/libcaf_core/caf/actor_pool.cpp
@@ -214,4 +214,8 @@ void actor_pool::quit(execution_unit* host) {
     unregister_from_system();
 }
 
+void actor_pool::force_close_mailbox() {
+  // nop
+}
+
 } // namespace caf

--- a/libcaf_core/caf/actor_pool.cpp
+++ b/libcaf_core/caf/actor_pool.cpp
@@ -118,14 +118,6 @@ const char* actor_pool::name() const {
   return "caf.actor-pool";
 }
 
-void actor_pool::on_destroy() {
-  CAF_PUSH_AID_FROM_PTR(this);
-  if (!getf(is_cleaned_up_flag)) {
-    cleanup(exit_reason::unreachable, nullptr);
-    unregister_from_system();
-  }
-}
-
 void actor_pool::on_cleanup(const error& reason) {
   CAF_PUSH_AID_FROM_PTR(this);
   CAF_IGNORE_UNUSED(reason);

--- a/libcaf_core/caf/actor_pool.hpp
+++ b/libcaf_core/caf/actor_pool.hpp
@@ -90,8 +90,6 @@ public:
 
   const char* name() const override;
 
-  void on_destroy() override;
-
   void setup_metrics() {
     // nop
   }

--- a/libcaf_core/caf/actor_pool.hpp
+++ b/libcaf_core/caf/actor_pool.hpp
@@ -104,6 +104,8 @@ private:
   // call without workers_mtx_ held
   void quit(execution_unit* host);
 
+  void force_close_mailbox() override;
+
   std::mutex workers_mtx_;
   std::vector<actor> workers_;
   policy policy_;

--- a/libcaf_core/caf/actor_storage.hpp
+++ b/libcaf_core/caf/actor_storage.hpp
@@ -70,7 +70,6 @@ public:
 private:
   static void data_dtor(abstract_actor* ptr) {
     // safe due to static assert #3
-    ptr->on_destroy();
     static_cast<T*>(ptr)->~T();
   }
 

--- a/libcaf_core/caf/blocking_actor.hpp
+++ b/libcaf_core/caf/blocking_actor.hpp
@@ -326,7 +326,7 @@ public:
   void receive_impl(receive_cond& rcc, message_id mid,
                     detail::blocking_behavior& bhvr);
 
-  bool cleanup(error&& fail_state, execution_unit* host) override;
+  void on_cleanup(const error& reason) override;
 
   // -- backwards compatibility ------------------------------------------------
 

--- a/libcaf_core/caf/blocking_actor.hpp
+++ b/libcaf_core/caf/blocking_actor.hpp
@@ -349,6 +349,10 @@ private:
 
   void unstash();
 
+  void close_mailbox(const error& reason);
+
+  void force_close_mailbox() final;
+
   template <class... Ts>
   size_t attach_functor(const typed_actor<Ts...>& x) {
     return attach_functor(actor_cast<strong_actor_ptr>(x));

--- a/libcaf_core/caf/forwarding_actor_proxy.cpp
+++ b/libcaf_core/caf/forwarding_actor_proxy.cpp
@@ -75,4 +75,8 @@ void forwarding_actor_proxy::kill_proxy(execution_unit* ctx, error rsn) {
   cleanup(std::move(rsn), ctx);
 }
 
+void forwarding_actor_proxy::force_close_mailbox() {
+  // nop
+}
+
 } // namespace caf

--- a/libcaf_core/caf/forwarding_actor_proxy.hpp
+++ b/libcaf_core/caf/forwarding_actor_proxy.hpp
@@ -32,6 +32,8 @@ public:
 private:
   bool forward_msg(strong_actor_ptr sender, message_id mid, message msg);
 
+  void force_close_mailbox() final;
+
   mutable std::shared_mutex broker_mtx_;
   actor broker_;
 };

--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -90,7 +90,7 @@ public:
 
   ~local_actor() override;
 
-  void on_destroy() override;
+  void on_cleanup(const error&) override;
 
   // This function performs additional steps to initialize actor-specific
   // metrics. It calls virtual functions and thus cannot run as part of the
@@ -368,8 +368,6 @@ public:
   }
 
   virtual void initialize();
-
-  bool cleanup(error&& fail_state, execution_unit* host) override;
 
   message_id new_request_id(message_priority mp) noexcept;
 

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -216,8 +216,8 @@ void scheduled_actor::launch(execution_unit* ctx, bool lazy, bool hide) {
   }
 }
 
-bool scheduled_actor::cleanup(error&& fail_state, execution_unit* host) {
-  CAF_LOG_TRACE(CAF_ARG(fail_state));
+void scheduled_actor::on_cleanup(const error& reason) {
+  CAF_LOG_TRACE(CAF_ARG(reason));
   pending_timeout_.dispose();
   // Shutdown hosting thread when running detached.
   if (private_thread_)
@@ -229,7 +229,7 @@ bool scheduled_actor::cleanup(error&& fail_state, execution_unit* host) {
   // Discard stashed messages.
   auto dropped = size_t{0};
   if (!stash_.empty()) {
-    detail::sync_request_bouncer bounce{fail_state};
+    detail::sync_request_bouncer bounce{reason};
     while (auto stashed = stash_.pop()) {
       bounce(*stashed);
       delete stashed;
@@ -238,11 +238,11 @@ bool scheduled_actor::cleanup(error&& fail_state, execution_unit* host) {
   }
   // Clear mailbox.
   if (!mailbox().closed())
-    dropped += mailbox().close(fail_state);
+    dropped += mailbox().close(reason);
   if (dropped > 0 && metrics_.mailbox_size)
     metrics_.mailbox_size->dec(static_cast<int64_t>(dropped));
-  // Dispatch to parent's `cleanup` function.
-  return super::cleanup(std::move(fail_state), host);
+  // Dispatch to parent's `on_cleanup` function.
+  super::on_cleanup(reason);
 }
 
 // -- overridden functions of resumable ----------------------------------------
@@ -875,7 +875,7 @@ void scheduled_actor::do_become(behavior bhvr, bool discard_old) {
 bool scheduled_actor::finalize() {
   CAF_LOG_TRACE("");
   // Repeated calls always return `true` but have no side effects.
-  if (getf(is_cleaned_up_flag))
+  if (is_terminated())
     return true;
   // An actor is considered alive as long as it has a behavior, didn't set
   // the terminated flag and has no watched flows remaining.
@@ -884,10 +884,9 @@ bool scheduled_actor::finalize() {
     return false;
   CAF_LOG_DEBUG("actor has no behavior and is ready for cleanup");
   CAF_ASSERT(!has_behavior());
-  on_exit();
   bhvr_stack_.cleanup();
   cleanup(std::move(fail_state_), context());
-  CAF_ASSERT(getf(is_cleaned_up_flag));
+  CAF_ASSERT(is_terminated());
   return true;
 }
 

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -206,7 +206,7 @@ public:
 
   void launch(execution_unit* eu, bool lazy, bool hide) override;
 
-  bool cleanup(error&& fail_state, execution_unit* host) override;
+  void on_cleanup(const error& reason) override;
 
   // -- overridden functions of resumable --------------------------------------
 

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -665,6 +665,12 @@ private:
     }
   }
 
+  // -- cleanup ----------------------------------------------------------------
+
+  void close_mailbox(const error& reason);
+
+  void force_close_mailbox() final;
+
   // -- timeout management -----------------------------------------------------
 
   disposable run_scheduled(timestamp when, action what);

--- a/libcaf_core/tests/legacy/actor_profiler.cpp
+++ b/libcaf_core/tests/legacy/actor_profiler.cpp
@@ -40,7 +40,7 @@ struct recorder : actor_profiler {
   }
 
   void remove_actor(const local_actor& self) override {
-    log.emplace_back("delete: ");
+    log.emplace_back("terminate: ");
     log.back() += self.name();
   }
 
@@ -134,8 +134,8 @@ CAF_TEST(profilers record actor construction) {
   CHECK_EQ(string_list({
              "new: foo",
              "new: bar, parent: foo",
-             "delete: bar",
-             "delete: foo",
+             "terminate: foo",
+             "terminate: bar",
            }),
            rec.log);
 }
@@ -170,9 +170,9 @@ CAF_TEST(profilers record asynchronous messaging) {
              R"__(bar sends: message("hello foo"))__",
              R"__(bar consumed the message)__",
              R"__(foo got: message("hello foo"))__",
-             R"__(delete: bar)__",
+             R"__(terminate: bar)__",
              R"__(foo consumed the message)__",
-             R"__(delete: foo)__",
+             R"__(terminate: foo)__",
            }),
            rec.log);
 }
@@ -210,14 +210,14 @@ CAF_TEST(profilers record request / response messaging) {
              "server got: message(19, 23)",
              "server sends: message(19, 23)",
              "server consumed the message",
-             "delete: server",
+             "terminate: server",
              "worker got: message(19, 23)",
              "worker sends: message(42)",
              "worker consumed the message",
              "client got: message(42)",
              "client consumed the message",
-             "delete: worker",
-             "delete: client",
+             "terminate: client",
+             "terminate: worker",
            }),
            rec.log);
 }

--- a/libcaf_io/caf/io/abstract_broker.cpp
+++ b/libcaf_io/caf/io/abstract_broker.cpp
@@ -36,13 +36,13 @@ void abstract_broker::launch(execution_unit* eu, bool lazy, bool hide) {
   eu->exec_later(this);
 }
 
-bool abstract_broker::cleanup(error&& reason, execution_unit* host) {
+void abstract_broker::on_cleanup(const error& reason) {
   CAF_LOG_TRACE(CAF_ARG(reason));
   close_all();
   CAF_ASSERT(doormen_.empty());
   CAF_ASSERT(scribes_.empty());
   CAF_ASSERT(datagram_servants_.empty());
-  return scheduled_actor::cleanup(std::move(reason), host);
+  return scheduled_actor::on_cleanup(reason);
 }
 
 abstract_broker::~abstract_broker() {

--- a/libcaf_io/caf/io/abstract_broker.hpp
+++ b/libcaf_io/caf/io/abstract_broker.hpp
@@ -88,7 +88,7 @@ public:
 
   // -- overridden modifiers of abstract_broker --------------------------------
 
-  bool cleanup(error&& reason, execution_unit* host) override;
+  void on_cleanup(const error& reason) override;
 
   // -- overridden modifiers of resumable --------------------------------------
 

--- a/libcaf_net/caf/net/abstract_actor_shell.cpp
+++ b/libcaf_net/caf/net/abstract_actor_shell.cpp
@@ -160,11 +160,11 @@ void abstract_actor_shell::launch(execution_unit*, bool, bool hide) {
     register_at_system();
 }
 
-bool abstract_actor_shell::cleanup(error&& fail_state, execution_unit* host) {
-  CAF_LOG_TRACE(CAF_ARG(fail_state));
+void abstract_actor_shell::on_cleanup(const error& reason) {
+  CAF_LOG_TRACE(CAF_ARG(reason));
   // Clear mailbox.
   if (!mailbox_.closed()) {
-    auto dropped = mailbox_.close(fail_state);
+    auto dropped = mailbox_.close(reason);
     while (dropped > 0 && getf(abstract_actor::collects_metrics_flag)) {
       auto val = static_cast<int64_t>(dropped);
       metrics_.mailbox_size->dec(val);
@@ -177,7 +177,7 @@ bool abstract_actor_shell::cleanup(error&& fail_state, execution_unit* host) {
     resume_.dispose();
   }
   // Dispatch to parent's `cleanup` function.
-  return super::cleanup(std::move(fail_state), host);
+  return super::on_cleanup(reason);
 }
 
 } // namespace caf::net

--- a/libcaf_net/caf/net/abstract_actor_shell.hpp
+++ b/libcaf_net/caf/net/abstract_actor_shell.hpp
@@ -106,6 +106,10 @@ protected:
   }
 
 private:
+  void close_mailbox(const error& reason);
+
+  void force_close_mailbox() final;
+
   /// Stores incoming actor messages.
   detail::default_mailbox mailbox_;
 

--- a/libcaf_net/caf/net/abstract_actor_shell.hpp
+++ b/libcaf_net/caf/net/abstract_actor_shell.hpp
@@ -98,7 +98,7 @@ public:
 
   void launch(execution_unit* eu, bool lazy, bool hide) override;
 
-  bool cleanup(error&& fail_state, execution_unit* host) override;
+  void on_cleanup(const error& reason) override;
 
 protected:
   void set_behavior_impl(behavior bhvr) {

--- a/libcaf_test/caf/test/dsl.hpp
+++ b/libcaf_test/caf/test/dsl.hpp
@@ -864,6 +864,10 @@ public:
       }
 
     private:
+      void force_close_mailbox() final {
+        // nop
+      }
+
       caf::message_handler mh_;
     };
 


### PR DESCRIPTION
In the past, users had to very careful about writing cleanup code for actors. If an actor became unreachable, it would run its cleanup code with a reference count of 0 and usually call the destructor after running the cleanup logic (except if there are other weak references). This meant that sending a message from cleanup code would cause UB by creating a strong reference to a destroyed actor.

This set of changes changes how CAF cleans up unreachable actors. If a reference count drops to 0, CAF will check whether the actor has properly terminated. If not, CAF will now *first* bump it back up to 1 and *then* call the cleanup code (which will set the terminated flag to make sure the cleanup code runs exactly once). After running the cleanup code, CAF decrements the reference count again (and proceeds with the regular logic if it drops back to 0 again).

This removes one of the sharp edges in CAF that made it really easy to cut yourself. I've also streamlined the flags and cleanup logic in general.