### PR TITLE
Fix typed_actor_view

### DIFF
--- a/libcaf_core/caf/typed_actor_view.hpp
+++ b/libcaf_core/caf/typed_actor_view.hpp
@@ -283,13 +283,16 @@ public:
     return self_->make_response_promise();
   }
 
-  void add_awaited_response_handler(message_id response_id, behavior bhvr) {
-    return self_->add_awaited_response_handler(response_id, std::move(bhvr));
+  void add_awaited_response_handler(message_id response_id, behavior bhvr,
+                                    disposable pending_timeout = {}) {
+    return self_->add_awaited_response_handler(response_id, std::move(bhvr),
+                                               std::move(pending_timeout));
   }
 
-  void add_multiplexed_response_handler(message_id response_id, behavior bhvr) {
-    return self_->add_multiplexed_response_handler(response_id,
-                                                   std::move(bhvr));
+  void add_multiplexed_response_handler(message_id response_id, behavior bhvr,
+                                        disposable pending_timeout = {}) {
+    return self_->add_multiplexed_response_handler(response_id, std::move(bhvr),
+                                                   std::move(pending_timeout));
   }
 
   template <class Handle, class... Ts>
@@ -311,6 +314,11 @@ public:
   /// @private
   void reset(scheduled_actor* ptr) {
     self_ = ptr;
+  }
+
+  /// @private
+  bool enqueue(mailbox_element_ptr what, scheduler* sched) {
+    return self_->enqueue(std::move(what), sched);
   }
 
   operator scheduled_actor*() const noexcept {


### PR DESCRIPTION
Recent API overhauls are incompatible with `typed_actor_view`. This patch resolves compiler errors caused by the recent changes.

Our unit tests didn't caught this, so we also should increase coverage there.