### PR TITLE
Allow setting name when using `actor_from_state`

### DIFF
--- a/libcaf_core/caf/actor_from_state.hpp
+++ b/libcaf_core/caf/actor_from_state.hpp
@@ -37,6 +37,18 @@ public:
       state.~State();
   }
 
+  const char* name() const override {
+    if constexpr (detail::has_name<State>::value) {
+      if constexpr (!std::is_member_pointer<decltype(&State::name)>::value) {
+        if constexpr (std::is_convertible<decltype(State::name),
+                                          const char*>::value) {
+          return State::name;
+        }
+      }
+    }
+    return super::name();
+  }
+
   union {
     State state;
   };


### PR DESCRIPTION
This adds the missing support for setting the actor name when using the new `actor_from_state` utility.

Note that there's a related bug in `detail::has_name<T>`, which doesn't compile when `T` is marked `final`. However, that is likely best fixed in a separate PR.