### PR TITLE
Refactor macro based logs for io

### DIFF
--- a/libcaf_io/caf/detail/prometheus_broker.cpp
+++ b/libcaf_io/caf/detail/prometheus_broker.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/detail/prometheus_broker.hpp"
 
+#include "caf/log/io.hpp"
 #include "caf/span.hpp"
 #include "caf/string_algorithms.hpp"
 #include "caf/telemetry/dbl_gauge.hpp"
@@ -104,7 +105,7 @@ behavior prometheus_broker::make_behavior() {
         quit();
     },
     [this](const io::acceptor_closed_msg&) {
-      CAF_LOG_ERROR("Prometheus Broker lost its acceptor!");
+      log::io::error("Prometheus Broker lost its acceptor!");
       if (num_connections() + num_doormen() == 0)
         quit();
     },

--- a/libcaf_io/caf/detail/socket_guard.cpp
+++ b/libcaf_io/caf/detail/socket_guard.cpp
@@ -10,7 +10,7 @@
 #  include <unistd.h>
 #endif
 
-#include "caf/logger.hpp"
+#include "caf/log/io.hpp"
 
 namespace caf::detail {
 
@@ -30,7 +30,7 @@ io::network::native_socket socket_guard::release() {
 
 void socket_guard::close() {
   if (fd_ != io::network::invalid_native_socket) {
-    CAF_LOG_DEBUG("close socket" << CAF_ARG(fd_));
+    log::io::debug("close socket fd = {}", fd_);
     io::network::close_socket(fd_);
     fd_ = io::network::invalid_native_socket;
   }

--- a/libcaf_io/caf/io/abstract_broker.cpp
+++ b/libcaf_io/caf/io/abstract_broker.cpp
@@ -10,7 +10,7 @@
 #include "caf/detail/scope_guard.hpp"
 #include "caf/detail/sync_request_bouncer.hpp"
 #include "caf/event_based_actor.hpp"
-#include "caf/logger.hpp"
+#include "caf/log/io.hpp"
 #include "caf/make_counted.hpp"
 #include "caf/none.hpp"
 #include "caf/scheduler/abstract_coordinator.hpp"
@@ -68,8 +68,9 @@ byte_buffer& abstract_broker::wr_buf(connection_handle hdl) {
   if (auto x = by_id(hdl)) {
     return x->wr_buf();
   } else {
-    CAF_LOG_ERROR("tried to access wr_buf() of an unknown connection_handle:"
-                  << CAF_ARG(hdl));
+    log::io::error(
+      "tried to access wr_buf() of an unknown connection_handle: hdl = {}",
+      hdl);
     return dummy_wr_buf_;
   }
 }
@@ -100,8 +101,8 @@ byte_buffer& abstract_broker::wr_buf(datagram_handle hdl) {
   if (auto x = by_id(hdl)) {
     return x->wr_buf(hdl);
   } else {
-    CAF_LOG_ERROR("tried to access wr_buf() of an unknown"
-                  "datagram_handle");
+    log::io::error("tried to access wr_buf() of an unknown"
+                   "datagram_handle");
     return dummy_wr_buf_;
   }
 }
@@ -110,8 +111,8 @@ void abstract_broker::enqueue_datagram(datagram_handle hdl, byte_buffer buf) {
   if (auto x = by_id(hdl))
     x->enqueue_datagram(hdl, std::move(buf));
   else
-    CAF_LOG_ERROR("tried to access datagram_buffer() of an unknown"
-                  "datagram_handle");
+    log::io::error("tried to access datagram_buffer() of an unknown"
+                   "datagram_handle");
 }
 
 void abstract_broker::write(datagram_handle hdl, size_t bs, const void* buf) {

--- a/libcaf_io/caf/io/basp/instance.cpp
+++ b/libcaf_io/caf/io/basp/instance.cpp
@@ -232,7 +232,9 @@ void instance::write_server_handshake(execution_unit* ctx, byte_buffer& out_buf,
     if (i != published_actors_.end())
       pa = &i->second;
   }
-  CAF_LOG_DEBUG_IF(!pa && port, "no actor published");
+  if (!pa && port) {
+    log::io::debug("no actor published");
+  }
   auto writer = make_callback([&](binary_serializer& sink) {
     using string_list = std::vector<std::string>;
     string_list app_ids;

--- a/libcaf_io/caf/io/basp/instance.cpp
+++ b/libcaf_io/caf/io/basp/instance.cpp
@@ -12,6 +12,7 @@
 #include "caf/binary_deserializer.hpp"
 #include "caf/binary_serializer.hpp"
 #include "caf/defaults.hpp"
+#include "caf/log/io.hpp"
 #include "caf/settings.hpp"
 #include "caf/telemetry/histogram.hpp"
 #include "caf/telemetry/timer.hpp"
@@ -54,26 +55,26 @@ connection_state instance::handle(execution_unit* ctx, new_data_msg& dm,
   if (is_payload) {
     payload = &dm.buf;
     if (payload->size() != hdr.payload_len) {
-      CAF_LOG_WARNING("received invalid payload, expected"
-                      << hdr.payload_len << "bytes, got" << payload->size());
+      log::io::warning("received invalid payload, expected {} bytes, got {}",
+                       hdr.payload_len, payload->size());
       return err(malformed_message);
     }
   } else {
     binary_deserializer source{ctx, dm.buf};
     if (!source.apply(hdr)) {
-      CAF_LOG_WARNING("failed to receive header:" << source.get_error());
+      log::io::warning("failed to receive header: {}", source.get_error());
       return err(malformed_message);
     }
     if (!valid(hdr)) {
-      CAF_LOG_WARNING("received invalid header:" << CAF_ARG(hdr));
+      log::io::warning("received invalid header: hdr = {}", CAF_ARG(hdr));
       return err(malformed_message);
     }
     if (hdr.payload_len > 0) {
-      CAF_LOG_DEBUG("await payload before processing further");
+      log::io::debug("await payload before processing further");
       return await_payload;
     }
   }
-  CAF_LOG_DEBUG(CAF_ARG(hdr));
+  log::io::debug("hdr = {}", hdr);
   return handle(ctx, dm.handle, hdr, payload);
 }
 
@@ -182,9 +183,9 @@ bool instance::dispatch(execution_unit* ctx, const strong_actor_ptr& sender,
                sender ? sender->id() : invalid_actor_id,
                dest_actor};
     auto writer = make_callback([&](binary_serializer& sink) {
-      CAF_LOG_DEBUG("send routed message: " << CAF_ARG(source_node)
-                                            << CAF_ARG(dest_node)
-                                            << CAF_ARG(msg));
+      log::io::debug(
+        "send routed message: source_node = {} dest_node = {} msg = {}",
+        source_node, dest_node, msg);
       return sink.apply(source_node)  //
              && sink.apply(dest_node) //
              && sink.apply(msg);
@@ -207,7 +208,7 @@ void instance::write(execution_unit* ctx, byte_buffer& buf, header& hdr,
     auto& mm_metrics = ctx->system().middleman().metric_singletons;
     auto t0 = telemetry::timer::clock_type::now();
     if (!(*pw)(sink)) {
-      CAF_LOG_ERROR(sink.get_error());
+      log::io::error("{}", sink.get_error());
       return;
     }
     telemetry::timer::observe(mm_metrics.serialization_time, t0);
@@ -218,7 +219,7 @@ void instance::write(execution_unit* ctx, byte_buffer& buf, header& hdr,
     hdr.payload_len = static_cast<uint32_t>(payload_len);
   }
   if (!sink.apply(hdr))
-    CAF_LOG_ERROR(sink.get_error());
+    log::io::error("{}", sink.get_error());
 }
 
 void instance::write_server_handshake(execution_unit* ctx, byte_buffer& out_buf,
@@ -307,11 +308,11 @@ connection_state instance::handle(execution_unit* ctx, connection_handle hdl,
   // Check payload validity.
   if (payload == nullptr) {
     if (hdr.payload_len != 0) {
-      CAF_LOG_WARNING("missing payload");
+      log::io::warning("missing payload");
       return malformed_message;
     }
   } else if (hdr.payload_len != payload->size()) {
-    CAF_LOG_WARNING("actual payload size differs from advertised size");
+    log::io::warning("actual payload size differs from advertised size");
     return malformed_message;
   }
   // Dispatch by message type.
@@ -328,8 +329,9 @@ connection_state instance::handle(execution_unit* ctx, connection_handle hdl,
           || !source.apply(app_ids)  //
           || !source.apply(aid)      //
           || !source.apply(sigs)) {
-        CAF_LOG_WARNING("unable to deserialize payload of server handshake:"
-                        << source.get_error());
+        log::io::warning(
+          "unable to deserialize payload of server handshake: {}",
+          source.get_error());
         return serializing_basp_payload_failed;
       }
       // Check the application ID.
@@ -343,31 +345,32 @@ connection_state instance::handle(execution_unit* ctx, connection_handle hdl,
       auto i = std::find_first_of(app_ids.begin(), app_ids.end(),
                                   whitelist.begin(), whitelist.end());
       if (i == app_ids.end()) {
-        CAF_LOG_WARNING("refuse to connect to server due to app ID mismatch:"
-                        << CAF_ARG(app_ids) << CAF_ARG(whitelist));
+        log::io::warning("refuse to connect to server due to app ID mismatch: "
+                         "app_ids = {} whitelist = {}",
+                         app_ids, whitelist);
         return incompatible_application_ids;
       }
       // Close connection to ourselves immediately after sending client HS.
       if (source_node == this_node_) {
-        CAF_LOG_DEBUG("close connection to self immediately");
+        log::io::debug("close connection to self immediately");
         callee_.finalize_handshake(source_node, aid, sigs);
         return redundant_connection;
       }
       // Close this connection if we already have a direct connection.
       if (tbl_.lookup_direct(source_node)) {
-        CAF_LOG_DEBUG(
-          "close redundant direct connection:" << CAF_ARG(source_node));
+        log::io::debug("close redundant direct connection: source_node = {}",
+                       source_node);
         callee_.finalize_handshake(source_node, aid, sigs);
         return redundant_connection;
       }
       // Add direct route to this node and remove any indirect entry.
-      CAF_LOG_DEBUG("new direct connection:" << CAF_ARG(source_node));
+      log::io::debug("new direct connection: source_node = {}", source_node);
       tbl_.add_direct(hdl, source_node);
       auto was_indirect = tbl_.erase_indirect(source_node);
       // write handshake as client in response
       auto path = tbl_.lookup(source_node);
       if (!path) {
-        CAF_LOG_ERROR("no route to host after server handshake");
+        log::io::error("no route to host after server handshake");
         return no_route_to_receiving_node;
       }
       callee_.learned_new_node_directly(source_node, was_indirect);
@@ -379,18 +382,19 @@ connection_state instance::handle(execution_unit* ctx, connection_handle hdl,
       binary_deserializer source{ctx, *payload};
       node_id source_node;
       if (!source.apply(source_node)) {
-        CAF_LOG_WARNING("unable to deserialize payload of client handshake:"
-                        << source.get_error());
+        log::io::warning(
+          "unable to deserialize payload of client handshake: {}",
+          source.get_error());
         return serializing_basp_payload_failed;
       }
       // Drop repeated handshakes.
       if (tbl_.lookup_direct(source_node)) {
-        CAF_LOG_DEBUG(
-          "received repeated client handshake:" << CAF_ARG(source_node));
+        log::io::debug("received repeated client handshake: source_node = {}",
+                       source_node);
         break;
       }
       // Add direct route to this node and remove any indirect entry.
-      CAF_LOG_DEBUG("new direct connection:" << CAF_ARG(source_node));
+      log::io::debug("new direct connection: source_node = {}", source_node);
       tbl_.add_direct(hdl, source_node);
       auto was_indirect = tbl_.erase_indirect(source_node);
       callee_.learned_new_node_directly(source_node, was_indirect);
@@ -402,9 +406,9 @@ connection_state instance::handle(execution_unit* ctx, connection_handle hdl,
       node_id source_node;
       node_id dest_node;
       if (!source.apply(source_node) || !source.apply(dest_node)) {
-        CAF_LOG_WARNING(
-          "unable to deserialize source and destination for routed message:"
-          << source.get_error());
+        log::io::warning("unable to deserialize source and destination for "
+                         "routed message: {}",
+                         source.get_error());
         return serializing_basp_payload_failed;
       }
       if (dest_node != this_node_) {
@@ -422,12 +426,12 @@ connection_state instance::handle(execution_unit* ctx, connection_handle hdl,
       auto worker = hub_.pop();
       auto last_hop = tbl_.lookup_direct(hdl);
       if (worker != nullptr) {
-        CAF_LOG_DEBUG("launch BASP worker for deserializing a"
-                      << hdr.operation);
+        log::io::debug("launch BASP worker for deserializing a {}",
+                       hdr.operation);
         worker->launch(last_hop, hdr, *payload);
       } else {
-        CAF_LOG_DEBUG("out of BASP workers, continue deserializing a"
-                      << hdr.operation);
+        log::io::debug("out of BASP workers, continue deserializing a {}",
+                       hdr.operation);
         // If no worker is available then we have no other choice than to take
         // the performance hit and deserialize in this thread.
         struct handler : remote_message_handler<handler> {
@@ -461,8 +465,8 @@ connection_state instance::handle(execution_unit* ctx, connection_handle hdl,
       node_id source_node;
       node_id dest_node;
       if (!source.apply(source_node) || !source.apply(dest_node)) {
-        CAF_LOG_WARNING("unable to deserialize payload of monitor message:"
-                        << source.get_error());
+        log::io::warning("unable to deserialize payload of monitor message: {}",
+                         source.get_error());
         return serializing_basp_payload_failed;
       }
       if (dest_node == this_node_)
@@ -480,8 +484,8 @@ connection_state instance::handle(execution_unit* ctx, connection_handle hdl,
       if (!source.apply(source_node)  //
           || !source.apply(dest_node) //
           || !source.apply(fail_state)) {
-        CAF_LOG_WARNING("unable to deserialize payload of down message:"
-                        << source.get_error());
+        log::io::warning("unable to deserialize payload of down message: {}",
+                         source.get_error());
         return serializing_basp_payload_failed;
       }
       if (dest_node == this_node_) {
@@ -504,7 +508,7 @@ connection_state instance::handle(execution_unit* ctx, connection_handle hdl,
       break;
     }
     default: {
-      CAF_LOG_ERROR("invalid operation");
+      log::io::error("invalid operation");
       return malformed_message;
     }
   }
@@ -518,13 +522,13 @@ void instance::forward(execution_unit* ctx, const node_id& dest_node,
   if (path) {
     binary_serializer sink{ctx, callee_.get_buffer(path->hdl)};
     if (!sink.apply(hdr)) {
-      CAF_LOG_ERROR("unable to serialize BASP header:" << sink.get_error());
+      log::io::error("unable to serialize BASP header: {}", sink.get_error());
       return;
     }
     sink.value(span<const std::byte>{payload.data(), payload.size()});
     flush(*path);
   } else {
-    CAF_LOG_WARNING("cannot forward message, no route to destination");
+    log::io::warning("cannot forward message, no route to destination");
   }
 }
 

--- a/libcaf_io/caf/io/basp_broker.cpp
+++ b/libcaf_io/caf/io/basp_broker.cpp
@@ -484,10 +484,14 @@ void basp_broker::finalize_handshake(const node_id& nid, actor_id aid,
     if (nid == this_node()) {
       // connected to self
       ptr = actor_cast<strong_actor_ptr>(system().registry().get(aid));
-      CAF_LOG_DEBUG_IF(!ptr, "actor not found:" << CAF_ARG(aid));
+      if (!ptr) {
+        log::io::debug("actor not found: aid = {}", aid);
+      }
     } else {
       ptr = namespace_.get_or_put(nid, aid);
-      CAF_LOG_ERROR_IF(!ptr, "creating actor in finalize_handshake failed");
+      if (!ptr) {
+        log::io::error("creating actor in finalize_handshake failed");
+      }
     }
   }
   cb->deliver(nid, std::move(ptr), std::move(sigs));

--- a/libcaf_io/caf/io/broker.cpp
+++ b/libcaf_io/caf/io/broker.cpp
@@ -20,8 +20,10 @@ void broker::initialize() {
   CAF_LOG_TRACE("");
   init_broker();
   auto bhvr = make_behavior();
-  CAF_LOG_DEBUG_IF(!bhvr, "make_behavior() did not return a behavior:"
-                            << CAF_ARG2("alive", alive()));
+  if (!bhvr) {
+    log::io::debug("make_behavior() did not return a behavior: alive = {}",
+                   alive());
+  }
   if (bhvr) {
     // make_behavior() did return a behavior instead of using become()
     log::io::debug("make_behavior() did return a valid behavior");

--- a/libcaf_io/caf/io/broker.cpp
+++ b/libcaf_io/caf/io/broker.cpp
@@ -10,7 +10,7 @@
 #include "caf/config.hpp"
 #include "caf/detail/scope_guard.hpp"
 #include "caf/detail/sync_request_bouncer.hpp"
-#include "caf/logger.hpp"
+#include "caf/log/io.hpp"
 #include "caf/make_counted.hpp"
 #include "caf/none.hpp"
 
@@ -24,7 +24,7 @@ void broker::initialize() {
                             << CAF_ARG2("alive", alive()));
   if (bhvr) {
     // make_behavior() did return a behavior instead of using become()
-    CAF_LOG_DEBUG("make_behavior() did return a valid behavior");
+    log::io::debug("make_behavior() did return a valid behavior");
     become(std::move(bhvr));
   }
 }

--- a/libcaf_io/caf/io/connection_helper.cpp
+++ b/libcaf_io/caf/io/connection_helper.cpp
@@ -12,6 +12,7 @@
 #include "caf/after.hpp"
 #include "caf/defaults.hpp"
 #include "caf/event_based_actor.hpp"
+#include "caf/log/io.hpp"
 #include "caf/stateful_actor.hpp"
 
 #include <chrono>
@@ -37,7 +38,7 @@ behavior connection_helper(stateful_actor<connection_helper_state>* self,
     // this config is send from the remote `ConfigServ`
     [=](const std::string& item, message& msg) {
       CAF_LOG_TRACE(CAF_ARG(item) << CAF_ARG(msg));
-      CAF_LOG_DEBUG("received requested config:" << CAF_ARG(msg));
+      log::io::debug("received requested config: msg = {}", msg);
       // whatever happens, we are done afterwards
       self->quit();
       message_handler f{
@@ -50,16 +51,17 @@ behavior connection_helper(stateful_actor<connection_helper_state>* self,
                 if (hdl) {
                   // gotcha! send scribe to our BASP broker
                   // to initiate handshake etc.
-                  CAF_LOG_INFO("connected directly:" << CAF_ARG(addr));
+                  log::io::info("connected directly: addr = {}", addr);
                   self->send(b, connect_atom_v, *hdl, port);
                   return;
                 }
               }
             }
-            CAF_LOG_INFO("could not connect to node directly");
+            log::io::info("could not connect to node directly");
           } else {
-            CAF_LOG_INFO("aborted direct connection attempt, unknown item: "
-                         << CAF_ARG(item));
+            log::io::info(
+              "aborted direct connection attempt, unknown item: item = {}",
+              item);
           }
         },
       };
@@ -69,7 +71,7 @@ behavior connection_helper(stateful_actor<connection_helper_state>* self,
       [=] {
         CAF_LOG_TRACE(CAF_ARG(""));
         // nothing heard in about 10 minutes... just a call it a day, then
-        CAF_LOG_INFO("aborted direct connection attempt after 10min");
+        log::io::info("aborted direct connection attempt after 10min");
         self->quit(exit_reason::user_shutdown);
       },
   };

--- a/libcaf_io/caf/io/middleman.cpp
+++ b/libcaf_io/caf/io/middleman.cpp
@@ -138,7 +138,7 @@ public:
     thread_ = mpx_.system().launch_thread("caf.io.prom", thread_owner::system,
                                           run_mpx);
     sync.wait();
-    CAF_LOG_INFO("expose Prometheus metrics at port" << actual_port);
+    log::io::info("expose Prometheus metrics at port {}", actual_port);
     return actual_port;
   }
 
@@ -298,7 +298,7 @@ strong_actor_ptr middleman::remote_lookup(std::string name,
       return message{};
     },
     after(std::chrono::minutes(5)) >>
-      [&] { CAF_LOG_WARNING("remote_lookup timed out"); });
+      [&] { log::io::warning("remote_lookup timed out"); });
   return result;
 }
 

--- a/libcaf_io/caf/io/middleman_actor_impl.cpp
+++ b/libcaf_io/caf/io/middleman_actor_impl.cpp
@@ -84,14 +84,14 @@ auto middleman_actor_impl::make_behavior() -> behavior_type {
       // respond immediately if endpoint is cached
       auto x = cached_tcp(key);
       if (x) {
-        CAF_LOG_DEBUG("found cached entry" << CAF_ARG(*x));
+        log::io::debug("found cached entry x = {}", *x);
         rp.deliver(get<0>(*x), get<1>(*x), get<2>(*x));
         return get_delegated{};
       }
       // attach this promise to a pending request if possible
       auto rps = pending(key);
       if (rps) {
-        CAF_LOG_DEBUG("attach to pending request");
+        log::io::debug("attach to pending request");
         rps->emplace_back(std::move(rp));
         return get_delegated{};
       }

--- a/libcaf_io/caf/io/network/datagram_handler.cpp
+++ b/libcaf_io/caf/io/network/datagram_handler.cpp
@@ -9,7 +9,7 @@
 #include "caf/actor_system_config.hpp"
 #include "caf/config_value.hpp"
 #include "caf/defaults.hpp"
-#include "caf/logger.hpp"
+#include "caf/log/io.hpp"
 
 #include <algorithm>
 
@@ -33,7 +33,7 @@ datagram_handler::datagram_handler(default_multiplexer& backend_ref,
   allow_udp_connreset(sockfd, false);
   auto es = send_buffer_size(sockfd);
   if (!es)
-    CAF_LOG_ERROR("cannot determine socket buffer size");
+    log::io::error("cannot determine socket buffer size");
   else
     send_buffer_size_ = *es;
 }
@@ -92,8 +92,8 @@ void datagram_handler::add_endpoint(datagram_handle hdl, const ip_endpoint& ep,
   } else if (!writer_) {
     writer_ = mgr;
   } else {
-    CAF_LOG_ERROR("cannot assign a second servant to the endpoint "
-                  << to_string(ep));
+    log::io::error("cannot assign a second servant to the endpoint {}",
+                   to_string(ep));
     abort();
   }
 }

--- a/libcaf_io/caf/io/network/default_multiplexer.cpp
+++ b/libcaf_io/caf/io/network/default_multiplexer.cpp
@@ -908,7 +908,7 @@ new_local_udp_endpoint_impl(uint16_t port, const char* addr, bool reuse,
                       addr_str);
   bool any = addr_str.empty() || addr_str == "::" || addr_str == "0.0.0.0";
   auto fd = invalid_native_socket;
-  protocol::network proto;
+  protocol::network proto{};
   for (auto& elem : addrs) {
     auto host = elem.first.c_str();
     auto p

--- a/libcaf_io/caf/io/network/default_multiplexer.hpp
+++ b/libcaf_io/caf/io/network/default_multiplexer.hpp
@@ -27,7 +27,7 @@
 #include "caf/config.hpp"
 #include "caf/detail/io_export.hpp"
 #include "caf/extend.hpp"
-#include "caf/logger.hpp"
+#include "caf/log/io.hpp"
 #include "caf/ref_counted.hpp"
 
 #include <cstdint>
@@ -185,26 +185,26 @@ private:
     if (i != last && i->fd == fd) {
       CAF_ASSERT(ptr == i->ptr);
       // squash events together
-      CAF_LOG_DEBUG("squash events:" << CAF_ARG(i->mask)
-                                     << CAF_ARG(fun(op, i->mask)));
+      log::io::debug("squash events: i->mask = {} fun(op, i->mask) = {}",
+                     i->mask, fun(op, i->mask));
       auto bf = i->mask;
       i->mask = fun(op, bf);
       if (i->mask == bf) {
         // didn't do a thing
-        CAF_LOG_DEBUG("squashing did not change the event");
+        log::io::debug("squashing did not change the event");
       } else if (i->mask == old_bf) {
         // just turned into a nop
-        CAF_LOG_DEBUG("squashing events resulted in a NOP");
+        log::io::debug("squashing events resulted in a NOP");
         events_.erase(i);
       }
     } else {
       // insert new element
       auto bf = fun(op, old_bf);
       if (bf == old_bf) {
-        CAF_LOG_DEBUG("event has no effect (discarded): " << CAF_ARG(bf) << ", "
-                                                          << CAF_ARG(old_bf));
+        log::io::debug("event has no effect (discarded): bf = {}, old-bf = {}",
+                       bf, old_bf);
       } else {
-        CAF_LOG_DEBUG("added handler:" << CAF_ARG(fd) << CAF_ARG(op));
+        log::io::debug("added handler: fd = {} op = {}", fd, op);
         events_.insert(i, event{fd, bf, ptr});
       }
     }

--- a/libcaf_io/caf/io/network/event_handler.cpp
+++ b/libcaf_io/caf/io/network/event_handler.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/io/network/default_multiplexer.hpp"
 
-#include "caf/logger.hpp"
+#include "caf/log/io.hpp"
 
 #ifdef CAF_WINDOWS
 #  include <winsock2.h>
@@ -27,7 +27,7 @@ event_handler::event_handler(default_multiplexer& dm, native_socket sockfd)
 
 event_handler::~event_handler() {
   if (fd_ != invalid_native_socket) {
-    CAF_LOG_DEBUG("close socket" << CAF_ARG(fd_));
+    log::io::debug("close socket fd = {}", fd_);
     close_socket(fd_);
   }
 }

--- a/libcaf_io/caf/io/network/manager.cpp
+++ b/libcaf_io/caf/io/network/manager.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/io/abstract_broker.hpp"
 
-#include "caf/logger.hpp"
+#include "caf/log/io.hpp"
 
 namespace caf::io::network {
 
@@ -34,7 +34,7 @@ void manager::detach(execution_unit*, bool invoke_disconnect_message) {
   remove_from_loop();
   // Disconnect from the broker if not already detached.
   if (!detached()) {
-    CAF_LOG_DEBUG("disconnect servant from broker");
+    log::io::debug("disconnect servant from broker");
     auto raw_ptr = parent();
     // Keep a strong reference to our parent until we go out of scope.
     strong_actor_ptr ptr;
@@ -51,7 +51,7 @@ void manager::detach(execution_unit*, bool invoke_disconnect_message) {
           raw_ptr->push_to_cache(std::move(mptr));
           break;
         case invoke_message_result::dropped:
-          CAF_LOG_INFO("broker dropped disconnect message");
+          log::io::info("broker dropped disconnect message");
           break;
       }
     }

--- a/libcaf_io/caf/io/network/operation.hpp
+++ b/libcaf_io/caf/io/network/operation.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "caf/detail/io_export.hpp"
+
 #include <string>
 
 namespace caf::io::network {
@@ -14,5 +16,16 @@ enum class operation {
   write,
   propagate_error,
 };
+
+CAF_IO_EXPORT std::string to_string(operation);
+
+CAF_IO_EXPORT bool from_string(std::string_view, operation&);
+
+CAF_IO_EXPORT bool from_integer(std::underlying_type_t<operation>, operation&);
+
+template <class Inspector>
+bool inspect(Inspector& f, operation& x) {
+  return default_enum_inspect(f, x);
+}
 
 } // namespace caf::io::network

--- a/libcaf_io/caf/io/typed_broker.hpp
+++ b/libcaf_io/caf/io/typed_broker.hpp
@@ -77,8 +77,10 @@ public:
     CAF_LOG_TRACE("");
     this->init_broker();
     auto bhvr = make_behavior();
-    CAF_LOG_DEBUG_IF(!bhvr, "make_behavior() did not return a behavior:"
-                              << CAF_ARG2("alive", this->alive()));
+    if (!bhvr) {
+      log::io::debug("make_behavior() did not return a behavior: alive = {}",
+                     this->alive());
+    }
     if (bhvr) {
       // make_behavior() did return a behavior instead of using become()
       log::io::debug("make_behavior() did return a valid behavior");

--- a/libcaf_io/caf/io/typed_broker.hpp
+++ b/libcaf_io/caf/io/typed_broker.hpp
@@ -81,7 +81,7 @@ public:
                               << CAF_ARG2("alive", this->alive()));
     if (bhvr) {
       // make_behavior() did return a behavior instead of using become()
-      CAF_LOG_DEBUG("make_behavior() did return a valid behavior");
+      log::io::debug("make_behavior() did return a valid behavior");
       this->do_become(std::move(bhvr.unbox()), true);
     }
   }

--- a/libcaf_io/caf/policy/tcp.cpp
+++ b/libcaf_io/caf/policy/tcp.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/io/network/native_socket.hpp"
 
-#include "caf/logger.hpp"
+#include "caf/log/io.hpp"
 
 #include <cstring>
 
@@ -36,14 +36,14 @@ rw_state tcp::read_some(size_t& result, native_socket fd, void* buf,
     // Make sure WSAGetLastError gets called immediately on Windows.
     auto err = last_socket_error();
     CAF_IGNORE_UNUSED(err);
-    CAF_LOG_ERROR("recv failed:" << socket_error_as_string(err));
+    log::io::error("recv failed: {}", socket_error_as_string(err));
     return rw_state::failure;
   } else if (sres == 0) {
     // recv returns 0  when the peer has performed an orderly shutdown
-    CAF_LOG_DEBUG("peer performed orderly shutdown" << CAF_ARG(fd));
+    log::io::debug("peer performed orderly shutdown fd = {}", fd);
     return rw_state::failure;
   }
-  CAF_LOG_DEBUG(CAF_ARG(len) << CAF_ARG(fd) << CAF_ARG(sres));
+  log::io::debug("len = {} fd = {} sres = {}", len, fd, sres);
   result = (sres > 0) ? static_cast<size_t>(sres) : 0;
   return rw_state::success;
 }
@@ -57,10 +57,10 @@ rw_state tcp::write_some(size_t& result, native_socket fd, const void* buf,
     // Make sure WSAGetLastError gets called immediately on Windows.
     auto err = last_socket_error();
     CAF_IGNORE_UNUSED(err);
-    CAF_LOG_ERROR("send failed:" << socket_error_as_string(err));
+    log::io::error("send failed: {}", socket_error_as_string(err));
     return rw_state::failure;
   }
-  CAF_LOG_DEBUG(CAF_ARG(len) << CAF_ARG(fd) << CAF_ARG(sres));
+  log::io::debug("len = {} fd = {} sres = {}", len, fd, sres);
   result = (sres > 0) ? static_cast<size_t>(sres) : 0;
   return rw_state::success;
 }
@@ -76,12 +76,12 @@ bool tcp::try_accept(native_socket& result, native_socket fd) {
   if (result == invalid_native_socket) {
     auto err = last_socket_error();
     if (!would_block_or_temporarily_unavailable(err)) {
-      CAF_LOG_ERROR("accept failed:" << socket_error_as_string(err));
+      log::io::error("accept failed {}", socket_error_as_string(err));
       return false;
     }
   }
   child_process_inherit(result, false);
-  CAF_LOG_DEBUG(CAF_ARG(fd) << CAF_ARG(result));
+  log::io::debug("fd = {} result = {}", fd, result);
   return true;
 }
 

--- a/libcaf_io/caf/policy/udp.cpp
+++ b/libcaf_io/caf/policy/udp.cpp
@@ -6,7 +6,7 @@
 
 #include "caf/io/network/native_socket.hpp"
 
-#include "caf/logger.hpp"
+#include "caf/log/io.hpp"
 
 #ifdef CAF_WINDOWS
 #  include <winsock2.h>
@@ -35,14 +35,15 @@ bool udp::read_datagram(size_t& result, native_socket fd, void* buf,
     // Make sure WSAGetLastError gets called immediately on Windows.
     auto err = last_socket_error();
     CAF_IGNORE_UNUSED(err);
-    CAF_LOG_ERROR("recvfrom failed:" << socket_error_as_string(err));
+    log::io::error("recvfrom failed: {}", socket_error_as_string(err));
     return false;
   }
   if (sres == 0)
-    CAF_LOG_INFO("Received empty datagram");
+    log::io::info("Received empty datagram");
   else if (sres > static_cast<signed_size_type>(buf_len))
-    CAF_LOG_WARNING("recvfrom cut of message, only received "
-                    << CAF_ARG(buf_len) << " of " << CAF_ARG(sres) << " bytes");
+    log::io::warning(
+      "recvfrom cut of message, only received buf-len = {} of sres = {} bytes",
+      buf_len, sres);
   result = (sres > 0) ? static_cast<size_t>(sres) : 0;
   *ep.length() = static_cast<size_t>(len);
   return true;
@@ -58,7 +59,7 @@ bool udp::write_datagram(size_t& result, native_socket fd, void* buf,
     // Make sure WSAGetLastError gets called immediately on Windows.
     auto err = last_socket_error();
     CAF_IGNORE_UNUSED(err);
-    CAF_LOG_ERROR("sendto failed:" << socket_error_as_string(err));
+    log::io::error("sendto failed: {}", socket_error_as_string(err));
     return false;
   }
   result = (sres > 0) ? static_cast<size_t>(sres) : 0;


### PR DESCRIPTION
Refactored debug, info, warning and error logs for libcaf_io. Also introduced `to_string`, `from_string`, `from_integer` for `operation` enum to provide support for new logging framework.