### PR TITLE
Bump FreeBSD from 13-2 to 13-3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,10 +10,10 @@ branch_filter: &BRANCH_FILTER
     $CIRRUS_PR != '' ||
     $CIRRUS_BRANCH == 'master'
 
-# FreeBSD 13.2 EOL: January 2026
+# FreeBSD 13.3 EOL: January 2026
 freebsd13_task:
   freebsd_instance:
-    image_family: freebsd-13-2
+    image_family: freebsd-13-3
     << : *RESOURCES_TEMPLATE
   prepare_script: .ci/freebsd-13/prepare.sh
   build_script: .ci/run.sh build .ci/debug-flags.cmake . build


### PR DESCRIPTION
FreeBSD version 13-2 started failing this weekend for some reason. Cirrus directs to google compute images, listed here: https://gcloud-compute.com/images.html. Even though 13-2 is still listed, I bumped our pipeline to 13-2. 