### PR TITLE
Implement new mail DSL for anonymous messages

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -91,6 +91,7 @@ caf_add_component(
     caf/actor_system.test.cpp
     caf/actor_system_config.cpp
     caf/actor_system_config.test.cpp
+    caf/anon_mail.test.cpp
     caf/async/batch.cpp
     caf/async/batch.test.cpp
     caf/async/blocking_consumer.test.cpp

--- a/libcaf_core/caf/actor_cast.hpp
+++ b/libcaf_core/caf/actor_cast.hpp
@@ -142,8 +142,8 @@ public:
   }
 };
 
-/// Converts actor handle `what` to a different actor
-/// handle or raw pointer of type `T`.
+/// Converts the actor handle `what` to a different actor handle or raw pointer
+/// of type `T`.
 template <class T, class U>
 T actor_cast(U&& what) {
   // Should use remove_cvref in C++20.
@@ -160,6 +160,13 @@ T actor_cast(U&& what) {
   // perform cast
   actor_cast_access<T, from_type, x * y> f;
   return f(std::forward<U>(what));
+}
+
+/// Converts the actor handle `what` to a different actor handle or raw pointer
+/// of type `Tag::handle_type`.
+template <class U, class Tag>
+auto actor_cast(U&& what, Tag) {
+  return actor_cast<typename Tag::handle_type>(std::forward<U>(what));
 }
 
 } // namespace caf

--- a/libcaf_core/caf/actor_clock.cpp
+++ b/libcaf_core/caf/actor_clock.cpp
@@ -218,11 +218,9 @@ disposable actor_clock::schedule_message(weak_actor_ptr sender,
   auto f = make_single_shot_action([src = std::move(sender),
                                     dst = std::move(receiver), mid,
                                     msg = std::move(content)]() mutable {
-    auto ssrc = src.lock();
-    if (!ssrc)
-      return;
-    dst->enqueue(make_mailbox_element(std::move(ssrc), mid, std::move(msg)),
-                 nullptr);
+    if (auto ssrc = src.lock())
+      dst->enqueue(make_mailbox_element(std::move(ssrc), mid, std::move(msg)),
+                   nullptr);
   });
   return schedule(timeout, std::move(f));
 }

--- a/libcaf_core/caf/actor_clock.hpp
+++ b/libcaf_core/caf/actor_clock.hpp
@@ -8,6 +8,7 @@
 #include "caf/fwd.hpp"
 
 #include <chrono>
+#include <cstddef>
 #include <string>
 
 namespace caf {
@@ -76,6 +77,42 @@ public:
   /// Schedules an arbitrary message to `receiver` for time point `t`.
   disposable schedule_message(time_point t, weak_actor_ptr receiver,
                               mailbox_element_ptr content);
+
+  /// Schedules an arbitrary message to `receiver` as an anonymous message that
+  /// shall be delivered when `timeout` has expired.
+  disposable schedule_message(std::nullptr_t, strong_actor_ptr receiver,
+                              time_point timeout, message_id mid,
+                              message content);
+
+  /// Schedules an arbitrary message to `receiver` as an anonymous message that
+  /// shall be delivered when `timeout` has expired.
+  disposable schedule_message(std::nullptr_t, weak_actor_ptr receiver,
+                              time_point timeout, message_id mid,
+                              message content);
+
+  /// Schedules an arbitrary message from `sender` to `receiver` that shall be
+  /// delivered when `timeout` has expired.
+  disposable schedule_message(strong_actor_ptr sender,
+                              strong_actor_ptr receiver, time_point timeout,
+                              message_id mid, message content);
+
+  /// Schedules an arbitrary message from `sender` to `receiver` that shall be
+  /// delivered when `timeout` has expired.
+  disposable schedule_message(strong_actor_ptr sender, weak_actor_ptr receiver,
+                              time_point timeout, message_id mid,
+                              message content);
+
+  /// Schedules an arbitrary message from `sender` to `receiver` that shall be
+  /// delivered when `timeout` has expired.
+  disposable schedule_message(weak_actor_ptr sender, strong_actor_ptr receiver,
+                              time_point timeout, message_id mid,
+                              message content);
+
+  /// Schedules an arbitrary message from `sender` to `receiver` that shall be
+  /// delivered when `timeout` has expired.
+  disposable schedule_message(weak_actor_ptr sender, weak_actor_ptr receiver,
+                              time_point timeout, message_id mid,
+                              message content);
 };
 
 } // namespace caf

