### PR TITLE
Implement new event_based_mail DSL

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ config = [
         'CAF_ENABLE_RUNTIME_CHECKS:BOOL=ON',
     ],
     // Our build matrix. Keys are the operating system labels and values are build configurations.
+    // Note on no-maybe-uninitialized: old GCC versions have a weird bug that causes false positives.
     buildMatrix: [
         // Release builds.
         ['almalinux-8', [ // EOL: June 2029
@@ -28,7 +29,7 @@ config = [
             tags: ['docker'],
             builds: ['release'],
             extraBuildFlags: [
-                'CMAKE_CXX_FLAGS:STRING=-Werror',
+                'CMAKE_CXX_FLAGS:STRING=-Werror -Wno-maybe-uninitialized',
             ],
         ]],
         ['almalinux-9', [ // EOL: May 2032
@@ -52,7 +53,7 @@ config = [
             tags: ['docker'],
             builds: ['release'],
             extraBuildFlags: [
-                'CMAKE_CXX_FLAGS:STRING=-Werror',
+                'CMAKE_CXX_FLAGS:STRING=-Werror -Wno-maybe-uninitialized',
             ],
         ]],
         ['debian-10', [ // EOL June 2024
@@ -60,7 +61,7 @@ config = [
             tags: ['docker'],
             builds: ['release'],
             extraBuildFlags: [
-                'CMAKE_CXX_FLAGS:STRING=-Werror',
+                'CMAKE_CXX_FLAGS:STRING=-Werror -Wno-maybe-uninitialized',
             ],
         ]],
         ['debian-11', [ // EOL June 2026
@@ -68,7 +69,7 @@ config = [
             tags: ['docker'],
             builds: ['release'],
             extraBuildFlags: [
-                'CMAKE_CXX_FLAGS:STRING=-Werror',
+                'CMAKE_CXX_FLAGS:STRING=-Werror -Wno-maybe-uninitialized',
             ],
         ]],
         ['fedora-38', [ // EOL June 2024

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -202,6 +202,7 @@ caf_add_component(
     caf/error.test.cpp
     caf/event_based_actor.cpp
     caf/event_based_actor.test.cpp
+    caf/event_based_mail.test.cpp
     caf/execution_unit.cpp
     caf/expected.test.cpp
     caf/flow/concat_map.test.cpp

--- a/libcaf_core/caf/abstract_actor.hpp
+++ b/libcaf_core/caf/abstract_actor.hpp
@@ -196,6 +196,9 @@ public:
   /// set a new behavior.
   static constexpr int is_shutting_down_flag = 0b0001'0000'0000;
 
+  /// Indicates that the actor is currently inactive.
+  static constexpr int is_inactive_flag = 0b0010'0000'0000;
+
   void setf(int flag) {
     auto x = flags();
     flags(x | flag);

--- a/libcaf_core/caf/actor_companion.hpp
+++ b/libcaf_core/caf/actor_companion.hpp
@@ -72,6 +72,7 @@ public:
 
   // -- messaging --------------------------------------------------------------
 
+  /// Starts a new message.
   template <class... Args>
   [[nodiscard]] auto mail(Args&&... args) {
     return async_mail(dynamically_typed{}, this, std::forward<Args>(args)...);

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -610,6 +610,7 @@ public:
                   "only scheduled actors may get spawned inactively");
     CAF_SET_LOGGER_SYS(this);
     actor_config cfg{dummy_execution_unit(), nullptr};
+    cfg.flags = abstract_actor::is_inactive_flag;
     if constexpr (has_detach_flag(Os))
       cfg.flags |= abstract_actor::is_detached_flag;
     if constexpr (has_hide_flag(Os))
@@ -624,8 +625,9 @@ public:
     auto launch = [strong_ptr = std::move(res), host{cfg.host}] {
       // Note: we pass `res` to this lambda instead of `ptr` to keep a strong
       //       reference to the actor.
-      static_cast<Impl*>(actor_cast<abstract_actor*>(strong_ptr))
-        ->launch(host, has_lazy_init_flag(Os), has_hide_flag(Os));
+      auto dptr = static_cast<Impl*>(actor_cast<abstract_actor*>(strong_ptr));
+      dptr->unsetf(abstract_actor::is_inactive_flag);
+      dptr->launch(host, has_lazy_init_flag(Os), has_hide_flag(Os));
     };
     return std::make_tuple(ptr, launcher<decltype(launch)>(std::move(launch)));
   }

--- a/libcaf_core/caf/detail/type_traits.hpp
+++ b/libcaf_core/caf/detail/type_traits.hpp
@@ -319,6 +319,7 @@ template <class T,
                        || std::is_member_function_pointer_v<T>,
           bool HasApplyOp = has_apply_operator<T>::value>
 struct get_callable_trait_helper {
+  static constexpr bool valid = true;
   using type = callable_trait<T>;
   using result_type = typename type::result_type;
   using arg_types = typename type::arg_types;
@@ -330,6 +331,7 @@ struct get_callable_trait_helper {
 // assume functor providing operator()
 template <class T>
 struct get_callable_trait_helper<T, false, true> {
+  static constexpr bool valid = true;
   using type = callable_trait<decltype(&T::operator())>;
   using result_type = typename type::result_type;
   using arg_types = typename type::arg_types;
@@ -339,7 +341,9 @@ struct get_callable_trait_helper<T, false, true> {
 };
 
 template <class T>
-struct get_callable_trait_helper<T, false, false> {};
+struct get_callable_trait_helper<T, false, false> {
+  static constexpr bool valid = false;
+};
 
 /// Gets a callable trait for `T,` where `T` is a function object type,
 /// i.e., a function, member function, or a class providing

--- a/libcaf_core/caf/event_based_actor.hpp
+++ b/libcaf_core/caf/event_based_actor.hpp
@@ -6,6 +6,8 @@
 
 #include "caf/actor_traits.hpp"
 #include "caf/detail/core_export.hpp"
+#include "caf/dynamically_typed.hpp"
+#include "caf/event_based_mail.hpp"
 #include "caf/extend.hpp"
 #include "caf/fwd.hpp"
 #include "caf/keep_behavior.hpp"
@@ -47,6 +49,15 @@ public:
   // -- overridden functions of local_actor ------------------------------------
 
   void initialize() override;
+
+  // -- messaging --------------------------------------------------------------
+
+  /// Starts a new message.
+  template <class... Args>
+  auto mail(Args&&... args) {
+    return event_based_mail(dynamically_typed{}, this,
+                            std::forward<Args>(args)...);
+  }
 
   // -- behavior management ----------------------------------------------------
 

--- a/libcaf_core/caf/event_based_mail.hpp
+++ b/libcaf_core/caf/event_based_mail.hpp
@@ -1,0 +1,142 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/async_mail.hpp"
+#include "caf/event_based_response_handle.hpp"
+#include "caf/scheduled_actor.hpp"
+
+namespace caf {
+
+/// Provides a fluent interface for sending asynchronous messages to actors at a
+/// specific point in time.
+template <message_priority Priority, class Trait, class... Args>
+class event_based_scheduled_mail_t
+  : public async_scheduled_mail_t<Priority, Trait, Args...> {
+public:
+  using super = async_scheduled_mail_t<Priority, Trait, Args...>;
+
+  event_based_scheduled_mail_t(scheduled_actor* self, message&& content,
+                               actor_clock::time_point timeout)
+    : super(self, std::move(content), timeout) {
+    // nop
+  }
+
+  /// Sends the message to `receiver` as a request message and returns a handle
+  /// for processing the response.
+  /// @param receiver The actor that should receive the message.
+  /// @param ref_tag Either `strong_ref` or `weak_ref`. When passing
+  ///                `strong_ref`, the system will keep a strong reference to
+  ///                the receiver until the message has been delivered.
+  ///                Otherwise, the system will only keep a weak reference to
+  ///                the receiver and the message will be dropped if the
+  ///                receiver has been garbage collected in the meantime.
+  /// @param self_ref_tag Either `strong_self_ref` or `weak_self_ref`. When
+  ///                     passing `strong_self_ref`, the system will keep a
+  ///                     strong reference to the sender until the message has
+  ///                     been delivered. Otherwise, the system will only keep
+  ///                     a weak reference to the sender and the message will be
+  ///                     dropped if the sender has been garbage collected in
+  ///                     the meantime.
+  template <class Handle, class RefTag = strong_ref_t,
+            class SelfRefTag = strong_self_ref_t>
+  [[nodiscard]] auto request(const Handle& receiver, RefTag ref_tag = {},
+                             SelfRefTag self_ref_tag = {}) && {
+    detail::send_type_check<typename Trait::signatures, Handle, Args...>();
+    using response_type = response_type_t<typename Handle::signatures, Args...>;
+    auto mid = self()->new_request_id(Priority);
+    disposable in_flight;
+    if (receiver) {
+      auto& clock = self()->clock();
+      in_flight = clock.schedule_message(actor_cast(super::self_, self_ref_tag),
+                                         actor_cast(receiver, ref_tag),
+                                         super::timeout_, mid,
+                                         std::move(super::content_));
+
+    } else {
+      self()->enqueue(make_mailbox_element(self()->ctrl(), mid.response_id(),
+                                           make_error(sec::invalid_request)),
+                      self()->context());
+    }
+    auto hdl = event_based_response_handle<response_type>{self(),
+                                                          mid.response_id()};
+    return std::pair{std::move(hdl), std::move(in_flight)};
+  }
+
+private:
+  scheduled_actor* self() {
+    return static_cast<scheduled_actor*>(super::self_);
+  }
+};
+
+/// Provides a fluent interface for sending asynchronous messages to actors.
+template <message_priority Priority, class Trait, class... Args>
+class event_based_mail_t : public async_mail_base_t<Priority, Trait, Args...> {
+public:
+  using super = async_mail_base_t<Priority, Trait, Args...>;
+
+  event_based_mail_t(scheduled_actor* self, message&& content)
+    : super(self, std::move(content)) {
+    // nop
+  }
+
+  /// Tags the message as urgent, i.e., sends it with high priority.
+  template <message_priority P = Priority,
+            class E = std::enable_if_t<P == message_priority::normal>>
+  [[nodiscard]] auto urgent() && {
+    using result_t = event_based_mail_t<message_priority::high, Trait, Args...>;
+    return result_t{self(), std::move(super::content_)};
+  }
+
+  /// Schedules the message for delivery with an absolute timeout.
+  [[nodiscard]] auto schedule(actor_clock::time_point timeout) && {
+    using result_t = event_based_scheduled_mail_t<Priority, Trait, Args...>;
+    return result_t{self(), std::move(super::content_), timeout};
+  }
+
+  /// Schedules the message for delivery with a relative timeout.
+  [[nodiscard]] auto delay(actor_clock::duration_type timeout) && {
+    using clock = actor_clock::clock_type;
+    using result_t = event_based_scheduled_mail_t<Priority, Trait, Args...>;
+    return result_t{self(), std::move(super::content_), clock::now() + timeout};
+  }
+
+  /// Sends the message to `receiver` as a request message and returns a handle
+  /// for processing the response.
+  template <class Handle>
+  [[nodiscard]] auto request(const Handle& receiver) && {
+    detail::send_type_check<typename Trait::signatures, Handle, Args...>();
+    using response_type = response_type_t<typename Handle::signatures, Args...>;
+    auto mid = self()->new_request_id(Priority);
+    if (receiver) {
+      auto* ptr = actor_cast<abstract_actor*>(receiver);
+      ptr->enqueue(make_mailbox_element(self()->ctrl(), mid,
+                                        std::move(super::content_)),
+                   self()->context());
+    } else {
+      self()->enqueue(make_mailbox_element(self()->ctrl(), mid.response_id(),
+                                           make_error(sec::invalid_request)),
+                      self()->context());
+    }
+    return event_based_response_handle<response_type>{self(),
+                                                      mid.response_id()};
+  }
+
+private:
+  scheduled_actor* self() {
+    return static_cast<scheduled_actor*>(super::self_);
+  }
+};
+
+/// Entry point for sending an event-based message to an actor.
+template <class Trait, class... Args>
+[[nodiscard]] auto
+event_based_mail(Trait, scheduled_actor* self, Args&&... args) {
+  using result_t = event_based_mail_t<message_priority::normal, Trait,
+                                      detail::strip_and_convert_t<Args>...>;
+  return result_t{self, make_message(std::forward<Args>(args)...)};
+}
+
+} // namespace caf

--- a/libcaf_core/caf/event_based_mail.test.cpp
+++ b/libcaf_core/caf/event_based_mail.test.cpp
@@ -1,0 +1,289 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/event_based_mail.hpp"
+
+#include "caf/test/fixture/deterministic.hpp"
+#include "caf/test/test.hpp"
+
+#include "caf/dynamically_typed.hpp"
+#include "caf/event_based_actor.hpp"
+#include "caf/typed_event_based_actor.hpp"
+
+// Note: functions inherited from async_mail are tested in async_mail.test.cpp.
+
+using namespace caf;
+using namespace std::literals;
+
+namespace {
+
+using dummy_actor = typed_actor<result<int>(int)>;
+
+using dummy_behavior = dummy_actor::behavior_type;
+
+WITH_FIXTURE(test::fixture::deterministic) {
+
+TEST("send request message") {
+  auto [self, launch] = sys.spawn_inactive<event_based_actor>();
+  auto self_hdl = actor_cast<actor>(self);
+  SECTION("using .then for the response") {
+    SECTION("valid response") {
+      auto dummy = sys.spawn([]() -> dummy_behavior {
+        return {
+          [](int value) { return value * value; },
+        };
+      });
+      auto result = std::make_shared<int>(0);
+      SECTION("regular message") {
+        self->mail(3).request(dummy).then([result](int x) { *result = x; });
+        launch();
+        expect<int>()
+          .with(3)
+          .priority(message_priority::normal)
+          .from(self_hdl)
+          .to(dummy);
+        expect<int>()
+          .with(9)
+          .priority(message_priority::normal)
+          .from(dummy)
+          .to(self_hdl);
+        check_eq(*result, 9);
+      }
+      SECTION("urgent message") {
+        self->mail(3)
+          .urgent()
+          .request(dummy) //
+          .then([result](int x) { *result = x; });
+        launch();
+        expect<int>()
+          .with(3)
+          .priority(message_priority::high)
+          .from(self_hdl)
+          .to(dummy);
+        expect<int>()
+          .with(9)
+          .priority(message_priority::high)
+          .from(dummy)
+          .to(self_hdl);
+        check_eq(*result, 9);
+      }
+    }
+    SECTION("invalid response") {
+      auto dummy = sys.spawn([](event_based_actor*) -> behavior {
+        return {
+          [](int) { return "ok"s; },
+        };
+      });
+      auto result = std::make_shared<error>();
+      self->mail(3)
+        .request(dummy) //
+        .then([this](int value) { fail("expected a string, got: {}", value); },
+              [result](error& err) { *result = std::move(err); });
+      launch();
+      expect<int>()
+        .with(3)
+        .priority(message_priority::normal)
+        .from(self_hdl)
+        .to(dummy);
+      expect<std::string>()
+        .priority(message_priority::normal)
+        .from(dummy)
+        .to(self_hdl);
+      check_eq(*result, make_error(sec::unexpected_response));
+    }
+    SECTION("invalid receiver") {
+      auto result = std::make_shared<error>();
+      self->mail(3)
+        .request(actor{}) //
+        .then([this](int value) { fail("expected a string, got: {}", value); },
+              [result](error& err) { *result = std::move(err); });
+      check_eq(mail_count(), 1u);
+      launch();
+      expect<error>().to(self_hdl);
+      check_eq(*result, make_error(sec::invalid_request));
+    }
+  }
+  SECTION("using .await for the response") {
+    SECTION("valid response") {
+      auto dummy = sys.spawn([]() -> dummy_behavior {
+        return {
+          [](int value) { return value * value; },
+        };
+      });
+      auto result = std::make_shared<int>(0);
+      SECTION("regular message") {
+        self->mail(3).request(dummy).await([result](int x) { *result = x; });
+        launch();
+        expect<int>()
+          .with(3)
+          .priority(message_priority::normal)
+          .from(self_hdl)
+          .to(dummy);
+        expect<int>()
+          .with(9)
+          .priority(message_priority::normal)
+          .from(dummy)
+          .to(self_hdl);
+        check_eq(*result, 9);
+      }
+      SECTION("urgent message") {
+        self->mail(3)
+          .urgent()
+          .request(dummy) //
+          .await([result](int x) { *result = x; });
+        launch();
+        expect<int>()
+          .with(3)
+          .priority(message_priority::high)
+          .from(self_hdl)
+          .to(dummy);
+        expect<int>()
+          .with(9)
+          .priority(message_priority::high)
+          .from(dummy)
+          .to(self_hdl);
+        check_eq(*result, 9);
+      }
+    }
+    SECTION("invalid response") {
+      auto dummy = sys.spawn([](event_based_actor*) -> behavior {
+        return {
+          [](int) { return "ok"s; },
+        };
+      });
+      auto result = std::make_shared<error>();
+      self->mail(3)
+        .request(dummy) //
+        .await([this](int value) { fail("expected a string, got: {}", value); },
+               [result](error& err) { *result = std::move(err); });
+      launch();
+      expect<int>()
+        .with(3)
+        .priority(message_priority::normal)
+        .from(self_hdl)
+        .to(dummy);
+      expect<std::string>()
+        .priority(message_priority::normal)
+        .from(dummy)
+        .to(self_hdl);
+      check_eq(*result, make_error(sec::unexpected_response));
+    }
+    SECTION("invalid receiver") {
+      auto result = std::make_shared<error>();
+      self->mail(3)
+        .request(actor{}) //
+        .await([this](int value) { fail("expected a string, got: {}", value); },
+               [result](error& err) { *result = std::move(err); });
+      check_eq(mail_count(), 1u);
+      launch();
+      expect<error>().to(self_hdl);
+      check_eq(*result, make_error(sec::invalid_request));
+    }
+  }
+}
+
+TEST("send delayed request message") {
+  auto [self, launch] = sys.spawn_inactive<event_based_actor>();
+  auto self_hdl = actor_cast<actor>(self);
+  auto dummy = sys.spawn([]() -> dummy_behavior {
+    return {
+      [](int value) { return value * value; },
+    };
+  });
+  auto result = std::make_shared<int>(0);
+  auto on_result = [result](int value) { *result = value; };
+  SECTION("strong receiver reference") {
+    self->mail(3).delay(1s).request(dummy, strong_ref).first.then(on_result);
+    launch();
+    check_eq(mail_count(), 0u);
+    check_eq(num_timeouts(), 1u);
+    trigger_timeout();
+    expect<int>()
+      .with(3)
+      .priority(message_priority::normal)
+      .from(self_hdl)
+      .to(dummy);
+    expect<int>()
+      .with(9)
+      .priority(message_priority::normal)
+      .from(dummy)
+      .to(self_hdl);
+    check_eq(*result, 9);
+  }
+  SECTION("weak receiver reference") {
+    self->mail(3)
+      .schedule(sys.clock().now() + 1s)
+      .request(dummy, weak_ref)
+      .first.then(on_result);
+    launch();
+    check_eq(mail_count(), 0u);
+    check_eq(num_timeouts(), 1u);
+    trigger_timeout();
+    expect<int>()
+      .with(3)
+      .priority(message_priority::normal)
+      .from(self_hdl)
+      .to(dummy);
+    expect<int>()
+      .with(9)
+      .priority(message_priority::normal)
+      .from(dummy)
+      .to(self_hdl);
+    check_eq(*result, 9);
+  }
+  SECTION("weak receiver reference that expires") {
+    self->mail(3)
+      .schedule(sys.clock().now() + 1s)
+      .request(dummy, weak_ref)
+      .first.then(on_result);
+    launch();
+    check_eq(mail_count(), 0u);
+    check_eq(num_timeouts(), 1u);
+    dummy = nullptr;
+    trigger_timeout();
+    expect<error>().with(make_error(sec::request_receiver_down)).to(self_hdl);
+  }
+  SECTION("weak sender reference that expires") {
+    self->mail(3)
+      .schedule(sys.clock().now() + 1s)
+      .request(dummy, strong_ref, weak_self_ref)
+      .first.then(on_result);
+    launch();
+    check_eq(mail_count(), 0u);
+    check_eq(num_timeouts(), 1u);
+    self_hdl = nullptr;
+    trigger_timeout();
+    check_eq(mail_count(), 0u);
+    check_eq(num_timeouts(), 0u);
+  }
+}
+
+TEST("send request message as a typed actor") {
+  using sender_actor = typed_actor<result<void>(int)>;
+  auto dummy = sys.spawn([]() -> dummy_behavior {
+    return {
+      [](int value) { return value * value; },
+    };
+  });
+  auto [self, launch] = sys.spawn_inactive<sender_actor::impl>();
+  auto self_hdl = actor_cast<actor>(self);
+  auto result = std::make_shared<int>(0);
+  self->mail(3).request(dummy).then([result](int x) { *result = x; });
+  launch();
+  expect<int>()
+    .with(3)
+    .priority(message_priority::normal)
+    .from(self_hdl)
+    .to(dummy);
+  expect<int>()
+    .with(9)
+    .priority(message_priority::normal)
+    .from(dummy)
+    .to(self_hdl);
+  check_eq(*result, 9);
+}
+
+} // WITH_FIXTURE(test::fixture::deterministic)
+
+} // namespace

--- a/libcaf_core/caf/event_based_mail.test.cpp
+++ b/libcaf_core/caf/event_based_mail.test.cpp
@@ -284,6 +284,39 @@ TEST("send request message as a typed actor") {
   check_eq(*result, 9);
 }
 
+TEST("send request message to an invalid receiver") {
+  auto dummy = sys.spawn([]() -> dummy_behavior {
+    return {
+      [](int value) { return value * value; },
+    };
+  });
+  auto [self, launch] = sys.spawn_inactive<event_based_actor>();
+  auto self_hdl = actor_cast<actor>(self);
+  auto result = std::make_shared<int>(0);
+  auto on_result = [result](int x) { *result = x; };
+  auto err = std::make_shared<error>();
+  auto on_error = [err](error x) { *err = x; };
+  SECTION("regular message") {
+    self->mail("hello world").request(actor{}).then(on_result, on_error);
+    launch();
+    expect<error>().with(make_error(sec::invalid_request)).to(self_hdl);
+    check_eq(*result, 0);
+    check_eq(*err, make_error(sec::invalid_request));
+  }
+  SECTION("delayed message") {
+    self->mail("hello world")
+      .delay(1s)
+      .request(actor{})
+      .first.then(on_result, on_error);
+    launch();
+    check_eq(mail_count(), 1u);
+    check_eq(num_timeouts(), 0u);
+    expect<error>().with(make_error(sec::invalid_request)).to(self_hdl);
+    check_eq(*result, 0);
+    check_eq(*err, make_error(sec::invalid_request));
+  }
+}
+
 } // WITH_FIXTURE(test::fixture::deterministic)
 
 } // namespace

--- a/libcaf_core/caf/event_based_response_handle.hpp
+++ b/libcaf_core/caf/event_based_response_handle.hpp
@@ -1,0 +1,100 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/actor_traits.hpp"
+#include "caf/catch_all.hpp"
+#include "caf/detail/type_list.hpp"
+#include "caf/detail/typed_actor_util.hpp"
+#include "caf/event_based_actor.hpp"
+#include "caf/flow/fwd.hpp"
+#include "caf/message_id.hpp"
+#include "caf/none.hpp"
+#include "caf/scheduled_actor.hpp"
+#include "caf/sec.hpp"
+#include "caf/system_messages.hpp"
+#include "caf/typed_behavior.hpp"
+
+#include <type_traits>
+
+namespace caf {
+
+/// This helper class identifies an expected response message and enables
+/// `request(...).then(...)`.
+template <class Result>
+class event_based_response_handle {
+public:
+  // -- constructors, destructors, and assignment operators --------------------
+
+  event_based_response_handle(scheduled_actor* self, message_id mid)
+    : self_(self), mid_(mid) {
+    // nop
+  }
+
+  template <class OnValue, class OnError>
+  void await(OnValue on_value, OnError on_error) && {
+    type_check<OnValue, OnError>();
+    auto bhvr = behavior{std::move(on_value), std::move(on_error)};
+    self_->add_awaited_response_handler(mid_, std::move(bhvr));
+  }
+
+  template <class OnValue>
+  void await(OnValue on_value) && {
+    return std::move(*this).await(std::move(on_value),
+                                  [self = self_](error& err) {
+                                    self->call_error_handler(err);
+                                  });
+  }
+
+  template <class OnValue, class OnError>
+  void then(OnValue on_value, OnError on_error) && {
+    type_check<OnValue, OnError>();
+    auto bhvr = behavior{std::move(on_value), std::move(on_error)};
+    self_->add_multiplexed_response_handler(mid_, std::move(bhvr));
+  }
+
+  template <class OnValue>
+  void then(OnValue on_value) && {
+    return std::move(*this).then(std::move(on_value),
+                                 [self = self_](error& err) {
+                                   self->call_error_handler(err);
+                                 });
+  }
+
+private:
+  template <class OnValue, class OnError>
+  static constexpr void type_check() {
+    // Type-check OnValue.
+    using on_value_trait_helper = typename detail::get_callable_trait<OnValue>;
+    static_assert(on_value_trait_helper::valid,
+                  "OnValue must provide a single, non-template operator()");
+    using on_value_trait = typename on_value_trait_helper::type;
+    static_assert(std::is_same_v<typename on_value_trait::result_type, void>,
+                  "OnValue must return void");
+    using on_value_args = typename on_value_trait::decayed_arg_types;
+    if constexpr (!std::is_same_v<Result, message>) {
+      static_assert(std::is_same_v<on_value_args, Result>,
+                    "OnValue does not match the expected response types");
+    }
+    // Type-check OnError.
+    using on_error_trait_helper = typename detail::get_callable_trait<OnError>;
+    static_assert(on_error_trait_helper::valid,
+                  "OnError must provide a single, non-template operator()");
+    using on_error_trait = typename on_error_trait_helper::type;
+    static_assert(std::is_same_v<typename on_error_trait::result_type, void>,
+                  "OnError must return void");
+    using on_error_args = typename on_error_trait::decayed_arg_types;
+    static_assert(std::is_same_v<on_error_args, detail::type_list<error>>,
+                  "OnError must accept a single argument of type caf::error");
+  }
+
+  /// Points to the parent actor.
+  scheduled_actor* self_;
+
+  /// Stores the ID of the message we are waiting for.
+  message_id mid_;
+};
+
+} // namespace caf

--- a/libcaf_core/caf/event_based_response_handle.hpp
+++ b/libcaf_core/caf/event_based_response_handle.hpp
@@ -4,18 +4,9 @@
 
 #pragma once
 
-#include "caf/actor_traits.hpp"
-#include "caf/catch_all.hpp"
 #include "caf/detail/type_list.hpp"
-#include "caf/detail/typed_actor_util.hpp"
-#include "caf/event_based_actor.hpp"
-#include "caf/flow/fwd.hpp"
 #include "caf/message_id.hpp"
-#include "caf/none.hpp"
 #include "caf/scheduled_actor.hpp"
-#include "caf/sec.hpp"
-#include "caf/system_messages.hpp"
-#include "caf/typed_behavior.hpp"
 
 #include <type_traits>
 

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -250,6 +250,11 @@ public:
     return getf(is_initialized_flag);
   }
 
+  /// Checks whether this actor is currently inactive, i.e., not ready to run.
+  bool inactive() const noexcept {
+    return getf(is_inactive_flag);
+  }
+
   // -- event handlers ---------------------------------------------------------
 
   /// Sets a custom handler for unexpected messages.

--- a/libcaf_core/caf/sec.hpp
+++ b/libcaf_core/caf/sec.hpp
@@ -167,6 +167,8 @@ enum class sec : uint8_t {
   logic_error,
   /// An actor tried to delegate a message to an invalid actor handle.
   invalid_delegate = 75,
+  /// An actor tried to delegate a message to an invalid actor handle.
+  invalid_request,
 };
 // --(rst-sec-end)--
 

--- a/libcaf_core/caf/typed_actor_view.hpp
+++ b/libcaf_core/caf/typed_actor_view.hpp
@@ -6,6 +6,7 @@
 
 #include "caf/actor_traits.hpp"
 #include "caf/config.hpp"
+#include "caf/event_based_mail.hpp"
 #include "caf/mixin/requester.hpp"
 #include "caf/mixin/sender.hpp"
 #include "caf/none.hpp"
@@ -37,6 +38,10 @@ public:
   using signatures = detail::type_list<Sigs...>;
 
   using pointer = scheduled_actor*;
+
+  struct trait {
+    using signatures = detail::type_list<Sigs...>;
+  };
 
   explicit typed_actor_view(scheduled_actor* ptr) : self_(ptr) {
     // nop
@@ -206,6 +211,14 @@ public:
   template <class Handle>
   void demonitor(const Handle& whom) {
     self_->demonitor(whom);
+  }
+
+  // -- messaging --------------------------------------------------------------
+
+  /// Starts a new message.
+  template <class... Args>
+  auto mail(Args&&... args) {
+    return event_based_mail(trait{}, self_, std::forward<Args>(args)...);
   }
 
   // -- sending asynchronous messages ------------------------------------------

--- a/libcaf_core/caf/typed_event_based_actor.hpp
+++ b/libcaf_core/caf/typed_event_based_actor.hpp
@@ -36,6 +36,10 @@ public:
 
   using actor_hdl = typed_actor<Sigs...>;
 
+  struct trait {
+    using signatures = detail::type_list<Sigs...>;
+  };
+
   // -- constructors, destructors, and assignment operators --------------------
 
   using super::super;
@@ -59,6 +63,14 @@ public:
       CAF_LOG_DEBUG("make_behavior() did return a valid behavior");
       this->do_become(std::move(bhvr.unbox()), true);
     }
+  }
+
+  // -- messaging --------------------------------------------------------------
+
+  /// Starts a new message.
+  template <class... Args>
+  auto mail(Args&&... args) {
+    return event_based_mail(trait{}, this, std::forward<Args>(args)...);
   }
 
   // -- behavior management ----------------------------------------------------

--- a/libcaf_test/caf/test/fixture/deterministic.cpp
+++ b/libcaf_test/caf/test/fixture/deterministic.cpp
@@ -474,7 +474,7 @@ protected:
         // Actors put their messages into events_ directly. However, we do run
         // them right away if they aren't initialized yet.
         auto dptr = static_cast<scheduled_actor*>(ptr);
-        if (!dptr->initialized())
+        if (!dptr->initialized() && !dptr->inactive())
           dptr->resume(system_.dummy_execution_unit(), 0);
         break;
       }


### PR DESCRIPTION
The `event_based_mail` API supports asynchronous messages (by extending the `async_mail` DSL) and `request` for event-based actors.

The new DSL also implements a new `event_based_response_handle` type instead of re-using the existing response handle type. This is in preparation of discontinuing the previous response handle type, which we want to get rid of since it became too complex over the years.

The new response handle does not implement `to_observable()` yet, this is going to be a followup.

Relates #1745.