### PR TITLE
Simplify function chaining on delayed requests

### DIFF
--- a/libcaf_core/caf/blocking_mail.hpp
+++ b/libcaf_core/caf/blocking_mail.hpp
@@ -63,9 +63,9 @@ public:
                                            make_error(sec::invalid_request)),
                       self()->context());
     }
-    using hdl_t = blocking_response_handle<response_type>;
-    auto hdl = hdl_t{self(), mid.response_id(), relative_timeout};
-    return std::pair{std::move(hdl), std::move(in_flight)};
+    using hdl_t = blocking_delayed_response_handle<response_type>;
+    return hdl_t{self(), mid.response_id(), relative_timeout,
+                 std::move(in_flight)};
   }
 
 private:

--- a/libcaf_core/caf/blocking_response_handle.hpp
+++ b/libcaf_core/caf/blocking_response_handle.hpp
@@ -78,4 +78,113 @@ private:
   timespan timeout_;
 };
 
+/// Similar to `blocking_response_handle`, but also holds the `disposable`
+/// for the delayed request message.
+template <class Result>
+class blocking_delayed_response_handle {
+public:
+  using decorated_type = blocking_response_handle<Result>;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  blocking_delayed_response_handle(abstract_blocking_actor* self,
+                                   message_id mid, timespan timeout,
+                                   disposable pending_request)
+    : decorated_(self, mid, timeout),
+      pending_request_(std::move(pending_request)) {
+    // nop
+  }
+
+  // -- then and await ---------------------------------------------------------
+
+  template <class OnValue, class OnError>
+  void receive(OnValue on_value, OnError on_error) && {
+    std::move(decorated_).receive(std::move(on_value), std::move(on_error));
+  }
+
+  // -- properties -------------------------------------------------------------
+
+  /// Returns the decorated handle.
+  decorated_type& decorated() {
+    return decorated_;
+  }
+
+  /// @copydoc decorated
+  const decorated_type& decorated() const {
+    return decorated_;
+  }
+
+  /// Returns the handle to the in-flight request message if the request was
+  /// delayed/scheduled. Otherwise, returns an empty handle.
+  disposable& pending_request() {
+    return pending_request_;
+  }
+
+  /// @copydoc pending_request
+  const disposable& pending_request() const {
+    return pending_request_;
+  }
+
+private:
+  /// The wrapped handle type.
+  decorated_type decorated_;
+
+  /// Stores a handle to the in-flight request if the request messages was
+  /// delayed/scheduled.
+  disposable pending_request_;
+};
+
+// tuple-like access for blocking_delayed_response_handle
+
+template <size_t I, class Result>
+decltype(auto) get(caf::blocking_delayed_response_handle<Result>& x) {
+  if constexpr (I == 0) {
+    return x.decorated();
+  } else {
+    static_assert(I == 1);
+    return x.pending_request();
+  }
+}
+
+template <size_t I, class Result>
+decltype(auto) get(const caf::blocking_delayed_response_handle<Result>& x) {
+  if constexpr (I == 0) {
+    return x.decorated();
+  } else {
+    static_assert(I == 1);
+    return x.pending_request();
+  }
+}
+
+template <size_t I, class Result>
+decltype(auto) get(caf::blocking_delayed_response_handle<Result>&& x) {
+  if constexpr (I == 0) {
+    return std::move(x.decorated());
+  } else {
+    static_assert(I == 1);
+    return std::move(x.pending_request());
+  }
+}
+
 } // namespace caf
+
+// enable structured bindings for blocking_delayed_response_handle
+
+namespace std {
+
+template <class Result>
+struct tuple_size<caf::blocking_delayed_response_handle<Result>> {
+  static constexpr size_t value = 2;
+};
+
+template <class Result>
+struct tuple_element<0, caf::blocking_delayed_response_handle<Result>> {
+  using type = caf::blocking_response_handle<Result>;
+};
+
+template <class Result>
+struct tuple_element<1, caf::blocking_delayed_response_handle<Result>> {
+  using type = caf::disposable;
+};
+
+} // namespace std

--- a/libcaf_core/caf/event_based_mail.hpp
+++ b/libcaf_core/caf/event_based_mail.hpp
@@ -70,9 +70,9 @@ public:
                                            make_error(sec::invalid_request)),
                       self()->context());
     }
-    using hdl_t = event_based_response_handle<response_type>;
-    auto hdl = hdl_t{self(), mid.response_id(), std::move(in_flight_timeout)};
-    return std::pair{std::move(hdl), std::move(in_flight_response)};
+    using hdl_t = event_based_delayed_response_handle<response_type>;
+    return hdl_t{self(), mid.response_id(), std::move(in_flight_timeout),
+                 std::move(in_flight_response)};
   }
 
 private:


### PR DESCRIPTION
@riemass here's the promised followup with the custom "pair" to make function chaining work similarly for regular and delayed requests. Calling `then` and `await` now simply returns the handle for the delayed request, so users that want to make use of it can simply obtain it as result of the entire chain. `as_observable` already has a return type and I'd rather leave it as-is. I think >90% of the time, users will drop the `disposable` anyways. If they do need it, though, the new type also gives access to its members and can be deconstructed like a regular `pair`.

Relates #1745.