### PR TITLE
Add missing unit tests to the CMake file

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -263,8 +263,13 @@ caf_add_component(
     caf/message_builder.test.cpp
     caf/message_handler.cpp
     caf/message_id.test.cpp
+    caf/message_lifetime.test.cpp
+    caf/messaging.test.cpp
+    caf/metaprogramming.test.cpp
     caf/mtl.test.cpp
     caf/node_id.cpp
+    caf/node_id.test.cpp
+    caf/or_else.test.cpp
     caf/policy/select_all.test.cpp
     caf/policy/select_any.test.cpp
     caf/policy/unprofiled.cpp


### PR DESCRIPTION
@shariarriday adding test code without actually running it on CI shouldn't have happened. I only found them today by accident.

Please make sure to actually run the tests you're working on locally. You can run `<binary> -s <name>` to run a single suite. For example, running `caf-core-test -s metaprogramming` would have shown you `Suites: 0 / 0`, clearly indicating that the test wasn't actually added to the build. At least the tests seem to work after enabling them.