### PR TITLE
Fix two bugs with the new monitoring API

### DIFF
--- a/libcaf_core/caf/event_based_actor.test.cpp
+++ b/libcaf_core/caf/event_based_actor.test.cpp
@@ -213,7 +213,7 @@ SCENARIO("setting an infinite idle timeout is an error") {
         });
         auto aut_down = std::make_shared<bool>(false);
         auto observer = sys.spawn([aut, aut_down](event_based_actor* self) {
-          self->monitor(aut, [aut_down](const down_msg&) { *aut_down = true; });
+          self->monitor(aut, [aut_down](const error&) { *aut_down = true; });
           return behavior{
             [=](const std::string&) {},
           };

--- a/libcaf_core/caf/monitor.test.cpp
+++ b/libcaf_core/caf/monitor.test.cpp
@@ -49,34 +49,34 @@ TEST("monitoring another actor") {
     auto call_count2 = std::make_shared<int32_t>(0);
     auto call_count3 = std::make_shared<int32_t>(0);
     auto observer = sys.spawn([=](event_based_actor* self) {
-      self->monitor(client1, [call_count1, client1](const down_msg& msg) {
+      self->monitor(client1, [call_count1, client1](const error& reason) {
         *call_count1 += 1;
-        test::runnable::current().check_eq(msg.source, client1->address());
+        test::runnable::current().check_eq(reason, exit_reason::user_shutdown);
       });
-      self->monitor(client2, [call_count2, client2](const down_msg& msg) {
+      self->monitor(client2, [call_count2, client2](const error& reason) {
         *call_count2 += 1;
-        test::runnable::current().check_eq(msg.source, client2->address());
+        test::runnable::current().check_eq(reason, exit_reason::user_shutdown);
       });
-      self->monitor(client3, [call_count3, client3](const down_msg& msg) {
+      self->monitor(client3, [call_count3, client3](const error& reason) {
         *call_count3 += 1;
-        test::runnable::current().check_eq(msg.source, client3->address());
+        test::runnable::current().check_eq(reason, exit_reason::user_shutdown);
       });
       return behavior{
         [](int32_t) {},
       };
     });
     inject_exit(client1);
-    expect<down_msg>().with(std::ignore).from(client1).to(observer);
+    expect<action>().to(observer);
     check_eq(*call_count1, 1);
     check_eq(*call_count2, 0);
     check_eq(*call_count3, 0);
     inject_exit(client2);
-    expect<down_msg>().with(std::ignore).from(client2).to(observer);
+    expect<action>().to(observer);
     check_eq(*call_count1, 1);
     check_eq(*call_count2, 1);
     check_eq(*call_count3, 0);
     inject_exit(client3);
-    expect<down_msg>().with(std::ignore).from(client3).to(observer);
+    expect<action>().to(observer);
     check_eq(*call_count1, 1);
     check_eq(*call_count2, 1);
     check_eq(*call_count3, 1);
@@ -104,11 +104,11 @@ TEST("monitoring another actor") {
     auto call_count1 = std::make_shared<int32_t>(0);
     auto call_count2 = std::make_shared<int32_t>(0);
     auto observer = sys.spawn([=](event_based_actor* self) {
-      auto disp1 = self->monitor(client1, [call_count1](const down_msg&) {
+      auto disp1 = self->monitor(client1, [call_count1](const error&) {
         *call_count1 += 1;
       });
       self->monitor(client2,
-                    [call_count2](const down_msg&) { *call_count2 += 1; });
+                    [call_count2](const error&) { *call_count2 += 1; });
       disp1.dispose();
       return behavior{
         [](int32_t) {},
@@ -119,7 +119,7 @@ TEST("monitoring another actor") {
     check_eq(*call_count1, 0);
     check_eq(*call_count2, 0);
     inject_exit(client2);
-    expect<down_msg>().with(std::ignore).from(client2).to(observer);
+    expect<action>().to(observer);
     check_eq(*call_count1, 0);
     check_eq(*call_count2, 1);
   }


### PR DESCRIPTION
- The new `monitor` overload with a callback would hold onto a strong reference to the monitored actor. By adding this permanent reference count, calling `monitor` once on an actor would prevent it from becoming unreachable. Furthermore, generating a `down_msg` is no longer necessary, since the callback should know which actor it belongs to. Hence, we can simplify the interface and only have an `error` argument.
- The new `monitor` overload would also store `this` as a raw pointer and later use that pointer to send a message back to `self`. This is fundamentally unsafe, because the raw pointer will be used by another actor at some point in the future. If `self` has been destroyed in the meantime, this would cause a heap-use-after-free.