### PR TITLE
Refactor the scheduler implementation

### DIFF
--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -143,13 +143,7 @@ public:
   /// An (optional) component of the actor system.
   class CAF_CORE_EXPORT module {
   public:
-    enum id_t {
-      scheduler,
-      middleman,
-      openssl_manager,
-      network_manager,
-      num_ids
-    };
+    enum id_t { middleman, openssl_manager, network_manager, num_ids };
 
     virtual ~module();
 
@@ -744,6 +738,9 @@ private:
 
   /// Maps well-known actor names to actor handles.
   actor_registry registry_;
+
+  /// Stores the actor system scheduler.
+  std::unique_ptr<caf::scheduler> scheduler_;
 
   /// Stores optional actor system components.
   module_array modules_;

--- a/libcaf_core/caf/actor_system_config.hpp
+++ b/libcaf_core/caf/actor_system_config.hpp
@@ -47,6 +47,9 @@ public:
 
   using thread_hooks = std::vector<std::unique_ptr<thread_hook>>;
 
+  using scheduler_factory_fn
+    = std::function<std::unique_ptr<caf::scheduler>(actor_system&)>;
+
   using module_factory = std::function<actor_system::module*(actor_system&)>;
 
   using module_factory_vector = std::vector<module_factory>;
@@ -225,6 +228,7 @@ public:
 
   actor_factory_map actor_factories;
   module_factory_vector module_factories;
+  scheduler_factory_fn scheduler_factory;
   hook_factory_vector hook_factories;
 
   // -- hooks ------------------------------------------------------------------

--- a/libcaf_core/caf/scheduler.hpp
+++ b/libcaf_core/caf/scheduler.hpp
@@ -18,7 +18,7 @@ namespace caf {
 /// the central printer instance for {@link aout}. It also forwards
 /// sends from detached workers or non-actor threads to randomly
 /// chosen workers.
-class CAF_CORE_EXPORT scheduler : public actor_system::module {
+class CAF_CORE_EXPORT scheduler {
 public:
   // -- factory functions ------------------------------------------------------
   static std::unique_ptr<scheduler> make_work_stealing(actor_system& sys);
@@ -27,22 +27,20 @@ public:
 
   // -- scheduler interface ----------------------------------------------------
 
+  virtual ~scheduler();
+
   /// Puts `what` into the queue of a randomly chosen worker.
   virtual void enqueue(resumable* what) = 0;
 
   virtual actor_clock& clock() noexcept = 0;
 
-  // -- implementation of actor_system::module ---------------------------------
+  virtual void start();
 
-  void start() override;
-
-  void init(actor_system_config& cfg) override;
-
-  id_t id() const override;
-
-  void* subtype_ptr() override;
+  virtual void stop() = 0;
 
   // -- utility functions ------------------------------------------------------
+
+  void init(actor_system_config& cfg);
 
   static void cleanup_and_release(resumable*);
 

--- a/libcaf_test/caf/test/dsl.hpp
+++ b/libcaf_test/caf/test/dsl.hpp
@@ -1070,10 +1070,10 @@ public:
     if (auto err = cfg.parse(caf::test::engine::argc(),
                              caf::test::engine::argv()))
       CAF_FAIL("failed to parse config: " << to_string(err));
-    cfg.module_factories.push_back(
-      [](caf::actor_system& sys) -> caf::actor_system::module* {
-        return new scheduler_type(sys);
-      });
+    cfg.scheduler_factory
+      = [](caf::actor_system& sys) -> std::unique_ptr<caf::scheduler> {
+      return std::make_unique<scheduler_type>(sys);
+    };
     if (cfg.custom_options().has_category("caf.middleman")) {
       cfg.set("caf.middleman.workers", size_t{0});
       cfg.set("caf.middleman.heartbeat-interval", caf::timespan{0});

--- a/libcaf_test/caf/test/fixture/deterministic.cpp
+++ b/libcaf_test/caf/test/fixture/deterministic.cpp
@@ -501,9 +501,9 @@ private:
 
 deterministic::config::config(deterministic* fix) {
   factory_ = std::make_unique<mailbox_factory_impl>(fix);
-  module_factories.push_back([fix](actor_system& sys) -> actor_system::module* {
-    return new scheduler_impl(sys, fix);
-  });
+  scheduler_factory = [fix](actor_system& sys) -> std::unique_ptr<scheduler> {
+    return std::make_unique<scheduler_impl>(sys, fix);
+  };
 }
 
 deterministic::config::~config() {


### PR DESCRIPTION
Cleanup the scheduler implementation. Since we hide the implementation details of the scheduler, we can remove the policy based implementation, and leave concrete implementations of the two schedulers we support. 

Also, this PR separates the scheduler from the module interface.

Relates #1674.