### PR TITLE
Re-implement actor_from_state using stateful_actor

### DIFF
--- a/libcaf_core/caf/actor_factory.hpp
+++ b/libcaf_core/caf/actor_factory.hpp
@@ -94,7 +94,7 @@ struct message_verifier<spawn_mode::function_with_selfptr,
 template <class F>
 actor_factory make_actor_factory(F fun) {
   return [fun](actor_config& cfg, message& msg) -> actor_factory_result {
-    using trait = infer_handle_from_fun<F>;
+    using trait = infer_handle_from_fun_trait_t<F>;
     using handle = typename trait::type;
     using impl = typename trait::impl;
     using behavior_t = typename trait::behavior_type;

--- a/libcaf_core/caf/actor_from_state.test.cpp
+++ b/libcaf_core/caf/actor_from_state.test.cpp
@@ -7,6 +7,7 @@
 #include "caf/test/fixture/deterministic.hpp"
 #include "caf/test/test.hpp"
 
+#include "caf/event_based_actor.hpp"
 #include "caf/typed_actor.hpp"
 
 using namespace caf;
@@ -101,6 +102,18 @@ TEST("passing a value to the cell constructor overrides the default value") {
     inject().with(get_atom_v).from(dummy).to(uut);
     expect<int>().with(23).from(uut).to(dummy);
   }
+}
+
+TEST("actors can spawn stateful actors as children") {
+  auto dummy = sys.spawn(dummy_impl);
+  auto [parent, run_parent] = sys.spawn_inactive<event_based_actor>();
+  auto uut = parent->spawn(actor_from_state<cell_state>, 42);
+  static_assert(std::is_same_v<decltype(uut), actor>);
+  inject().with(get_atom_v).from(dummy).to(uut);
+  expect<int>().with(42).from(uut).to(dummy);
+  inject().with(put_atom_v, 23).from(dummy).to(uut);
+  inject().with(get_atom_v).from(dummy).to(uut);
+  expect<int>().with(23).from(uut).to(dummy);
 }
 
 struct id_cell_state {

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -93,6 +93,9 @@ public:
   friend class net::middleman;
   friend class abstract_actor;
 
+  template <class>
+  friend class actor_from_state_t;
+
   /// Returns the internal actor for dynamic spawn operations.
   const strong_actor_ptr& spawn_serv() const {
     return spawn_serv_;
@@ -433,6 +436,14 @@ public:
     cfg.mbox_factory = mailbox_factory();
     return spawn_functor<Os>(std::bool_constant<spawnable>{}, cfg, fun,
                              std::forward<Ts>(xs)...);
+  }
+
+  /// Returns a new stateful actor.
+  template <spawn_options Options = no_spawn_options, class CustomSpawn,
+            class... Args>
+  typename CustomSpawn::handle_type spawn(CustomSpawn, Args&&... args) {
+    return CustomSpawn::template do_spawn<Options>(*this,
+                                                   std::forward<Args>(args)...);
   }
 
   /// Returns a new actor with run-time type `name`, constructed

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -21,6 +21,8 @@ namespace caf {
 // -- 1 param templates --------------------------------------------------------
 
 template <class> class [[nodiscard]] error_code;
+
+template <class> class actor_from_state_t;
 template <class> class basic_cow_string;
 template <class> class callback;
 template <class> class cow_vector;
@@ -32,7 +34,6 @@ template <class> class span;
 template <class> class typed_stream;
 template <class> class weak_intrusive_ptr;
 
-template <class> struct actor_from_state_t;
 template <class> struct inspector_access;
 template <class> struct timeout_definition;
 template <class> struct type_id;

--- a/libcaf_core/caf/infer_handle.hpp
+++ b/libcaf_core/caf/infer_handle.hpp
@@ -91,36 +91,31 @@ struct infer_handle_from_fun_impl<typed_behavior<Sigs...>, Impl*, true> {
 };
 
 /// Deduces an actor handle type from a function or function object.
-template <class F>
-struct infer_handle_from_fun {
-  using trait = detail::get_callable_trait_t<F>;
-  using result_type = typename trait::result_type;
-  using arg_types = typename trait::arg_types;
+template <class Trait>
+struct infer_handle_from_fun_trait {
+  using result_type = typename Trait::result_type;
+  using arg_types = typename Trait::arg_types;
   using first_arg = detail::tl_head_t<arg_types>;
   using delegate = infer_handle_from_fun_impl<result_type, first_arg>;
   using type = typename delegate::type;
   using impl = typename delegate::impl;
   using behavior_type = typename delegate::behavior_type;
-  using fun_type = typename trait::fun_type;
+  using fun_type = typename Trait::fun_type;
   static constexpr spawn_mode mode = delegate::mode;
-};
-
-template <class State>
-struct infer_handle_from_fun<actor_from_state_t<State>> {
-  using fun_type = actor_from_state_t<State>;
-  using behavior_type = typename fun_type::behavior_type;
-  using type = infer_handle_from_behavior_t<behavior_type>;
-  using impl = typename fun_type::impl_type;
-  static constexpr spawn_mode mode = spawn_mode::function_with_selfptr;
 };
 
 /// @relates infer_handle_from_fun
 template <class F>
-using infer_handle_from_fun_t = typename infer_handle_from_fun<F>::type;
+using infer_handle_from_fun_trait_t
+  = infer_handle_from_fun_trait<detail::get_callable_trait_t<F>>;
 
 /// @relates infer_handle_from_fun
-template <class T>
-using infer_impl_from_fun_t = typename infer_handle_from_fun<T>::impl;
+template <class F>
+using infer_handle_from_fun_t = typename infer_handle_from_fun_trait_t<F>::type;
+
+/// @relates infer_handle_from_fun
+template <class F>
+using infer_impl_from_fun_t = typename infer_handle_from_fun_trait_t<F>::impl;
 
 /// Deduces `actor` for dynamically typed actors, otherwise `typed_actor<...>`
 /// is deduced.

--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -121,6 +121,13 @@ public:
                            cfg, std::forward<Ts>(xs)...));
   }
 
+  template <spawn_options Options = no_spawn_options, class CustomSpawn,
+            class... Args>
+  typename CustomSpawn::handle_type spawn(CustomSpawn, Args&&... args) {
+    return CustomSpawn::template do_spawn<Options>(system(),
+                                                   std::forward<Args>(args)...);
+  }
+
   template <spawn_options Os = no_spawn_options, class F, class... Ts>
   infer_handle_from_fun_t<F> spawn(F fun, Ts&&... xs) {
     using impl = infer_impl_from_fun_t<F>;

--- a/libcaf_io/caf/io/broker.hpp
+++ b/libcaf_io/caf/io/broker.hpp
@@ -12,6 +12,7 @@
 #include "caf/detail/io_export.hpp"
 #include "caf/extend.hpp"
 #include "caf/fwd.hpp"
+#include "caf/infer_handle.hpp"
 #include "caf/keep_behavior.hpp"
 #include "caf/local_actor.hpp"
 #include "caf/mixin/requester.hpp"
@@ -42,7 +43,8 @@ public:
     CAF_ASSERT(context() != nullptr);
     auto sptr = this->take(hdl);
     CAF_ASSERT(sptr->hdl() == hdl);
-    using impl = typename infer_handle_from_fun<F>::impl;
+    using trait = infer_handle_from_fun_trait_t<F>;
+    using impl = typename trait::impl;
     actor_config cfg{context()};
     detail::init_fun_factory<impl, F> fac;
     cfg.init_fun = fac(std::move(fun), hdl, std::forward<Ts>(xs)...);

--- a/libcaf_io/caf/io/middleman.hpp
+++ b/libcaf_io/caf/io/middleman.hpp
@@ -14,6 +14,7 @@
 #include "caf/detail/unique_function.hpp"
 #include "caf/expected.hpp"
 #include "caf/fwd.hpp"
+#include "caf/infer_handle.hpp"
 #include "caf/node_id.hpp"
 #include "caf/proxy_registry.hpp"
 #include "caf/send.hpp"
@@ -217,7 +218,7 @@ public:
             class F = std::function<void(broker*)>, class... Ts>
   expected<infer_handle_from_fun_t<F>>
   spawn_client(F fun, const std::string& host, uint16_t port, Ts&&... xs) {
-    using impl = typename infer_handle_from_fun<F>::impl;
+    using impl = typename infer_handle_from_fun_trait_t<F>::impl;
     return spawn_client_impl<Os, impl>(std::move(fun), host, port,
                                        std::forward<Ts>(xs)...);
   }
@@ -228,7 +229,7 @@ public:
             class F = std::function<void(broker*)>, class... Ts>
   expected<infer_handle_from_fun_t<F>>
   spawn_server(F fun, uint16_t& port, Ts&&... xs) {
-    using impl = typename infer_handle_from_fun<F>::impl;
+    using impl = typename infer_handle_from_fun_trait_t<F>::impl;
     return spawn_server_impl<Os, impl>(std::move(fun), port,
                                        std::forward<Ts>(xs)...);
   }
@@ -240,7 +241,7 @@ public:
   expected<infer_handle_from_fun_t<F>>
   spawn_server(F fun, const uint16_t& port, Ts&&... xs) {
     uint16_t dummy = port;
-    using impl = typename infer_handle_from_fun<F>::impl;
+    using impl = typename infer_handle_from_fun_trait_t<F>::impl;
     return spawn_server_impl<Os, impl>(std::move(fun), dummy,
                                        std::forward<Ts>(xs)...);
   }

--- a/libcaf_io/caf/io/typed_broker.hpp
+++ b/libcaf_io/caf/io/typed_broker.hpp
@@ -91,7 +91,7 @@ public:
     CAF_ASSERT(this->context() != nullptr);
     auto sptr = this->take(hdl);
     CAF_ASSERT(sptr->hdl() == hdl);
-    using impl = typename infer_handle_from_fun<F>::impl;
+    using impl = typename infer_handle_from_fun_trait_t<F>::impl;
     static_assert(
       std::is_convertible<typename impl::actor_hdl, connection_handler>::value,
       "Cannot fork: new broker misses required handlers");


### PR DESCRIPTION
Re-using the `stateful_actor` to implement `actor_from_state` reduces code duplication and using `actor_from_state` no longer delays constructing of the state. Previously, the state would only be constructed when calling `make_behavior`. This means accessing the state prior would be undefined behavior. This change makes it now safe the access the state as soon as the actor has been fully constructed.

Notably, this will allow us to have `stateful_actor::name()` return a member of the `State` class. Up until now, users had to provide a `static const char* name` member in the state class. Now, we can think about how to allow users to have a simple `std::string name` member or `std::string_view name()` getter.