### PR TITLE
Implement new mail cache type for manual stashing

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -144,6 +144,7 @@ caf_add_component(
     caf/detail/atomic_ref_counted.cpp
     caf/detail/base64.cpp
     caf/detail/base64.test.cpp
+    caf/detail/beacon.cpp
     caf/detail/behavior_impl.cpp
     caf/detail/behavior_stack.cpp
     caf/detail/blocking_behavior.cpp
@@ -284,6 +285,8 @@ caf_add_component(
     caf/log/event.cpp
     caf/log/event.test.cpp
     caf/logger.cpp
+    caf/mail_cache.cpp
+    caf/mail_cache.test.cpp
     caf/mailbox_element.cpp
     caf/mailbox_element.test.cpp
     caf/make_config_option.cpp
@@ -369,7 +372,6 @@ caf_add_component(
     caf/uri_builder.cpp
     caf/uuid.cpp
     caf/uuid.test.cpp
-    caf/detail/beacon.cpp
   LEGACY_TEST_SOURCES
     tests/legacy/core-test.cpp
   LEGACY_TEST_SUITES

--- a/libcaf_core/caf/blocking_actor.cpp
+++ b/libcaf_core/caf/blocking_actor.cpp
@@ -383,6 +383,10 @@ void blocking_actor::force_close_mailbox() {
   close_mailbox(make_error(exit_reason::unreachable));
 }
 
+void blocking_actor::do_unstash(mailbox_element_ptr ptr) {
+  mailbox().push_front(std::move(ptr));
+}
+
 void blocking_actor::do_receive(message_id mid, behavior& bhvr,
                                 timespan timeout) {
   accept_one_cond cond;

--- a/libcaf_core/caf/blocking_actor.hpp
+++ b/libcaf_core/caf/blocking_actor.hpp
@@ -349,6 +349,8 @@ public:
   /// @endcond
 
 private:
+  void do_unstash(mailbox_element_ptr ptr) override;
+
   void do_receive(message_id mid, behavior& bhvr, timespan timeout) override;
 
   size_t attach_functor(const actor&);

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -119,6 +119,7 @@ class json_value;
 class json_writer;
 class local_actor;
 class logger;
+class mail_cache;
 class mailbox_element;
 class message;
 class message_builder;

--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -39,6 +39,10 @@ namespace caf {
 /// living in an own thread or cooperatively scheduled.
 class CAF_CORE_EXPORT local_actor : public abstract_actor {
 public:
+  // -- friends ----------------------------------------------------------------
+
+  friend class mail_cache;
+
   // -- member types -----------------------------------------------------------
 
   /// Defines a monotonic clock suitable for measuring intervals.
@@ -457,6 +461,9 @@ protected:
   detail::unique_function<behavior(local_actor*)> initial_behavior_fac_;
 
   metrics_t metrics_;
+
+private:
+  virtual void do_unstash(mailbox_element_ptr ptr) = 0;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/mail_cache.cpp
+++ b/libcaf_core/caf/mail_cache.cpp
@@ -1,0 +1,42 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/mail_cache.hpp"
+
+#include "caf/config.hpp"
+#include "caf/detail/sync_request_bouncer.hpp"
+#include "caf/local_actor.hpp"
+
+namespace caf {
+
+mail_cache::~mail_cache() {
+  if (!empty()) {
+    detail::sync_request_bouncer bouncer{make_error(sec::disposed)};
+    while (auto raw = elements_.pop()) {
+      auto ptr = mailbox_element_ptr{raw};
+      bouncer(*ptr);
+    }
+  }
+}
+
+void mail_cache::stash(message msg) {
+#ifdef CAF_ENABLE_EXCEPTIONS
+  if (size_ == max_size_)
+    throw std::runtime_error("mail cache exceeded its maximum size");
+#endif
+  auto element = make_mailbox_element(self_->current_sender(),
+                                      self_->take_current_message_id(),
+                                      std::move(msg));
+  ++size_;
+  elements_.push(element.release());
+}
+
+void mail_cache::unstash() {
+  size_ = 0;
+  while (auto ptr = elements_.pop()) {
+    self_->do_unstash(mailbox_element_ptr{ptr});
+  }
+}
+
+} // namespace caf

--- a/libcaf_core/caf/mail_cache.hpp
+++ b/libcaf_core/caf/mail_cache.hpp
@@ -1,0 +1,64 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/detail/core_export.hpp"
+#include "caf/intrusive/stack.hpp"
+#include "caf/intrusive_ptr.hpp"
+#include "caf/mailbox_element.hpp"
+#include "caf/ref_counted.hpp"
+
+#include <cstddef>
+
+namespace caf {
+
+/// A simple cache for storing mailbox elements for an actor for later reuse.
+class CAF_CORE_EXPORT mail_cache {
+public:
+  mail_cache(local_actor* self, size_t max_size)
+    : self_(self), max_size_(max_size) {
+    // nop
+  }
+
+  ~mail_cache();
+
+  // -- properties -------------------------------------------------------------
+
+  /// Returns the maximum number of elements this cache can store.
+  size_t max_size() const noexcept {
+    return max_size_;
+  }
+
+  /// Returns the current number of elements in the cache.
+  size_t size() const noexcept {
+    return size_;
+  }
+
+  /// Checks whether the cache is empty.
+  bool empty() const noexcept {
+    return size_ == 0;
+  }
+
+  /// Checks whether the cache reached its maximum size.
+  bool full() const noexcept {
+    return size_ >= max_size_;
+  }
+
+  // -- modifiers --------------------------------------------------------------
+
+  /// Adds `msg` to the cache.
+  void stash(message msg);
+
+  /// Removes all elements from the cache and returns them to the mailbox.
+  void unstash();
+
+private:
+  local_actor* self_;
+  size_t max_size_ = 0;
+  size_t size_ = 0;
+  intrusive::stack<mailbox_element> elements_;
+};
+
+} // namespace caf

--- a/libcaf_core/caf/mail_cache.test.cpp
+++ b/libcaf_core/caf/mail_cache.test.cpp
@@ -1,0 +1,87 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/mail_cache.hpp"
+
+#include "caf/test/test.hpp"
+
+#include "caf/actor_from_state.hpp"
+#include "caf/actor_system.hpp"
+#include "caf/actor_system_config.hpp"
+#include "caf/event_based_actor.hpp"
+#include "caf/scoped_actor.hpp"
+
+using namespace caf;
+using namespace std::literals;
+
+namespace {
+
+struct testee_state {
+  explicit testee_state(event_based_actor* self) : self(self), cache(self, 5) {
+    // nop
+  }
+
+  behavior make_behavior() {
+    return {
+      [this](ok_atom) {
+        self->become(behavior{
+          [this](get_atom) { return value; },
+          [this](add_atom, int increment) { value += increment; },
+        });
+        cache.unstash();
+      },
+      [this](message msg) { cache.stash(std::move(msg)); },
+    };
+  }
+
+  event_based_actor* self;
+  mail_cache cache;
+  int value = 0;
+};
+
+struct fixture {
+  actor_system_config cfg;
+  actor_system sys;
+  scoped_actor self;
+
+  fixture() : sys(init(cfg)), self(sys) {
+    // nop
+  }
+
+  static actor_system_config& init(actor_system_config& cfg) {
+    cfg.set("caf.scheduler.max-threads", 2);
+    return cfg;
+  }
+};
+
+WITH_FIXTURE(fixture) {
+
+TEST("a mail cache can buffer messages until the actor is ready") {
+  auto aut = sys.spawn(actor_from_state<testee_state>);
+  self->mail(add_atom_v, 1).send(aut);
+  self->mail(add_atom_v, 2).send(aut);
+  self->mail(add_atom_v, 3).send(aut);
+  self->mail(ok_atom_v).send(aut);
+  self->mail(add_atom_v, 4).send(aut);
+  auto res = self->mail(get_atom_v).request(aut, 1s).receive<int>();
+  check_eq(res, 10);
+}
+
+#ifdef CAF_ENABLE_EXCEPTIONS
+TEST("a mail cache throws when exceeding its capacity") {
+  auto aut = sys.spawn(actor_from_state<testee_state>);
+  self->mail(add_atom_v, 1).send(aut);
+  self->mail(add_atom_v, 2).send(aut);
+  self->mail(add_atom_v, 3).send(aut);
+  self->mail(add_atom_v, 4).send(aut);
+  self->mail(add_atom_v, 5).send(aut);
+  self->mail(add_atom_v, 6).send(aut);
+  auto res = self->mail(get_atom_v).request(aut, 1s).receive<int>();
+  check_eq(res, make_error(sec::runtime_error));
+}
+#endif // CAF_ENABLE_EXCEPTIONS
+
+} // WITH_FIXTURE(fixture)
+
+} // namespace

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -1016,6 +1016,10 @@ void scheduled_actor::unstash() {
     mailbox().push_front(mailbox_element_ptr{stashed});
 }
 
+void scheduled_actor::do_unstash(mailbox_element_ptr ptr) {
+  mailbox().push_front(std::move(ptr));
+}
+
 void scheduled_actor::cancel_flows_and_streams() {
   // Note: we always swap out a map before iterating it, because some callbacks
   //       may call erase on the map while we are iterating it.

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -642,6 +642,8 @@ private:
   flow::assert_scheduled_actor_hdr_t<flow::single<T>>
   single_from_response(message_id mid, disposable pending_timeout);
 
+  void do_unstash(mailbox_element_ptr ptr) override;
+
   // -- utilities for instrumenting actors -------------------------------------
 
   /// Places all messages from the `stash_` back into the mailbox.

--- a/libcaf_net/caf/net/abstract_actor_shell.cpp
+++ b/libcaf_net/caf/net/abstract_actor_shell.cpp
@@ -192,6 +192,10 @@ void abstract_actor_shell::on_cleanup(const error& reason) {
 
 // -- private member functions -------------------------------------------------
 
+void abstract_actor_shell::do_unstash(mailbox_element_ptr ptr) {
+  mailbox_.push_front(std::move(ptr));
+}
+
 void abstract_actor_shell::close_mailbox(const error& reason) {
   if (!mailbox_.closed()) {
     auto dropped = mailbox_.close(reason);

--- a/libcaf_net/caf/net/abstract_actor_shell.hpp
+++ b/libcaf_net/caf/net/abstract_actor_shell.hpp
@@ -115,6 +115,8 @@ protected:
 private:
   using multiplexed_response = std::pair<behavior, disposable>;
 
+  void do_unstash(mailbox_element_ptr ptr) override;
+
   void close_mailbox(const error& reason);
 
   void force_close_mailbox() final;


### PR DESCRIPTION
Adds a new `mail_cache` type and uses it in the dining philosophers example. By giving users an explicit way for skipping messages, we can go ahead and deprecate the old `skip` approach (as a followup).

Relates #1474.