--- a/libcaf_core/caf/anon_mail.hpp
+++ b/libcaf_core/caf/anon_mail.hpp
@@ -1,0 +1,119 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/abstract_actor.hpp"
+#include "caf/actor_cast.hpp"
+#include "caf/actor_clock.hpp"
+#include "caf/detail/core_export.hpp"
+#include "caf/detail/implicit_conversions.hpp"
+#include "caf/detail/send_type_check.hpp"
+#include "caf/disposable.hpp"
+#include "caf/mailbox_element.hpp"
+#include "caf/message.hpp"
+#include "caf/message_priority.hpp"
+#include "caf/none.hpp"
+#include "caf/ref.hpp"
+
+namespace caf {
+
+/// Provides a fluent interface for sending anonymous messages to actors at a
+/// specific point in time.
+template <message_priority Priority, class... Args>
+class anon_scheduled_mail_t {
+public:
+  anon_scheduled_mail_t(message&& content, actor_clock::time_point timeout)
+    : content_(std::move(content)), timeout_(timeout) {
+    // nop
+  }
+
+  anon_scheduled_mail_t(const anon_scheduled_mail_t&) = delete;
+
+  anon_scheduled_mail_t& operator=(const anon_scheduled_mail_t&) = delete;
+
+  /// Sends the message to `receiver`.
+  /// @param receiver The actor that should receive the message.
+  /// @param ref_tag Either `strong_ref` or `weak_ref`. When passing
+  ///                `strong_ref`, the system will keep a strong reference to
+  ///                the receiver until the message has been delivered.
+  ///                Otherwise, the system will only keep a weak reference to
+  ///                the receiver and the message will be dropped if the
+  ///                receiver has been garbage collected in the meantime.
+  template <class Handle, class RefTag = strong_ref_t>
+  disposable send(const Handle& receiver, RefTag ref_tag = {}) && {
+    static_assert(is_ref_tag<RefTag>);
+    detail::send_type_check<none_t, Handle, Args...>();
+    if (!receiver)
+      return {};
+    auto* ptr = actor_cast<abstract_actor*>(receiver);
+    auto& clock = ptr->home_system().clock();
+    return clock.schedule_message(nullptr, actor_cast(receiver, ref_tag),
+                                  timeout_, make_message_id(Priority),
+                                  std::move(content_));
+  }
+
+private:
+  message content_;
+  actor_clock::time_point timeout_;
+};
+
+/// Provides a fluent interface for sending anonymous messages to actors.
+template <message_priority Priority, class... Args>
+class anon_mail_t {
+public:
+  explicit anon_mail_t(message&& content) : content_(std::move(content)) {
+    // nop
+  }
+
+  anon_mail_t(const anon_mail_t&) = delete;
+
+  anon_mail_t& operator=(const anon_mail_t&) = delete;
+
+  /// Tags the message as urgent, i.e., sends it with high priority.
+  template <message_priority P = Priority,
+            class E = std::enable_if_t<P == message_priority::normal>>
+  [[nodiscard]] auto urgent() && {
+    using result_t = anon_mail_t<message_priority::high, Args...>;
+    return result_t{std::move(content_)};
+  }
+
+  /// Schedules the message for delivery with an absolute timeout.
+  [[nodiscard]] auto schedule(actor_clock::time_point timeout) && {
+    using result_t = anon_scheduled_mail_t<Priority, Args...>;
+    return result_t{std::move(content_), timeout};
+  }
+
+  /// Schedules the message for delivery with a relative timeout.
+  [[nodiscard]] auto delay(actor_clock::duration_type timeout) && {
+    using clock = actor_clock::clock_type;
+    using result_t = anon_scheduled_mail_t<Priority, Args...>;
+    return result_t{std::move(content_), clock::now() + timeout};
+  }
+
+  /// Sends the message to `receiver`.
+  template <class Handle>
+  void send(const Handle& receiver) && {
+    detail::send_type_check<none_t, Handle, Args...>();
+    if (!receiver)
+      return;
+    auto* ptr = actor_cast<abstract_actor*>(receiver);
+    ptr->enqueue(make_mailbox_element(nullptr, make_message_id(Priority),
+                                      std::move(content_)),
+                 nullptr);
+  }
+
+private:
+  message content_;
+};
+
+/// Entry point for sending an anonymous message to an actor.
+template <class... Args>
+[[nodiscard]] auto anon_mail(Args&&... args) {
+  using result_t = anon_mail_t<message_priority::normal,
+                               detail::strip_and_convert_t<Args>...>;
+  return result_t{make_message(std::forward<Args>(args)...)};
+}
+
+} // namespace caf

