### PR TITLE
Lift type_list from detail to general namespace

### DIFF
--- a/libcaf_core/caf/actor_factory.hpp
+++ b/libcaf_core/caf/actor_factory.hpp
@@ -28,8 +28,7 @@ template <class F, class T, class Bhvr, spawn_mode Mode, class R, class Sig>
 class fun_decorator;
 
 template <class F, class T, class Bhvr, class R, class... Ts>
-class fun_decorator<F, T, Bhvr, spawn_mode::function, R,
-                    detail::type_list<Ts...>> {
+class fun_decorator<F, T, Bhvr, spawn_mode::function, R, type_list<Ts...>> {
 public:
   fun_decorator(F f, T*, behavior* bhvr) : f_(std::move(f)), bhvr_(bhvr) {
     // nop
@@ -51,7 +50,7 @@ private:
 
 template <class F, class T, class Bhvr, class R, class... Ts>
 class fun_decorator<F, T, Bhvr, spawn_mode::function_with_selfptr, R,
-                    detail::type_list<T*, Ts...>> {
+                    type_list<T*, Ts...>> {
 public:
   fun_decorator(F f, T* ptr, behavior* bhvr)
     : f_(std::move(f)), ptr_(ptr), bhvr_(bhvr) {
@@ -77,7 +76,7 @@ template <spawn_mode Mode, class Args>
 struct message_verifier;
 
 template <class... Ts>
-struct message_verifier<spawn_mode::function, detail::type_list<Ts...>> {
+struct message_verifier<spawn_mode::function, type_list<Ts...>> {
   bool operator()(message& msg) {
     return msg.types() == make_type_id_list<Ts...>();
   }
@@ -85,7 +84,7 @@ struct message_verifier<spawn_mode::function, detail::type_list<Ts...>> {
 
 template <class Self, class... Ts>
 struct message_verifier<spawn_mode::function_with_selfptr,
-                        detail::type_list<Self*, Ts...>> {
+                        type_list<Self*, Ts...>> {
   bool operator()(message& msg) {
     return msg.types() == make_type_id_list<Ts...>();
   }

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -253,12 +253,12 @@ public:
   using mpi = std::set<std::string>;
 
   template <class T, class E = std::enable_if_t<!is_typed_actor_v<T>>>
-  mpi message_types(detail::type_list<T>) const {
+  mpi message_types(type_list<T>) const {
     return mpi{};
   }
 
   template <class... Ts>
-  mpi message_types(detail::type_list<typed_actor<Ts...>>) const {
+  mpi message_types(type_list<typed_actor<Ts...>>) const {
     static_assert(sizeof...(Ts) > 0, "empty typed actor handle given");
     mpi result{detail::get_rtti_from_mpi<Ts>()...};
     return result;
@@ -266,7 +266,7 @@ public:
 
   template <class T, class E = std::enable_if_t<!detail::is_type_list_v<T>>>
   mpi message_types(const T&) const {
-    detail::type_list<T> token;
+    type_list<T> token;
     return message_types(token);
   }
 
@@ -274,7 +274,7 @@ public:
   /// interface using portable names;
   template <class T>
   mpi message_types() const {
-    detail::type_list<T> token;
+    type_list<T> token;
     return message_types(token);
   }
 

--- a/libcaf_core/caf/actor_system_config.hpp
+++ b/libcaf_core/caf/actor_system_config.hpp
@@ -139,7 +139,7 @@ public:
   actor_system_config& load() {
     T::add_module_options(*this);
     module_factories.push_back([](actor_system& sys) -> actor_system::module* {
-      return T::make(sys, detail::type_list<Ts...>{});
+      return T::make(sys, type_list<Ts...>{});
     });
     return *this;
   }

--- a/libcaf_core/caf/behavior.hpp
+++ b/libcaf_core/caf/behavior.hpp
@@ -6,7 +6,6 @@
 
 #include "caf/detail/behavior_impl.hpp"
 #include "caf/detail/core_export.hpp"
-#include "caf/detail/type_list.hpp"
 #include "caf/detail/type_traits.hpp"
 #include "caf/none.hpp"
 #include "caf/timeout_definition.hpp"

--- a/libcaf_core/caf/config_value.hpp
+++ b/libcaf_core/caf/config_value.hpp
@@ -84,8 +84,8 @@ public:
 
   using dictionary = caf::dictionary<config_value>;
 
-  using types = detail::type_list<none_t, integer, boolean, real, timespan, uri,
-                                  string, list, dictionary>;
+  using types = type_list<none_t, integer, boolean, real, timespan, uri, string,
+                          list, dictionary>;
 
   using variant_type = detail::tl_apply_t<types, std::variant>;
 

--- a/libcaf_core/caf/const_typed_message_view.hpp
+++ b/libcaf_core/caf/const_typed_message_view.hpp
@@ -48,7 +48,7 @@ private:
 template <size_t Index, class... Ts>
 const auto& get(const_typed_message_view<Ts...> xs) {
   static_assert(Index < sizeof...(Ts));
-  using type = caf::detail::tl_at_t<caf::detail::type_list<Ts...>, Index>;
+  using type = caf::detail::tl_at_t<caf::type_list<Ts...>, Index>;
   return *reinterpret_cast<const type*>(xs->storage()
                                         + detail::offset_at<Index, Ts...>);
 }

--- a/libcaf_core/caf/detail/functor_attachable.hpp
+++ b/libcaf_core/caf/detail/functor_attachable.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "caf/attachable.hpp"
-#include "caf/detail/type_list.hpp"
 #include "caf/detail/type_traits.hpp"
 
 namespace caf::detail {

--- a/libcaf_core/caf/detail/int_list.hpp
+++ b/libcaf_core/caf/detail/int_list.hpp
@@ -4,7 +4,9 @@
 
 #pragma once
 
-#include "caf/detail/type_list.hpp"
+#include "caf/type_list.hpp"
+
+#include <cstddef>
 
 namespace caf::detail {
 

--- a/libcaf_core/caf/detail/mtl_util.hpp
+++ b/libcaf_core/caf/detail/mtl_util.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include "caf/actor.hpp"
-#include "caf/detail/type_list.hpp"
 #include "caf/fwd.hpp"
+#include "caf/type_list.hpp"
 
 #include <type_traits>
 

--- a/libcaf_core/caf/detail/send_type_check.hpp
+++ b/libcaf_core/caf/detail/send_type_check.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include "caf/detail/implicit_conversions.hpp"
-#include "caf/detail/type_list.hpp"
 #include "caf/response_type.hpp"
+#include "caf/type_list.hpp"
 
 #include <type_traits>
 
@@ -25,7 +25,7 @@ constexpr void send_type_check() {
   static_assert((detail::sendable<Ts> && ...),
                 "at least one type has no ID, "
                 "did you forgot to announce it via CAF_ADD_TYPE_ID?");
-  using inputs = detail::type_list<detail::strip_and_convert_t<Ts>...>;
+  using inputs = type_list<detail::strip_and_convert_t<Ts>...>;
   using response_opt = response_type_unbox<signatures_of_t<Handle>, inputs>;
   static_assert(response_opt::valid, "receiver does not accept given message");
   if constexpr (!std::is_same_v<SenderInterface, none_t>) {

--- a/libcaf_core/caf/detail/type_list.hpp
+++ b/libcaf_core/caf/detail/type_list.hpp
@@ -6,6 +6,7 @@
 
 #include "caf/fwd.hpp"
 #include "caf/none.hpp"
+#include "caf/type_list.hpp"
 #include "caf/unit.hpp"
 
 #include <cstddef>
@@ -13,14 +14,6 @@
 #include <typeinfo>
 
 namespace caf::detail {
-
-/// A list of types.
-template <class... Ts>
-struct type_list {
-  constexpr type_list() {
-    // nop
-  }
-};
 
 /// Denotes the empty list.
 using empty_type_list = type_list<>;

--- a/libcaf_core/caf/event_based_response_handle.hpp
+++ b/libcaf_core/caf/event_based_response_handle.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "caf/detail/type_list.hpp"
 #include "caf/message_id.hpp"
 #include "caf/scheduled_actor.hpp"
+#include "caf/type_list.hpp"
 
 #include <type_traits>
 
@@ -77,7 +77,7 @@ private:
     static_assert(std::is_same_v<typename on_error_trait::result_type, void>,
                   "OnError must return void");
     using on_error_args = typename on_error_trait::decayed_arg_types;
-    static_assert(std::is_same_v<on_error_args, detail::type_list<error>>,
+    static_assert(std::is_same_v<on_error_args, type_list<error>>,
                   "OnError must accept a single argument of type caf::error");
   }
 

--- a/libcaf_core/caf/exec_main.hpp
+++ b/libcaf_core/caf/exec_main.hpp
@@ -18,7 +18,7 @@ template <class>
 struct exec_main_helper;
 
 template <class System>
-struct exec_main_helper<detail::type_list<System&>> {
+struct exec_main_helper<type_list<System&>> {
   using config = actor_system_config;
 
   template <class F>
@@ -28,7 +28,7 @@ struct exec_main_helper<detail::type_list<System&>> {
 };
 
 template <class System, class Config>
-struct exec_main_helper<detail::type_list<System&, const Config&>> {
+struct exec_main_helper<type_list<System&, const Config&>> {
   using config = Config;
 
   template <class F>
@@ -128,7 +128,7 @@ auto do_init_host_system(type_list<Module...>, type_list<T, Ts...>) {
 #define CAF_MAIN(...)                                                          \
   int main(int argc, char** argv) {                                            \
     [[maybe_unused]] auto host_init_guard = caf::detail::do_init_host_system(  \
-      caf::detail::type_list<>{}, caf::detail::type_list<__VA_ARGS__>{});      \
+      caf::type_list<>{}, caf::type_list<__VA_ARGS__>{});                      \
     caf::exec_main_init_meta_objects<__VA_ARGS__>();                           \
     caf::core::init_global_meta_objects();                                     \
     return caf::exec_main<__VA_ARGS__>(caf_main, argc, argv);                  \

--- a/libcaf_core/caf/flow/op/from_generator.hpp
+++ b/libcaf_core/caf/flow/op/from_generator.hpp
@@ -131,9 +131,9 @@ private:
 };
 
 template <class Generator, class... Steps>
-using from_generator_output_t =            //
-  typename detail::tl_back_t<              //
-    detail::type_list<Generator, Steps...> //
+using from_generator_output_t =    //
+  typename detail::tl_back_t<      //
+    type_list<Generator, Steps...> //
     >::output_type;
 
 /// Converts a `Generator` to an @ref observable.

--- a/libcaf_core/caf/flow/op/from_steps.hpp
+++ b/libcaf_core/caf/flow/op/from_steps.hpp
@@ -8,6 +8,7 @@
 #include "caf/detail/plain_ref_counted.hpp"
 #include "caf/detail/scope_guard.hpp"
 #include "caf/detail/type_list.hpp"
+#include "caf/flow/observer.hpp"
 
 #include <deque>
 #include <tuple>
@@ -17,7 +18,7 @@ namespace caf::flow::op {
 
 template <class... Steps>
 using from_steps_output_t =
-  typename detail::tl_back_t<detail::type_list<Steps...>>::output_type;
+  typename detail::tl_back_t<type_list<Steps...>>::output_type;
 
 template <class Input, class... Steps>
 class from_steps_sub : public subscription::impl_base,

--- a/libcaf_core/caf/inspector_access.hpp
+++ b/libcaf_core/caf/inspector_access.hpp
@@ -8,7 +8,6 @@
 #include "caf/detail/as_mutable_ref.hpp"
 #include "caf/detail/parse.hpp"
 #include "caf/detail/print.hpp"
-#include "caf/detail/type_list.hpp"
 #include "caf/error.hpp"
 #include "caf/fwd.hpp"
 #include "caf/inspector_access_base.hpp"
@@ -17,6 +16,7 @@
 #include "caf/intrusive_ptr.hpp"
 #include "caf/sec.hpp"
 #include "caf/span.hpp"
+#include "caf/type_list.hpp"
 
 #include <chrono>
 #include <cstddef>
@@ -594,24 +594,23 @@ struct variant_inspector_traits<std::variant<Ts...>> {
   }
 
   template <class F>
-  static bool load(type_id_t, F&, detail::type_list<>) {
+  static bool load(type_id_t, F&, type_list<>) {
     return false;
   }
 
   template <class F, class U, class... Us>
-  static bool
-  load(type_id_t type, F& continuation, detail::type_list<U, Us...>) {
+  static bool load(type_id_t type, F& continuation, type_list<U, Us...>) {
     if (type_id_v<U> == type) {
       auto tmp = U{};
       continuation(tmp);
       return true;
     }
-    return load(type, continuation, detail::type_list<Us...>{});
+    return load(type, continuation, type_list<Us...>{});
   }
 
   template <class F>
   static bool load(type_id_t type, F continuation) {
-    return load(type, continuation, detail::type_list<Ts...>{});
+    return load(type, continuation, type_list<Ts...>{});
   }
 };
 

--- a/libcaf_core/caf/interface_mismatch.hpp
+++ b/libcaf_core/caf/interface_mismatch.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "caf/detail/type_list.hpp"
 #include "caf/fwd.hpp"
+#include "caf/type_list.hpp"
 
 namespace caf::detail {
 
@@ -92,7 +92,6 @@ namespace caf {
 /// first mismatch. Returns the number of elements on a match.
 /// @pre len(Found) == len(Expected)
 template <class Found, class Expected>
-using interface_mismatch_t
-  = detail::imi<0, Found, Expected, detail::type_list<>>;
+using interface_mismatch_t = detail::imi<0, Found, Expected, type_list<>>;
 
 } // namespace caf

--- a/libcaf_core/caf/policy/select_all.hpp
+++ b/libcaf_core/caf/policy/select_all.hpp
@@ -6,13 +6,13 @@
 
 #include "caf/behavior.hpp"
 #include "caf/config.hpp"
-#include "caf/detail/type_list.hpp"
 #include "caf/detail/type_traits.hpp"
 #include "caf/detail/typed_actor_util.hpp"
 #include "caf/disposable.hpp"
 #include "caf/error.hpp"
 #include "caf/logger.hpp"
 #include "caf/message_id.hpp"
+#include "caf/type_list.hpp"
 
 #include <cstddef>
 #include <functional>
@@ -102,18 +102,17 @@ template <class F, class = typename detail::get_callable_trait<F>::arg_types>
 struct select_select_all_helper;
 
 template <class F, class... Ts>
-struct select_select_all_helper<
-  F, detail::type_list<std::vector<std::tuple<Ts...>>>> {
+struct select_select_all_helper<F, type_list<std::vector<std::tuple<Ts...>>>> {
   using type = select_all_helper<F, Ts...>;
 };
 
 template <class F, class T>
-struct select_select_all_helper<F, detail::type_list<std::vector<T>>> {
+struct select_select_all_helper<F, type_list<std::vector<T>>> {
   using type = select_all_helper<F, T>;
 };
 
 template <class F>
-struct select_select_all_helper<F, detail::type_list<>> {
+struct select_select_all_helper<F, type_list<>> {
   using type = select_all_helper<F>;
 };
 

--- a/libcaf_core/caf/policy/select_all.test.cpp
+++ b/libcaf_core/caf/policy/select_all.test.cpp
@@ -46,7 +46,7 @@ struct fixture : test::fixture::deterministic {
 
   template <class... ResponseHandles>
   auto fuse(ResponseHandles&... handles) {
-    return select_all<detail::type_list<int>>{
+    return select_all<type_list<int>>{
       {handles.id()...},
       disposable::make_composite({handles.policy().pending_timeouts()...})};
   }

--- a/libcaf_core/caf/policy/select_any.hpp
+++ b/libcaf_core/caf/policy/select_any.hpp
@@ -6,12 +6,12 @@
 
 #include "caf/behavior.hpp"
 #include "caf/config.hpp"
-#include "caf/detail/type_list.hpp"
 #include "caf/detail/type_traits.hpp"
 #include "caf/detail/typed_actor_util.hpp"
 #include "caf/disposable.hpp"
 #include "caf/logger.hpp"
 #include "caf/sec.hpp"
+#include "caf/type_list.hpp"
 
 #include <cstddef>
 #include <memory>

--- a/libcaf_core/caf/policy/select_any.test.cpp
+++ b/libcaf_core/caf/policy/select_any.test.cpp
@@ -44,7 +44,7 @@ struct fixture : test::fixture::deterministic {
 
   template <class... ResponseHandles>
   auto fuse(ResponseHandles&... handles) {
-    return select_any<detail::type_list<int>>{
+    return select_any<type_list<int>>{
       {handles.id()...},
       disposable::make_composite({handles.policy().pending_timeouts()...})};
   }

--- a/libcaf_core/caf/policy/single_response.hpp
+++ b/libcaf_core/caf/policy/single_response.hpp
@@ -7,7 +7,6 @@
 #include "caf/behavior.hpp"
 #include "caf/config.hpp"
 #include "caf/detail/dispose_on_call.hpp"
-#include "caf/detail/type_list.hpp"
 #include "caf/detail/type_traits.hpp"
 #include "caf/detail/typed_actor_util.hpp"
 #include "caf/disposable.hpp"

--- a/libcaf_core/caf/response_handle.hpp
+++ b/libcaf_core/caf/response_handle.hpp
@@ -6,13 +6,13 @@
 
 #include "caf/actor_traits.hpp"
 #include "caf/catch_all.hpp"
-#include "caf/detail/type_list.hpp"
 #include "caf/detail/typed_actor_util.hpp"
 #include "caf/flow/fwd.hpp"
 #include "caf/message_id.hpp"
 #include "caf/none.hpp"
 #include "caf/sec.hpp"
 #include "caf/system_messages.hpp"
+#include "caf/type_list.hpp"
 #include "caf/typed_behavior.hpp"
 
 #include <type_traits>
@@ -106,14 +106,14 @@ public:
 
   template <class T>
   flow::assert_scheduled_actor_hdr_t<flow::single<T>> as_single() && {
-    static_assert(std::is_same_v<response_type, detail::type_list<T>>
+    static_assert(std::is_same_v<response_type, type_list<T>>
                   || std::is_same_v<response_type, message>);
     return self_->template single_from_response<T>(policy_);
   }
 
   template <class T>
   flow::assert_scheduled_actor_hdr_t<flow::observable<T>> as_observable() && {
-    static_assert(std::is_same_v<response_type, detail::type_list<T>>
+    static_assert(std::is_same_v<response_type, type_list<T>>
                   || std::is_same_v<response_type, message>);
     return self_->template single_from_response<T>(policy_).as_observable();
   }

--- a/libcaf_core/caf/response_promise.hpp
+++ b/libcaf_core/caf/response_promise.hpp
@@ -88,7 +88,7 @@ public:
   /// @post `pending() == false`
   template <class... Ts>
   void deliver(Ts... xs) {
-    using arg_types = detail::type_list<Ts...>;
+    using arg_types = type_list<Ts...>;
     static_assert(!detail::tl_exists_v<arg_types, detail::is_result>,
                   "delivering a result<T> is not supported");
     static_assert(!detail::tl_exists_v<arg_types, detail::is_expected>,
@@ -131,8 +131,8 @@ public:
     if (pending()) {
       if constexpr (P == message_priority::high)
         state_->id = state_->id.with_high_priority();
-      if constexpr (std::is_same_v<detail::type_list<message>,
-                                   detail::type_list<std::decay_t<Ts>...>>)
+      if constexpr (std::is_same_v<type_list<message>,
+                                   type_list<std::decay_t<Ts>...>>)
         state_->delegate_impl(actor_cast<abstract_actor*>(receiver),
                               std::forward<Ts>(args)...);
       else

--- a/libcaf_core/caf/response_type.hpp
+++ b/libcaf_core/caf/response_type.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "caf/detail/type_list.hpp"
 #include "caf/fwd.hpp"
+#include "caf/type_list.hpp"
 
 #include <tuple>
 
@@ -30,20 +30,20 @@ struct response_type<none_t, Xs...> {
 
 // end of recursion (suppress type definitions for enabling SFINAE)
 template <class... Xs>
-struct response_type<detail::type_list<>, Xs...> {
+struct response_type<type_list<>, Xs...> {
   static constexpr bool valid = false;
 };
 
 // case #1: no match
 template <class... Out, class... In, class... Fs, class... Xs>
-struct response_type<detail::type_list<result<Out...>(In...), Fs...>, Xs...>
-  : response_type<detail::type_list<Fs...>, Xs...> {};
+struct response_type<type_list<result<Out...>(In...), Fs...>, Xs...>
+  : response_type<type_list<Fs...>, Xs...> {};
 
 // case #2: match `result<Out...>(In...)`
 template <class... Out, class... In, class... Fs>
-struct response_type<detail::type_list<result<Out...>(In...), Fs...>, In...> {
+struct response_type<type_list<result<Out...>(In...), Fs...>, In...> {
   static constexpr bool valid = true;
-  using type = detail::type_list<Out...>;
+  using type = type_list<Out...>;
   using tuple_type = std::tuple<Out...>;
   using delegated_type = delegated<Out...>;
 };
@@ -65,8 +65,7 @@ template <class Ts, class Xs>
 struct response_type_unbox;
 
 template <class Ts, class... Xs>
-struct response_type_unbox<Ts, detail::type_list<Xs...>>
-  : response_type<Ts, Xs...> {};
+struct response_type_unbox<Ts, type_list<Xs...>> : response_type<Ts, Xs...> {};
 
 template <class Ts>
 struct response_type_unbox<Ts, message> : response_type<Ts, message> {};

--- a/libcaf_core/caf/result.hpp
+++ b/libcaf_core/caf/result.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "caf/delegated.hpp"
-#include "caf/detail/type_list.hpp"
 #include "caf/detail/type_traits.hpp"
 #include "caf/error.hpp"
 #include "caf/expected.hpp"
@@ -13,6 +12,7 @@
 #include "caf/message.hpp"
 #include "caf/none.hpp"
 #include "caf/skip.hpp"
+#include "caf/type_list.hpp"
 #include "caf/variant_wrapper.hpp"
 
 #include <type_traits>
@@ -35,7 +35,7 @@ class result_base {
 public:
   static_assert(sizeof...(Ts) > 0);
 
-  using types = detail::type_list<delegated<Ts...>, message, error>;
+  using types = type_list<delegated<Ts...>, message, error>;
 
   result_base() = default;
 

--- a/libcaf_core/caf/type_list.hpp
+++ b/libcaf_core/caf/type_list.hpp
@@ -1,0 +1,17 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+namespace caf {
+
+/// A list of types.
+template <class... Ts>
+struct type_list {
+  constexpr type_list() {
+    // nop
+  }
+};
+
+} // namespace caf

--- a/libcaf_core/caf/typed_actor.hpp
+++ b/libcaf_core/caf/typed_actor.hpp
@@ -55,7 +55,7 @@ public:
   static constexpr bool has_weak_ptr_semantics = false;
 
   /// Stores the template parameter pack.
-  using signatures = detail::type_list<Sigs...>;
+  using signatures = type_list<Sigs...>;
 
   /// Creates a new `typed_actor` type by extending this one with `Es...`.
   template <class... Es>
@@ -114,9 +114,8 @@ public:
 
   template <class... Ts>
   typed_actor(const typed_actor<Ts...>& other) : ptr_(other.ptr_) {
-    static_assert(
-      detail::tl_subset_of<signatures, detail::type_list<Ts...>>::value,
-      "Cannot assign incompatible handle");
+    static_assert(detail::tl_subset_of<signatures, type_list<Ts...>>::value,
+                  "Cannot assign incompatible handle");
   }
 
   // allow `handle_type{this}` for typed actors
@@ -140,9 +139,8 @@ public:
 
   template <class... Ts>
   typed_actor& operator=(const typed_actor<Ts...>& other) {
-    static_assert(
-      detail::tl_subset_of<signatures, detail::type_list<Ts...>>::value,
-      "Cannot assign incompatible handle");
+    static_assert(detail::tl_subset_of<signatures, type_list<Ts...>>::value,
+                  "Cannot assign incompatible handle");
     ptr_ = other.ptr_;
     return *this;
   }

--- a/libcaf_core/caf/typed_actor_pointer.hpp
+++ b/libcaf_core/caf/typed_actor_pointer.hpp
@@ -15,7 +15,7 @@ template <class... Sigs>
 class typed_actor_pointer : public typed_actor_view_base {
 public:
   /// Stores the template parameter pack.
-  using signatures = detail::type_list<Sigs...>;
+  using signatures = type_list<Sigs...>;
 
   typed_actor_pointer() : view_(nullptr) {
     // nop
@@ -23,16 +23,16 @@ public:
 
   template <class Supertype,
             class = std::enable_if_t< //
-              detail::tl_subset_of<detail::type_list<Sigs...>,
+              detail::tl_subset_of<type_list<Sigs...>,
                                    typename Supertype::signatures>::value>>
   typed_actor_pointer(Supertype* selfptr) : view_(selfptr) {
     // nop
   }
 
-  template <class... OtherSigs,
-            class = std::enable_if_t< //
-              detail::tl_subset_of<detail::type_list<Sigs...>,
-                                   detail::type_list<OtherSigs...>>::value>>
+  template <
+    class... OtherSigs,
+    class = std::enable_if_t< //
+      detail::tl_subset_of<type_list<Sigs...>, type_list<OtherSigs...>>::value>>
   typed_actor_pointer(typed_actor_pointer<OtherSigs...> other)
     : view_(other.internal_ptr()) {
     // nop
@@ -56,10 +56,10 @@ public:
     return *this;
   }
 
-  template <class... OtherSigs,
-            class = std::enable_if_t< //
-              detail::tl_subset_of<detail::type_list<Sigs...>,
-                                   detail::type_list<OtherSigs...>>::value>>
+  template <
+    class... OtherSigs,
+    class = std::enable_if_t< //
+      detail::tl_subset_of<type_list<Sigs...>, type_list<OtherSigs...>>::value>>
   typed_actor_pointer& operator=(typed_actor_pointer<OtherSigs...> other) {
     using namespace detail;
     static_assert(

--- a/libcaf_core/caf/typed_actor_view.hpp
+++ b/libcaf_core/caf/typed_actor_view.hpp
@@ -35,12 +35,12 @@ class typed_actor_view
                   typed_actor_view<Sigs...>>::template with<mixin::requester> {
 public:
   /// Stores the template parameter pack.
-  using signatures = detail::type_list<Sigs...>;
+  using signatures = type_list<Sigs...>;
 
   using pointer = scheduled_actor*;
 
   struct trait {
-    using signatures = detail::type_list<Sigs...>;
+    using signatures = type_list<Sigs...>;
   };
 
   explicit typed_actor_view(scheduled_actor* ptr) : self_(ptr) {

--- a/libcaf_core/caf/typed_behavior.hpp
+++ b/libcaf_core/caf/typed_behavior.hpp
@@ -36,7 +36,7 @@ struct input_only<type_list<Ts...>> {
   using type = type_list<typename input_args<Ts>::type...>;
 };
 
-using skip_list = detail::type_list<skip_t>;
+using skip_list = type_list<skip_t>;
 
 template <class Input, class RepliesToWith>
 struct same_input : std::is_same<Input, typename RepliesToWith::input_types> {};
@@ -159,7 +159,7 @@ public:
   // -- member types -----------------------------------------------------------
 
   /// Stores the template parameter pack in a type list.
-  using signatures = detail::type_list<Sigs...>;
+  using signatures = type_list<Sigs...>;
 
   // -- constructors, destructors, and assignment operators --------------------
 
@@ -170,7 +170,7 @@ public:
 
   template <class... Ts>
   typed_behavior(const typed_behavior<Ts...>& other) : bhvr_(other.bhvr_) {
-    using other_signatures = detail::type_list<Ts...>;
+    using other_signatures = type_list<Ts...>;
     using m = interface_mismatch_t<other_signatures, signatures>;
     // trigger static assert on mismatch
     detail::static_error_printer<static_cast<int>(sizeof...(Ts)), m::value,
@@ -247,7 +247,7 @@ private:
   void set(intrusive_ptr<
            detail::default_behavior_impl<std::tuple<Ts...>, TimeoutDefinition>>
              bp) {
-    using found_signatures = detail::type_list<deduce_mpi_t<Ts>...>;
+    using found_signatures = type_list<deduce_mpi_t<Ts>...>;
     using m = interface_mismatch_t<found_signatures, signatures>;
     // trigger static assert on mismatch
     detail::static_error_printer<static_cast<int>(sizeof...(Ts)), m::value,

--- a/libcaf_core/caf/typed_event_based_actor.hpp
+++ b/libcaf_core/caf/typed_event_based_actor.hpp
@@ -29,14 +29,14 @@ public:
     typename extend<scheduled_actor, typed_event_based_actor<Sigs...>>::
       template with<mixin::sender, mixin::requester>;
 
-  using signatures = detail::type_list<Sigs...>;
+  using signatures = type_list<Sigs...>;
 
   using behavior_type = typed_behavior<Sigs...>;
 
   using actor_hdl = typed_actor<Sigs...>;
 
   struct trait {
-    using signatures = detail::type_list<Sigs...>;
+    using signatures = type_list<Sigs...>;
   };
 
   // -- constructors, destructors, and assignment operators --------------------
@@ -46,7 +46,7 @@ public:
   // -- overrides --------------------------------------------------------------
 
   std::set<std::string> message_types() const override {
-    detail::type_list<typed_actor<Sigs...>> token;
+    type_list<typed_actor<Sigs...>> token;
     return this->system().message_types(token);
   }
 

--- a/libcaf_core/caf/typed_message_view.hpp
+++ b/libcaf_core/caf/typed_message_view.hpp
@@ -44,7 +44,7 @@ private:
 template <size_t Index, class... Ts>
 auto& get(typed_message_view<Ts...> x) {
   static_assert(Index < sizeof...(Ts));
-  using type = caf::detail::tl_at_t<caf::detail::type_list<Ts...>, Index>;
+  using type = caf::detail::tl_at_t<caf::type_list<Ts...>, Index>;
   return *reinterpret_cast<type*>(x->storage()
                                   + detail::offset_at<Index, Ts...>);
 }

--- a/libcaf_core/caf/typed_response_promise.hpp
+++ b/libcaf_core/caf/typed_response_promise.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "caf/detail/type_list.hpp"
 #include "caf/message.hpp"
 #include "caf/response_promise.hpp"
+#include "caf/type_list.hpp"
 
 #include <type_traits>
 
@@ -66,8 +66,8 @@ public:
   }
 
   /// Satisfies the promise by sending an empty response message.
-  template <class L = detail::type_list<Ts...>>
-  std::enable_if_t<std::is_same_v<L, detail::type_list<void>>> deliver() {
+  template <class L = type_list<Ts...>>
+  std::enable_if_t<std::is_same_v<L, type_list<void>>> deliver() {
     promise_.deliver();
   }
 
@@ -80,8 +80,7 @@ public:
   /// Satisfies the promise by sending either an error or a non-error response
   /// message.
   template <class T>
-  std::enable_if_t<
-    std::is_same_v<detail::type_list<T>, detail::type_list<Ts...>>>
+  std::enable_if_t<std::is_same_v<type_list<T>, type_list<Ts...>>>
   deliver(expected<T> x) {
     promise_.deliver(std::move(x));
   }

--- a/libcaf_io/caf/io/middleman.cpp
+++ b/libcaf_io/caf/io/middleman.cpp
@@ -206,7 +206,7 @@ void middleman::add_module_options(actor_system_config& cfg) {
               defaults::middleman::connection_timeout);
 }
 
-actor_system::module* middleman::make(actor_system& sys, detail::type_list<>) {
+actor_system::module* middleman::make(actor_system& sys, type_list<>) {
   return new mm_impl<network::default_multiplexer>(sys);
 }
 

--- a/libcaf_io/caf/io/middleman.hpp
+++ b/libcaf_io/caf/io/middleman.hpp
@@ -84,7 +84,7 @@ public:
   template <class Handle>
   expected<uint16_t> publish(Handle&& whom, uint16_t port,
                              const char* in = nullptr, bool reuse = false) {
-    detail::type_list<std::decay_t<Handle>> tk;
+    type_list<std::decay_t<Handle>> tk;
     return publish(actor_cast<strong_actor_ptr>(std::forward<Handle>(whom)),
                    system().message_types(tk), port, in, reuse);
   }
@@ -104,7 +104,7 @@ public:
   ///          a remote actor or an `error`.
   template <class ActorHandle = actor>
   expected<ActorHandle> remote_actor(std::string host, uint16_t port) {
-    detail::type_list<ActorHandle> tk;
+    type_list<ActorHandle> tk;
     auto x = remote_actor(system().message_types(tk), std::move(host), port);
     if (!x)
       return x.error();
@@ -250,11 +250,10 @@ public:
   static void add_module_options(actor_system_config& cfg);
 
   /// Returns a middleman using the default network backend.
-  static actor_system::module* make(actor_system&, detail::type_list<>);
+  static actor_system::module* make(actor_system&, type_list<>);
 
   template <class Backend>
-  static actor_system::module*
-  make(actor_system& sys, detail::type_list<Backend>) {
+  static actor_system::module* make(actor_system& sys, type_list<Backend>) {
     class impl : public middleman {
     public:
       impl(actor_system& ref) : middleman(ref), backend_(&ref) {

--- a/libcaf_io/caf/io/typed_broker.hpp
+++ b/libcaf_io/caf/io/typed_broker.hpp
@@ -54,7 +54,7 @@ class typed_broker
     public statically_typed_actor_base {
   // clang-format on
 public:
-  using signatures = detail::type_list<Sigs...>;
+  using signatures = type_list<Sigs...>;
 
   using actor_hdl = typed_actor<Sigs...>;
 
@@ -67,7 +67,7 @@ public:
   /// @cond PRIVATE
 
   std::set<std::string> message_types() const override {
-    detail::type_list<typed_actor<Sigs...>> hdl;
+    type_list<typed_actor<Sigs...>> hdl;
     return this->system().message_types(hdl);
   }
 

--- a/libcaf_net/caf/net/http/route.hpp
+++ b/libcaf_net/caf/net/http/route.hpp
@@ -238,7 +238,7 @@ private:
 template <class F, class... Args>
 net::http::route_ptr
 make_http_route_impl(std::string& path, std::optional<net::http::method> method,
-                     F& f, detail::type_list<net::http::responder&, Args...>) {
+                     F& f, type_list<net::http::responder&, Args...>) {
   if constexpr (sizeof...(Args) == 0) {
     using impl_t = http_simple_route_impl<F>;
     return make_counted<impl_t>(std::move(path), method, std::move(f));

--- a/libcaf_net/caf/net/http/router.hpp
+++ b/libcaf_net/caf/net/http/router.hpp
@@ -12,8 +12,6 @@
 #include "caf/net/http/upper_layer.hpp"
 
 #include "caf/detail/print.hpp"
-#include "caf/detail/type_list.hpp"
-#include "caf/detail/type_traits.hpp"
 #include "caf/expected.hpp"
 #include "caf/intrusive_ptr.hpp"
 #include "caf/ref_counted.hpp"

--- a/libcaf_net/caf/net/middleman.cpp
+++ b/libcaf_net/caf/net/middleman.cpp
@@ -139,7 +139,7 @@ void* middleman::subtype_ptr() {
   return this;
 }
 
-actor_system::module* middleman::make(actor_system& sys, detail::type_list<>) {
+actor_system::module* middleman::make(actor_system& sys, type_list<>) {
   return new middleman(sys);
 }
 

--- a/libcaf_net/caf/net/middleman.hpp
+++ b/libcaf_net/caf/net/middleman.hpp
@@ -10,8 +10,8 @@
 
 #include "caf/actor_system.hpp"
 #include "caf/detail/net_export.hpp"
-#include "caf/detail/type_list.hpp"
 #include "caf/fwd.hpp"
+#include "caf/type_list.hpp"
 
 #include <thread>
 
@@ -62,7 +62,7 @@ public:
 
   // -- factory functions ------------------------------------------------------
 
-  static module* make(actor_system& sys, detail::type_list<>);
+  static module* make(actor_system& sys, type_list<>);
 
   /// Adds module-specific options to the config before loading the module.
   static void add_module_options(actor_system_config& cfg);

--- a/libcaf_net/caf/net/typed_actor_shell.hpp
+++ b/libcaf_net/caf/net/typed_actor_shell.hpp
@@ -9,12 +9,12 @@
 
 #include "caf/actor_traits.hpp"
 #include "caf/detail/net_export.hpp"
-#include "caf/detail/type_list.hpp"
 #include "caf/extend.hpp"
 #include "caf/fwd.hpp"
 #include "caf/mixin/requester.hpp"
 #include "caf/mixin/sender.hpp"
 #include "caf/none.hpp"
+#include "caf/type_list.hpp"
 #include "caf/typed_actor.hpp"
 
 namespace caf::net {
@@ -42,7 +42,7 @@ public:
              with<mixin::sender, mixin::requester>;
   // clang-format on
 
-  using signatures = detail::type_list<Sigs...>;
+  using signatures = type_list<Sigs...>;
 
   using behavior_type = typed_behavior<Sigs...>;
 

--- a/libcaf_net/caf/net/web_socket/switch_protocol.hpp
+++ b/libcaf_net/caf/net/web_socket/switch_protocol.hpp
@@ -4,11 +4,12 @@
 
 #pragma once
 
+#include "caf/net/http/route.hpp"
 #include "caf/net/web_socket/acceptor.hpp"
 #include "caf/net/web_socket/default_trait.hpp"
 #include "caf/net/web_socket/server_factory.hpp"
 
-#include "caf/detail/type_list.hpp"
+#include "caf/type_list.hpp"
 
 #include <memory>
 
@@ -192,7 +193,7 @@ public:
 private:
   template <class OnStart, class... Out, class... Ts>
   auto make(OnStart& on_start,
-            detail::type_list<net::web_socket::acceptor<Out...>&, Ts...>) {
+            type_list<net::web_socket::acceptor<Out...>&, Ts...>) {
     using namespace detail;
     using state_t = ws_switch_protocol_state<OnRequest, OnStart>;
     using impl_t = ws_switch_protocol<Trait, state_t, type_list<Out...>, Ts...>;

--- a/libcaf_openssl/caf/openssl/manager.cpp
+++ b/libcaf_openssl/caf/openssl/manager.cpp
@@ -161,7 +161,7 @@ void manager::add_module_options(actor_system_config& cfg) {
   put_missing(grp, "cafile", cfg.openssl_cafile);
 }
 
-actor_system::module* manager::make(actor_system& sys, detail::type_list<>) {
+actor_system::module* manager::make(actor_system& sys, type_list<>) {
   if (!sys.has_middleman())
     CAF_RAISE_ERROR("Cannot start OpenSSL module without middleman.");
   auto ptr = &sys.middleman().backend();

--- a/libcaf_openssl/caf/openssl/manager.hpp
+++ b/libcaf_openssl/caf/openssl/manager.hpp
@@ -57,7 +57,7 @@ public:
   //           a custom implementation.
   /// @throws `logic_error` if the middleman is not loaded or is not using the
   ///         default network backend.
-  static actor_system::module* make(actor_system&, detail::type_list<>);
+  static actor_system::module* make(actor_system&, type_list<>);
 
   /// Adds message types of the OpenSSL module to the global meta object table.
   static void init_global_meta_objects();

--- a/libcaf_openssl/caf/openssl/remote_actor.hpp
+++ b/libcaf_openssl/caf/openssl/remote_actor.hpp
@@ -28,7 +28,7 @@ remote_actor(actor_system& sys, const std::set<std::string>& mpi,
 template <class ActorHandle = actor>
 expected<ActorHandle>
 remote_actor(actor_system& sys, std::string host, uint16_t port) {
-  detail::type_list<ActorHandle> tk;
+  type_list<ActorHandle> tk;
   auto res = remote_actor(sys, sys.message_types(tk), std::move(host), port);
   if (res)
     return actor_cast<ActorHandle>(std::move(*res));

--- a/libcaf_test/caf/test/caf_test_main.hpp
+++ b/libcaf_test/caf/test/caf_test_main.hpp
@@ -12,7 +12,7 @@
 #define CAF_TEST_MAIN(...)                                                     \
   int main(int argc, char** argv) {                                            \
     [[maybe_unused]] auto host_init_guard = caf::detail::do_init_host_system(  \
-      caf::detail::type_list<>{}, caf::detail::type_list<__VA_ARGS__>{});      \
+      caf::type_list<>{}, caf::type_list<__VA_ARGS__>{});                      \
     caf::exec_main_init_meta_objects<__VA_ARGS__>();                           \
     caf::core::init_global_meta_objects();                                     \
     caf::test::registry::run_init_callbacks();                                 \

--- a/scripts/demystify.py
+++ b/scripts/demystify.py
@@ -39,7 +39,7 @@ def next_element(x, pos, last):
 
 def atom_read(x):
   result = ""
-  read_chars = ((x & 0xF000000000000000) >> 60) == 0xF 
+  read_chars = ((x & 0xF000000000000000) >> 60) == 0xF
   mask = 0x0FC0000000000000
   bitshift = 54
   while bitshift >= 0:
@@ -79,10 +79,10 @@ def stringify_list(xs):
       res += ", "
     res += stringify(xs[index].strip(' '))
   return res
-  
+
 
 def decompose_typed_actor(x, first, last):
-  needle = "caf::detail::type_list<"
+  needle = "caf::type_list<"
   # first type list -> input types
   j = x.find(needle, first) + len(needle)
   k = end_of_template(x, j)


### PR DESCRIPTION
Relates #1600.
This PR lifts `type_list` to the `caf` namespace, with appropriate changes to the source.
`detail/type_list.hpp` still has the meta programming utilities related to `type_list`. I've changed the include from `detail/type_list.hpp` to `type_list.hpp` where meta-programming stuff wasn't used.  