### PR TITLE
Make the state member in stateful actors private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## [Unreleased]
 
+### Changed
+
+- Stateful actors now provide a getter function `state()` instead of declaring a
+  public `state` member variable. This change enables more flexibility in the
+  implementation for future CAF versions.
+
 ### Fixed
 
 - Fix building CAF with shared libraries (DLLs) enabled on Windows (#1715).

--- a/libcaf_core/caf/function_view.test.cpp
+++ b/libcaf_core/caf/function_view.test.cpp
@@ -59,8 +59,8 @@ struct cell_state {
 
 cell::behavior_type simple_cell(cell::stateful_pointer<cell_state> self) {
   return {
-    [=](put_atom, int val) { self->state.value = val; },
-    [=](get_atom) { return self->state.value; },
+    [=](put_atom, int val) { self->state().value = val; },
+    [=](get_atom) { return self->state().value; },
   };
 }
 

--- a/libcaf_core/caf/stateful_actor.test.cpp
+++ b/libcaf_core/caf/stateful_actor.test.cpp
@@ -29,8 +29,8 @@ struct counter {
 
 behavior adder(stateful_actor<counter>* self) {
   return {
-    [=](add_atom, int x) { self->state.value += x; },
-    [=](get_atom) { return self->state.value; },
+    [=](add_atom, int x) { self->state().value += x; },
+    [=](get_atom) { return self->state().value; },
   };
 }
 
@@ -48,8 +48,8 @@ public:
 typed_adder_actor::behavior_type
 typed_adder(typed_adder_actor::stateful_pointer<counter> self) {
   return {
-    [=](add_atom, int x) { self->state.value += x; },
-    [=](get_atom) { return self->state.value; },
+    [=](add_atom, int x) { self->state().value += x; },
+    [=](get_atom) { return self->state().value; },
   };
 }
 
@@ -173,7 +173,7 @@ TEST("states can accept constructor arguments and provide a behavior") {
   };
   using actor_type = stateful_actor<state_type>;
   auto testee = sys.spawn<actor_type>(10, 20, add_operation);
-  auto& state = deref<actor_type>(testee).state;
+  auto& state = deref<actor_type>(testee).state();
   check_eq(state.x, 10);
   check_eq(state.y, 20);
   inject().with(get_atom_v).from(self).to(testee);
@@ -210,7 +210,7 @@ TEST("states optionally take the self pointer as first argument") {
   };
   using actor_type = stateful_actor<state_type>;
   auto testee = sys.spawn<actor_type>(10);
-  auto& state = deref<actor_type>(testee).state;
+  auto& state = deref<actor_type>(testee).state();
   check(state.self == &deref<actor_type>(testee));
   check_eq(state.x, 10);
   inject().with(get_atom_v).from(self).to(testee);
@@ -237,7 +237,7 @@ TEST("typed actors can use typed_actor_pointer as self pointer") {
   };
   using actor_type = typed_adder_actor::stateful_impl<state_type>;
   auto testee = sys.spawn<actor_type>(10);
-  auto& state = deref<actor_type>(testee).state;
+  auto& state = deref<actor_type>(testee).state();
   check(state.self == &deref<actor_type>(testee));
   check_eq(state.value, 10);
   inject().with(add_atom_v, 1).from(self).to(testee);

--- a/libcaf_core/tests/legacy/request_timeout.cpp
+++ b/libcaf_core/tests/legacy/request_timeout.cpp
@@ -85,9 +85,9 @@ behavior ping_nested1(ping_actor* self, bool* had_timeout, const actor& buddy) {
   return {
     [=](pong_atom) { CAF_FAIL("received pong atom"); },
     [=](timeout_atom) {
-      self->state.had_first_timeout = true;
+      self->state().had_first_timeout = true;
       self->become(after(milliseconds(100)) >> [=] {
-        CHECK(self->state.had_first_timeout);
+        CHECK(self->state().had_first_timeout);
         *had_timeout = true;
         self->quit();
       });
@@ -103,9 +103,9 @@ behavior ping_nested2(ping_actor* self, bool* had_timeout, const actor& buddy) {
     [=](pong_atom) { CAF_FAIL("received pong atom"); },
     after(std::chrono::seconds(1)) >>
       [=] {
-        self->state.had_first_timeout = true;
+        self->state().had_first_timeout = true;
         self->become(after(milliseconds(100)) >> [=] {
-          CHECK(self->state.had_first_timeout);
+          CHECK(self->state().had_first_timeout);
           *had_timeout = true;
           self->quit();
         });
@@ -124,12 +124,12 @@ behavior ping_nested3(ping_actor* self, bool* had_timeout, const actor& buddy) {
       },
       [=](const error& err) {
         CAF_REQUIRE_EQUAL(err, sec::request_timeout);
-        self->state.had_first_timeout = true;
+        self->state().had_first_timeout = true;
       });
   return {
     after(milliseconds(100)) >>
       [=] {
-        CHECK(self->state.had_first_timeout);
+        CHECK(self->state().had_first_timeout);
         *had_timeout = true;
         self->quit();
       },
@@ -143,8 +143,8 @@ behavior ping_multiplexed1(ping_actor* self, bool* had_timeout,
     .then([=](pong_atom) { CAF_FAIL("received pong atom"); },
           [=](const error& err) {
             CAF_REQUIRE_EQUAL(err, sec::request_timeout);
-            if (!self->state.had_first_timeout)
-              self->state.had_first_timeout = true;
+            if (!self->state().had_first_timeout)
+              self->state().had_first_timeout = true;
             else
               *had_timeout = true;
           });
@@ -152,8 +152,8 @@ behavior ping_multiplexed1(ping_actor* self, bool* had_timeout,
     .then([=](pong_atom) { CAF_FAIL("received pong atom"); },
           [=](const error& err) {
             CAF_REQUIRE_EQUAL(err, sec::request_timeout);
-            if (!self->state.had_first_timeout)
-              self->state.had_first_timeout = true;
+            if (!self->state().had_first_timeout)
+              self->state().had_first_timeout = true;
             else
               *had_timeout = true;
           });
@@ -167,8 +167,8 @@ behavior ping_multiplexed2(ping_actor* self, bool* had_timeout,
     .await([=](pong_atom) { CAF_FAIL("received pong atom"); },
            [=](const error& err) {
              CAF_REQUIRE_EQUAL(err, sec::request_timeout);
-             if (!self->state.had_first_timeout)
-               self->state.had_first_timeout = true;
+             if (!self->state().had_first_timeout)
+               self->state().had_first_timeout = true;
              else
                *had_timeout = true;
            });
@@ -176,8 +176,8 @@ behavior ping_multiplexed2(ping_actor* self, bool* had_timeout,
     .await([=](pong_atom) { CAF_FAIL("received pong atom"); },
            [=](const error& err) {
              CAF_REQUIRE_EQUAL(err, sec::request_timeout);
-             if (!self->state.had_first_timeout)
-               self->state.had_first_timeout = true;
+             if (!self->state().had_first_timeout)
+               self->state().had_first_timeout = true;
              else
                *had_timeout = true;
            });
@@ -191,8 +191,8 @@ behavior ping_multiplexed3(ping_actor* self, bool* had_timeout,
     .then([=](pong_atom) { CAF_FAIL("received pong atom"); },
           [=](const error& err) {
             CAF_REQUIRE_EQUAL(err, sec::request_timeout);
-            if (!self->state.had_first_timeout)
-              self->state.had_first_timeout = true;
+            if (!self->state().had_first_timeout)
+              self->state().had_first_timeout = true;
             else
               *had_timeout = true;
           });
@@ -200,8 +200,8 @@ behavior ping_multiplexed3(ping_actor* self, bool* had_timeout,
     .await([=](pong_atom) { CAF_FAIL("received pong atom"); },
            [=](const error& err) {
              CAF_REQUIRE_EQUAL(err, sec::request_timeout);
-             if (!self->state.had_first_timeout)
-               self->state.had_first_timeout = true;
+             if (!self->state().had_first_timeout)
+               self->state().had_first_timeout = true;
              else
                *had_timeout = true;
            });
@@ -256,7 +256,7 @@ CAF_TEST(nested_timeout) {
     CAF_REQUIRE_EQUAL(sched.trigger_timeout(), true);
     CAF_REQUIRE_EQUAL(sched.next_job<local_actor>().name(), "ping"s);
     CHECK(!had_timeout);
-    CHECK(sched.next_job<ping_actor>().state.had_first_timeout);
+    CHECK(sched.next_job<ping_actor>().state().had_first_timeout);
     sched.run();
     CHECK(had_timeout);
   }


### PR DESCRIPTION
> Stateful actors now provide a getter function `state()` instead of declaring a public `state` member variable. This change enables more flexibility in the implementation for future CAF versions.