--- a/libcaf_core/caf/anon_mail.test.cpp
+++ b/libcaf_core/caf/anon_mail.test.cpp
@@ -1,0 +1,153 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/anon_mail.hpp"
+
+#include "caf/test/fixture/deterministic.hpp"
+#include "caf/test/test.hpp"
+
+#include "caf/behavior.hpp"
+#include "caf/event_based_actor.hpp"
+#include "caf/mailbox_element.hpp"
+#include "caf/message_priority.hpp"
+
+using namespace caf;
+using namespace std::literals;
+
+namespace {
+
+WITH_FIXTURE(test::fixture::deterministic) {
+
+TEST("send asynchronous message") {
+  auto dummy = sys.spawn([](event_based_actor*) -> behavior {
+    return {
+      [=](const std::string&) {},
+    };
+  });
+  SECTION("regular message") {
+    anon_mail("hello world").send(dummy);
+    expect<std::string>()
+      .with("hello world")
+      .priority(message_priority::normal)
+      .from(nullptr)
+      .to(dummy);
+  }
+  SECTION("urgent message") {
+    anon_mail("hello world").urgent().send(dummy);
+    expect<std::string>()
+      .with("hello world")
+      .priority(message_priority::high)
+      .from(nullptr)
+      .to(dummy);
+  }
+  SECTION("invalid receiver") {
+    anon_mail("hello world").urgent().send(actor{});
+    check_eq(mail_count(), 0u);
+  }
+}
+
+TEST("send delayed message") {
+  auto dummy = sys.spawn([](event_based_actor*) -> behavior {
+    return {
+      [=](const std::string&) {},
+    };
+  });
+  SECTION("regular message") {
+    SECTION("strong reference to the receiver") {
+      anon_mail("hello world").delay(1s).send(dummy);
+      check_eq(mail_count(), 0u);
+      check_eq(num_timeouts(), 1u);
+      trigger_timeout();
+      expect<std::string>()
+        .with("hello world")
+        .priority(message_priority::normal)
+        .from(nullptr)
+        .to(dummy);
+    }
+    SECTION("weak reference to the receiver") {
+      anon_mail("hello world").delay(1s).send(dummy, weak_ref);
+      check_eq(mail_count(), 0u);
+      check_eq(num_timeouts(), 1u);
+      trigger_timeout();
+      expect<std::string>()
+        .with("hello world")
+        .priority(message_priority::normal)
+        .from(nullptr)
+        .to(dummy);
+    }
+  }
+  SECTION("urgent message") {
+    SECTION("strong reference to the receiver") {
+      anon_mail("hello world").urgent().delay(1s).send(dummy, strong_ref);
+      check_eq(mail_count(), 0u);
+      check_eq(num_timeouts(), 1u);
+      trigger_timeout();
+      expect<std::string>()
+        .with("hello world")
+        .priority(message_priority::high)
+        .from(nullptr)
+        .to(dummy);
+    }
+    SECTION("weak reference to the receiver") {
+      anon_mail("hello world").urgent().delay(1s).send(dummy, weak_ref);
+      check_eq(mail_count(), 0u);
+      check_eq(num_timeouts(), 1u);
+      trigger_timeout();
+      expect<std::string>()
+        .with("hello world")
+        .priority(message_priority::high)
+        .from(nullptr)
+        .to(dummy);
+    }
+    SECTION("invalid receiver") {
+      anon_mail("hello world").delay(1s).send(actor{});
+      check_eq(mail_count(), 0u);
+    }
+  }
+}
+
+TEST("implicit cancel of a delayed message") {
+  auto dummy = sys.spawn([](event_based_actor*) -> behavior {
+    return {
+      [=](const std::string&) {},
+    };
+  });
+  anon_mail("hello world").delay(1s).send(dummy, weak_ref);
+  dummy = nullptr;
+  check_eq(mail_count(), 0u);
+  check_eq(num_timeouts(), 1u);
+  trigger_timeout();
+  check_eq(mail_count(), 0u);
+  check_eq(num_timeouts(), 0u);
+}
+
+TEST("explicit cancel of a delayed message") {
+  auto dummy = sys.spawn([](event_based_actor*) -> behavior {
+    return {
+      [=](const std::string&) {},
+    };
+  });
+  SECTION("strong reference to the receiver") {
+    auto hdl = anon_mail("hello world").delay(1s).send(dummy, strong_ref);
+    check_eq(mail_count(), 0u);
+    check_eq(num_timeouts(), 1u);
+    hdl.dispose();
+    trigger_timeout();
+    check_eq(mail_count(), 0u);
+    check_eq(num_timeouts(), 0u);
+  }
+  SECTION("weak reference to the receiver") {
+    auto hdl = anon_mail("hello world").delay(1s).send(dummy, weak_ref);
+    check_eq(mail_count(), 0u);
+    check_eq(num_timeouts(), 1u);
+    hdl.dispose();
+    trigger_timeout();
+    check_eq(mail_count(), 0u);
+    check_eq(num_timeouts(), 0u);
+  }
+}
+
+} // WITH_FIXTURE(test::fixture::deterministic)
+
+} // namespace

