### PR TITLE
Scheduler unification step 1

### DIFF
--- a/libcaf_core/caf/action.cpp
+++ b/libcaf_core/caf/action.cpp
@@ -8,6 +8,18 @@
 
 namespace caf {
 
+resumable::subtype_t action::impl::subtype() const noexcept {
+  return resumable::function_object;
+}
+
+void action::impl::ref_resumable() const noexcept {
+  ref_disposable();
+}
+
+void action::impl::deref_resumable() const noexcept {
+  deref_disposable();
+}
+
 action::action(impl_ptr ptr) noexcept : pimpl_(std::move(ptr)) {
   // nop
 }

--- a/libcaf_core/caf/actor_clock.cpp
+++ b/libcaf_core/caf/actor_clock.cpp
@@ -47,7 +47,7 @@ public:
     deref();
   }
 
-  void run() override {
+  resume_result resume(execution_unit*, size_t) override {
     CAF_ASSERT(decorated_ != nullptr);
     WorkerPtr tmp;
     {
@@ -64,6 +64,7 @@ public:
       if (tmp)
         do_run(tmp);
     }
+    return resumable::done;
   }
 
   state current_state() const noexcept override {

--- a/libcaf_core/caf/actor_control_block.hpp
+++ b/libcaf_core/caf/actor_control_block.hpp
@@ -171,15 +171,14 @@ CAF_CORE_EXPORT error_code<sec> load_actor(strong_actor_ptr& storage,
                                            const node_id& nid);
 
 CAF_CORE_EXPORT error_code<sec> save_actor(strong_actor_ptr& storage,
-                                           execution_unit*, actor_id aid,
-                                           const node_id& nid);
+                                           actor_id aid, const node_id& nid);
 
 template <class Inspector>
 auto context_of(Inspector* f) -> decltype(f->context()) {
   return f->context();
 }
 
-inline execution_unit* context_of(void*) {
+inline auto context_of(void*) {
   return nullptr;
 }
 
@@ -203,7 +202,7 @@ bool inspect(Inspector& f, strong_actor_ptr& x) {
     }
   }
   auto load_cb = [&] { return load_actor(x, context_of(&f), aid, nid); };
-  auto save_cb = [&] { return save_actor(x, context_of(&f), aid, nid); };
+  auto save_cb = [&] { return save_actor(x, aid, nid); };
   return f.object(x)
     .pretty_name("actor")
     .on_load(load_cb)

--- a/libcaf_core/caf/blocking_actor.cpp
+++ b/libcaf_core/caf/blocking_actor.cpp
@@ -109,7 +109,7 @@ public:
     intrusive_ptr_add_ref(self->ctrl());
   }
 
-  resumable::subtype_t subtype() const override {
+  resumable::subtype_t subtype() const noexcept final {
     return resumable::function_object;
   }
 
@@ -142,11 +142,11 @@ public:
     return resumable::done;
   }
 
