### PR TITLE
High-level caf-net primitive for custom binary protocols

### DIFF
--- a/libcaf_core/caf/defaults.hpp
+++ b/libcaf_core/caf/defaults.hpp
@@ -173,4 +173,7 @@ constexpr auto http_default_port = uint16_t{80};
 /// The default port for HTTPS servers.
 constexpr auto https_default_port = uint16_t{443};
 
+/// The default buffer size for reading and writing octet streams.
+constexpr auto octet_stream_buffer_size = uint32_t{1024};
+
 } // namespace caf::defaults::net

--- a/libcaf_core/caf/detail/flow_source.hpp
+++ b/libcaf_core/caf/detail/flow_source.hpp
@@ -1,0 +1,26 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/async/fwd.hpp"
+#include "caf/fwd.hpp"
+#include "caf/ref_counted.hpp"
+
+namespace caf::detail {
+
+template <class T>
+class flow_source : public ref_counted {
+public:
+  virtual ~flow_source() {
+    // nop
+  }
+
+  virtual void add(async::producer_resource<T> sink) = 0;
+};
+
+template <class T>
+using flow_source_ptr = intrusive_ptr<flow_source<T>>;
+
+} // namespace caf::detail

--- a/libcaf_core/caf/flow/op/ucast.hpp
+++ b/libcaf_core/caf/flow/op/ucast.hpp
@@ -43,6 +43,12 @@ public:
       // nop
     }
 
+    /// Called when an observer subscribes to the `ucast_sub_state`.
+    /// @param state The `ucast_sub_state` object that was subscribed to.
+    virtual void on_subscribed([[maybe_unused]] ucast_sub_state* state) {
+      // nop
+    }
+
     /// Called when the `ucast_sub_state` is disposed.
     virtual void on_disposed(ucast_sub_state* state, bool from_external) = 0;
 
@@ -52,7 +58,7 @@ public:
     }
 
     /// Called when the `ucast_sub_state` has consumed some items.
-    /// @param state The `ucast_sub_state` that consumed items.
+    /// @param state The `ucast_sub_state` that has consumed items.
     /// @param old_buffer_size The number of items in the buffer before
     ///                        consuming items.
     /// @param new_buffer_size The number of items in the buffer after
@@ -182,6 +188,12 @@ public:
       lptr->on_disposed(this, false);
     }
     out.release_later();
+  }
+
+  void set_observer(observer<T> obs) {
+    out = std::move(obs);
+    if (listener)
+      listener->on_subscribed(this);
   }
 
   // -- implementation of coordinated ------------------------------------------
@@ -359,7 +371,7 @@ public:
         out, make_error(sec::too_many_observers,
                         "may only subscribe once to an unicast operator"));
     }
-    state_->out = out;
+    state_->set_observer(out);
     auto ptr = super::parent_->add_child(std::in_place_type<ucast_sub<T>>,
                                          state_);
     out.on_subscribe(subscription{ptr});