--- a/libcaf_core/caf/anon_mail.test.cpp
+++ b/libcaf_core/caf/anon_mail.test.cpp
@@ -66,7 +66,9 @@ TEST("send delayed message") {
         .to(dummy);
     }
     SECTION("weak reference to the receiver") {
-      anon_mail("hello world").delay(1s).send(dummy, weak_ref);
+      anon_mail("hello world")
+        .schedule(sys.clock().now() + 1s)
+        .send(dummy, weak_ref);
       check_eq(mail_count(), 0u);
       check_eq(num_timeouts(), 1u);
       trigger_timeout();

--- a/libcaf_core/caf/message.hpp
+++ b/libcaf_core/caf/message.hpp
@@ -12,6 +12,7 @@
 #include "caf/fwd.hpp"
 #include "caf/intrusive_cow_ptr.hpp"
 #include "caf/raise_error.hpp"
+#include "caf/type_id.hpp"
 
 #include <sstream>
 #include <tuple>

--- a/libcaf_core/caf/message_id.hpp
+++ b/libcaf_core/caf/message_id.hpp
@@ -104,6 +104,12 @@ public:
     return category() == normal_message_category;
   }
 
+  /// Returns the priority part from the `category()`.
+  constexpr message_priority priority() const noexcept {
+    return is_urgent_message() ? message_priority::high
+                               : message_priority::normal;
+  }
+
   /// Returns a response ID for the current request or an asynchronous ID with
   /// the same priority as this ID.
   constexpr message_id response_id() const noexcept {

--- a/libcaf_core/caf/ref.hpp
+++ b/libcaf_core/caf/ref.hpp
@@ -1,0 +1,52 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/fwd.hpp"
+
+namespace caf {
+
+/// Tag type to indicate that the system should keep a strong reference to an
+/// actor.
+struct strong_ref_t {
+  using handle_type = strong_actor_ptr;
+};
+
+/// Tag to indicate that the system should keep a weak reference to an actor.
+inline constexpr strong_ref_t strong_ref = {};
+
+/// Tag type to indicate that the system should keep a weak reference to an
+/// actor.
+struct weak_ref_t {
+  using handle_type = weak_actor_ptr;
+};
+
+/// Tag to indicate that the system should keep a weak reference to an actor.
+inline constexpr weak_ref_t weak_ref = {};
+
+namespace detail {
+
+template <class T>
+struct is_ref_tag_oracle {
+  static constexpr bool value = false;
+};
+
+template <>
+struct is_ref_tag_oracle<strong_ref_t> {
+  static constexpr bool value = true;
+};
+
+template <>
+struct is_ref_tag_oracle<weak_ref_t> {
+  static constexpr bool value = true;
+};
+
+} // namespace detail
+
+/// Evaluates to `true` if `T` is either `strong_ref_t` or `weak_ref_t`.
+template <class T>
+inline constexpr bool is_ref_tag = detail::is_ref_tag_oracle<T>::value;
+
+} // namespace caf

--- a/libcaf_test/caf/test/fixture/deterministic.hpp
+++ b/libcaf_test/caf/test/fixture/deterministic.hpp
@@ -265,6 +265,11 @@ public:
       return std::move(*this);
     }
 
+    evaluator&& priority(message_priority priority) && {
+      priority_ = priority;
+      return std::move(*this);
+    }
+
     /// Sets the target actor for this evaluator and evaluate the predicate.
     template <class T>
     bool to(const T& dst) && {
@@ -308,6 +313,13 @@ public:
           ctx.fail({"no matching message found", loc_});
         return false;
       }
+      if (priority_) {
+        if (event->item->mid.priority() != *priority_) {
+          if (fail_on_mismatch)
+            ctx.fail({"message priority does not match", loc_});
+          return false;
+        }
+      }
       fix_->prepone_event_impl(dst);
       if (fail_on_mismatch) {
         if (!fix_->dispatch_message())
@@ -334,6 +346,7 @@ public:
     evaluator_algorithm algo_;
     actor_predicate from_;
     message_predicate<Ts...> with_;
+    std::optional<message_priority> priority_;
   };
 
   /// Utility class for injecting messages into the mailbox of an actor and then


### PR DESCRIPTION
First chunk for the new `mail` API. The anonymous messages are the simplest DSL, but the other pieces will follow the same template.

Relates #1745.