### PR TITLE
Add new format_to_error utility function

### DIFF
--- a/examples/http/rest.cpp
+++ b/examples/http/rest.cpp
@@ -12,6 +12,7 @@
 #include "caf/deep_to_string.hpp"
 #include "caf/defaults.hpp"
 #include "caf/event_based_actor.hpp"
+#include "caf/format_to_error.hpp"
 #include "caf/scheduled_actor/flow.hpp"
 
 #include <algorithm>
@@ -63,7 +64,7 @@ struct kvs_actor_state {
         if (auto i = data.find(key); i != data.end())
           return i->second;
         else
-          return make_error(caf::sec::no_such_key, key + " not found");
+          return format_to_error(caf::sec::no_such_key, "{} not found", key);
       },
       [this](caf::put_atom, const std::string& key, std::string& value) {
         data.insert_or_assign(key, std::move(value));

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -310,6 +310,7 @@ caf_add_component(
     caf/node_id.cpp
     caf/node_id.test.cpp
     caf/or_else.test.cpp
+    caf/parser_state.cpp
     caf/policy/select_all.test.cpp
     caf/policy/select_any.test.cpp
     caf/proxy_registry.cpp

--- a/libcaf_core/caf/actor_system_config.cpp
+++ b/libcaf_core/caf/actor_system_config.cpp
@@ -12,6 +12,7 @@
 #include "caf/detail/config_consumer.hpp"
 #include "caf/detail/parser/read_config.hpp"
 #include "caf/detail/parser/read_string.hpp"
+#include "caf/format_to_error.hpp"
 #include "caf/logger.hpp"
 #include "caf/message_builder.hpp"
 #include "caf/pec.hpp"
@@ -363,7 +364,8 @@ error actor_system_config::parse(string_list args, std::istream& config) {
   } else {
     // Not finding an explicitly defined config file is an error.
     if (auto fname = get_if<std::string>(&content, "config-file"))
-      return make_error(sec::cannot_open_file, *fname);
+      return format_to_error(sec::cannot_open_file,
+                             "cannot open config file: {}", *fname);
   }
   // Environment variables override the content of the config file.
   for (auto& opt : custom_options_) {
@@ -478,7 +480,8 @@ actor_system_config::parse_config_file(const char* filename,
                                        const config_option_set& opts) {
   std::ifstream f{filename};
   if (!f.is_open())
-    return make_error(sec::cannot_open_file, filename);
+    return format_to_error(sec::cannot_open_file, "cannot open config file: {}",
+                           filename);
   return parse_config(f, opts);
 }
 
@@ -505,7 +508,9 @@ error actor_system_config::parse_config(std::istream& source,
   parser_state<config_iter, config_sentinel> res{config_iter{&source}};
   detail::parser::read_config(res, consumer);
   if (res.i != res.e)
-    return make_error(res.code, res.line, res.column);
+    return format_to_error(
+      res.code, "failed to parse config: invalid syntax in line {} column {}",
+      res.line, res.column);
   return none;
 }
 

--- a/libcaf_core/caf/config_value.cpp
+++ b/libcaf_core/caf/config_value.cpp
@@ -456,10 +456,9 @@ bool config_value::can_convert_to_dictionary() const {
     [](const auto&) { return false; },
     [this](const std::string&) {
       // TODO: implement some dry-run mode and use it here to avoid creating
-      // an
-      //       actual dictionary only to throw it away.
+      // an actual dictionary only to throw it away.
       auto maybe_dict = to_dictionary();
-      return static_cast<bool>(maybe_dict);
+      return maybe_dict.has_value();
     },
     [](const dictionary&) { return true; });
   return visit(f, data_);

--- a/libcaf_core/caf/config_value.cpp
+++ b/libcaf_core/caf/config_value.cpp
@@ -6,6 +6,7 @@
 
 #include "caf/detail/assert.hpp"
 #include "caf/detail/config_consumer.hpp"
+#include "caf/detail/format.hpp"
 #include "caf/detail/meta_object.hpp"
 #include "caf/detail/overload.hpp"
 #include "caf/detail/parse.hpp"
@@ -13,6 +14,7 @@
 #include "caf/detail/scope_guard.hpp"
 #include "caf/detail/type_traits.hpp"
 #include "caf/expected.hpp"
+#include "caf/format_to_error.hpp"
 #include "caf/parser_state.hpp"
 #include "caf/pec.hpp"
 #include "caf/settings.hpp"
@@ -33,13 +35,11 @@ const char* type_names[] = {"none",   "integer",  "boolean",
 
 template <class To, class From>
 auto no_conversion() {
-  return [](const From&) {
-    std::string msg = "cannot convert ";
-    msg += type_names[detail::tl_index_of_v<config_value::types, From>];
-    msg += " to ";
-    msg += type_names[detail::tl_index_of_v<config_value::types, To>];
-    auto err = make_error(sec::conversion_failed, std::move(msg));
-    return expected<To>{std::move(err)};
+  return [](const From&) -> expected<To> {
+    return format_to_error(
+      sec::conversion_failed, "cannot convert from type {} to type {}",
+      type_names[detail::tl_index_of_v<config_value::types, From>],
+      type_names[detail::tl_index_of_v<config_value::types, To>]);
   };
 }
 
@@ -90,10 +90,10 @@ expected<config_value> config_value::parse(std::string_view::iterator first,
     case '{':
     case '"':
     case '\'':
-      return make_error(res.code);
+      return error{res.code};
     default:
       if (isdigit(*i))
-        return make_error(res.code);
+        return error{res.code};
       return config_value{std::string{first, last}};
   }
 }
@@ -226,42 +226,32 @@ expected<bool> config_value::to_boolean() const {
     no_conversions<bool, none_t, integer, real, timespan, uri,
                    config_value::list>(),
     [](boolean x) { return result_type{x}; },
-    [](const std::string& x) {
+    [](const std::string& x) -> result_type {
       if (x == "true") {
         return result_type{true};
-      } else if (x == "false") {
-        return result_type{false};
-      } else {
-        std::string msg = "cannot convert ";
-        detail::print_escaped(msg, x);
-        msg += " to a boolean";
-        return result_type{make_error(sec::conversion_failed, std::move(msg))};
       }
+      if (x == "false") {
+        return result_type{false};
+      }
+      return format_to_error(sec::conversion_failed,
+                             "cannot convert '{}' to a boolean", x);
     },
-    [](const dictionary& x) {
+    [](const dictionary& x) -> result_type {
       if (auto i = x.find("@type");
           i != x.end() && holds_alternative<std::string>(i->second)) {
         const auto& tn = get<std::string>(i->second);
         if (tn == type_name_v<bool>) {
           if (auto j = x.find("value"); j != x.end()) {
             return j->second.to_boolean();
-          } else {
-            std::string msg = "missing value for object of type ";
-            msg += tn;
-            return result_type{
-              make_error(sec::conversion_failed, std::move(msg))};
           }
-        } else {
-          std::string msg = "cannot convert ";
-          msg += tn;
-          msg += " to a boolean";
-          return result_type{
-            make_error(sec::conversion_failed, std::move(msg))};
+          return format_to_error(sec::conversion_failed,
+                                 "missing value for object of type {}", tn);
         }
-      } else {
-        std::string msg = "cannot convert a dictionary to a boolean";
-        return result_type{make_error(sec::conversion_failed, std::move(msg))};
+        return format_to_error(sec::conversion_failed,
+                               "cannot convert '{}' to a boolean", tn);
       }
+      return format_to_error(sec::conversion_failed,
+                             "cannot convert a dictionary to a boolean");
     });
   return visit(f, data_);
 }
@@ -271,21 +261,19 @@ expected<config_value::integer> config_value::to_integer() const {
   auto f = detail::make_overload(
     no_conversions<integer, none_t, bool, timespan, uri, config_value::list>(),
     [](integer x) { return result_type{x}; },
-    [](real x) {
+    [](real x) -> result_type {
       using limits = std::numeric_limits<config_value::integer>;
       if (std::isfinite(x)            // never convert NaN & friends
           && std::fmod(x, 1.0) == 0.0 // only convert whole numbers
           && x <= static_cast<config_value::real>(limits::max())
           && x >= static_cast<config_value::real>(limits::min())) {
         return result_type{static_cast<config_value::integer>(x)};
-      } else {
-        auto err = make_error(
-          sec::conversion_failed,
-          "cannot convert decimal or out-of-bounds real number to an integer");
-        return result_type{std::move(err)};
       }
+      return format_to_error(sec::conversion_failed,
+                             "cannot convert decimal or out-of-bounds "
+                             "real number to an integer");
     },
-    [](const std::string& x) {
+    [](const std::string& x) -> result_type {
       auto tmp_int = config_value::integer{0};
       if (detail::parse(x, tmp_int) == none)
         return result_type{tmp_int};
@@ -293,12 +281,10 @@ expected<config_value::integer> config_value::to_integer() const {
       if (detail::parse(x, tmp_real) == none)
         if (auto ival = config_value{tmp_real}.to_integer())
           return result_type{*ival};
-      std::string msg = "cannot convert ";
-      detail::print_escaped(msg, x);
-      msg += " to an integer";
-      return result_type{make_error(sec::conversion_failed, std::move(msg))};
+      return format_to_error(sec::conversion_failed,
+                             "cannot convert '{} to an integer", x);
     },
-    [](const dictionary& x) {
+    [](const dictionary& x) -> result_type {
       if (auto i = x.find("@type");
           i != x.end() && holds_alternative<std::string>(i->second)) {
         const auto& tn = get<std::string>(i->second);
@@ -311,23 +297,15 @@ expected<config_value::integer> config_value::to_integer() const {
         if (std::any_of(std::begin(valid_types), std::end(valid_types), eq)) {
           if (auto j = x.find("value"); j != x.end()) {
             return j->second.to_integer();
-          } else {
-            std::string msg = "missing value for object of type ";
-            msg += tn;
-            return result_type{
-              make_error(sec::conversion_failed, std::move(msg))};
           }
-        } else {
-          std::string msg = "cannot convert ";
-          msg += tn;
-          msg += " to an integer";
-          return result_type{
-            make_error(sec::conversion_failed, std::move(msg))};
+          return format_to_error(sec::conversion_failed,
+                                 "missing value for object of type {}", tn);
         }
-      } else {
-        std::string msg = "cannot convert a dictionary to an integer";
-        return result_type{make_error(sec::conversion_failed, std::move(msg))};
+        return format_to_error(sec::conversion_failed,
+                               "cannot convert {} to an integer", tn);
       }
+      return format_to_error(sec::conversion_failed,
+                             "cannot convert a dictionary to an integer");
     });
   return visit(f, data_);
 }
@@ -343,16 +321,14 @@ expected<config_value::real> config_value::to_real() const {
       return result_type{static_cast<real>(x)};
     },
     [](real x) { return result_type{x}; },
-    [](const std::string& x) {
+    [](const std::string& x) -> result_type {
       auto tmp = 0.0;
       if (detail::parse(x, tmp) == none)
         return result_type{tmp};
-      std::string msg = "cannot convert ";
-      detail::print_escaped(msg, x);
-      msg += " to a floating point number";
-      return result_type{make_error(sec::conversion_failed, std::move(msg))};
+      return format_to_error(sec::conversion_failed,
+                             "cannot convert {} to a floating point number", x);
     },
-    [](const dictionary& x) {
+    [](const dictionary& x) -> result_type {
       if (auto i = x.find("@type");
           i != x.end() && holds_alternative<std::string>(i->second)) {
         const auto& tn = get<std::string>(i->second);
@@ -362,24 +338,17 @@ expected<config_value::real> config_value::to_real() const {
         if (std::any_of(std::begin(valid_types), std::end(valid_types), eq)) {
           if (auto j = x.find("value"); j != x.end()) {
             return j->second.to_real();
-          } else {
-            std::string msg = "missing value for object of type ";
-            msg += tn;
-            return result_type{
-              make_error(sec::conversion_failed, std::move(msg))};
           }
-        } else {
-          std::string msg = "cannot convert ";
-          msg += tn;
-          msg += " to a floating point number";
-          return result_type{
-            make_error(sec::conversion_failed, std::move(msg))};
+          return format_to_error(sec::conversion_failed,
+                                 "missing value for object of type {}", tn);
         }
-      } else {
-        std::string msg
-          = "cannot convert a dictionary to a floating point number";
-        return result_type{make_error(sec::conversion_failed, std::move(msg))};
+        return format_to_error(sec::conversion_failed,
+                               "cannot convert {} to a floating point number",
+                               tn);
       }
+      return format_to_error(sec::conversion_failed,
+                             "cannot convert a dictionary to "
+                             "a floating point number");
     });
   return visit(f, data_);
 }
@@ -390,14 +359,12 @@ expected<timespan> config_value::to_timespan() const {
     no_conversions<timespan, none_t, bool, integer, real, uri,
                    config_value::list, config_value::dictionary>(),
     [](timespan x) { return result_type{x}; },
-    [](const std::string& x) {
+    [](const std::string& x) -> result_type {
       auto tmp = timespan{};
       if (detail::parse(x, tmp) == none)
         return result_type{tmp};
-      std::string msg = "cannot convert ";
-      detail::print_escaped(msg, x);
-      msg += " to a timespan";
-      return result_type{make_error(sec::conversion_failed, std::move(msg))};
+      return format_to_error(sec::conversion_failed,
+                             "cannot convert '{}' to a timespan", x);
     });
   return visit(f, data_);
 }
@@ -425,7 +392,7 @@ expected<config_value::list> config_value::to_list() const {
   };
   auto f = detail::make_overload(
     no_conversions<list, none_t, bool, integer, real, timespan, uri>(),
-    [dict_to_list](const std::string& x) {
+    [dict_to_list](const std::string& x) -> result_type {
       // Check whether we can parse the string as a list. However, we also
       // accept dictionaries that we convert to lists of key-value pairs. We
       // need to try converting to dictionary *first*, because detail::parse for
@@ -437,10 +404,8 @@ expected<config_value::list> config_value::to_list() const {
       }
       if (config_value::list tmp; detail::parse(x, tmp) == none)
         return result_type{std::move(tmp)};
-      std::string msg = "cannot convert ";
-      detail::print_escaped(msg, x);
-      msg += " to a list";
-      return result_type{make_error(sec::conversion_failed, std::move(msg))};
+      return format_to_error(sec::conversion_failed,
+                             "cannot convert '{}' to a list", x);
     },
     [](const list& x) { return result_type{x}; },
     [dict_to_list](const dictionary& x) {
@@ -455,7 +420,7 @@ expected<config_value::dictionary> config_value::to_dictionary() const {
   using result_type = expected<dictionary>;
   auto f = detail::make_overload(
     no_conversions<dictionary, none_t, bool, integer, timespan, real, uri>(),
-    [](const list& x) {
+    [](const list& x) -> result_type {
       dictionary tmp;
       auto lift = [&tmp](const config_value& element) {
         auto ls = element.to_list();
@@ -466,14 +431,12 @@ expected<config_value::dictionary> config_value::to_dictionary() const {
       };
       if (std::all_of(x.begin(), x.end(), lift)) {
         return result_type{std::move(tmp)};
-      } else {
-        auto err = make_error(sec::conversion_failed,
-                              "cannot convert list to dictionary unless each "
-                              "element in the list is a key-value pair");
-        return result_type{std::move(err)};
       }
+      return error{sec::conversion_failed,
+                   "cannot convert list to dictionary unless each "
+                   "element in the list is a key-value pair"};
     },
-    [this](const std::string& x) {
+    [this](const std::string& x) -> result_type {
       if (dictionary tmp; detail::parse(x, tmp) == none)
         return result_type{std::move(tmp)};
       if (auto lst = to_list()) {
@@ -481,10 +444,8 @@ expected<config_value::dictionary> config_value::to_dictionary() const {
         if (auto res = ls.to_dictionary())
           return res;
       }
-      std::string msg = "cannot convert ";
-      detail::print_escaped(msg, x);
-      msg += " to a dictionary";
-      return result_type{make_error(sec::conversion_failed, std::move(msg))};
+      return format_to_error(sec::conversion_failed,
+                             "cannot convert '{}' to a dictionary", x);
     },
     [](const dictionary& x) { return result_type{x}; });
   return visit(f, data_);
@@ -494,7 +455,8 @@ bool config_value::can_convert_to_dictionary() const {
   auto f = detail::make_overload( //
     [](const auto&) { return false; },
     [this](const std::string&) {
-      // TODO: implement some dry-run mode and use it here to avoid creating an
+      // TODO: implement some dry-run mode and use it here to avoid creating
+      // an
       //       actual dictionary only to throw it away.
       auto maybe_dict = to_dictionary();
       return static_cast<bool>(maybe_dict);
@@ -602,7 +564,6 @@ bool operator>=(const config_value& x, const config_value& y) {
 }
 
 namespace {
-
 void to_string_impl(std::string& str, const config_value& x);
 
 struct to_string_visitor {

--- a/libcaf_core/caf/config_value_reader.cpp
+++ b/libcaf_core/caf/config_value_reader.cpp
@@ -11,6 +11,7 @@
 #include "caf/detail/parse.hpp"
 #include "caf/detail/parser/add_ascii.hpp"
 #include "caf/detail/print.hpp"
+#include "caf/format_to_error.hpp"
 #include "caf/settings.hpp"
 
 namespace {
@@ -235,9 +236,9 @@ bool config_value_reader::begin_object(type_id_t type, std::string_view) {
       if (auto i = obj->find("@type"); i != obj->end()) {
         if (auto got = get_if<std::string>(std::addressof(i->second))) {
           if (want != *got) {
-            emplace_error(sec::type_clash,
-                          "expected type: " + std::string{want},
-                          "found type: " + *got);
+            err_ = format_to_error(sec::type_clash,
+                                   "expected type: {}, found type: {}", want,
+                                   *got);
             return false;
           }
         }

--- a/libcaf_core/caf/deserializer.cpp
+++ b/libcaf_core/caf/deserializer.cpp
@@ -5,6 +5,7 @@
 #include "caf/deserializer.hpp"
 
 #include "caf/actor_system.hpp"
+#include "caf/format_to_error.hpp"
 
 namespace caf {
 
@@ -36,18 +37,14 @@ bool deserializer::assert_next_object_name(std::string_view type_name) {
   if (fetch_next_object_name(found)) {
     if (type_name == found) {
       return true;
-    } else {
-      std::string str = "required type ";
-      str.insert(str.end(), type_name.begin(), type_name.end());
-      str += ", got ";
-      str.insert(str.end(), found.begin(), found.end());
-      emplace_error(sec::type_clash, __func__, std::move(str));
-      return false;
     }
-  } else {
-    emplace_error(sec::runtime_error, __func__, "no type name available");
+    err_ = format_to_error(sec::type_clash, "{}: expected type {}, got {}",
+                           __func__, type_name, found);
     return false;
   }
+  err_ = format_to_error(sec::type_clash, "{}: expected type {}, got none",
+                         __func__, type_name);
+  return false;
 }
 
 bool deserializer::begin_key_value_pair() {

--- a/libcaf_core/caf/detail/parse.test.cpp
+++ b/libcaf_core/caf/detail/parse.test.cpp
@@ -50,7 +50,7 @@ expected<T> read(std::string_view str) {
   detail::parse(ps, result);
   if (ps.code == pec::success)
     return result;
-  return make_error(ps);
+  return ps.error();
 }
 
 #define CHECK_NUMBER(type, value) check_eq(read<type>(#value), type(value))

--- a/libcaf_core/caf/detail/parser/read_number.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_number.test.cpp
@@ -104,8 +104,7 @@ struct range_parser {
     detail::parser::read_number(res, f, std::true_type{}, std::true_type{});
     if (res.code == pec::success)
       return expected<std::vector<int64_t>>{std::move(f.xs)};
-    else
-      return make_error(res);
+    return res.error();
   }
 };
 

--- a/libcaf_core/caf/detail/parser/read_string.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_string.test.cpp
@@ -7,6 +7,7 @@
 #include "caf/test/test.hpp"
 
 #include "caf/expected.hpp"
+#include "caf/format_to_error.hpp"
 #include "caf/parser_state.hpp"
 
 #include <string>
@@ -31,7 +32,7 @@ struct string_parser {
     detail::parser::read_string(res, f);
     if (res.code == pec::success)
       return f.x;
-    return make_error(res.code, res.column, std::string{res.i, res.e});
+    return res.error();
   }
 };
 

--- a/libcaf_core/caf/detail/pretty_type_name.cpp
+++ b/libcaf_core/caf/detail/pretty_type_name.cpp
@@ -25,19 +25,10 @@ void prettify_type_name(std::string& class_name) {
   replace_all(class_name, "::", ".");
   replace_all(class_name, "(anonymous namespace)", "ANON");
   replace_all(class_name, ".__1.", "."); // gets rid of weird Clang-lib names
-  // hide CAF magic in logs
-  auto strip_magic = [&](const char* prefix_begin, const char* prefix_end) {
-    auto last = class_name.end();
-    auto i = std::search(class_name.begin(), last, prefix_begin, prefix_end);
-    auto comma_or_angle_bracket = [](char c) { return c == ',' || c == '>'; };
-    auto e = std::find_if(i, last, comma_or_angle_bracket);
-    if (i != e) {
-      std::string substr(i + (prefix_end - prefix_begin), e);
-      class_name.swap(substr);
-    }
-  };
-  char prefix1[] = "caf.detail.embedded<";
-  strip_magic(prefix1, prefix1 + (sizeof(prefix1) - 1));
+  replace_all(class_name, "class ", ".");
+  replace_all(class_name, "struct ", ".");
+  while (class_name[0] == '.' || class_name[0] == ' ')
+    class_name.erase(class_name.begin());
   // Drop template parameters, only leaving the template class name.
   auto i = std::find(class_name.begin(), class_name.end(), '<');
   if (i != class_name.end())

--- a/libcaf_core/caf/error.cpp
+++ b/libcaf_core/caf/error.cpp
@@ -48,6 +48,15 @@ error::error(uint8_t code, type_id_t category, message context)
   // nop
 }
 
+std::string_view error::what() const noexcept {
+  if (data_ == nullptr)
+    return {};
+  auto& ctx = data_->context;
+  if (!ctx.match_elements<std::string>())
+    return {};
+  return ctx.get_as<std::string>(0);
+}
+
 // -- observers ----------------------------------------------------------------
 
 int error::compare(const error& x) const noexcept {

--- a/libcaf_core/caf/format_to_error.hpp
+++ b/libcaf_core/caf/format_to_error.hpp
@@ -1,0 +1,20 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/detail/format.hpp"
+#include "caf/error.hpp"
+
+namespace caf {
+
+/// Formats the given arguments into a string and returns an error with the
+/// specified code and the formatted string as message.
+template <class Enum, class... Args>
+std::enable_if_t<is_error_code_enum_v<Enum>, error>
+format_to_error(Enum code, std::string_view fstr, Args&&... args) {
+  return error{code, detail::format(fstr, std::forward<Args>(args)...)};
+}
+
+} // namespace caf

--- a/libcaf_core/caf/ipv4_address.cpp
+++ b/libcaf_core/caf/ipv4_address.cpp
@@ -99,8 +99,7 @@ error parse(std::string_view str, ipv4_address& dest) {
   parser::read_ipv4_address(res, f);
   if (res.code == pec::success)
     return none;
-  return make_error(res.code, static_cast<size_t>(res.line),
-                    static_cast<size_t>(res.column));
+  return res.error();
 }
 
 } // namespace caf

--- a/libcaf_core/caf/ipv6_address.cpp
+++ b/libcaf_core/caf/ipv6_address.cpp
@@ -215,8 +215,7 @@ error parse(std::string_view str, ipv6_address& dest) {
   parser::read_ipv6_address(res, f);
   if (res.code == pec::success)
     return none;
-  return make_error(res.code, static_cast<size_t>(res.line),
-                    static_cast<size_t>(res.column));
+  return res.error();
 }
 
 } // namespace caf

--- a/libcaf_core/caf/json_reader.hpp
+++ b/libcaf_core/caf/json_reader.hpp
@@ -229,8 +229,6 @@ private:
 
   std::string current_field_name();
 
-  std::string mandatory_field_missing_str(std::string_view name);
-
   template <bool PopOrAdvanceOnSuccess, class F>
   bool consume(const char* fun_name, F f);
 

--- a/libcaf_core/caf/json_value.cpp
+++ b/libcaf_core/caf/json_value.cpp
@@ -170,7 +170,7 @@ expected<json_value> json_value::parse(std::string_view str) {
   auto root = detail::json::parse(ps, &storage->buf);
   if (ps.code == pec::success)
     return {json_value{root, std::move(storage)}};
-  return {make_error(ps)};
+  return {ps.error()};
 }
 
 expected<json_value> json_value::parse_shallow(std::string_view str) {
@@ -179,7 +179,7 @@ expected<json_value> json_value::parse_shallow(std::string_view str) {
   auto root = detail::json::parse_shallow(ps, &storage->buf);
   if (ps.code == pec::success)
     return {json_value{root, std::move(storage)}};
-  return {make_error(ps)};
+  return {ps.error()};
 }
 
 expected<json_value> json_value::parse_in_situ(std::string& str) {
@@ -189,7 +189,7 @@ expected<json_value> json_value::parse_in_situ(std::string& str) {
   auto root = detail::json::parse_in_situ(ps, &storage->buf);
   if (ps.code == pec::success)
     return {json_value{root, std::move(storage)}};
-  return {make_error(ps)};
+  return {ps.error()};
 }
 
 expected<json_value> json_value::parse_file(const char* path) {
@@ -202,7 +202,7 @@ expected<json_value> json_value::parse_file(const char* path) {
   auto root = detail::json::parse(ps, &storage->buf);
   if (ps.code == pec::success)
     return {json_value{root, std::move(storage)}};
-  return {make_error(ps)};
+  return {ps.error()};
 }
 
 expected<json_value> json_value::parse_file(const std::string& path) {

--- a/libcaf_core/caf/parser_state.cpp
+++ b/libcaf_core/caf/parser_state.cpp
@@ -1,0 +1,17 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/parser_state.hpp"
+
+#include "caf/detail/format.hpp"
+#include "caf/error.hpp"
+
+namespace caf {
+
+error parser_state_to_error(pec code, int32_t line, int32_t column) {
+  return {code, detail::format("error in line {} column {}: {}", line, column,
+                               to_string(code))};
+}
+
+} // namespace caf

--- a/libcaf_core/caf/parser_state.hpp
+++ b/libcaf_core/caf/parser_state.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "caf/detail/core_export.hpp"
+#include "caf/error.hpp"
 #include "caf/fwd.hpp"
 #include "caf/pec.hpp"
 
@@ -12,6 +14,10 @@
 #include <string_view>
 
 namespace caf {
+
+/// Converts the code and the current position of a parser to an error.
+CAF_CORE_EXPORT error parser_state_to_error(pec code, int32_t line,
+                                            int32_t column);
 
 /// Stores all information necessary for implementing an FSM-based parser.
 template <class Iterator, class Sentinel>
@@ -126,17 +132,12 @@ struct parser_state {
     }
     return false;
   }
-};
 
-/// Returns an error object from the current code in `ps` as well as its
-/// current position.
-template <class Iterator, class Sentinel, class... Ts>
-auto make_error(const parser_state<Iterator, Sentinel>& ps, Ts&&... xs)
-  -> decltype(make_error(ps.code, ps.line, ps.column)) {
-  if (ps.code == pec::success)
-    return {};
-  return make_error(ps.code, ps.line, ps.column, std::forward<Ts>(xs)...);
-}
+  /// Returns an error from the current state.
+  auto error() {
+    return parser_state_to_error(code, line, column);
+  }
+};
 
 /// Specialization for parsers operating on string views.
 using string_parser_state = parser_state<std::string_view::iterator>;

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -101,7 +101,7 @@ error scheduled_actor::default_exception_handler(local_actor* ptr,
   } catch (std::exception& e) {
     auto pretty_type = detail::pretty_type_name(typeid(e));
     ptr->println(
-      "*** unhandled exception: [id: {}, name: {}, exception typeid {}]: {}",
+      "*** unhandled exception: [id: {}, name: {}, exception: {}]: {}",
       ptr->id(), ptr->name(), pretty_type, e.what());
     return format_to_error(sec::runtime_error,
                            "unhandled exception of type {}: {}", pretty_type,

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -17,6 +17,7 @@
 #include "caf/detail/sync_request_bouncer.hpp"
 #include "caf/flow/observable_builder.hpp"
 #include "caf/flow/op/mcast.hpp"
+#include "caf/format_to_error.hpp"
 #include "caf/log/core.hpp"
 #include "caf/log/system.hpp"
 #include "caf/mailbox_element.hpp"
@@ -102,12 +103,15 @@ error scheduled_actor::default_exception_handler(local_actor* ptr,
     ptr->println(
       "*** unhandled exception: [id: {}, name: {}, exception typeid {}]: {}",
       ptr->id(), ptr->name(), pretty_type, e.what());
-    return make_error(sec::runtime_error, std::move(pretty_type), e.what());
+    return format_to_error(sec::runtime_error,
+                           "unhandled exception of type {}: {}", pretty_type,
+                           e.what());
   } catch (...) {
     ptr->println(
       "*** unhandled exception: [id: {}, name: {}]: unknown exception",
       ptr->id(), ptr->name());
-    return sec::runtime_error;
+    return make_error(sec::runtime_error,
+                      "unhandled exception of unknown type");
   }
 }
 #endif // CAF_ENABLE_EXCEPTIONS

--- a/libcaf_core/caf/uri.cpp
+++ b/libcaf_core/caf/uri.cpp
@@ -277,7 +277,7 @@ error parse(std::string_view str, uri& dest) {
   parse(ps, dest);
   if (ps.code == pec::success)
     return none;
-  return make_error(ps);
+  return ps.error();
 }
 
 expected<uri> make_uri(std::string_view str) {

--- a/libcaf_core/tests/legacy/custom_exception_handler.cpp
+++ b/libcaf_core/tests/legacy/custom_exception_handler.cpp
@@ -50,12 +50,8 @@ CAF_TEST(the default exception handler includes the error message) {
     .receive( //
       [] { CAF_FAIL("unexpected response"); },
       [](const error& err) {
-        auto msg = err.context();
-        if (auto view = make_typed_message_view<string, string>(msg)) {
-          CHECK_EQ(get<1>(view), "whatever");
-        } else {
-          CAF_FAIL("unexpected error contest: " << err.context());
-        }
+        CHECK_EQ(err.what(),
+                 "unhandled exception of type std.runtime_error: whatever");
       });
 }
 

--- a/libcaf_io/caf/detail/call_cfun.hpp
+++ b/libcaf_io/caf/detail/call_cfun.hpp
@@ -7,6 +7,7 @@
 #include "caf/io/network/native_socket.hpp"
 
 #include "caf/error.hpp"
+#include "caf/format_to_error.hpp"
 #include "caf/sec.hpp"
 
 #include <cstdio>
@@ -38,8 +39,8 @@ inline bool cc_valid_socket(caf::io::network::native_socket fd) {
 #define CALL_CFUN(var, predicate, fun_name, expr)                              \
   auto var = expr;                                                             \
   if (!predicate(var))                                                         \
-  return make_error(sec::network_syscall_failed, fun_name,                     \
-                    last_socket_error_as_string())
+  return format_to_error(sec::network_syscall_failed, "{}: {}", fun_name,      \
+                         last_socket_error_as_string())
 
 /// Calls a C functions and calls exit() if `predicate(var)` returns false.
 #define CALL_CRITICAL_CFUN(var, predicate, funname, expr)                      \

--- a/libcaf_io/caf/io/middleman.cpp
+++ b/libcaf_io/caf/io/middleman.cpp
@@ -18,6 +18,7 @@
 #include "caf/detail/assert.hpp"
 #include "caf/detail/latch.hpp"
 #include "caf/detail/prometheus_broker.hpp"
+#include "caf/format_to_error.hpp"
 #include "caf/function_view.hpp"
 #include "caf/init_global_meta_objects.hpp"
 #include "caf/log/system.hpp"
@@ -274,10 +275,12 @@ expected<strong_actor_ptr> middleman::remote_actor(std::set<std::string> ifs,
     return std::move(res.error());
   strong_actor_ptr ptr = std::move(std::get<1>(*res));
   if (!ptr)
-    return make_error(sec::no_actor_published_at_port, port);
+    return format_to_error(sec::no_actor_published_at_port,
+                           "no actor published at port {} on host {}", port);
   if (!system().assignable(std::get<2>(*res), ifs))
-    return make_error(sec::unexpected_actor_messaging_interface, std::move(ifs),
-                      std::move(std::get<2>(*res)));
+    return format_to_error(sec::unexpected_actor_messaging_interface,
+                           "expected interface {}, got {}", std::move(ifs),
+                           std::get<2>(*res));
   return ptr;
 }
 

--- a/libcaf_io/caf/io/network/native_socket.cpp
+++ b/libcaf_io/caf/io/network/native_socket.cpp
@@ -393,8 +393,8 @@ expected<string> local_addr_of_fd(native_socket fd) {
     default:
       break;
   }
-  return make_error(sec::invalid_protocol_family, "local_addr_of_fd",
-                    sa->sa_family);
+  return format_to_error(sec::invalid_protocol_family,
+                         "invalid protocol family: {}", sa->sa_family);
 }
 
 expected<uint16_t> local_port_of_fd(native_socket fd) {
@@ -422,8 +422,8 @@ expected<string> remote_addr_of_fd(native_socket fd) {
     default:
       break;
   }
-  return make_error(sec::invalid_protocol_family, "remote_addr_of_fd",
-                    sa->sa_family);
+  return format_to_error(sec::invalid_protocol_family,
+                         "invalid protocol family: {}", sa->sa_family);
 }
 
 expected<uint16_t> remote_port_of_fd(native_socket fd) {

--- a/libcaf_net/caf/detail/net_syscall.hpp
+++ b/libcaf_net/caf/detail/net_syscall.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "caf/error.hpp"
+#include "caf/format_to_error.hpp"
 #include "caf/sec.hpp"
 
 #include <cstdio>
@@ -14,8 +15,9 @@
 #define CAF_NET_SYSCALL(funname, var, op, rhs, expr)                           \
   auto var = expr;                                                             \
   if (var op rhs)                                                              \
-  return make_error(sec::network_syscall_failed, funname,                      \
-                    last_socket_error_as_string())
+  return format_to_error(sec::network_syscall_failed,                          \
+                         "error in function {}: {}", funname,                  \
+                         last_socket_error_as_string())
 
 /// Calls a C functions and calls exit() if `var op rhs` returns `true`.
 #define CAF_NET_CRITICAL_SYSCALL(funname, var, op, rhs, expr)                  \

--- a/libcaf_net/caf/net/dsl/config_base.hpp
+++ b/libcaf_net/caf/net/dsl/config_base.hpp
@@ -17,6 +17,7 @@
 #include "caf/defaults.hpp"
 #include "caf/detail/net_export.hpp"
 #include "caf/error.hpp"
+#include "caf/format_to_error.hpp"
 #include "caf/intrusive_ptr.hpp"
 #include "caf/ref_counted.hpp"
 #include "caf/sec.hpp"
@@ -51,10 +52,10 @@ public:
   /// Convenience function for setting a default error if `as_has_make_ctx`
   /// returns `nullptr` while trying to set an SSL context.
   error cannot_add_ctx() {
-    return make_error(
-      sec::logic_error,
-      "cannot add an SSL context or context factory to a config of type "
-        + std::string{name()});
+    return format_to_error(sec::logic_error,
+                           "cannot add an SSL context or context factory "
+                           "to a config of type {}",
+                           name());
   }
 
   /// Inspects the data of this configuration and returns a pointer to it as

--- a/libcaf_net/caf/net/network_socket.cpp
+++ b/libcaf_net/caf/net/network_socket.cpp
@@ -11,6 +11,7 @@
 #include "caf/detail/socket_sys_includes.hpp"
 #include "caf/error.hpp"
 #include "caf/expected.hpp"
+#include "caf/format_to_error.hpp"
 #include "caf/logger.hpp"
 #include "caf/sec.hpp"
 
@@ -50,8 +51,8 @@ namespace caf::net {
 
 error allow_sigpipe(network_socket x, bool) {
   if (x == invalid_socket)
-    return make_error(sec::network_syscall_failed, "setsockopt",
-                      "invalid socket");
+    return make_error(sec::network_syscall_failed,
+                      "allow_sigpipe: invalid socket");
   return none;
 }
 
@@ -73,8 +74,8 @@ error allow_sigpipe(network_socket x, [[maybe_unused]] bool new_value) {
                              static_cast<unsigned>(sizeof(value))));
 #  else  // CAF_HAS_NO_SIGPIPE_SOCKET_FLAG
   if (x == invalid_socket)
-    return make_error(sec::network_syscall_failed, "setsockopt",
-                      "invalid socket");
+    return make_error(sec::network_syscall_failed,
+                      "allow_sigpipe: invalid socket");
 #  endif // CAF_HAS_NO_SIGPIPE_SOCKET_FLAG
   return none;
 }
@@ -82,8 +83,8 @@ error allow_sigpipe(network_socket x, [[maybe_unused]] bool new_value) {
 error allow_udp_connreset(network_socket x, bool) {
   // SIO_UDP_CONNRESET only exists on Windows
   if (x == invalid_socket)
-    return make_error(sec::network_syscall_failed, "WSAIoctl",
-                      "invalid socket");
+    return make_error(sec::network_syscall_failed,
+                      "allow_udp_connreset: invalid socket");
   return none;
 }
 
@@ -125,7 +126,9 @@ expected<std::string> local_addr(network_socket x) {
     default:
       break;
   }
-  return make_error(sec::invalid_protocol_family, "local_addr", sa->sa_family);
+  return format_to_error(sec::invalid_protocol_family,
+                         "local_addr: invalid protocol family {}",
+                         sa->sa_family);
 }
 
 expected<uint16_t> local_port(network_socket x) {
@@ -153,7 +156,9 @@ expected<std::string> remote_addr(network_socket x) {
     default:
       break;
   }
-  return make_error(sec::invalid_protocol_family, "remote_addr", sa->sa_family);
+  return format_to_error(sec::invalid_protocol_family,
+                         "remote_addr: invalid protocol family {}",
+                         sa->sa_family);
 }
 
 expected<uint16_t> remote_port(network_socket x) {

--- a/libcaf_net/caf/net/pipe_socket.cpp
+++ b/libcaf_net/caf/net/pipe_socket.cpp
@@ -10,6 +10,7 @@
 #include "caf/detail/socket_sys_aliases.hpp"
 #include "caf/detail/socket_sys_includes.hpp"
 #include "caf/expected.hpp"
+#include "caf/format_to_error.hpp"
 #include "caf/log/net.hpp"
 #include "caf/message.hpp"
 #include "caf/sec.hpp"
@@ -48,8 +49,8 @@ ptrdiff_t read(pipe_socket x, byte_span buf) {
 expected<std::pair<pipe_socket, pipe_socket>> make_pipe() {
   socket_id pipefds[2];
   if (pipe(pipefds) != 0)
-    return make_error(sec::network_syscall_failed, "pipe",
-                      last_socket_error_as_string());
+    return format_to_error(sec::network_syscall_failed, "make_pipe failed: {}",
+                           last_socket_error_as_string());
   auto guard = detail::scope_guard{[&]() noexcept {
     close(socket{pipefds[0]});
     close(socket{pipefds[1]});

--- a/libcaf_net/caf/net/ssl/tcp_acceptor.cpp
+++ b/libcaf_net/caf/net/ssl/tcp_acceptor.cpp
@@ -8,6 +8,7 @@
 #include "caf/net/tcp_stream_socket.hpp"
 
 #include "caf/expected.hpp"
+#include "caf/format_to_error.hpp"
 
 namespace caf::net::ssl {
 
@@ -37,12 +38,14 @@ tcp_acceptor::make_with_cert_file(tcp_accept_socket fd,
     return {make_error(sec::runtime_error, "unable to create SSL context")};
   }
   if (!ctx->use_certificate_file(cert_file_path, file_format)) {
-    return {make_error(sec::runtime_error, "unable to load certificate file",
-                       ctx->last_error_string())};
+    return {format_to_error(sec::runtime_error,
+                            "unable to load certificate file: {}",
+                            ctx->last_error_string())};
   }
   if (!ctx->use_private_key_file(key_file_path, file_format)) {
-    return {make_error(sec::runtime_error, "unable to load private key file",
-                       ctx->last_error_string())};
+    return {format_to_error(sec::runtime_error,
+                            "unable to load private key file: {}",
+                            ctx->last_error_string())};
   }
   return {tcp_acceptor{fd, std::move(*ctx)}};
 }


### PR DESCRIPTION
This was originally part of #1816, but I thought it's worth keeping even though we're not going through with the `error` redesign.