### PR TITLE
Wait for LP server to start in robot test

### DIFF
--- a/examples/length_prefix_framing/chat-server.cpp
+++ b/examples/length_prefix_framing/chat-server.cpp
@@ -131,6 +131,7 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
         .start([&sys](lp::default_trait::acceptor_resource accept_events) {
           sys.spawn(worker_impl, std::move(accept_events));
         });
+  std::cout << "*** server started" << std::endl;
   // Report any error to the user.
   if (!server) {
     std::cerr << "*** unable to run at port " << port << ": "

--- a/robot/lp/communication.robot
+++ b/robot/lp/communication.robot
@@ -37,6 +37,7 @@ Start Chat Server
     ...  --caf.logger.file.path  server.log
     ...  stdout=server.out
     ...  stderr=server.err
+    Wait For Server Startup
 
 Start Chat Client
     [Arguments]    ${name}   ${stdin}
@@ -68,3 +69,10 @@ Count Connected Clients
 Wait For Client
     [Arguments]    ${client_count}
     Wait Until Keyword Succeeds    5s    125ms    Count Connected Clients    ${client_count}
+
+Has Server Started
+    ${output}=      Grep File        server.out    server started
+    Should Not Be Empty  ${output}
+
+Wait For Server Startup
+    Wait Until Keyword Succeeds    5s    125ms    Has Server Started


### PR DESCRIPTION
I've run the `robot-lp-communication` test a dozen times locally and it seems that in some runs both clients fail to connect to the server. The cause is that we didn't wait for the server to start up. 
There is another, **very rare** test failure where both clients connect (`alice` and `bob`), but the messages from the second client never arrive to the first one. I couldn't discover the cause for this, so I hope the first issue was what triggered our pipeline to crash. 