### PR TITLE
Hide most actor_system_config fields

### DIFF
--- a/examples/config/read-json.cpp
+++ b/examples/config/read-json.cpp
@@ -47,14 +47,15 @@ CAF_END_TYPE_ID_BLOCK(example_app)
 int caf_main(caf::actor_system& sys) {
   // Get file path from config (positional argument).
   auto& cfg = sys.config();
-  if (cfg.remainder.size() != 1) {
+  auto remainder = cfg.remainder();
+  if (remainder.size() != 1) {
     std::cerr
       << "*** expected one positional argument: path to a JSON file\n"
       << "\n\nNote: expected a JSON list of user objects. For example:\n"
       << example_input << '\n';
     return EXIT_FAILURE;
   }
-  auto& file_path = cfg.remainder[0];
+  auto& file_path = remainder[0];
   // Read JSON-formatted file.
   caf::json_reader reader;
   if (!reader.load_file(file_path)) {

--- a/examples/http/client.cpp
+++ b/examples/http/client.cpp
@@ -60,12 +60,13 @@ std::atomic<bool> shutdown_flag;
 int caf_main(caf::actor_system& sys, const config& cfg) {
   signal(SIGTERM, [](int) { shutdown_flag = true; });
   // Get URI from config (positional argument).
-  if (cfg.remainder.size() != 1) {
+  auto remainder = cfg.remainder();
+  if (remainder.size() != 1) {
     std::cerr << "*** expected mandatory positional argument: URL" << std::endl;
     return EXIT_FAILURE;
   }
   uri resource;
-  if (auto err = parse(cfg.remainder[0], resource)) {
+  if (auto err = parse(remainder[0], resource)) {
     std::cerr << "*** failed to parse URI: " << to_string(err) << std::endl;
     return EXIT_FAILURE;
   }

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -142,6 +142,7 @@ caf_add_component(
     caf/detail/abstract_worker_hub.cpp
     caf/detail/actor_local_printer.cpp
     caf/detail/actor_system_access.cpp
+    caf/detail/actor_system_config_access.cpp
     caf/detail/assert.cpp
     caf/detail/atomic_ref_counted.cpp
     caf/detail/base64.cpp

--- a/libcaf_core/caf/actor_factory.test.cpp
+++ b/libcaf_core/caf/actor_factory.test.cpp
@@ -7,6 +7,7 @@
 #include "caf/actor_registry.hpp"
 #include "caf/actor_system_config.hpp"
 #include "caf/all.hpp"
+#include "caf/config.hpp"
 #include "caf/log/test.hpp"
 #include "caf/type_id.hpp"
 
@@ -77,6 +78,8 @@ TEST("fun_one_arg_selfptr") {
   test_spawn(make_message(42));
 }
 
+CAF_PUSH_DEPRECATED_WARNING
+
 TEST("class_no_arg_invalid") {
   cfg.add_actor_type<test_actor_no_args>("test_actor");
   test_spawn(make_message(42), true);
@@ -96,6 +99,8 @@ TEST("class_one_arg_valid") {
   cfg.add_actor_type<test_actor_one_arg, const int&>("test_actor");
   test_spawn(make_message(42));
 }
+
+CAF_POP_WARNINGS
 
 } // WITH_FIXTURE(fixture)
 

--- a/libcaf_core/caf/detail/actor_system_config_access.cpp
+++ b/libcaf_core/caf/detail/actor_system_config_access.cpp
@@ -1,0 +1,17 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/detail/actor_system_config_access.hpp"
+
+#include "caf/actor_system_config.hpp"
+#include "caf/detail/mailbox_factory.hpp"
+
+namespace caf::detail {
+
+void actor_system_config_access::mailbox_factory(
+  std::unique_ptr<detail::mailbox_factory> factory) {
+  cfg_->mailbox_factory(std::move(factory));
+}
+
+} // namespace caf::detail

--- a/libcaf_core/caf/detail/actor_system_config_access.hpp
+++ b/libcaf_core/caf/detail/actor_system_config_access.hpp
@@ -1,0 +1,26 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/detail/core_export.hpp"
+#include "caf/fwd.hpp"
+
+#include <memory>
+
+namespace caf::detail {
+
+class CAF_CORE_EXPORT actor_system_config_access {
+public:
+  explicit actor_system_config_access(actor_system_config& cfg) : cfg_(&cfg) {
+    // nop
+  }
+
+  void mailbox_factory(std::unique_ptr<detail::mailbox_factory> factory);
+
+private:
+  actor_system_config* cfg_;
+};
+
+} // namespace caf::detail

--- a/libcaf_core/caf/exec_main.hpp
+++ b/libcaf_core/caf/exec_main.hpp
@@ -84,7 +84,7 @@ int exec_main(F fun, int argc, char** argv) {
     return EXIT_FAILURE;
   }
   // Return immediately if a help text was printed.
-  if (cfg.cli_helptext_printed)
+  if (cfg.helptext_printed())
     return EXIT_SUCCESS;
   // Initialize the actor system.
   actor_system system{cfg};
@@ -92,10 +92,9 @@ int exec_main(F fun, int argc, char** argv) {
   using result_type = decltype(f(fun, system, cfg));
   if constexpr (std::is_convertible_v<result_type, int>) {
     return f(fun, system, cfg);
-  } else {
-    f(fun, system, cfg);
-    return EXIT_SUCCESS;
   }
+  f(fun, system, cfg);
+  return EXIT_SUCCESS;
 }
 
 } // namespace caf

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -269,6 +269,7 @@ using int_gauge_family = metric_family_impl<int_gauge>;
 namespace detail {
 
 class actor_system_access;
+class actor_system_config_access;
 class mailbox_factory;
 class monotonic_buffer_resource;
 
@@ -302,7 +303,6 @@ using gauge = detail::gauge_oracle_t<ValueType>;
 
 namespace io {
 
-class hook;
 class broker;
 class middleman;
 template <class...>

--- a/libcaf_io/caf/io/middleman.cpp
+++ b/libcaf_io/caf/io/middleman.cpp
@@ -208,7 +208,7 @@ void middleman::add_module_options(actor_system_config& cfg) {
               defaults::middleman::connection_timeout);
 }
 
-actor_system::module* middleman::make(actor_system& sys, type_list<>) {
+actor_system::module* middleman::make(actor_system& sys) {
   return new mm_impl<network::default_multiplexer>(sys);
 }
 

--- a/libcaf_io/caf/io/middleman.hpp
+++ b/libcaf_io/caf/io/middleman.hpp
@@ -249,25 +249,7 @@ public:
   static void add_module_options(actor_system_config& cfg);
 
   /// Returns a middleman using the default network backend.
-  static actor_system::module* make(actor_system&, type_list<>);
-
-  template <class Backend>
-  static actor_system::module* make(actor_system& sys, type_list<Backend>) {
-    class impl : public middleman {
-    public:
-      impl(actor_system& ref) : middleman(ref), backend_(&ref) {
-        // nop
-      }
-
-      network::multiplexer& backend() override {
-        return backend_;
-      }
-
-    private:
-      Backend backend_;
-    };
-    return new impl(sys);
-  }
+  static actor_system::module* make(actor_system&);
 
   /// @private
   actor get_named_broker(const std::string& name) {

--- a/libcaf_net/caf/net/middleman.cpp
+++ b/libcaf_net/caf/net/middleman.cpp
@@ -140,7 +140,7 @@ void* middleman::subtype_ptr() {
   return this;
 }
 
-actor_system::module* middleman::make(actor_system& sys, type_list<>) {
+actor_system::module* middleman::make(actor_system& sys) {
   return new middleman(sys);
 }
 

--- a/libcaf_net/caf/net/middleman.hpp
+++ b/libcaf_net/caf/net/middleman.hpp
@@ -62,7 +62,7 @@ public:
 
   // -- factory functions ------------------------------------------------------
 
-  static module* make(actor_system& sys, type_list<>);
+  static module* make(actor_system& sys);
 
   /// Adds module-specific options to the config before loading the module.
   static void add_module_options(actor_system_config& cfg);

--- a/libcaf_openssl/caf/openssl/manager.cpp
+++ b/libcaf_openssl/caf/openssl/manager.cpp
@@ -164,7 +164,7 @@ void manager::add_module_options(actor_system_config& cfg) {
                       "colon-separated list of OpenSSL cipher strings to use");
 }
 
-actor_system::module* manager::make(actor_system& sys, type_list<>) {
+actor_system::module* manager::make(actor_system& sys) {
   if (!sys.has_middleman())
     CAF_RAISE_ERROR("Cannot start OpenSSL module without middleman.");
   auto ptr = &sys.middleman().backend();

--- a/libcaf_openssl/caf/openssl/manager.hpp
+++ b/libcaf_openssl/caf/openssl/manager.hpp
@@ -57,7 +57,7 @@ public:
   //           a custom implementation.
   /// @throws `logic_error` if the middleman is not loaded or is not using the
   ///         default network backend.
-  static actor_system::module* make(actor_system&, type_list<>);
+  static actor_system::module* make(actor_system&);
 
   /// Adds message types of the OpenSSL module to the global meta object table.
   static void init_global_meta_objects();

--- a/libcaf_test/caf/test/fixture/deterministic.hpp
+++ b/libcaf_test/caf/test/fixture/deterministic.hpp
@@ -161,19 +161,6 @@ private:
 public:
   // -- public member types ----------------------------------------------------
 
-  /// The configuration type for this fixture.
-  class config : public actor_system_config {
-  public:
-    explicit config(deterministic* fix);
-
-    ~config() override;
-
-  private:
-    detail::mailbox_factory* mailbox_factory() override;
-
-    std::unique_ptr<detail::mailbox_factory> factory_;
-  };
-
   /// The custom system implementation for this fixture.
   class system_impl : public actor_system {
   public:
@@ -182,6 +169,9 @@ public:
     detail::actor_local_printer_ptr printer_for(local_actor* self) override;
 
   private:
+    static actor_system_config& prepare(actor_system_config& cfg,
+                                        deterministic* fix);
+
     static void custom_setup(actor_system& sys, actor_system_config& cfg,
                              void* custom_setup_data);
 
@@ -675,7 +665,7 @@ private:
 
 public:
   /// Configures the actor system with deterministic scheduling.
-  config cfg;
+  actor_system_config cfg;
 
   /// The actor system instance for the tests.
   system_impl sys;


### PR DESCRIPTION
Moving the fields for the actor-system config into an opaque member will allow us adding new fields mid-release without breaking ABI.

Relates #1254.