--- a/libcaf_net/CMakeLists.txt
+++ b/libcaf_net/CMakeLists.txt
@@ -75,6 +75,7 @@ caf_add_component(
     caf/net/octet_stream/policy.cpp
     caf/net/octet_stream/transport.cpp
     caf/net/octet_stream/upper_layer.cpp
+    caf/net/octet_stream/with.test.cpp
     caf/net/pipe_socket.cpp
     caf/net/prometheus.cpp
     caf/net/socket.cpp

--- a/libcaf_net/CMakeLists.txt
+++ b/libcaf_net/CMakeLists.txt
@@ -69,6 +69,8 @@ caf_add_component(
     caf/net/middleman.cpp
     caf/net/multiplexer.cpp
     caf/net/network_socket.cpp
+    caf/net/octet_stream/flow_bridge.cpp
+    caf/net/octet_stream/flow_bridge.test.cpp
     caf/net/octet_stream/lower_layer.cpp
     caf/net/octet_stream/policy.cpp
     caf/net/octet_stream/transport.cpp

--- a/libcaf_net/caf/net/dsl/client_factory_base.hpp
+++ b/libcaf_net/caf/net/dsl/client_factory_base.hpp
@@ -25,8 +25,6 @@ class client_factory_base {
 public:
   using config_type = Config;
 
-  using trait_type = typename config_type::trait_type;
-
   using config_pointer = intrusive_ptr<config_type>;
 
   client_factory_base(const client_factory_base&) = default;
@@ -36,6 +34,10 @@ public:
   template <class T, class... Ts>
   explicit client_factory_base(dsl::client_config_tag<T> token, Ts&&... xs) {
     cfg_ = config_type::make(token, std::forward<Ts>(xs)...);
+  }
+
+  explicit client_factory_base(config_pointer cfg) : cfg_(std::move(cfg)) {
+    // nop
   }
 
   /// Sets the callback for errors.

--- a/libcaf_net/caf/net/fwd.hpp
+++ b/libcaf_net/caf/net/fwd.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "caf/async/fwd.hpp"
+#include "caf/detail/net_export.hpp"
 #include "caf/fwd.hpp"
 #include "caf/intrusive_ptr.hpp"
 #include "caf/type_id.hpp"
@@ -48,6 +49,10 @@ struct udp_datagram_socket;
 
 // -- smart pointer aliases ----------------------------------------------------
 
+CAF_NET_EXPORT void intrusive_ptr_add_ref(socket_manager* ptr) noexcept;
+
+CAF_NET_EXPORT void intrusive_ptr_release(socket_manager* ptr) noexcept;
+
 using multiplexer_ptr = intrusive_ptr<multiplexer>;
 using socket_manager_ptr = intrusive_ptr<socket_manager>;
 
@@ -81,6 +86,7 @@ make_actor_shell(actor_system&, async::execution_context_ptr);
 
 namespace caf::net::octet_stream {
 
+class flow_bridge;
 class lower_layer;
 class policy;
 class transport;

--- a/libcaf_net/caf/net/multiplexer.hpp
+++ b/libcaf_net/caf/net/multiplexer.hpp
@@ -20,6 +20,13 @@ namespace caf::net {
 /// Multiplexes any number of ::socket_manager objects with a ::socket.
 class CAF_NET_EXPORT multiplexer : public async::execution_context {
 public:
+  // -- member types -----------------------------------------------------------
+
+  using super = async::execution_context;
+
+  /// A time point of the monotonic clock.
+  using steady_time_point = std::chrono::steady_clock::time_point;
+
   // -- static utility functions -----------------------------------------------
 
   /// Blocks the PIPE signal on the current thread when running on Linux. Has no
@@ -45,6 +52,16 @@ public:
   // -- initialization ---------------------------------------------------------
 
   virtual error init() = 0;
+
+  // -- scheduling of actions --------------------------------------------------
+
+  using super::schedule;
+
+  /// Schedules @p what to run after reaching @p when on the event loop of the
+  /// execution context. This member function may get called from external
+  /// sources or threads.
+  /// @thread-safe
+  virtual void schedule(steady_time_point when, action what) = 0;
 
   // -- properties -------------------------------------------------------------
 

--- a/libcaf_net/caf/net/octet_stream/client_factory.hpp
+++ b/libcaf_net/caf/net/octet_stream/client_factory.hpp
@@ -1,0 +1,211 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/net/checked_socket.hpp"
+#include "caf/net/dsl/client_factory_base.hpp"
+#include "caf/net/dsl/generic_config.hpp"
+#include "caf/net/octet_stream/flow_bridge.hpp"
+#include "caf/net/octet_stream/transport.hpp"
+#include "caf/net/ssl/transport.hpp"
+#include "caf/net/tcp_stream_socket.hpp"
+
+#include "caf/defaults.hpp"
+#include "caf/flow/coordinator.hpp"
+#include "caf/flow/observable.hpp"
+#include "caf/flow/observable_builder.hpp"
+
+#include <functional>
+#include <type_traits>
+
+namespace caf::detail {
+
+struct octet_stream_no_outputs {
+  auto operator()(flow::coordinator* self) {
+    return self->make_observable().never<std::byte>();
+  }
+};
+
+} // namespace caf::detail
+
+namespace caf::net::octet_stream {
+
+/// Configuration for the `with(...).connect(...).start(...)` DSL.
+class client_factory_config : public dsl::client_config_value {
+public:
+  using super = dsl::client_config_value;
+
+  using super::super;
+
+  /// Sets the default buffer size for reading from the network.
+  uint32_t read_buffer_size = defaults::net::octet_stream_buffer_size;
+
+  /// Sets the default buffer size for writing to the network.
+  uint32_t write_buffer_size = defaults::net::octet_stream_buffer_size;
+
+  template <class T, class... Args>
+  static auto make(dsl::client_config_tag<T>,
+                   const dsl::generic_config_value& from, Args&&... args) {
+    return super::make_impl(std::in_place_type<client_factory_config>, from,
+                            std::in_place_type<T>, std::forward<Args>(args)...);
+  }
+};
+
+/// Factory for the `with(...).connect(...).start(...)` DSL.
+template <class MakeOutputs>
+class client_factory_with_outputs
+  : public dsl::client_factory_base<client_factory_config,
+                                    client_factory_with_outputs<MakeOutputs>> {
+public:
+  using super
+    = dsl::client_factory_base<client_factory_config,
+                               client_factory_with_outputs<MakeOutputs>>;
+
+  using config_pointer = intrusive_ptr<client_factory_config>;
+
+  template <class MakeInputs>
+  using publisher_type = flow_bridge_publisher_t<MakeInputs, MakeOutputs>;
+
+  client_factory_with_outputs(config_pointer cfg, MakeOutputs make_outputs)
+    : super(std::move(cfg)), make_outputs_(std::move(make_outputs)) {
+    // nop
+  }
+
+  /// Starts the client and returns a publisher for receiving its inputs and a
+  /// disposable for shutting down the client.
+  /// @param make_inputs A function that takes an `observable<std::byte>` and
+  ///                    optionally returns a new `observable` for modifying the
+  ///                    inputs. The function may return `void`, but it must
+  ///                    subscribe to the input observable in this case. To
+  ///                    discard any data from socket, pass `std::ignore` to
+  ///                    `subscribe`.
+  template <class MakeInputs>
+  [[nodiscard]] auto start(MakeInputs make_inputs) && {
+    return super::config().visit([this, &make_inputs](auto& data) { //
+      return this->do_start(data, make_inputs);
+    });
+  }
+
+private:
+  template <class Conn, class MakeInputs>
+  auto do_start_impl(Conn conn, MakeInputs& make_inputs) {
+    auto& cfg = super::config();
+    auto bridge = flow_bridge::make(cfg.read_buffer_size, cfg.write_buffer_size,
+                                    std::move(make_inputs),
+                                    std::move(make_outputs_));
+    auto bridge_ptr = bridge.get();
+    auto transport = std::unique_ptr<octet_stream::transport>{};
+    if constexpr (std::is_same_v<Conn, ssl::connection>)
+      transport = ssl::transport::make(std::move(conn), std::move(bridge));
+    else
+      transport = octet_stream::transport::make(std::move(conn),
+                                                std::move(bridge));
+    transport->active_policy().connect();
+    auto ptr = net::socket_manager::make(cfg.mpx, std::move(transport));
+    bridge_ptr->init(ptr.get());
+    auto pub = bridge_ptr->publisher();
+    cfg.mpx->start(ptr);
+    return expected{std::pair{pub, disposable{std::move(ptr)}}};
+  }
+
+  template <class MakeInputs>
+  auto do_start(dsl::client_config::lazy& data, dsl::server_address& addr,
+                MakeInputs& make_inputs) {
+    return detail::tcp_try_connect(std::move(addr.host), addr.port,
+                                   data.connection_timeout,
+                                   data.max_retry_count, data.retry_delay)
+      .and_then(
+        this->with_ssl_connection_or_socket([this, &make_inputs](auto&& conn) {
+          using conn_t = decltype(conn);
+          return this->do_start_impl(std::forward<conn_t>(conn), make_inputs);
+        }));
+  }
+
+  template <class MakeInputs>
+  auto
+  do_start(dsl::client_config::lazy&, const uri&, MakeInputs& make_inputs) {
+    auto err = make_error(sec::invalid_argument,
+                          "connecting via URI is not supported");
+    return do_start(err, make_inputs);
+  }
+
+  template <class MakeInputs>
+  auto do_start(dsl::client_config::lazy& data, MakeInputs& make_inputs) {
+    auto fn = [this, &data, &make_inputs](auto& addr) {
+      return this->do_start(data, addr, make_inputs);
+    };
+    return std::visit(fn, data.server);
+  }
+
+  template <class MakeInputs>
+  auto do_start(dsl::client_config::socket& data, MakeInputs& make_inputs) {
+    return expected{data.take_fd()}
+      .and_then(check_socket)
+      .and_then(
+        this->with_ssl_connection_or_socket([this, &make_inputs](auto&& conn) {
+          using conn_t = decltype(conn);
+          return this->do_start_impl(std::forward<conn_t>(conn), make_inputs);
+        })
+
+      );
+  }
+
+  template <class MakeInputs>
+  auto do_start(dsl::client_config::conn& data, MakeInputs& make_inputs) {
+    return do_start_impl(std::move(data.state), make_inputs);
+  }
+
+  template <class MakeInputs>
+  auto do_start(error& err, MakeInputs&) {
+    using pub_t = publisher_type<MakeInputs>;
+    super::config().call_on_error(err);
+    return expected<std::pair<pub_t, disposable>>{std::move(err)};
+  }
+
+  MakeOutputs make_outputs_;
+};
+
+/// Factory for the `with(...).connect(...).start(...)` DSL.
+class client_factory
+  : public dsl::client_factory_base<client_factory_config, client_factory> {
+public:
+  using super = dsl::client_factory_base<client_factory_config, client_factory>;
+
+  using super::super;
+
+  using config_type = typename super::config_type;
+
+  /// Overrides the default buffer size for reading from the network.
+  client_factory&& read_buffer_size(uint32_t new_value) && {
+    config().read_buffer_size = new_value;
+    return std::move(*this);
+  }
+
+  /// Overrides the default buffer size for writing to the network.
+  client_factory&& write_buffer_size(uint32_t new_value) && {
+    config().write_buffer_size = new_value;
+    return std::move(*this);
+  }
+
+  /// Configures the client to send the outputs from the observable created by
+  /// `make_outputs`.
+  /// @param make_outputs A function that takes a `flow::coordinator*` and
+  ///                     returns an `observable<std::byte>`.
+  template <class MakeOutputs>
+  client_factory_with_outputs<MakeOutputs>
+  send_from(MakeOutputs make_outputs) && {
+    return {std::move(super::cfg_), std::move(make_outputs)};
+  }
+
+  /// @copydoc client_factory_with_outputs::start
+  template <class MakeInputs>
+  [[nodiscard]] auto start(MakeInputs make_inputs) && {
+    return std::move(*this)
+      .send_from(detail::octet_stream_no_outputs{})
+      .start(std::move(make_inputs));
+  }
+};
+
+} // namespace caf::net::octet_stream

--- a/libcaf_net/caf/net/octet_stream/flow_bridge.cpp
+++ b/libcaf_net/caf/net/octet_stream/flow_bridge.cpp
@@ -1,0 +1,148 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/net/octet_stream/flow_bridge.hpp"
+
+namespace caf::detail {
+
+flow::coordinator* octet_stream_observer::parent() const noexcept {
+  return parent_;
+}
+
+void octet_stream_observer::on_next(const std::byte& item) {
+  if (listener_)
+    listener_->on_next(item);
+}
+
+void octet_stream_observer::on_error(const error& what) {
+  if (listener_) {
+    listener_->on_error(what);
+    listener_ = nullptr;
+  }
+}
+
+void octet_stream_observer::on_complete() {
+  if (listener_) {
+    listener_->on_complete();
+    listener_ = nullptr;
+  }
+}
+
+void octet_stream_observer::on_subscribe(flow::subscription new_sub) {
+  if (listener_)
+    listener_->on_subscribe(std::move(new_sub));
+}
+
+} // namespace caf::detail
+
+namespace caf::net::octet_stream {
+
+void flow_bridge::on_subscribed(ucast_sub_state*) {
+  down_->configure_read(receive_policy::up_to(read_buffer_size_));
+}
+
+void flow_bridge::on_disposed(ucast_sub_state*, bool from_external) {
+  if (from_external) {
+    self_->schedule_fn([this] { on_disposed(nullptr, false); });
+    return;
+  }
+  down_->shutdown();
+}
+
+void flow_bridge::on_consumed_some(ucast_sub_state*, size_t,
+                                   size_t new_buffer_size) {
+  if (new_buffer_size < read_buffer_size_) {
+    auto delta = static_cast<uint32_t>(read_buffer_size_ - new_buffer_size);
+    down_->configure_read(receive_policy::up_to(delta));
+  }
+}
+
+void flow_bridge::init(socket_manager* ptr) {
+  self_ = ptr;
+  in_ = make_counted<flow::op::ucast<std::byte>>(ptr);
+  in_->state().listener = this;
+}
+
+error flow_bridge::start(lower_layer* down) {
+  down_ = down;
+  on_start();
+  return none;
+}
+
+void flow_bridge::prepare_send() {
+  // nop
+}
+
+bool flow_bridge::done_sending() {
+  return true;
+}
+
+void flow_bridge::abort(const error& reason) {
+  in_->state().abort(reason);
+  out_.cancel();
+}
+
+ptrdiff_t flow_bridge::consume(byte_span buf, byte_span) {
+  if (!in_) {
+    CAF_LOG_DEBUG("flow_bridge::consume: !in_");
+    return -1;
+  }
+  auto& st = in_->state();
+  if (st.disposed) {
+    CAF_LOG_DEBUG("flow_bridge::consume: st.disposed");
+    return -1;
+  }
+  for (auto val : buf) {
+    // Note: we can safely ignore the return value here, because buffering the
+    //       values is fine. We tie the buffer size to the read buffer size,
+    //       which means we can't overflow the buffer.
+    std::ignore = st.push(val);
+  }
+  return static_cast<ptrdiff_t>(buf.size());
+}
+
+void flow_bridge::written(size_t num_bytes) {
+  if (!out_)
+    return;
+  if (overflow_ > 0) {
+    auto delta = std::min(overflow_, num_bytes);
+    overflow_ -= delta;
+    num_bytes -= delta;
+  }
+  if (num_bytes > 0) {
+    out_.request(num_bytes);
+    requested_ += num_bytes;
+  }
+}
+
+void flow_bridge::on_next(std::byte item) {
+  if (requested_ > 0)
+    --requested_;
+  else
+    ++overflow_;
+  down_->begin_output();
+  down_->output_buffer().push_back(item);
+  down_->end_output();
+}
+
+void flow_bridge::on_error(const error& what) {
+  abort(what);
+  out_.release_later();
+}
+
+void flow_bridge::on_complete() {
+  out_.release_later();
+}
+
+void flow_bridge::on_subscribe(flow::subscription sub) {
+  if (out_) {
+    sub.cancel();
+    return;
+  }
+  out_ = std::move(sub);
+  out_.request(write_buffer_size_);
+  requested_ = write_buffer_size_;
+}
+
+} // namespace caf::net::octet_stream

--- a/libcaf_net/caf/net/octet_stream/flow_bridge.hpp
+++ b/libcaf_net/caf/net/octet_stream/flow_bridge.hpp
@@ -1,0 +1,397 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/net/multiplexer.hpp"
+#include "caf/net/octet_stream/lower_layer.hpp"
+#include "caf/net/octet_stream/upper_layer.hpp"
+#include "caf/net/receive_policy.hpp"
+#include "caf/net/socket_manager.hpp"
+
+#include "caf/actor_system.hpp"
+#include "caf/async/consumer_adapter.hpp"
+#include "caf/async/future.hpp"
+#include "caf/async/producer_adapter.hpp"
+#include "caf/async/promise.hpp"
+#include "caf/async/publisher.hpp"
+#include "caf/detail/type_traits.hpp"
+#include "caf/flow/coordinator.hpp"
+#include "caf/flow/fwd.hpp"
+#include "caf/flow/observable.hpp"
+#include "caf/flow/observable_builder.hpp"
+#include "caf/flow/op/ucast.hpp"
+#include "caf/flow/subscription.hpp"
+#include "caf/sec.hpp"
+#include "caf/settings.hpp"
+
+#include <cstddef>
+#include <future>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+namespace caf::detail {
+
+/// Trivial observer that forwards all events to a
+/// `net::octet_stream::flow_bridge`.
+class octet_stream_observer : public flow::observer_impl_base<std::byte> {
+public:
+  using input_type = std::byte;
+
+  octet_stream_observer(flow::coordinator* parent,
+                        net::octet_stream::flow_bridge* listener)
+    : parent_(parent), listener_(listener) {
+    // nop
+  }
+
+  flow::coordinator* parent() const noexcept override;
+
+  void on_next(const std::byte& item) override;
+
+  void on_error(const error&) override;
+
+  void on_complete() override;
+
+  void on_subscribe(flow::subscription new_sub) override;
+
+private:
+  flow::coordinator* parent_;
+  net::octet_stream::flow_bridge* listener_;
+};
+
+} // namespace caf::detail
+
+namespace caf::net::octet_stream {
+
+using ucast_sub_state = flow::op::ucast_sub_state<std::byte>;
+
+/// Translates between a byte-oriented transport and data flows. Utility class
+/// for the `with` DSL.
+class flow_bridge : public upper_layer,
+                    public ucast_sub_state::abstract_listener {
+public:
+  flow_bridge(uint32_t read_buffer_size, uint32_t write_buffer_size)
+    : read_buffer_size_(read_buffer_size),
+      write_buffer_size_(write_buffer_size) {
+    // nop
+  }
+
+  template <class MakeInputs, class MakeOutputs>
+  static auto make(uint32_t read_buffer_size, uint32_t write_buffer_size,
+                   MakeInputs make_inputs, MakeOutputs make_outputs);
+
+  void on_subscribed(ucast_sub_state* state) override;
+
+  void on_disposed(ucast_sub_state*, bool from_external) override;
+
+  void on_consumed_some(ucast_sub_state*, size_t,
+                        size_t new_buffer_size) override;
+
+  virtual void init(socket_manager* ptr);
+
+  error start(lower_layer* down) override;
+
+  void prepare_send() override;
+
+  bool done_sending() override;
+
+  void abort(const error& reason) override;
+
+  ptrdiff_t consume(byte_span buf, byte_span) override;
+
+  void written(size_t) override;
+
+  void on_next(std::byte item);
+
+  void on_error(const error& what);
+
+  void on_complete();
+
+  void on_subscribe(flow::subscription sub);
+
+protected:
+  virtual void on_start() = 0;
+
+  /// The socket manager that owns this flow bridge.
+  socket_manager* self_ = nullptr;
+
+  /// The maximum size of the read buffer.
+  uint32_t read_buffer_size_ = 0;
+
+  /// The maximum size of the write buffer.
+  uint32_t write_buffer_size_ = 0;
+
+  /// Points to the next layer down the protocol stack.
+  lower_layer* down_ = nullptr;
+
+  /// The flow that consumes the bytes we receive from the lower layer.
+  flow::op::ucast_ptr<std::byte> in_;
+
+  /// The subscription for the flow that generates the bytes to send.
+  flow::subscription out_;
+
+  /// Stores how many bytes we have requested from `out_`.
+  size_t requested_ = 0;
+
+  /// Stores excess bytes from `out_` that exceeded the assigned capacity.
+  size_t overflow_ = 0;
+};
+
+/// Adapter for constructing a `publisher<T>` that forwards subscriptions to a
+/// flow bridge.
+template <class T>
+class flow_bridge_adapter : public detail::flow_source<T> {
+public:
+  flow_bridge_adapter(async::execution_context_ptr ctx) : ctx_(std::move(ctx)) {
+    // nop
+  }
+
+  void add(async::producer_resource<T> sink) override {
+    ctx_->schedule_fn([sink = std::move(sink), thisptr = shared()]() mutable {
+      thisptr->do_add(std::move(sink));
+    });
+  }
+
+  void init(flow::observable<T>* inputs) {
+    inputs_ = inputs;
+  }
+
+  void close() {
+    inputs_ = nullptr;
+  }
+
+  void abort(error reason) {
+    inputs_ = nullptr;
+    error_ = std::move(reason);
+  }
+
+private:
+  void do_add(async::producer_resource<T> sink) {
+    if (auto ptr = inputs_)
+      ptr->subscribe(std::move(sink));
+    else if (error_)
+      sink.abort(error_);
+    else
+      sink.close();
+  }
+
+  intrusive_ptr<flow_bridge_adapter> shared() {
+    return this;
+  }
+
+  async::execution_context_ptr ctx_;
+
+  flow::observable<T>* inputs_ = nullptr;
+
+  error error_;
+};
+
+/// Forwards only the `on_complete` or `on_error` event to subscribers.
+template <class T>
+class flow_bridge_signalizer : public detail::flow_source<T> {
+public:
+  void add(async::producer_resource<T> sink) override {
+    std::lock_guard guard{mtx_};
+    if (closed_) {
+      if (error_)
+        sink.abort(error_);
+      else
+        sink.close();
+      return;
+    }
+    sinks_.push_back(std::move(sink));
+  }
+
+  void close() {
+    std::lock_guard guard{mtx_};
+    closed_ = true;
+    for (auto& sink : sinks_)
+      sink.close();
+    sinks_.clear();
+  }
+
+  void abort(error reason) {
+    std::lock_guard guard{mtx_};
+    closed_ = true;
+    error_ = std::move(reason);
+    for (auto& sink : sinks_)
+      sink.abort(error_);
+    sinks_.clear();
+  }
+
+private:
+  std::mutex mtx_;
+
+  std::vector<async::producer_resource<T>> sinks_;
+
+  bool closed_ = false;
+
+  error error_;
+};
+
+/// Implementation detail for `flow_bridge_inputs_t`.
+template <class MakeInputsResult>
+struct flow_bridge_inputs_oracle {
+  using type = typename MakeInputsResult::output_type;
+};
+
+template <>
+struct flow_bridge_inputs_oracle<void> {
+  using type = void;
+};
+
+/// Extracts the item type from a `MakeInputs` callback or `void` if the
+/// callback does not return an observable.
+template <class MakeInputs>
+using flow_bridge_inputs_t = typename flow_bridge_inputs_oracle<
+  decltype(std::declval<MakeInputs&>()(flow::observable<std::byte>{}))>::type;
+
+/// Provides boilerplate code for flow bridges that can be subscribed to via a
+/// publisher.
+template <class T>
+class flow_bridge_impl_base : public flow_bridge {
+public:
+  using super = flow_bridge;
+
+  using publisher_type = async::publisher<T>;
+
+  flow_bridge_impl_base(uint32_t read_buffer_size, uint32_t write_buffer_size)
+    : super(read_buffer_size, write_buffer_size) {
+  }
+
+  ~flow_bridge_impl_base() {
+    source_->close();
+  }
+
+  void init(socket_manager* ptr) override {
+    source_ = make_counted<flow_bridge_adapter<T>>(ptr);
+    super::init(ptr);
+  }
+
+  async::publisher<T> publisher() {
+    return async::publisher<T>::from(source_);
+  }
+
+protected:
+  template <class Init>
+  void init_inputs(Init&& inputs) {
+    inputs_ = std::forward<Init>(inputs).as_observable();
+    source_->init(&inputs_);
+  }
+
+private:
+  flow::observable<T> inputs_;
+  caf::intrusive_ptr<flow_bridge_adapter<T>> source_;
+};
+
+/// Specialization for flow bridges that do not have an input flow.
+template <>
+class flow_bridge_impl_base<void> : public flow_bridge {
+public:
+  static constexpr bool has_publisher = false;
+
+  using super = flow_bridge;
+
+  using publisher_type = async::publisher<unit_t>;
+
+  using super::super;
+
+  ~flow_bridge_impl_base() {
+    source_->close();
+  }
+
+  void init(socket_manager* ptr) override {
+    source_ = make_counted<flow_bridge_signalizer<unit_t>>();
+    super::init(ptr);
+  }
+
+  publisher_type publisher() const {
+    return async::publisher<unit_t>::from(source_);
+  }
+
+protected:
+  caf::intrusive_ptr<flow_bridge_signalizer<unit_t>> source_;
+};
+
+/// Implements the flow bridge with two factory functions for creating the input
+/// and output flows.
+template <class MakeInputs, class MakeOutputs>
+class flow_bridge_impl
+  : public flow_bridge_impl_base<flow_bridge_inputs_t<MakeInputs>> {
+public:
+  using input_type = flow_bridge_inputs_t<MakeInputs>;
+
+  using super = flow_bridge_impl_base<input_type>;
+
+  flow_bridge_impl(uint32_t read_buffer_size, uint32_t write_buffer_size,
+                   MakeInputs&& make_inputs, MakeOutputs&& make_outputs)
+    : super(read_buffer_size, write_buffer_size) {
+    new (&make_inputs_) MakeInputs(std::move(make_inputs));
+    new (&make_outputs_) MakeOutputs(std::move(make_outputs));
+  }
+
+  ~flow_bridge_impl() {
+    if (!started) {
+      make_inputs_.~MakeInputs();
+      make_outputs_.~MakeOutputs();
+    }
+  }
+
+private:
+  void on_start() override {
+    CAF_ASSERT(!started);
+    auto self = static_cast<flow::coordinator*>(super::self_);
+    auto obs_ptr = make_counted<detail::octet_stream_observer>(self, this);
+    auto obs = flow::observer<std::byte>{std::move(obs_ptr)};
+    make_outputs_(self).subscribe(std::move(obs));
+    if constexpr (std::is_void_v<input_type>) {
+      auto src = super::source_;
+      make_inputs_(
+        flow::observable<std::byte>{super::in_}
+          .do_on_complete([src] { src->close(); })
+          .do_on_error([src](error reason) { src->abort(std::move(reason)); })
+          .as_observable());
+    } else {
+      this->init_inputs(make_inputs_(flow::observable<std::byte>{super::in_}));
+    }
+    started = true;
+    make_inputs_.~MakeInputs();
+    make_outputs_.~MakeOutputs();
+  }
+
+  bool started = false;
+
+  union {
+    MakeInputs make_inputs_;
+  };
+
+  union {
+    MakeOutputs make_outputs_;
+  };
+};
+
+template <class MakeInputs, class MakeOutputs>
+auto flow_bridge::make(uint32_t read_buffer_size, uint32_t write_buffer_size,
+                       MakeInputs make_inputs, MakeOutputs make_outputs) {
+  using res_t = decltype(make_inputs(flow::observable<std::byte>{}));
+  static_assert(std::is_same_v<res_t, void> || flow::is_observable_v<res_t>,
+                "MakeInputs must return void or an observable");
+  using out_t
+    = decltype(make_outputs(static_cast<flow::coordinator*>(nullptr)));
+  static_assert(flow::is_observable_v<out_t>,
+                "MakeOutputs must return an observable emitting std::byte");
+  static_assert(std::is_same_v<typename out_t::output_type, std::byte>,
+                "MakeOutputs must return an observable emitting std::byte");
+  using impl_t = flow_bridge_impl<MakeInputs, MakeOutputs>;
+  return std::make_unique<impl_t>(read_buffer_size, write_buffer_size,
+                                  std::move(make_inputs),
+                                  std::move(make_outputs));
+}
+
+template <class MakeInputs, class MakeOutputs>
+using flow_bridge_publisher_t =
+  typename flow_bridge_impl<MakeInputs, MakeOutputs>::publisher_type;
+
+} // namespace caf::net::octet_stream

--- a/libcaf_net/caf/net/octet_stream/flow_bridge.hpp
+++ b/libcaf_net/caf/net/octet_stream/flow_bridge.hpp
@@ -16,6 +16,7 @@
 #include "caf/async/producer_adapter.hpp"
 #include "caf/async/promise.hpp"
 #include "caf/async/publisher.hpp"
+#include "caf/detail/net_export.hpp"
 #include "caf/detail/type_traits.hpp"
 #include "caf/flow/coordinator.hpp"
 #include "caf/flow/fwd.hpp"
@@ -36,7 +37,8 @@ namespace caf::detail {
 
 /// Trivial observer that forwards all events to a
 /// `net::octet_stream::flow_bridge`.
-class octet_stream_observer : public flow::observer_impl_base<std::byte> {
+class CAF_NET_EXPORT octet_stream_observer
+  : public flow::observer_impl_base<std::byte> {
 public:
   using input_type = std::byte;
 
@@ -69,8 +71,8 @@ using ucast_sub_state = flow::op::ucast_sub_state<std::byte>;
 
 /// Translates between a byte-oriented transport and data flows. Utility class
 /// for the `with` DSL.
-class flow_bridge : public upper_layer,
-                    public ucast_sub_state::abstract_listener {
+class CAF_NET_EXPORT flow_bridge : public upper_layer,
+                                   public ucast_sub_state::abstract_listener {
 public:
   flow_bridge(uint32_t read_buffer_size, uint32_t write_buffer_size)
     : read_buffer_size_(read_buffer_size),

--- a/libcaf_net/caf/net/octet_stream/flow_bridge.test.cpp
+++ b/libcaf_net/caf/net/octet_stream/flow_bridge.test.cpp
@@ -1,0 +1,264 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/net/octet_stream/flow_bridge.hpp"
+
+#include "caf/test/test.hpp"
+
+#include "caf/net/fwd.hpp"
+#include "caf/net/multiplexer.hpp"
+#include "caf/net/octet_stream/transport.hpp"
+#include "caf/net/socket_manager.hpp"
+#include "caf/net/stream_socket.hpp"
+
+#include "caf/detail/latch.hpp"
+#include "caf/flow/observable_builder.hpp"
+#include "caf/flow/scoped_coordinator.hpp"
+#include "caf/log/test.hpp"
+
+using namespace caf;
+
+using net::octet_stream::flow_bridge;
+
+using namespace std::literals;
+
+namespace {
+
+// Simple loop receiving `num_items` bytes and sending them back incremented by
+// one.
+void ping_pong(net::stream_socket fd, int num_items) {
+  auto guard = detail::scope_guard{[fd]() noexcept { net::close(fd); }};
+  for (int i = 0; i < num_items; ++i) {
+    std::byte buf;
+    if (net::read(fd, make_span(&buf, 1)) != 1) {
+      return;
+    }
+    buf = std::byte{static_cast<uint8_t>(std::to_integer<int>(buf) + 1)};
+    if (net::write(fd, make_span(&buf, 1)) != 1) {
+      return;
+    }
+  }
+}
+
+// Send `num_items` bytes to the given socket.
+void iota_send(net::stream_socket fd, int num_items) {
+  auto guard = detail::scope_guard{[fd]() noexcept { net::close(fd); }};
+  for (int i = 1; i <= num_items; ++i) {
+    std::byte buf{static_cast<uint8_t>(i % 256)};
+    if (net::write(fd, make_span(&buf, 1)) != 1) {
+      return;
+    }
+  }
+}
+
+struct fixture {
+  fixture() {
+    mpx = net::multiplexer::make(nullptr);
+    std::ignore = mpx->init();
+    mpx_thread = std::thread{[mpx = mpx] {
+      mpx->set_thread_id();
+      mpx->run();
+    }};
+  }
+
+  ~fixture() {
+    mpx->shutdown();
+    mpx_thread.join();
+  }
+
+  net::multiplexer_ptr mpx;
+  std::thread mpx_thread;
+};
+
+WITH_FIXTURE(fixture) {
+
+TEST("a flow bridge connects flows to a socket") {
+  // Socket and thread setup.
+  auto fd_pair = net::make_stream_socket_pair();
+  require(fd_pair.has_value());
+  auto [fd1, fd2] = *fd_pair;
+  auto ping_pong_thread = std::thread{ping_pong, fd2, 50};
+  // Bridge setup.
+  auto received = std::make_shared<std::vector<int>>();
+  auto rendezvous = detail::latch{2};
+  auto bridge = flow_bridge::make(
+    16, 16,
+    [received, &rendezvous](flow::observable<std::byte> bytes) {
+      bytes.map([](std::byte item) { return std::to_integer<int>(item); })
+        .do_finally([&rendezvous] { rendezvous.count_down(); })
+        .for_each([received](int item) { received->push_back(item); });
+    },
+    [](flow::coordinator* self) {
+      return self->make_observable()
+        .iota(1) //
+        .take(50)
+        .map([](int x) { return std::byte{static_cast<uint8_t>(x)}; });
+    });
+  auto bridge_ptr = bridge.get();
+  auto transport = net::octet_stream::transport::make(fd1, std::move(bridge));
+  transport->active_policy().connect();
+  auto ptr = net::socket_manager::make(mpx.get(), std::move(transport));
+  bridge_ptr->init(ptr.get());
+  mpx->start(ptr);
+  // Check the results.
+  rendezvous.count_down_and_wait();
+  auto want = std::vector<int>();
+  want.resize(50);
+  std::iota(want.begin(), want.end(), 2);
+  check_eq(*received, want);
+  // Cleanup.
+  ping_pong_thread.join();
+}
+
+TEST("a bridge can make received data available through a publisher") {
+  // Socket and thread setup.
+  auto fd_pair = net::make_stream_socket_pair();
+  require(fd_pair.has_value());
+  auto [fd1, fd2] = *fd_pair;
+  auto ping_pong_thread = std::thread{ping_pong, fd2, 50};
+  // Bridge setup.
+  auto bridge = net::octet_stream::flow_bridge::make(
+    16, 16,
+    [](flow::observable<std::byte> bytes) {
+      return bytes
+        .map([](std::byte item) { return std::to_integer<int>(item); })
+        .share(1);
+    },
+    [](flow::coordinator* self) {
+      return self->make_observable()
+        .iota(1) //
+        .take(50)
+        .map([](int x) { return std::byte{static_cast<uint8_t>(x)}; });
+    });
+  auto bridge_ptr = bridge.get();
+  auto transport = net::octet_stream::transport::make(fd1, std::move(bridge));
+  transport->active_policy().connect();
+  auto ptr = net::socket_manager::make(mpx.get(), std::move(transport));
+  bridge_ptr->init(ptr.get());
+  auto res = bridge_ptr->publisher();
+  mpx->start(ptr);
+  // Receive the results. We wait a bit here to subscribe after the bridge has
+  // been fully set up in order to trigger more code paths.
+  std::this_thread::sleep_for(10ms);
+  auto received = std::make_shared<std::vector<int>>();
+  auto self = flow::scoped_coordinator::make();
+  res.observe_on(self.get()).for_each([received](int item) {
+    received->push_back(item);
+  });
+  self->run();
+  // Check the results.
+  auto want = std::vector<int>();
+  want.resize(50);
+  std::iota(want.begin(), want.end(), 2);
+  check_eq(*received, want);
+  // Cleanup.
+  ping_pong_thread.join();
+}
+
+TEST("a bridge may use time-based flow operators") {
+  // Socket and thread setup.
+  auto fd_pair = net::make_stream_socket_pair();
+  require(fd_pair.has_value());
+  auto [fd1, fd2] = *fd_pair;
+  auto ping_pong_thread = std::thread{ping_pong, fd2, 5};
+  // Bridge setup.
+  auto received = std::make_shared<std::vector<int>>();
+  auto rendezvous = detail::latch{2};
+  auto bridge = net::octet_stream::flow_bridge::make(
+    16, 16,
+    [received, &rendezvous](flow::observable<std::byte> bytes) {
+      bytes.map([](std::byte item) { return std::to_integer<int>(item); })
+        .do_finally([&rendezvous] { rendezvous.count_down(); })
+        .for_each([received](int item) { received->push_back(item); });
+    },
+    [](flow::coordinator* self) {
+      return self->make_observable()
+        .interval(10ms) //
+        .take(5)
+        .map([](int64_t x) { return std::byte{static_cast<uint8_t>(x)}; });
+    });
+  auto bridge_ptr = bridge.get();
+  auto transport = net::octet_stream::transport::make(fd1, std::move(bridge));
+  transport->active_policy().connect();
+  auto ptr = net::socket_manager::make(mpx.get(), std::move(transport));
+  bridge_ptr->init(ptr.get());
+  mpx->start(ptr);
+  // Check the results.
+  rendezvous.count_down_and_wait();
+  auto want = std::vector<int>();
+  want.resize(5);
+  std::iota(want.begin(), want.end(), 1);
+  check_eq(*received, want);
+  // Cleanup.
+  ping_pong_thread.join();
+}
+
+TEST("passing never to a flow bridge omits outputs") {
+  // Socket and thread setup.
+  auto fd_pair = net::make_stream_socket_pair();
+  require(fd_pair.has_value());
+  auto [fd1, fd2] = *fd_pair;
+  auto ping_pong_thread = std::thread{iota_send, fd2, 1024};
+  // Bridge setup.
+  auto received_total = std::make_shared<size_t>();
+  auto rendezvous = detail::latch{2};
+  auto bridge = net::octet_stream::flow_bridge::make(
+    16, 16,
+    [received_total, &rendezvous](flow::observable<std::byte> bytes) {
+      bytes.map([](std::byte item) { return std::to_integer<int>(item); })
+        .do_finally([&rendezvous] { rendezvous.count_down(); })
+        .for_each([received_total](int) { *received_total += 1; });
+    },
+    [](flow::coordinator* self) {
+      return self->make_observable().never<std::byte>();
+    });
+  auto bridge_ptr = bridge.get();
+  auto transport = net::octet_stream::transport::make(fd1, std::move(bridge));
+  transport->active_policy().connect();
+  auto ptr = net::socket_manager::make(mpx.get(), std::move(transport));
+  bridge_ptr->init(ptr.get());
+  mpx->start(ptr);
+  // Check the results.
+  rendezvous.count_down_and_wait();
+  check_eq(*received_total, 1024u);
+  // Cleanup.
+  ping_pong_thread.join();
+}
+
+TEST("subscribing std::ignore to the inputs discards received data") {
+  // Socket and thread setup.
+  auto fd_pair = net::make_stream_socket_pair();
+  require(fd_pair.has_value());
+  auto [fd1, fd2] = *fd_pair;
+  auto ping_pong_thread = std::thread{iota_send, fd2, 1024};
+  // Bridge setup.
+  auto received_total = std::make_shared<size_t>();
+  auto rendezvous = detail::latch{2};
+  auto bridge = net::octet_stream::flow_bridge::make(
+    16, 16,
+    [received_total, &rendezvous](flow::observable<std::byte> bytes) {
+      bytes.map([](std::byte item) { return std::to_integer<int>(item); })
+        .do_finally([&rendezvous] { rendezvous.count_down(); })
+        .do_on_next([received_total](int) { *received_total += 1; })
+        .subscribe(std::ignore);
+    },
+    [](flow::coordinator* self) {
+      return self->make_observable().never<std::byte>();
+    });
+  auto bridge_ptr = bridge.get();
+  auto transport = net::octet_stream::transport::make(fd1, std::move(bridge));
+  transport->active_policy().connect();
+  auto ptr = net::socket_manager::make(mpx.get(), std::move(transport));
+  bridge_ptr->init(ptr.get());
+  mpx->start(ptr);
+  // Check the results.
+  rendezvous.count_down_and_wait();
+  check_eq(*received_total, 1024u);
+  // Cleanup.
+  ping_pong_thread.join();
+}
+
+} // WITH_FIXTURE(fixture)
+
+} // namespace

--- a/libcaf_net/caf/net/octet_stream/flow_bridge.test.cpp
+++ b/libcaf_net/caf/net/octet_stream/flow_bridge.test.cpp
@@ -194,12 +194,12 @@ TEST("a bridge may use time-based flow operators") {
   ping_pong_thread.join();
 }
 
-TEST("passing never to a flow bridge omits outputs") {
+TEST("passing never as output flow produces no output to the socket") {
   // Socket and thread setup.
   auto fd_pair = net::make_stream_socket_pair();
   require(fd_pair.has_value());
   auto [fd1, fd2] = *fd_pair;
-  auto ping_pong_thread = std::thread{iota_send, fd2, 1024};
+  auto iota_thread = std::thread{iota_send, fd2, 1024};
   // Bridge setup.
   auto received_total = std::make_shared<size_t>();
   auto rendezvous = detail::latch{2};
@@ -223,7 +223,7 @@ TEST("passing never to a flow bridge omits outputs") {
   rendezvous.count_down_and_wait();
   check_eq(*received_total, 1024u);
   // Cleanup.
-  ping_pong_thread.join();
+  iota_thread.join();
 }
 
 TEST("subscribing std::ignore to the inputs discards received data") {

--- a/libcaf_net/caf/net/octet_stream/transport.cpp
+++ b/libcaf_net/caf/net/octet_stream/transport.cpp
@@ -328,6 +328,7 @@ void transport::handle_write_event() {
   auto write_res = policy_->write(write_buf_);
   if (write_res > 0) {
     write_buf_.erase(write_buf_.begin(), write_buf_.begin() + write_res);
+    up_->written(static_cast<size_t>(write_res));
     if (write_buf_.empty() && up_->done_sending()) {
       if (!flags_.shutting_down) {
         parent_->deregister_writing();

--- a/libcaf_net/caf/net/octet_stream/upper_layer.cpp
+++ b/libcaf_net/caf/net/octet_stream/upper_layer.cpp
@@ -10,4 +10,8 @@ upper_layer::~upper_layer() {
   // nop
 }
 
+void upper_layer::written(size_t) {
+  // nop
+}
+
 } // namespace caf::net::octet_stream

--- a/libcaf_net/caf/net/octet_stream/upper_layer.hpp
+++ b/libcaf_net/caf/net/octet_stream/upper_layer.hpp
@@ -30,6 +30,9 @@ public:
   ///          input or negative to signal an error.
   [[nodiscard]] virtual ptrdiff_t consume(byte_span buffer, byte_span delta)
     = 0;
+
+  /// Called from the lower layer whenever data has been written.
+  virtual void written(size_t num_bytes);
 };
 
 } // namespace caf::net::octet_stream

--- a/libcaf_net/caf/net/octet_stream/with.hpp
+++ b/libcaf_net/caf/net/octet_stream/with.hpp
@@ -1,0 +1,61 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/net/dsl/generic_config.hpp"
+#include "caf/net/dsl/has_accept.hpp"
+#include "caf/net/dsl/has_context.hpp"
+#include "caf/net/dsl/has_uri_connect.hpp"
+#include "caf/net/multiplexer.hpp"
+#include "caf/net/octet_stream/client_factory.hpp"
+#include "caf/net/ssl/context.hpp"
+#include "caf/net/tcp_accept_socket.hpp"
+
+#include "caf/extend.hpp"
+#include "caf/fwd.hpp"
+
+#include <cstdint>
+
+namespace caf::net::octet_stream {
+
+/// Entry point for the `with(...)` DSL.
+class with_t
+  : public extend<dsl::base, with_t>::with<dsl::has_connect, dsl::has_context> {
+public:
+  using config_type = dsl::generic_config_value;
+
+  template <class... Ts>
+  explicit with_t(multiplexer* mpx) : config_(make_counted<config_type>(mpx)) {
+    // nop
+  }
+
+  with_t(const with_t&) noexcept = default;
+
+  with_t& operator=(const with_t&) noexcept = default;
+
+  /// @private
+  config_type& config() {
+    return *config_;
+  }
+
+  /// @private
+  template <class T, class... Ts>
+  auto make(dsl::client_config_tag<T> token, Ts&&... xs) {
+    return client_factory{token, *config_, std::forward<Ts>(xs)...};
+  }
+
+private:
+  intrusive_ptr<config_type> config_;
+};
+
+inline auto with(actor_system& sys) {
+  return with_t{multiplexer::from(sys)};
+}
+
+inline auto with(multiplexer* mpx) {
+  return with_t{mpx};
+}
+
+} // namespace caf::net::octet_stream

--- a/libcaf_net/caf/net/octet_stream/with.test.cpp
+++ b/libcaf_net/caf/net/octet_stream/with.test.cpp
@@ -1,0 +1,267 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/net/octet_stream/with.hpp"
+
+#include "caf/test/test.hpp"
+
+#include "caf/net/fwd.hpp"
+#include "caf/net/multiplexer.hpp"
+#include "caf/net/octet_stream/transport.hpp"
+#include "caf/net/socket_manager.hpp"
+#include "caf/net/stream_socket.hpp"
+
+#include "caf/detail/latch.hpp"
+#include "caf/flow/observable_builder.hpp"
+#include "caf/flow/scoped_coordinator.hpp"
+#include "caf/log/test.hpp"
+
+// Note: the test here are similar to flow_bridge.test.cpp, except that they use
+//       the `with` DSL instead of the `flow_bridge` class directly.
+
+using namespace caf;
+
+using net::octet_stream::flow_bridge;
+
+using namespace std::literals;
+
+namespace {
+
+// Simple loop receiving `num_items` bytes and sending them back incremented by
+// one.
+void ping_pong(net::stream_socket fd, int num_items) {
+  auto guard = detail::scope_guard{[fd]() noexcept { net::close(fd); }};
+  for (int i = 0; i < num_items; ++i) {
+    std::byte buf;
+    if (net::read(fd, make_span(&buf, 1)) != 1) {
+      return;
+    }
+    buf = std::byte{static_cast<uint8_t>(std::to_integer<int>(buf) + 1)};
+    if (net::write(fd, make_span(&buf, 1)) != 1) {
+      return;
+    }
+  }
+}
+
+// Send `num_items` bytes to the given socket.
+void iota_send(net::stream_socket fd, int num_items) {
+  auto guard = detail::scope_guard{[fd]() noexcept { net::close(fd); }};
+  for (int i = 1; i <= num_items; ++i) {
+    std::byte buf{static_cast<uint8_t>(i % 256)};
+    if (net::write(fd, make_span(&buf, 1)) != 1) {
+      return;
+    }
+  }
+}
+
+struct fixture {
+  fixture() {
+    mpx = net::multiplexer::make(nullptr);
+    std::ignore = mpx->init();
+    mpx_thread = std::thread{[mpx = mpx] {
+      mpx->set_thread_id();
+      mpx->run();
+    }};
+  }
+
+  ~fixture() {
+    mpx->shutdown();
+    mpx_thread.join();
+  }
+
+  net::multiplexer_ptr mpx;
+  std::thread mpx_thread;
+};
+
+WITH_FIXTURE(fixture) {
+
+TEST("a flow bridge connects flows to a socket") {
+  // Socket and thread setup.
+  auto fd_pair = net::make_stream_socket_pair();
+  require(fd_pair.has_value());
+  auto [fd1, fd2] = *fd_pair;
+  auto ping_pong_thread = std::thread{ping_pong, fd2, 50};
+  // Bridge setup.
+  auto received = std::make_shared<std::vector<int>>();
+  auto rendezvous = detail::latch{2};
+  auto start_res
+    = net::octet_stream::with(mpx.get())
+        .connect(fd1)
+        .read_buffer_size(16)
+        .write_buffer_size(16)
+        .send_from([](flow::coordinator* self) {
+          return self->make_observable()
+            .iota(1) //
+            .take(50)
+            .map([](int x) { return std::byte{static_cast<uint8_t>(x)}; });
+        })
+        .start([received, &rendezvous](flow::observable<std::byte> bytes) {
+          bytes.map([](std::byte item) { return std::to_integer<int>(item); })
+            .do_finally([&rendezvous] { rendezvous.count_down(); })
+            .for_each([received](int item) { received->push_back(item); });
+        });
+  require(start_res.has_value());
+  // Check the results.
+  rendezvous.count_down_and_wait();
+  auto want = std::vector<int>();
+  want.resize(50);
+  std::iota(want.begin(), want.end(), 2);
+  check_eq(*received, want);
+  // Cleanup.
+  ping_pong_thread.join();
+  // Must be closed by now.
+  auto self = flow::scoped_coordinator::make();
+  auto closed = std::make_shared<bool>(false);
+  auto err = std::make_shared<error>();
+  start_res->first.observe_on(self.get())
+    .do_on_complete([closed] { *closed = true; })
+    .do_on_error([closed, err](error x) {
+      *closed = true;
+      *err = std::move(x);
+    })
+    .for_each([received](unit_t) {});
+  self->run();
+  check(*closed);
+  check_eq(*err, sec::socket_disconnected);
+}
+
+TEST("a bridge can make received data available through a publisher") {
+  // Socket and thread setup.
+  auto fd_pair = net::make_stream_socket_pair();
+  require(fd_pair.has_value());
+  auto [fd1, fd2] = *fd_pair;
+  auto ping_pong_thread = std::thread{ping_pong, fd2, 50};
+  // Bridge setup.
+  auto start_res
+    = net::octet_stream::with(mpx.get())
+        .connect(fd1)
+        .read_buffer_size(16)
+        .write_buffer_size(16)
+        .send_from([](flow::coordinator* self) {
+          return self->make_observable()
+            .iota(1) //
+            .take(50)
+            .map([](int x) { return std::byte{static_cast<uint8_t>(x)}; });
+        })
+        .start([](flow::observable<std::byte> bytes) {
+          return bytes
+            .map([](std::byte item) { return std::to_integer<int>(item); })
+            .share(1);
+        });
+  require(start_res.has_value());
+  auto res = start_res->first;
+  // Receive the results. We wait a bit here to subscribe after the bridge has
+  // been fully set up in order to trigger more code paths.
+  std::this_thread::sleep_for(10ms);
+  auto received = std::make_shared<std::vector<int>>();
+  auto self = flow::scoped_coordinator::make();
+  res.observe_on(self.get()).for_each([received](int item) {
+    received->push_back(item);
+  });
+  self->run();
+  // Check the results.
+  auto want = std::vector<int>();
+  want.resize(50);
+  std::iota(want.begin(), want.end(), 2);
+  check_eq(*received, want);
+  // Cleanup.
+  ping_pong_thread.join();
+}
+
+TEST("a bridge may use time-based flow operators") {
+  // Socket and thread setup.
+  auto fd_pair = net::make_stream_socket_pair();
+  require(fd_pair.has_value());
+  auto [fd1, fd2] = *fd_pair;
+  auto ping_pong_thread = std::thread{ping_pong, fd2, 5};
+  // Bridge setup.
+  auto received = std::make_shared<std::vector<int>>();
+  auto rendezvous = detail::latch{2};
+  auto start_res
+    = net::octet_stream::with(mpx.get())
+        .connect(fd1)
+        .read_buffer_size(16)
+        .write_buffer_size(16)
+        .send_from([](flow::coordinator* self) {
+          return self->make_observable()
+            .interval(10ms) //
+            .take(5)
+            .map([](int64_t x) { return std::byte{static_cast<uint8_t>(x)}; });
+        })
+        .start([received, &rendezvous](flow::observable<std::byte> bytes) {
+          bytes.map([](std::byte item) { return std::to_integer<int>(item); })
+            .do_finally([&rendezvous] { rendezvous.count_down(); })
+            .for_each([received](int item) { received->push_back(item); });
+        });
+  require(start_res.has_value());
+  // Check the results.
+  rendezvous.count_down_and_wait();
+  auto want = std::vector<int>();
+  want.resize(5);
+  std::iota(want.begin(), want.end(), 1);
+  check_eq(*received, want);
+  // Cleanup.
+  ping_pong_thread.join();
+}
+
+TEST("passing never to a flow bridge omits outputs") {
+  // Socket and thread setup.
+  auto fd_pair = net::make_stream_socket_pair();
+  require(fd_pair.has_value());
+  auto [fd1, fd2] = *fd_pair;
+  auto ping_pong_thread = std::thread{iota_send, fd2, 1024};
+  // Bridge setup.
+  auto received_total = std::make_shared<size_t>();
+  auto rendezvous = detail::latch{2};
+  auto start_res
+    = net::octet_stream::with(mpx.get())
+        .connect(fd1)
+        .read_buffer_size(16)
+        .write_buffer_size(16)
+        .start(
+          [received_total, &rendezvous](flow::observable<std::byte> bytes) {
+            bytes.map([](std::byte item) { return std::to_integer<int>(item); })
+              .do_finally([&rendezvous] { rendezvous.count_down(); })
+              .for_each([received_total](int) { *received_total += 1; });
+          });
+  require(start_res.has_value());
+  // Check the results.
+  rendezvous.count_down_and_wait();
+  check_eq(*received_total, 1024u);
+  // Cleanup.
+  ping_pong_thread.join();
+}
+
+TEST("subscribing std::ignore to the inputs discards received data") {
+  // Socket and thread setup.
+  auto fd_pair = net::make_stream_socket_pair();
+  require(fd_pair.has_value());
+  auto [fd1, fd2] = *fd_pair;
+  auto ping_pong_thread = std::thread{iota_send, fd2, 1024};
+  // Bridge setup.
+  auto received_total = std::make_shared<size_t>();
+  auto rendezvous = detail::latch{2};
+  auto start_res
+    = net::octet_stream::with(mpx.get())
+        .connect(fd1)
+        .read_buffer_size(16)
+        .write_buffer_size(16)
+        .start(
+          [received_total, &rendezvous](flow::observable<std::byte> bytes) {
+            bytes.map([](std::byte item) { return std::to_integer<int>(item); })
+              .do_finally([&rendezvous] { rendezvous.count_down(); })
+              .do_on_next([received_total](int) { *received_total += 1; })
+              .subscribe(std::ignore);
+          });
+  require(start_res.has_value());
+  // Check the results.
+  rendezvous.count_down_and_wait();
+  check_eq(*received_total, 1024u);
+  // Cleanup.
+  ping_pong_thread.join();
+}
+
+} // WITH_FIXTURE(fixture)
+
+} // namespace

--- a/libcaf_net/caf/net/octet_stream/with.test.cpp
+++ b/libcaf_net/caf/net/octet_stream/with.test.cpp
@@ -205,12 +205,12 @@ TEST("a bridge may use time-based flow operators") {
   ping_pong_thread.join();
 }
 
-TEST("passing never to a flow bridge omits outputs") {
+TEST("omitting send_from produces no output on the socket") {
   // Socket and thread setup.
   auto fd_pair = net::make_stream_socket_pair();
   require(fd_pair.has_value());
   auto [fd1, fd2] = *fd_pair;
-  auto ping_pong_thread = std::thread{iota_send, fd2, 1024};
+  auto iota_thread = std::thread{iota_send, fd2, 1024};
   // Bridge setup.
   auto received_total = std::make_shared<size_t>();
   auto rendezvous = detail::latch{2};
@@ -230,7 +230,7 @@ TEST("passing never to a flow bridge omits outputs") {
   rendezvous.count_down_and_wait();
   check_eq(*received_total, 1024u);
   // Cleanup.
-  ping_pong_thread.join();
+  iota_thread.join();
 }
 
 TEST("subscribing std::ignore to the inputs discards received data") {


### PR DESCRIPTION
Implements a new flow source that operates on octet streams.

@riemass this is only the client-side DSL for now. The server part is going to be a followup after agreeing on the implementation details. This setup is slightly different to what we use for WebSocket etc., because it hands a `publisher<T>` to the user for consuming the results. However, it basically gives you the full range of the flow API in a socket handler now. I quite like this approach and I'm thinking to use the same approach for the WebSocket and length-prefix protocols. Let me know what you think. 🙂

Relates #1752.