### PR TITLE
Add new println abstraction on the actor system

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,8 +17,8 @@ endfunction()
 # -- examples for CAF::core ----------------------------------------------------
 
 # introductory applications
-add_core_example(. aout)
 add_core_example(. hello_world)
+add_core_example(. println)
 
 # configuration API
 add_core_example(config read-json)

--- a/examples/custom_type/custom_types_1.cpp
+++ b/examples/custom_type/custom_types_1.cpp
@@ -74,12 +74,12 @@ struct testee_state {
       // note: we sent a foo_pair2, but match on foo_pair
       // that works because both are aliases for std::pair<int, int>
       [this](const foo_pair& val) {
-        aout(self).println("foo_pair{}", val);
+        self->println("foo_pair{}", val);
         if (--remaining == 0)
           self->quit();
       },
       [this](const foo& val) {
-        aout(self).println("{}", val);
+        self->println("{}", val);
         if (--remaining == 0)
           self->quit();
       },

--- a/examples/custom_type/custom_types_2.cpp
+++ b/examples/custom_type/custom_types_2.cpp
@@ -59,7 +59,7 @@ private:
 
 behavior testee(event_based_actor* self) {
   return {
-    [self](const foo& x) { aout(self).println("{}", x); },
+    [self](const foo& x) { self->println("{}", x); },
   };
 }
 

--- a/examples/custom_type/custom_types_3.cpp
+++ b/examples/custom_type/custom_types_3.cpp
@@ -74,7 +74,7 @@ bool inspect(Inspector& f, foo& x) {
 
 behavior testee(event_based_actor* self) {
   return {
-    [self](const foo& x) { aout(self).println("{}", x); },
+    [self](const foo& x) { self->println("{}", x); },
   };
 }
 

--- a/examples/custom_type/custom_types_4.cpp
+++ b/examples/custom_type/custom_types_4.cpp
@@ -238,12 +238,12 @@ void caf_main(caf::actor_system& sys) {
   shapes.emplace_back(nullptr);
   shapes.emplace_back(rectangle::make({10, 10}, {20, 20}));
   shapes.emplace_back(circle::make({15, 15}, 5));
-  aout(self).println("shapes:");
+  self->println("shapes:");
   for (auto& ptr : shapes) {
-    aout(self).println("- value: {}", ptr);
+    self->println("- value: {}", ptr);
     auto copy = serialization_roundtrip(ptr);
     assert(!ptr || ptr.get() != copy.get());
-    aout(self).println("-  copy: {}", copy);
+    self->println("-  copy: {}", copy);
   }
 }
 

--- a/examples/dynamic_behavior/skip_messages.cpp
+++ b/examples/dynamic_behavior/skip_messages.cpp
@@ -48,14 +48,12 @@ void caf_main(actor_system& sys) {
     .request(serv, 10s)
     .receive(
       [&self, worker](pong_atom) {
-        aout(self).println("received response from {}",
-                           self->current_sender() == worker ? "worker"
-                                                            : "server");
+        self->println("received response from {}",
+                      self->current_sender() == worker ? "worker" : "server");
       },
       [&self, worker](error& err) {
-        aout(self).println("received error {} from {}", err,
-                           self->current_sender() == worker ? "worker"
-                                                            : "server");
+        self->println("received error {} from {}", err,
+                      self->current_sender() == worker ? "worker" : "server");
       });
   self->send_exit(serv, exit_reason::user_shutdown);
 }

--- a/examples/hello_world.cpp
+++ b/examples/hello_world.cpp
@@ -18,7 +18,7 @@ behavior mirror(event_based_actor* self) {
     // that replies with a string
     [self](const std::string& what) -> std::string {
       // prints "Hello World!" via aout (thread-safe cout wrapper)
-      aout(self).println("{}", what);
+      self->println("{}", what);
       // reply "!dlroW olleH"
       return std::string{what.rbegin(), what.rend()};
     },
@@ -33,7 +33,7 @@ void hello_world(event_based_actor* self, const actor& buddy) {
       // ... wait up to 10s for a response ...
       [self](const std::string& what) {
         // ... and print it
-        aout(self).println("{}", what);
+        self->println("{}", what);
       });
 }
 

--- a/examples/message_passing/calculator.cpp
+++ b/examples/message_passing/calculator.cpp
@@ -86,10 +86,10 @@ void tester(scoped_actor& self, const Handle& hdl, int32_t x, int32_t y,
     .request(hdl, infinite)
     .receive(
       [&self, x, y](int32_t z) { //
-        aout(self).println("{} + {} = {}", x, y, z);
+        self->println("{} + {} = {}", x, y, z);
       },
       [&self](const error& err) {
-        aout(self).println("AUT (actor under test) failed: {}", err);
+        self->println("AUT (actor under test) failed: {}", err);
       });
   tester(self, std::forward<Ts>(xs)...);
 }

--- a/examples/message_passing/delegating.cpp
+++ b/examples/message_passing/delegating.cpp
@@ -34,7 +34,7 @@ adder_actor::behavior_type server_impl(adder_actor::pointer self,
 void client_impl(event_based_actor* self, adder_actor adder, int32_t x,
                  int32_t y) {
   self->mail(add_atom_v, x, y).request(adder, 10s).then([=](int32_t result) {
-    aout(self).println("{} + {} = {}", x, y, result);
+    self->println("{} + {} = {}", x, y, result);
   });
 }
 

--- a/examples/message_passing/divider.cpp
+++ b/examples/message_passing/divider.cpp
@@ -95,10 +95,9 @@ void caf_main(actor_system& system) {
   scoped_actor self{system};
   self->mail(div_atom_v, x, y)
     .request(div, 10s)
-    .receive([&](double z) { aout(self).println("{} / {} = {}", x, y, z); },
+    .receive([&](double z) { self->println("{} / {} = {}", x, y, z); },
              [&](const error& err) {
-               aout(self).println("*** cannot compute {} / {} => {}", x, y,
-                                  err);
+               self->println("*** cannot compute {} / {} => {}", x, y, err);
              });
   // --(rst-request-end)--
 }

--- a/examples/message_passing/idle_timeout_once.cpp
+++ b/examples/message_passing/idle_timeout_once.cpp
@@ -40,12 +40,11 @@ struct collector_state {
     // actor holds a reference to it and run the callback only once.
     self->set_idle_handler(500ms, strong_ref, once, [this] {
       if (!buf.empty()) {
-        aout(self)
-          .println("Timeout reached!")
-          .println("Received message length: {}", buf.size())
-          .println("Message content: {}", str());
+        self->println("Timeout reached!");
+        self->println("Received message length: {}", buf.size());
+        self->println("Message content: {}", str());
       } else {
-        aout(self).println("Timeout reached with an empty buffer!");
+        self->println("Timeout reached with an empty buffer!");
       }
       self->quit();
     });
@@ -54,9 +53,8 @@ struct collector_state {
       [this](char c) {
         buf.push_back(c);
         if (buf.size() == flush_threshold) {
-          aout(self)
-            .println("Received message length: {}", buf.size())
-            .println("Message content: {}", str());
+          self->println("Received message length: {}", buf.size());
+          self->println("Message content: {}", str());
           buf.clear();
         }
       },

--- a/examples/message_passing/promises.cpp
+++ b/examples/message_passing/promises.cpp
@@ -40,7 +40,7 @@ void client_impl(event_based_actor* self, adder_actor adder, int32_t x,
                  int32_t y) {
   using namespace std::literals::chrono_literals;
   self->mail(add_atom_v, x, y).request(adder, 10s).then([=](int32_t result) {
-    aout(self).println("{} + {} = {}", x, y, result);
+    self->println("{} + {} = {}", x, y, result);
   });
 }
 

--- a/examples/message_passing/request.cpp
+++ b/examples/message_passing/request.cpp
@@ -51,14 +51,14 @@ struct cell_state {
 void waiting_testee(event_based_actor* self, vector<cell> cells) {
   for (auto& x : cells)
     self->mail(get_atom_v).request(x, 1s).await([self, x](int32_t y) {
-      aout(self).println("cell #{} -> {}", x.id(), y);
+      self->println("cell #{} -> {}", x.id(), y);
     });
 }
 
 void multiplexed_testee(event_based_actor* self, vector<cell> cells) {
   for (auto& x : cells)
     self->mail(get_atom_v).request(x, 1s).then([self, x](int32_t y) {
-      aout(self).println("cell #{} -> {}", x.id(), y);
+      self->println("cell #{} -> {}", x.id(), y);
     });
 }
 
@@ -66,9 +66,10 @@ void blocking_testee(scoped_actor& self, vector<cell> cells) {
   for (auto& x : cells)
     self->mail(get_atom_v)
       .request(x, 1s)
-      .receive(
-        [&](int32_t y) { aout(self).println("cell #{} -> {}", x.id(), y); },
-        [&](error& err) { aout(self).println("cell #{} -> {}", x.id(), err); });
+      .receive([&](int32_t y) { self->println("cell #{} -> {}", x.id(), y); },
+               [&](error& err) {
+                 self->println("cell #{} -> {}", x.id(), err);
+               });
 }
 // --(rst-testees-end)--
 
@@ -78,13 +79,13 @@ void caf_main(actor_system& sys) {
   for (int32_t i = 0; i < 5; ++i)
     cells.emplace_back(sys.spawn(actor_from_state<cell_state>, i * i));
   scoped_actor self{sys};
-  aout(self).println("spawn waiting testee");
+  self->println("spawn waiting testee");
   auto x1 = self->spawn(waiting_testee, cells);
   self->wait_for(x1);
-  aout(self).println("spawn multiplexed testee");
+  self->println("spawn multiplexed testee");
   auto x2 = self->spawn(multiplexed_testee, cells);
   self->wait_for(x2);
-  aout(self).println("run blocking testee");
+  self->println("run blocking testee");
   blocking_testee(self, cells);
 }
 // --(rst-main-end)--

--- a/examples/println.cpp
+++ b/examples/println.cpp
@@ -10,19 +10,22 @@
 
 using namespace caf;
 
+constexpr int32_t num_actors = 50;
+
 behavior printer(event_based_actor* self, int32_t num, int32_t delay) {
-  aout(self).println("Hi there! This is actor nr. {}!", num);
+  self->println("Hi there! This is actor nr. {}!", num);
   auto timeout = std::chrono::milliseconds{delay};
   self->mail(timeout_atom_v).delay(timeout).send(self);
   return {
     [=](timeout_atom) {
-      aout(self).println("Actor nr. {} says goodbye after waiting for {}ms!",
-                         num, delay);
+      self->println("Actor nr. {} says goodbye after waiting for {}ms!", num,
+                    delay);
     },
   };
 }
 
 void caf_main(actor_system& sys) {
+  sys.println("Spawning {} actors...", num_actors);
   std::random_device rd;
   std::minstd_rand re{rd()};
   std::uniform_int_distribution<int32_t> dis{1, 99};

--- a/examples/remoting/remote_spawn.cpp
+++ b/examples/remoting/remote_spawn.cpp
@@ -39,9 +39,6 @@ CAF_BEGIN_TYPE_ID_BLOCK(remote_spawn, first_custom_type_id)
 
 CAF_END_TYPE_ID_BLOCK(remote_spawn)
 
-using std::cerr;
-using std::cout;
-using std::endl;
 using std::string;
 
 using namespace caf;
@@ -49,11 +46,11 @@ using namespace caf;
 calculator::behavior_type calculator_fun(calculator::pointer self) {
   return {
     [self](add_atom, int32_t a, int32_t b) {
-      aout(self).println("received task from a remote node");
+      self->println("received task from a remote node");
       return a + b;
     },
     [self](sub_atom, int32_t a, int32_t b) {
-      aout(self).println("received task from a remote node");
+      self->println("received task from a remote node");
       return a - b;
     },
   };
@@ -71,12 +68,12 @@ string trim(string s) {
 
 // implements our main loop for reading user input
 void client_repl(actor_system& sys, calculator hdl) {
-  auto usage = [] {
-    cout << "Usage:" << endl
-         << "  quit                  : terminate program" << endl
-         << "  <x> + <y>             : adds two int32_tegers" << endl
-         << "  <x> - <y>             : subtracts two int32_tegers" << endl
-         << endl;
+  auto usage = [&sys] {
+    sys.println("Usage:");
+    sys.println("  quit                  : terminate program");
+    sys.println("  <x> + <y>             : adds two integers");
+    sys.println("  <x> - <y>             : subtracts two integers");
+    sys.println("");
   };
   usage();
   scoped_actor self{sys};
@@ -111,7 +108,7 @@ void client_repl(actor_system& sys, calculator hdl) {
     else
       self->mail(sub_atom_v, *x, *y).send(hdl);
     self->receive([&self, x = *x, y = *y, op = words[1][0]](int32_t result) {
-      aout(self).println("{} {} {} = {}", x, op, y, result);
+      self->println("{} {} {} = {}", x, op, y, result);
     });
   }
 }
@@ -142,11 +139,11 @@ void server(actor_system& sys, const config& cfg) {
   const auto port = get_or(cfg, "port", default_port);
   auto res = sys.middleman().open(port);
   if (!res) {
-    cerr << "*** cannot open port: " << to_string(res.error()) << endl;
+    sys.println("*** cannot open port: {}", to_string(res.error()));
     return;
   }
-  cout << "*** running on port: " << *res << endl
-       << "*** press <enter> to shutdown server" << endl;
+  sys.println("*** running on port: {}", *res);
+  sys.println("*** press <enter> to shutdown server");
   getchar();
 }
 
@@ -156,7 +153,7 @@ void client(actor_system& sys, const config& cfg) {
   auto port = get_or(cfg, "port", default_port);
   auto node = sys.middleman().connect(host, port);
   if (!node) {
-    cerr << "*** connect failed: " << to_string(node.error()) << endl;
+    sys.println("*** connect failed: {}", node.error());
     return;
   }
   auto type = "calculator";             // type of the actor we wish to spawn
@@ -165,7 +162,7 @@ void client(actor_system& sys, const config& cfg) {
   auto worker = sys.middleman().remote_spawn<calculator>(*node, type, args,
                                                          tout);
   if (!worker) {
-    cerr << "*** remote spawn failed: " << to_string(worker.error()) << endl;
+    sys.println("*** remote spawn failed: {}", worker.error());
     return;
   }
   // start using worker in main loop

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -11,6 +11,7 @@
 #include "caf/actor_registry.hpp"
 #include "caf/detail/actor_local_printer.hpp"
 #include "caf/detail/core_export.hpp"
+#include "caf/detail/format.hpp"
 #include "caf/detail/init_fun_factory.hpp"
 #include "caf/detail/private_thread_pool.hpp"
 #include "caf/detail/set_thread_name.hpp"
@@ -26,16 +27,21 @@
 #include "caf/spawn_options.hpp"
 #include "caf/string_algorithms.hpp"
 #include "caf/telemetry/metric_registry.hpp"
+#include "caf/term.hpp"
 #include "caf/type_id.hpp"
 
 #include <array>
 #include <atomic>
 #include <cstddef>
+#include <cstdio>
+#include <iterator>
 #include <memory>
 #include <string>
 #include <thread>
 
 namespace caf::detail {
+
+struct printer_actor_state;
 
 template <class>
 struct typed_mpi_access;
@@ -98,6 +104,8 @@ public:
 
   template <class>
   friend class actor_from_state_t;
+
+  friend struct detail::printer_actor_state;
 
   /// Returns the internal actor for dynamic spawn operations.
   const strong_actor_ptr& spawn_serv() const {
@@ -486,6 +494,34 @@ public:
   /// Returns the number of detached actors.
   size_t detached_actors() const noexcept;
 
+  // -- println ----------------------------------------------------------------
+
+  /// Adds a new line to stdout.
+  template <class... Args>
+  void println(term color, std::string_view fmt, Args&&... args) {
+    auto buf = std::vector<char>{};
+    buf.reserve(fmt.size() + 64);
+    detail::format_to(std::back_inserter(buf), fmt,
+                      std::forward<Args>(args)...);
+    buf.push_back('\n');
+    print_state_->print(color, buf.data(), buf.size());
+  }
+
+  /// Adds a new line to stdout.
+  template <class... Args>
+  void println(std::string_view fmt, Args&&... args) {
+    println(term::reset, fmt, std::forward<Args>(args)...);
+  }
+
+  /// Redirects the output of `println` to a custom function.
+  /// @param out The new output stream to write to.
+  /// @param write The new print function to use. Must not be null.
+  /// @param cleanup Deletes the output stream when the actor system shuts down.
+  ///                May be null if no cleanup is necessary.
+  void redirect_text_output(void* out,
+                            void (*write)(void*, term, const char*, size_t),
+                            void (*cleanup)(void*));
+
   /// @cond PRIVATE
 
   /// Calls all thread started hooks
@@ -747,6 +783,36 @@ private:
 
   /// Ties the lifetime of the meta objects table to the actor system.
   detail::global_meta_objects_guard_type meta_objects_guard_;
+
+  class CAF_CORE_EXPORT print_state {
+  public:
+    using print_fun = void (*)(void*, term, const char*, size_t);
+
+    using cleanup = void (*)(void*);
+
+    explicit print_state(const actor_system_config& cfg);
+
+    ~print_state();
+
+    void reset(void* new_out, print_fun do_print, cleanup do_cleanup);
+
+    void print(term color, const char* buf, size_t);
+
+  private:
+    /// Mutex for printing to the console.
+    std::mutex mtx_;
+
+    /// File descriptor for printing to the console.
+    void* out_ = nullptr;
+
+    /// Function for printing to the console.
+    print_fun do_print_ = nullptr;
+
+    /// Function for cleaning up out_.
+    cleanup do_cleanup_ = nullptr;
+  };
+
+  std::unique_ptr<print_state> print_state_;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/actor_system_config.cpp
+++ b/libcaf_core/caf/actor_system_config.cpp
@@ -87,6 +87,9 @@ actor_system_config::actor_system_config()
   opt_group{custom_options_, "caf.metrics-filters.actors"}
     .add<string_list>("includes", "selects actors for run-time metrics")
     .add<string_list>("excludes", "excludes actors from run-time metrics");
+  opt_group{custom_options_, "caf.console"}
+    .add<bool>("colored", "forces colored or uncolored output")
+    .add<string>("stream", "either 'stdout' (default), 'stderr' or 'none'");
 }
 
 // -- properties ---------------------------------------------------------------

--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -109,6 +109,20 @@ public:
   /// @pre `mid.is_request()`
   disposable request_response_timeout(timespan d, message_id mid);
 
+  // -- printing ---------------------------------------------------------------
+
+  /// Adds a new line to stdout.
+  template <class... Args>
+  void println(std::string_view fmt, Args&&... args) {
+    system().println(fmt, std::forward<Args>(args)...);
+  }
+
+  /// Adds a new line to stdout.
+  template <class... Args>
+  void println(term color, std::string_view fmt, Args&&... args) {
+    system().println(color, fmt, std::forward<Args>(args)...);
+  }
+
   // -- spawn functions --------------------------------------------------------
 
   template <class T, spawn_options Os = no_spawn_options, class... Ts>

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -41,8 +41,8 @@ skippable_result reflect_and_quit(scheduled_actor* ptr, message& msg) {
 skippable_result print_and_drop(scheduled_actor* ptr, message& msg) {
   log::system::warning("discarded unexpected message (id: {}, name: {}): {}",
                        ptr->id(), ptr->name(), msg);
-  aout(ptr).println("*** unexpected message [id: {}, name: {}]: {}", ptr->id(),
-                    ptr->name(), msg);
+  ptr->println("*** unexpected message [id: {}, name: {}]: {}", ptr->id(),
+               ptr->name(), msg);
   return make_error(sec::unexpected_message);
 }
 
@@ -74,14 +74,14 @@ void scheduled_actor::default_error_handler(scheduled_actor* ptr, error& x) {
 }
 
 void scheduled_actor::default_down_handler(scheduled_actor* ptr, down_msg& x) {
-  aout(ptr).println("*** unhandled down message [id: {}, name: {}]: {}",
-                    ptr->id(), ptr->name(), x);
+  ptr->println("*** unhandled down message [id: {}, name: {}]: {}", ptr->id(),
+               ptr->name(), x);
 }
 
 void scheduled_actor::default_node_down_handler(scheduled_actor* ptr,
                                                 node_down_msg& x) {
-  aout(ptr).println("*** unhandled node down message [id: {} , name: {}]: {}",
-                    ptr->id(), ptr->name(), x);
+  ptr->println("*** unhandled node down message [id: {} , name: {}]: {}",
+               ptr->id(), ptr->name(), x);
 }
 
 void scheduled_actor::default_exit_handler(scheduled_actor* ptr, exit_msg& x) {
@@ -97,12 +97,12 @@ error scheduled_actor::default_exception_handler(local_actor* ptr,
     std::rethrow_exception(x);
   } catch (std::exception& e) {
     auto pretty_type = detail::pretty_type_name(typeid(e));
-    aout(ptr).println(
+    ptr->println(
       "*** unhandled exception: [id: {}, name: {}, exception typeid {}]: {}",
       ptr->id(), ptr->name(), pretty_type, e.what());
     return make_error(sec::runtime_error, std::move(pretty_type), e.what());
   } catch (...) {
-    aout(ptr).println(
+    ptr->println(
       "*** unhandled exception: [id: {}, name: {}]: unknown exception",
       ptr->id(), ptr->name());
     return sec::runtime_error;

--- a/manual/Actors.rst
+++ b/manual/Actors.rst
@@ -520,7 +520,7 @@ loops.
      [&](int value1) {
        self->receive (
          [&](float value2) {
-           aout(self).println("{} => {}", value1, value2);
+           self->println("{} => {}", value1, value2);
          }
        );
      },


### PR DESCRIPTION
The `aout` API relies on a printer actor that permanently runs in the background and adds additional overhead to printing due to the messaging involved. Binding the new printing API directly onto the actor system removes the messaging overhead and is also simpler to use.

Relates #1800 (for deprecating `aout`).