### PR TITLE
Use more concise C++17 namespace syntax

### DIFF
--- a/libcaf_core/caf/detail/padded_size.hpp
+++ b/libcaf_core/caf/detail/padded_size.hpp
@@ -6,8 +6,7 @@
 
 #include <cstddef>
 
-namespace caf {
-namespace detail {
+namespace caf::detail {
 
 /// Calculates the size for `T` including padding for aligning to `max_align_t`.
 template <class T>
@@ -16,5 +15,4 @@ constexpr size_t padded_size_v
      + static_cast<size_t>(sizeof(T) % alignof(max_align_t) != 0))
     * alignof(max_align_t);
 
-} // namespace detail
-} // namespace caf
+} // namespace caf::detail


### PR DESCRIPTION
Just a small nitpick I've found.