-  void intrusive_ptr_add_ref_impl() override {
+  void ref_resumable() const noexcept final {
     // nop
   }
 
-  void intrusive_ptr_release_impl() override {
+  void deref_resumable() const noexcept final {
     delete this;
   }
 

--- a/libcaf_core/caf/detail/abstract_worker.cpp
+++ b/libcaf_core/caf/detail/abstract_worker.cpp
@@ -18,15 +18,15 @@ abstract_worker::~abstract_worker() {
 
 // -- implementation of resumable ----------------------------------------------
 
-resumable::subtype_t abstract_worker::subtype() const {
+resumable::subtype_t abstract_worker::subtype() const noexcept {
   return resumable::function_object;
 }
 
-void abstract_worker::intrusive_ptr_add_ref_impl() {
+void abstract_worker::ref_resumable() const noexcept {
   ref();
 }
 
-void abstract_worker::intrusive_ptr_release_impl() {
+void abstract_worker::deref_resumable() const noexcept {
   deref();
 }
 

--- a/libcaf_core/caf/detail/abstract_worker.hpp
+++ b/libcaf_core/caf/detail/abstract_worker.hpp
@@ -25,11 +25,11 @@ public:
 
   // -- implementation of resumable --------------------------------------------
 
-  subtype_t subtype() const override;
+  subtype_t subtype() const noexcept final;
 
-  void intrusive_ptr_add_ref_impl() override;
+  void ref_resumable() const noexcept final;
 
-  void intrusive_ptr_release_impl() override;
+  void deref_resumable() const noexcept final;
 
 private:
   // -- member variables -------------------------------------------------------

--- a/libcaf_core/caf/detail/abstract_worker_hub.cpp
+++ b/libcaf_core/caf/detail/abstract_worker_hub.cpp
@@ -19,7 +19,7 @@ abstract_worker_hub::~abstract_worker_hub() {
   auto head = head_.load();
   while (head != nullptr) {
     auto next = head->next_.load();
-    head->intrusive_ptr_release_impl();
+    head->deref_resumable();
     head = next;
   }
 }

--- a/libcaf_core/caf/detail/beacon.cpp
+++ b/libcaf_core/caf/detail/beacon.cpp
@@ -37,10 +37,11 @@ action::state beacon::current_state() const noexcept {
   }
 }
 
-void beacon::run() {
+resumable::resume_result beacon::resume(execution_unit*, size_t) {
   std::unique_lock guard{mtx_};
   state_ = state::lit;
   cv_.notify_all();
+  return resumable::done;
 }
 
 } // namespace caf::detail

--- a/libcaf_core/caf/detail/beacon.hpp
+++ b/libcaf_core/caf/detail/beacon.hpp
@@ -31,7 +31,7 @@ public:
 
   action::state current_state() const noexcept override;
 
-  void run() override;
+  resume_result resume(execution_unit*, size_t) override;
 
   [[nodiscard]] state wait() {
     std::unique_lock guard{mtx_};

--- a/libcaf_core/caf/detail/monitor_action.hpp
+++ b/libcaf_core/caf/detail/monitor_action.hpp
@@ -46,7 +46,7 @@ public:
     return state_;
   }
 
-  void run() override {
+  resume_result resume(execution_unit*, size_t) override {
     // We can only run a scheduled action.
     std::lock_guard guard{mtx_};
     if (state_ == action::state::scheduled) {
@@ -54,6 +54,7 @@ public:
       f_();
       f_.~function_wrapper();
     }
+    return resumable::done;
   }
 
   bool arg(down_msg err) {

--- a/libcaf_core/caf/detail/private_thread_pool.test.cpp
+++ b/libcaf_core/caf/detail/private_thread_pool.test.cpp
@@ -52,18 +52,18 @@ SCENARIO("private threads count towards detached actors") {
 SCENARIO("private threads rerun their resumable when it returns resume_later") {
   struct testee : resumable {
     std::atomic<size_t> runs = 0;
-    std::atomic<size_t> refs_added = 0;
-    std::atomic<size_t> refs_released = 0;
-    subtype_t subtype() const override {
+    mutable std::atomic<size_t> refs_added = 0;
+    mutable std::atomic<size_t> refs_released = 0;
+    subtype_t subtype() const noexcept override {
       return resumable::function_object;
     }
     resume_result resume(execution_unit*, size_t) override {
       return ++runs < 2 ? resumable::resume_later : resumable::done;
     }
-    void intrusive_ptr_add_ref_impl() override {
+    void ref_resumable() const noexcept final {
       ++refs_added;
     }
-    void intrusive_ptr_release_impl() override {
+    void deref_resumable() const noexcept final {
       ++refs_released;
     }
   };

--- a/libcaf_core/caf/execution_unit.cpp
+++ b/libcaf_core/caf/execution_unit.cpp
@@ -6,8 +6,7 @@
 
 namespace caf {
 
-execution_unit::execution_unit(actor_system* sys)
-  : system_(sys), proxies_(nullptr) {
+execution_unit::execution_unit(actor_system* sys) : system_(sys) {
   // nop
 }
 

--- a/libcaf_core/caf/execution_unit.hpp
+++ b/libcaf_core/caf/execution_unit.hpp
@@ -36,19 +36,8 @@ public:
     return *system_;
   }
 
-  /// Returns a pointer to the proxy factory currently associated to this unit.
-  proxy_registry* proxy_registry_ptr() {
-    return proxies_;
-  }
-
-  /// Associated a new proxy factory to this unit.
-  void proxy_registry_ptr(proxy_registry* ptr) noexcept {
-    proxies_ = ptr;
-  }
-
 protected:
   actor_system* system_ = nullptr;
-  proxy_registry* proxies_ = nullptr;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/proxy_registry.cpp
+++ b/libcaf_core/caf/proxy_registry.cpp
@@ -17,6 +17,20 @@
 
 namespace caf {
 
+namespace {
+
+thread_local proxy_registry* current_proxy_registry;
+
+} // namespace
+
+proxy_registry* proxy_registry::current() noexcept {
+  return current_proxy_registry;
+}
+
+void proxy_registry::current(proxy_registry* ptr) noexcept {
+  current_proxy_registry = ptr;
+}
+
 proxy_registry::backend::~backend() {
   // nop
 }

--- a/libcaf_core/caf/proxy_registry.hpp
+++ b/libcaf_core/caf/proxy_registry.hpp
@@ -36,6 +36,12 @@ public:
     virtual void set_last_hop(node_id* ptr) = 0;
   };
 
+  /// Returns the current proxy registry for the calling thread.
+  static proxy_registry* current() noexcept;
+
+  /// Sets the current proxy registry for the calling thread.
+  static void current(proxy_registry*) noexcept;
+
   proxy_registry(actor_system& sys, backend& be);
 
   proxy_registry(const proxy_registry&) = delete;

--- a/libcaf_core/caf/resumable.cpp
+++ b/libcaf_core/caf/resumable.cpp
@@ -12,7 +12,7 @@ resumable::~resumable() {
   // nop
 }
 
-resumable::subtype_t resumable::subtype() const {
+resumable::subtype_t resumable::subtype() const noexcept {
   return unspecified;
 }
 

--- a/libcaf_core/caf/resumable.hpp
+++ b/libcaf_core/caf/resumable.hpp
@@ -46,29 +46,31 @@ public:
   /// Returns a subtype hint for this object. This allows an execution
   /// unit to limit processing to a specific set of resumables and
   /// delegate other subtypes to dedicated workers.
-  virtual subtype_t subtype() const;
+  virtual subtype_t subtype() const noexcept;
 
   /// Resume any pending computation until it is either finished
   /// or needs to be re-scheduled later.
   virtual resume_result resume(execution_unit*, size_t max_throughput) = 0;
 
   /// Add a strong reference count to this object.
-  virtual void intrusive_ptr_add_ref_impl() = 0;
+  virtual void ref_resumable() const noexcept = 0;
 
   /// Remove a strong reference count from this object.
-  virtual void intrusive_ptr_release_impl() = 0;
+  virtual void deref_resumable() const noexcept = 0;
 };
 
 // enables intrusive_ptr<resumable> without introducing ambiguity
 template <class T>
-std::enable_if_t<std::is_same_v<T*, resumable*>> intrusive_ptr_add_ref(T* ptr) {
-  ptr->intrusive_ptr_add_ref_impl();
+std::enable_if_t<std::is_same_v<T*, resumable*>>
+intrusive_ptr_add_ref(const T* ptr) {
+  ptr->ref_resumable();
 }
 
 // enables intrusive_ptr<resumable> without introducing ambiguity
 template <class T>
-std::enable_if_t<std::is_same_v<T*, resumable*>> intrusive_ptr_release(T* ptr) {
-  ptr->intrusive_ptr_release_impl();
+std::enable_if_t<std::is_same_v<T*, resumable*>>
+intrusive_ptr_release(const T* ptr) {
+  ptr->deref_resumable();
 }
 
 } // namespace caf

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -236,15 +236,15 @@ void scheduled_actor::on_cleanup(const error& reason) {
 
 // -- overridden functions of resumable ----------------------------------------
 
-resumable::subtype_t scheduled_actor::subtype() const {
+resumable::subtype_t scheduled_actor::subtype() const noexcept {
   return resumable::scheduled_actor;
 }
 
-void scheduled_actor::intrusive_ptr_add_ref_impl() {
+void scheduled_actor::ref_resumable() const noexcept {
   intrusive_ptr_add_ref(ctrl());
 }
 
-void scheduled_actor::intrusive_ptr_release_impl() {
+void scheduled_actor::deref_resumable() const noexcept {
   intrusive_ptr_release(ctrl());
 }
 
@@ -541,10 +541,10 @@ scheduled_actor::categorize(mailbox_element& x) {
       return message_category::internal;
     }
     case type_id_v<action>: {
-      auto ptr = content.get_as<action>(0).ptr();
-      CAF_ASSERT(ptr != nullptr);
+      auto what = content.get_as<action>(0);
+      CAF_ASSERT(what.ptr() != nullptr);
       log::core::debug("run action");
-      ptr->run();
+      what.run();
       return message_category::internal;
     }
     case type_id_v<node_down_msg>: {

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -203,11 +203,11 @@ public:
 
   // -- overridden functions of resumable --------------------------------------
 
-  subtype_t subtype() const override;
+  subtype_t subtype() const noexcept override;
 
-  void intrusive_ptr_add_ref_impl() override;
+  void ref_resumable() const noexcept final;
 
-  void intrusive_ptr_release_impl() override;
+  void deref_resumable() const noexcept final;
 
   resume_result resume(execution_unit*, size_t) override;
 

--- a/libcaf_core/caf/scheduler.cpp
+++ b/libcaf_core/caf/scheduler.cpp
@@ -311,12 +311,13 @@ public:
         cv.notify_all();
         return resumable::shutdown_execution_unit;
       }
-      void intrusive_ptr_add_ref_impl() override {
-        intrusive_ptr_add_ref(this);
+
+      void ref_resumable() const noexcept final {
+        ref();
       }
 
-      void intrusive_ptr_release_impl() override {
-        intrusive_ptr_release(this);
+      void deref_resumable() const noexcept final {
+        deref();
       }
       shutdown_helper() : last_worker(nullptr) {
         // nop
@@ -539,12 +540,11 @@ public:
         cv.notify_all();
         return resumable::shutdown_execution_unit;
       }
-      void intrusive_ptr_add_ref_impl() override {
-        intrusive_ptr_add_ref(this);
+      void ref_resumable() const noexcept final {
+        ref();
       }
-
-      void intrusive_ptr_release_impl() override {
-        intrusive_ptr_release(this);
+      void deref_resumable() const noexcept final {
+        deref();
       }
       shutdown_helper() : last_worker(nullptr) {
         // nop

--- a/libcaf_core/caf/scheduler.test.cpp
+++ b/libcaf_core/caf/scheduler.test.cpp
@@ -22,7 +22,7 @@ struct testee : resumable, ref_counted {
   testee(std::shared_ptr<latch> latch_handle)
     : rendesvous(std::move(latch_handle)) {
   }
-  subtype_t subtype() const override {
+  subtype_t subtype() const noexcept override {
     return resumable::function_object;
   }
   resume_result resume(execution_unit*, size_t max_throughput) override {
@@ -33,10 +33,10 @@ struct testee : resumable, ref_counted {
     }
     return resumable::resume_later;
   }
-  void intrusive_ptr_add_ref_impl() override {
+  void ref_resumable() const noexcept final {
     ref();
   }
-  void intrusive_ptr_release_impl() override {
+  void deref_resumable() const noexcept final {
     deref();
   }
   std::atomic<size_t> runs = 0;
@@ -106,7 +106,7 @@ struct awaiting_testee : resumable, ref_counted {
   awaiting_testee(std::shared_ptr<latch> latch_handle)
     : rendesvous(std::move(latch_handle)) {
   }
-  subtype_t subtype() const override {
+  subtype_t subtype() const noexcept override {
     return resumable::function_object;
   }
   resume_result resume(execution_unit*, size_t) override {
@@ -114,10 +114,10 @@ struct awaiting_testee : resumable, ref_counted {
     rendesvous->count_down();
     return resumable::awaiting_message;
   }
-  void intrusive_ptr_add_ref_impl() override {
+  void ref_resumable() const noexcept final {
     ref();
   }
-  void intrusive_ptr_release_impl() override {
+  void deref_resumable() const noexcept final {
     deref();
   }
   std::atomic<size_t> runs = 0;

--- a/libcaf_io/caf/io/abstract_broker.cpp
+++ b/libcaf_io/caf/io/abstract_broker.cpp
@@ -332,7 +332,7 @@ void abstract_broker::close_all() {
     datagram_servants_.begin()->second->graceful_shutdown();
 }
 
-resumable::subtype_t abstract_broker::subtype() const {
+resumable::subtype_t abstract_broker::subtype() const noexcept {
   return io_actor;
 }
 

--- a/libcaf_io/caf/io/abstract_broker.hpp
+++ b/libcaf_io/caf/io/abstract_broker.hpp
@@ -332,7 +332,7 @@ public:
 
   // -- overridden observers of resumable --------------------------------------
 
-  subtype_t subtype() const override;
+  subtype_t subtype() const noexcept override;
 
   // -- observers --------------------------------------------------------------
 

--- a/libcaf_io/caf/io/basp/instance.hpp
+++ b/libcaf_io/caf/io/basp/instance.hpp
@@ -18,6 +18,7 @@
 #include "caf/detail/io_export.hpp"
 #include "caf/detail/worker_hub.hpp"
 #include "caf/error.hpp"
+#include "caf/proxy_registry.hpp"
 
 #include <limits>
 

--- a/libcaf_io/caf/io/basp/worker.cpp
+++ b/libcaf_io/caf/io/basp/worker.cpp
@@ -41,7 +41,10 @@ void worker::launch(const node_id& last_hop, const basp::header& hdr,
 // -- implementation of resumable ----------------------------------------------
 
 resumable::resume_result worker::resume(execution_unit* ctx, size_t) {
-  ctx->proxy_registry_ptr(proxies_);
+  proxy_registry::current(proxies_);
+  auto guard = detail::scope_guard{[]() noexcept { //
+    proxy_registry::current(nullptr);
+  }};
   handle_remote_message(ctx);
   hub_->push(this);
   return resumable::awaiting_message;

--- a/libcaf_io/caf/io/basp_broker.cpp
+++ b/libcaf_io/caf/io/basp_broker.cpp
@@ -430,9 +430,10 @@ proxy_registry* basp_broker::proxy_registry_ptr() {
 }
 
 resumable::resume_result basp_broker::resume(execution_unit* ctx, size_t mt) {
-  ctx->proxy_registry_ptr(&instance.proxies());
-  auto guard
-    = detail::scope_guard{[=]() noexcept { ctx->proxy_registry_ptr(nullptr); }};
+  proxy_registry::current(&instance.proxies());
+  auto guard = detail::scope_guard{[]() noexcept { //
+    proxy_registry::current(nullptr);
+  }};
   return super::resume(ctx, mt);
 }
 

--- a/libcaf_io/caf/io/middleman.hpp
+++ b/libcaf_io/caf/io/middleman.hpp
@@ -16,7 +16,6 @@
 #include "caf/fwd.hpp"
 #include "caf/infer_handle.hpp"
 #include "caf/node_id.hpp"
-#include "caf/proxy_registry.hpp"
 #include "caf/send.hpp"
 #include "caf/timespan.hpp"
 

--- a/libcaf_io/caf/io/network/multiplexer.cpp
+++ b/libcaf_io/caf/io/network/multiplexer.cpp
@@ -26,16 +26,16 @@ multiplexer::supervisor::~supervisor() {
   // nop
 }
 
-resumable::subtype_t multiplexer::runnable::subtype() const {
+resumable::subtype_t multiplexer::runnable::subtype() const noexcept {
   return resumable::function_object;
 }
 
-void multiplexer::runnable::intrusive_ptr_add_ref_impl() {
-  intrusive_ptr_add_ref(this);
+void multiplexer::runnable::ref_resumable() const noexcept {
+  ref();
 }
 
-void multiplexer::runnable::intrusive_ptr_release_impl() {
-  intrusive_ptr_release(this);
+void multiplexer::runnable::deref_resumable() const noexcept {
+  deref();
 }
 
 } // namespace caf::io::network

--- a/libcaf_io/caf/io/network/multiplexer.hpp
+++ b/libcaf_io/caf/io/network/multiplexer.hpp
@@ -78,9 +78,9 @@ public:
   /// Simple wrapper for runnables
   class CAF_IO_EXPORT runnable : public resumable, public ref_counted {
   public:
-    subtype_t subtype() const override;
-    void intrusive_ptr_add_ref_impl() override;
-    void intrusive_ptr_release_impl() override;
+    subtype_t subtype() const noexcept final;
+    void ref_resumable() const noexcept final;
+    void deref_resumable() const noexcept final;
   };
 
   /// Makes sure the multiplier does not exit its event loop until


### PR DESCRIPTION
We currently have multiple scheduler interfaces:
- `caf::scheduler`
- `caf::execution_unit`
- `caf::async::execution_context`
- `caf::flow::coordinator` (derives from `caf::async::execution_context`)

The `scheduler` cares about `resumable`, while the latter two operate on `action`. However, there's no real reason why the latter two shouldn't simply extend our `scheduler` interface. The `execution_context` is a weird one, it basically introduces a coupling between the `proxy_registry` and scheduling, which we should get rid of.

This PR is step 1 in consolidating the various interfaces. It refactors `action::impl` to derive from `resumable` and breaks the coupling of the `proxy_registry` to the scheduling. These two refactoring steps will then allow us to get rid of the execution unit entirely and to have `async::execution_context` inherit from `scheduler`.