### PR TITLE
Implementation hiding of `caf::net` protocol specific classes

### DIFF
--- a/examples/length_prefix_framing/chat-client.cpp
+++ b/examples/length_prefix_framing/chat-client.cpp
@@ -6,6 +6,7 @@
 #include "caf/actor_system.hpp"
 #include "caf/actor_system_config.hpp"
 #include "caf/caf_main.hpp"
+#include "caf/chunk.hpp"
 #include "caf/event_based_actor.hpp"
 #include "caf/scheduled_actor/flow.hpp"
 #include "caf/span.hpp"

--- a/examples/length_prefix_framing/chat-server.cpp
+++ b/examples/length_prefix_framing/chat-server.cpp
@@ -6,6 +6,7 @@
 #include "caf/actor_system.hpp"
 #include "caf/actor_system_config.hpp"
 #include "caf/caf_main.hpp"
+#include "caf/chunk.hpp"
 #include "caf/event_based_actor.hpp"
 #include "caf/scheduled_actor/flow.hpp"
 #include "caf/uuid.hpp"

--- a/examples/web_socket/stock-ticker.cpp
+++ b/examples/web_socket/stock-ticker.cpp
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <cstdint>
 #include <iostream>
+#include <random>
 #include <utility>
 
 using namespace std::literals;

--- a/libcaf_net/caf/net/fwd.hpp
+++ b/libcaf_net/caf/net/fwd.hpp
@@ -130,6 +130,7 @@ class lower_layer;
 class request;
 class request_header;
 class responder;
+class response;
 class response_header;
 class route;
 class router;

--- a/libcaf_net/caf/net/http/async_client.cpp
+++ b/libcaf_net/caf/net/http/async_client.cpp
@@ -4,66 +4,116 @@
 
 #include "caf/net/http/async_client.hpp"
 
+#include "caf/net/http/response.hpp"
 #include "caf/net/http/response_header.hpp"
 
+#include "caf/async/future.hpp"
+#include "caf/async/promise.hpp"
 #include "caf/log/net.hpp"
+
+#include <utility>
 
 namespace caf::net::http {
 
+namespace {
+
+/// HTTP client for sending requests and receiving responses via promises.
+class async_client_impl : public async_client {
+public:
+  // -- constructors, destructors, and assignment operators --------------------
+  async_client_impl(http::method method, std::string path,
+                    unordered_flat_map<std::string, std::string> fields,
+                    byte_buffer payload)
+    : method_{method},
+      path_{std::move(path)},
+      fields_{std::move(fields)},
+      payload_{std::move(payload)} {
+  }
+
+  // -- generic lower layer implementation -------------------------------------
+
+  void prepare_send() override {
+    // nop
+  }
+
+  bool done_sending() override {
+    return true;
+  }
+
+  void abort(const caf::error& reason) override {
+    log::net::error("Response abortet with: {}", to_string(reason));
+    response_.set_error(reason);
+  }
+
+  // -- http::client lower layer implementation --------------------------------
+
+  caf::error start(http::lower_layer::client* ll) override {
+    down = ll;
+    return send_request();
+  }
+
+  ptrdiff_t consume(const http::response_header& hdr,
+                    caf::const_byte_span payload) override {
+    log::net::info("Received a message");
+    http::response::fields_map fields;
+    hdr.for_each_field([&fields](auto key, auto value) {
+      fields.container().emplace_back(key, value);
+    });
+    http::response resp{static_cast<http::status>(hdr.status()),
+                        std::move(fields),
+                        byte_buffer{payload.begin(), payload.end()}};
+    response_.set_value(std::move(resp));
+    return static_cast<ptrdiff_t>(payload.size());
+  }
+
+  // -- http::async_client implementation --------------------------------------
+
+  async::future<response> get_future() const override {
+    return response_.get_future();
+  }
+
+private:
+  // -- utility functions ------------------------------------------------------
+
+  caf::error send_request() {
+    down->begin_header(method_, path_);
+    for (const auto& [key, value] : fields_)
+      down->add_header_field(key, value);
+    if (!payload_.empty())
+      down->add_header_field("Content-Length", std::to_string(payload_.size()));
+    down->end_header();
+    if (!payload_.empty())
+      down->send_payload(payload_);
+    // Await response.
+    down->request_messages();
+    return caf::none;
+  }
+
+  http::lower_layer::client* down = nullptr;
+  http::method method_;
+  std::string path_;
+  unordered_flat_map<std::string, std::string> fields_;
+  byte_buffer payload_;
+  async::promise<response> response_;
+};
+
+} // namespace
+
+// -- factories ----------------------------------------------------------------
+
+std::unique_ptr<async_client>
+async_client::make(http::method method, std::string path,
+                   unordered_flat_map<std::string, std::string> fields,
+                   const_byte_span payload) {
+  return std::make_unique<async_client_impl>(method, std::move(path), fields,
+                                             byte_buffer{payload.begin(),
+                                                         payload.end()});
+}
+
+// -- constructors, destructors, and assignment operators ----------------------
+
 async_client::~async_client() {
   // nop
-}
-
-// -- generic lower layer implementation -------------------------------------
-
-void async_client::prepare_send() {
-  // nop
-}
-
-bool async_client::done_sending() {
-  return true;
-}
-
-void async_client::abort(const caf::error& reason) {
-  log::net::error("Response abortet with: {}", to_string(reason));
-  response_.set_error(reason);
-}
-
-// -- http::client lower layer implementation --------------------------------
-
-caf::error async_client::start(http::lower_layer::client* ll) {
-  down = ll;
-  return send_request();
-}
-
-ptrdiff_t async_client::consume(const http::response_header& hdr,
-                                caf::const_byte_span payload) {
-  log::net::info("Received a message");
-  http::response::fields_map fields;
-  hdr.for_each_field([&fields](auto key, auto value) {
-    fields.container().emplace_back(key, value);
-  });
-  http::response resp{static_cast<http::status>(hdr.status()),
-                      std::move(fields),
-                      byte_buffer{payload.begin(), payload.end()}};
-  response_.set_value(std::move(resp));
-  return static_cast<ptrdiff_t>(payload.size());
-}
-
-// -- utility functions --------------------------------------------------------
-
-caf::error async_client::send_request() {
-  down->begin_header(method_, path_);
-  for (const auto& [key, value] : fields_)
-    down->add_header_field(key, value);
-  if (!payload_.empty())
-    down->add_header_field("Content-Length", std::to_string(payload_.size()));
-  down->end_header();
-  if (!payload_.empty())
-    down->send_payload(payload_);
-  // Await response.
-  down->request_messages();
-  return caf::none;
 }
 
 } // namespace caf::net::http

--- a/libcaf_net/caf/net/http/async_client.cpp
+++ b/libcaf_net/caf/net/http/async_client.cpp
@@ -4,6 +4,8 @@
 
 #include "caf/net/http/async_client.hpp"
 
+#include "caf/net/http/response_header.hpp"
+
 #include "caf/log/net.hpp"
 
 namespace caf::net::http {

--- a/libcaf_net/caf/net/http/async_client.hpp
+++ b/libcaf_net/caf/net/http/async_client.hpp
@@ -4,10 +4,7 @@
 
 #pragma once
 
-#include "caf/net/http/response.hpp"
 #include "caf/net/http/upper_layer.hpp"
-
-#include "caf/async/future.hpp"
 
 namespace caf::net::http {
 
@@ -23,7 +20,7 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  virtual ~async_client();
+  ~async_client() override;
 
   // -- properties -------------------------------------------------------------
 

--- a/libcaf_net/caf/net/http/async_client.hpp
+++ b/libcaf_net/caf/net/http/async_client.hpp
@@ -4,69 +4,30 @@
 
 #pragma once
 
-#include "caf/net/http/client.hpp"
 #include "caf/net/http/response.hpp"
+#include "caf/net/http/upper_layer.hpp"
 
 #include "caf/async/future.hpp"
-#include "caf/async/promise.hpp"
-#include "caf/disposable.hpp"
-
-#include <chrono>
-#include <cstdint>
-#include <type_traits>
-#include <utility>
 
 namespace caf::net::http {
 
 /// HTTP client for sending requests and receiving responses via promises.
 class CAF_NET_EXPORT async_client : public http::upper_layer::client {
 public:
-  static auto make(http::method method, std::string path,
-                   unordered_flat_map<std::string, std::string> fields,
-                   const_byte_span payload) {
-    return std::make_unique<async_client>(method, std::move(path), fields,
-                                          byte_buffer{payload.begin(),
-                                                      payload.end()});
-  }
+  // -- factories --------------------------------------------------------------
 
-  async_client(http::method method, std::string path,
-               unordered_flat_map<std::string, std::string> fields,
-               byte_buffer payload)
-    : method_{method},
-      path_{std::move(path)},
-      fields_{std::move(fields)},
-      payload_{std::move(payload)} {
-  }
+  static std::unique_ptr<async_client>
+  make(http::method method, std::string path,
+       unordered_flat_map<std::string, std::string> fields,
+       const_byte_span payload);
+
+  // -- constructors, destructors, and assignment operators --------------------
 
   virtual ~async_client();
 
-  // -- generic lower layer implementation -------------------------------------
-  void prepare_send() override;
+  // -- properties -------------------------------------------------------------
 
-  [[nodiscard]] bool done_sending() override;
-
-  void abort(const caf::error& reason) override;
-
-  // -- http::client lower layer implementation --------------------------------
-
-  caf::error start(http::lower_layer::client* ll) override;
-
-  ptrdiff_t consume(const http::response_header& hdr,
-                    caf::const_byte_span payload) override;
-
-  async::future<response> get_future() const {
-    return response_.get_future();
-  }
-
-private:
-  caf::error send_request();
-
-  http::lower_layer::client* down = nullptr;
-  http::method method_;
-  std::string path_;
-  unordered_flat_map<std::string, std::string> fields_;
-  byte_buffer payload_;
-  async::promise<response> response_;
+  virtual async::future<response> get_future() const = 0;
 };
 
 } // namespace caf::net::http

--- a/libcaf_net/caf/net/http/client.cpp
+++ b/libcaf_net/caf/net/http/client.cpp
@@ -1,185 +1,270 @@
 #include "caf/net/http/client.hpp"
 
+#include "caf/net/fwd.hpp"
+#include "caf/net/http/lower_layer.hpp"
+#include "caf/net/http/response_header.hpp"
+#include "caf/net/http/status.hpp"
+#include "caf/net/http/upper_layer.hpp"
+#include "caf/net/http/v1.hpp"
+#include "caf/net/multiplexer.hpp"
 #include "caf/net/octet_stream/lower_layer.hpp"
+#include "caf/net/octet_stream/upper_layer.hpp"
+#include "caf/net/receive_policy.hpp"
+#include "caf/net/socket_manager.hpp"
 
+#include "caf/byte_span.hpp"
+#include "caf/detail/append_hex.hpp"
 #include "caf/detail/format.hpp"
+#include "caf/detail/message_flow_bridge.hpp"
+#include "caf/detail/net_export.hpp"
+#include "caf/error.hpp"
 #include "caf/log/net.hpp"
+#include "caf/logger.hpp"
+#include "caf/pec.hpp"
+#include "caf/settings.hpp"
+#include "caf/unordered_flat_map.hpp"
+
+#include <algorithm>
 
 namespace caf::net::http {
+
+namespace {
+
+class client_impl : public client {
+public:
+  // -- member types -----------------------------------------------------------
+
+  enum class mode {
+    read_header,
+    read_payload,
+    read_chunks,
+  };
+
+  // -- constants --------------------------------------------------------------
+
+  /// Default maximum size for incoming HTTP responses: 512KiB.
+  static constexpr uint32_t default_max_response_size = 512 * 1024;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  explicit client_impl(upper_layer_ptr up) : up_(std::move(up)) {
+    // nop
+  }
+
+  // -- properties -------------------------------------------------------------
+
+  size_t max_response_size() const override {
+    return max_response_size_;
+  }
+
+  void max_response_size(size_t value) override {
+    max_response_size_ = value;
+  }
+
+  // -- http::lower_layer::client implementation -------------------------------
+
+  socket_manager* manager() noexcept override {
+    return down_->manager();
+  }
+
+  bool can_send_more() const noexcept override {
+    return down_->can_send_more();
+  }
+
+  bool is_reading() const noexcept override {
+    return down_->is_reading();
+  }
+
+  void write_later() override {
+    down_->write_later();
+  }
+
+  void shutdown() override {
+    down_->shutdown();
+  }
+
+  void request_messages() override {
+    if (!down_->is_reading())
+      down_->configure_read(receive_policy::up_to(max_response_size_));
+  }
+
+  void suspend_reading() override {
+    down_->configure_read(receive_policy::stop());
+  }
+
+  void begin_header(http::method method, std::string_view path) override {
+    down_->begin_output();
+    v1::begin_request_header(method, path, down_->output_buffer());
+  }
+
+  void add_header_field(std::string_view key, std::string_view val) override {
+    v1::add_header_field(key, val, down_->output_buffer());
+  }
+
+  bool end_header() override {
+    return v1::end_header(down_->output_buffer()) && down_->end_output();
+  }
+
+  bool send_payload(const_byte_span bytes) override {
+    down_->begin_output();
+    auto& buf = down_->output_buffer();
+    buf.insert(buf.end(), bytes.begin(), bytes.end());
+    down_->end_output();
+    return true;
+  }
+
+  bool send_chunk(const_byte_span bytes) override {
+    down_->begin_output();
+    auto& buf = down_->output_buffer();
+    auto size_str = detail::format("{:X}\r\n", bytes.size());
+    std::transform(size_str.begin(), size_str.end(), std::back_inserter(buf),
+                   [](auto c) { return static_cast<std::byte>(c); });
+    buf.insert(buf.end(), bytes.begin(), bytes.end());
+    buf.emplace_back(std::byte{'\r'});
+    buf.emplace_back(std::byte{'\n'});
+    return down_->end_output();
+  }
+
+  bool send_end_of_chunks() override {
+    std::string_view str = "0\r\n\r\n";
+    auto bytes = as_bytes(make_span(str));
+    down_->begin_output();
+    auto& buf = down_->output_buffer();
+    buf.insert(buf.end(), bytes.begin(), bytes.end());
+    return down_->end_output();
+  }
+
+  void
+  switch_protocol(std::unique_ptr<octet_stream::upper_layer> next) override {
+    down_->switch_protocol(std::move(next));
+  }
+
+  // -- octet_stream::upper_layer implementation -------------------------------
+
+  error start(octet_stream::lower_layer* down) override {
+    down_ = down;
+    return up_->start(this);
+  }
+
+  void abort(const error& reason) override {
+    up_->abort(reason);
+  }
+
+  void prepare_send() override {
+    up_->prepare_send();
+  }
+
+  bool done_sending() override {
+    return up_->done_sending();
+  }
+
+  ptrdiff_t consume(byte_span input, byte_span) override {
+    auto lg = log::net::trace("bytes = {}", input.size());
+    ptrdiff_t consumed = 0;
+    if (mode_ == mode::read_header) {
+      if (input.size() >= max_response_size_) {
+        abort("Header exceeds maximum size.");
+        return -1;
+      }
+      auto [hdr, remainder] = v1::split_header(input);
+      // Wait for more data.
+      if (hdr.empty())
+        return 0;
+      // Note: handle_header already calls up_->abort().
+      if (!handle_header(hdr))
+        return -1;
+      // Prepare for next call to consume.
+      consumed = static_cast<ptrdiff_t>(hdr.size());
+      input = remainder;
+      // Transition to the next mode.
+      if (hdr_.chunked_transfer_encoding()) {
+        mode_ = mode::read_chunks;
+      } else if (auto len = hdr_.content_length()) {
+        // Protect against payloads that exceed the maximum size.
+        if (*len >= max_response_size_) {
+          abort("Payload exceeds maximum size.");
+          return -1;
+        }
+        // Transition to read_payload mode and continue.
+        payload_len_ = *len;
+        mode_ = mode::read_payload;
+      } else {
+        // TODO: we may *still* have a payload since HTTP can omit the
+        //       Content-Length field and simply close the connection
+        //       after the payload.
+        if (!invoke_upper_layer(const_byte_span{}))
+          return -1;
+        return consumed;
+      }
+    }
+    if (mode_ == mode::read_payload) {
+      if (input.size() < payload_len_)
+        // Wait for more data.
+        return consumed;
+      if (!invoke_upper_layer(input.subspan(0, payload_len_)))
+        return -1;
+      consumed += static_cast<ptrdiff_t>(payload_len_);
+      input.subspan(payload_len_);
+      mode_ = mode::read_header;
+      return consumed;
+    }
+    // else  if (mode_ == mode::read_chunks) {
+    // TODO: implement me
+    abort("Chunked transfer not implemented yet.");
+    return -1;
+  }
+
+private:
+  // -- utility functions ------------------------------------------------------
+
+  void abort(std::string_view message) {
+    up_->abort(make_error(sec::protocol_error, message));
+  }
+
+  bool invoke_upper_layer(const_byte_span payload) {
+    return up_->consume(hdr_, payload) >= 0;
+  }
+
+  bool handle_header(std::string_view http) {
+    // Parse the header and reject invalid inputs.
+    auto [code, msg] = hdr_.parse(http);
+    if (code != status::ok) {
+      log::net::debug("received malformed header");
+      abort(msg);
+      return false;
+    }
+    return true;
+  }
+
+  /// Points to the transport layer below.
+  octet_stream::lower_layer* down_;
+
+  /// Next layer in the processing chain.
+  upper_layer_ptr up_;
+
+  /// Buffer for re-using memory.
+  response_header hdr_;
+
+  /// Stores whether we are currently waiting for the payload.
+  mode mode_ = mode::read_header;
+
+  /// Stores the expected payload size when in read_payload mode.
+  size_t payload_len_ = 0;
+
+  /// Maximum size for incoming HTTP requests.
+  size_t max_response_size_ = default_max_response_size;
+};
+
+} // namespace
+
+client::~client() {
+  // nop
+}
 
 // -- factories ----------------------------------------------------------------
 
 std::unique_ptr<client> client::make(upper_layer_ptr up) {
-  return std::make_unique<client>(std::move(up));
-}
-
-// -- http::lower_layer implementation -----------------------------------------
-
-socket_manager* client::manager() noexcept {
-  return down_->manager();
-}
-
-bool client::can_send_more() const noexcept {
-  return down_->can_send_more();
-}
-
-bool client::is_reading() const noexcept {
-  return down_->is_reading();
-}
-
-void client::write_later() {
-  down_->write_later();
-}
-
-void client::shutdown() {
-  down_->shutdown();
-}
-
-void client::request_messages() {
-  if (!down_->is_reading())
-    down_->configure_read(receive_policy::up_to(max_response_size_));
-}
-
-void client::suspend_reading() {
-  down_->configure_read(receive_policy::stop());
-}
-
-void client::begin_header(http::method method, std::string_view path) {
-  down_->begin_output();
-  v1::begin_request_header(method, path, down_->output_buffer());
-}
-
-void client::add_header_field(std::string_view key, std::string_view val) {
-  v1::add_header_field(key, val, down_->output_buffer());
-}
-
-bool client::end_header() {
-  return v1::end_header(down_->output_buffer()) && down_->end_output();
-}
-
-bool client::send_payload(const_byte_span bytes) {
-  down_->begin_output();
-  auto& buf = down_->output_buffer();
-  buf.insert(buf.end(), bytes.begin(), bytes.end());
-  down_->end_output();
-  return true;
-}
-
-bool client::send_chunk(const_byte_span bytes) {
-  down_->begin_output();
-  auto& buf = down_->output_buffer();
-  auto size_str = detail::format("{:X}\r\n", bytes.size());
-  std::transform(size_str.begin(), size_str.end(), std::back_inserter(buf),
-                 [](auto c) { return static_cast<std::byte>(c); });
-  buf.insert(buf.end(), bytes.begin(), bytes.end());
-  buf.emplace_back(std::byte{'\r'});
-  buf.emplace_back(std::byte{'\n'});
-  return down_->end_output();
-}
-
-bool client::send_end_of_chunks() {
-  std::string_view str = "0\r\n\r\n";
-  auto bytes = as_bytes(make_span(str));
-  down_->begin_output();
-  auto& buf = down_->output_buffer();
-  buf.insert(buf.end(), bytes.begin(), bytes.end());
-  return down_->end_output();
-}
-
-void client::switch_protocol(std::unique_ptr<octet_stream::upper_layer> next) {
-  down_->switch_protocol(std::move(next));
-}
-
-// -- octet_stream::upper_layer implementation ---------------------------------
-
-error client::start(octet_stream::lower_layer* down) {
-  down_ = down;
-  return up_->start(this);
-}
-
-void client::abort(const error& reason) {
-  up_->abort(reason);
-}
-
-void client::prepare_send() {
-  up_->prepare_send();
-}
-
-bool client::done_sending() {
-  return up_->done_sending();
-}
-
-ptrdiff_t client::consume(byte_span input, byte_span) {
-  auto lg = log::net::trace("bytes = {}", input.size());
-  ptrdiff_t consumed = 0;
-  if (mode_ == mode::read_header) {
-    if (input.size() >= max_response_size_) {
-      abort("Header exceeds maximum size.");
-      return -1;
-    }
-    auto [hdr, remainder] = v1::split_header(input);
-    // Wait for more data.
-    if (hdr.empty())
-      return 0;
-    // Note: handle_header already calls up_->abort().
-    if (!handle_header(hdr))
-      return -1;
-    // Prepare for next call to consume.
-    consumed = static_cast<ptrdiff_t>(hdr.size());
-    input = remainder;
-    // Transition to the next mode.
-    if (hdr_.chunked_transfer_encoding()) {
-      mode_ = mode::read_chunks;
-    } else if (auto len = hdr_.content_length()) {
-      // Protect against payloads that exceed the maximum size.
-      if (*len >= max_response_size_) {
-        abort("Payload exceeds maximum size.");
-        return -1;
-      }
-      // Transition to read_payload mode and continue.
-      payload_len_ = *len;
-      mode_ = mode::read_payload;
-    } else {
-      // TODO: we may *still* have a payload since HTTP can omit the
-      //       Content-Length field and simply close the connection
-      //       after the payload.
-      if (!invoke_upper_layer(const_byte_span{}))
-        return -1;
-      return consumed;
-    }
-  }
-  if (mode_ == mode::read_payload) {
-    if (input.size() < payload_len_)
-      // Wait for more data.
-      return consumed;
-    if (!invoke_upper_layer(input.subspan(0, payload_len_)))
-      return -1;
-    consumed += static_cast<ptrdiff_t>(payload_len_);
-    input.subspan(payload_len_);
-    mode_ = mode::read_header;
-    return consumed;
-  }
-  // else  if (mode_ == mode::read_chunks) {
-  // TODO: implement me
-  abort("Chunked transfer not implemented yet.");
-  return -1;
-}
-
-// -- utility functions ------------------------------------------------------
-
-bool client::invoke_upper_layer(const_byte_span payload) {
-  return up_->consume(hdr_, payload) >= 0;
-}
-
-bool client::handle_header(std::string_view http) {
-  // Parse the header and reject invalid inputs.
-  auto [code, msg] = hdr_.parse(http);
-  if (code != status::ok) {
-    log::net::debug("received malformed header");
-    abort(msg);
-    return false;
-  }
-  return true;
+  return std::make_unique<client_impl>(std::move(up));
 }
 
 } // namespace caf::net::http

--- a/libcaf_net/caf/net/http/client.hpp
+++ b/libcaf_net/caf/net/http/client.hpp
@@ -4,28 +4,11 @@
 
 #pragma once
 
-#include "caf/net/fwd.hpp"
 #include "caf/net/http/lower_layer.hpp"
-#include "caf/net/http/response_header.hpp"
-#include "caf/net/http/status.hpp"
 #include "caf/net/http/upper_layer.hpp"
-#include "caf/net/http/v1.hpp"
-#include "caf/net/multiplexer.hpp"
 #include "caf/net/octet_stream/upper_layer.hpp"
-#include "caf/net/receive_policy.hpp"
-#include "caf/net/socket_manager.hpp"
 
-#include "caf/byte_span.hpp"
-#include "caf/detail/append_hex.hpp"
-#include "caf/detail/message_flow_bridge.hpp"
-#include "caf/detail/net_export.hpp"
-#include "caf/error.hpp"
-#include "caf/logger.hpp"
-#include "caf/pec.hpp"
-#include "caf/settings.hpp"
-#include "caf/unordered_flat_map.hpp"
-
-#include <algorithm>
+#include <memory>
 
 namespace caf::net::http {
 
@@ -35,117 +18,21 @@ class CAF_NET_EXPORT client : public octet_stream::upper_layer,
 public:
   // -- member types -----------------------------------------------------------
 
-  enum class mode {
-    read_header,
-    read_payload,
-    read_chunks,
-  };
-
   using upper_layer_ptr = std::unique_ptr<http::upper_layer::client>;
 
-  // -- constants --------------------------------------------------------------
+  // -- constructors, destructors, and assignment operators --------------------
 
-  /// Default maximum size for incoming HTTP responses: 512KiB.
-  static constexpr uint32_t default_max_response_size = 512 * 1024;
+  ~client() override;
 
   // -- factories --------------------------------------------------------------
 
   static std::unique_ptr<client> make(upper_layer_ptr up);
 
-  // -- constructors, destructors, and assignment operators --------------------
-
-  explicit client(upper_layer_ptr up) : up_(std::move(up)) {
-    // nop
-  }
-
   // -- properties -------------------------------------------------------------
 
-  auto& upper_layer() noexcept {
-    return *up_;
-  }
+  virtual size_t max_response_size() const = 0;
 
-  const auto& upper_layer() const noexcept {
-    return *up_;
-  }
-
-  size_t max_response_size() const noexcept {
-    return max_response_size_;
-  }
-
-  void max_response_size(size_t value) noexcept {
-    max_response_size_ = value;
-  }
-
-  // -- http::lower_layer::client implementation -------------------------------
-
-  socket_manager* manager() noexcept override;
-
-  bool can_send_more() const noexcept override;
-
-  bool is_reading() const noexcept override;
-
-  void write_later() override;
-
-  void shutdown() override;
-
-  void request_messages() override;
-
-  void suspend_reading() override;
-
-  void begin_header(http::method method, std::string_view path) override;
-
-  void add_header_field(std::string_view key, std::string_view val) override;
-
-  bool end_header() override;
-
-  bool send_payload(const_byte_span bytes) override;
-
-  bool send_chunk(const_byte_span bytes) override;
-
-  bool send_end_of_chunks() override;
-
-  void switch_protocol(std::unique_ptr<octet_stream::upper_layer>) override;
-
-  // -- octet_stream::upper_layer implementation -------------------------------
-
-  error start(octet_stream::lower_layer* down) override;
-
-  void abort(const error& reason) override;
-
-  void prepare_send() override;
-
-  bool done_sending() override;
-
-  ptrdiff_t consume(byte_span input, byte_span) override;
-
-private:
-  // -- utility functions ------------------------------------------------------
-
-  void abort(std::string_view message) {
-    up_->abort(make_error(sec::protocol_error, message));
-  }
-
-  bool invoke_upper_layer(const_byte_span payload);
-
-  bool handle_header(std::string_view http);
-
-  /// Points to the transport layer below.
-  octet_stream::lower_layer* down_;
-
-  /// Next layer in the processing chain.
-  upper_layer_ptr up_;
-
-  /// Buffer for re-using memory.
-  response_header hdr_;
-
-  /// Stores whether we are currently waiting for the payload.
-  mode mode_ = mode::read_header;
-
-  /// Stores the expected payload size when in read_payload mode.
-  size_t payload_len_ = 0;
-
-  /// Maximum size for incoming HTTP requests.
-  size_t max_response_size_ = default_max_response_size;
+  virtual void max_response_size(size_t value) = 0;
 };
 
 } // namespace caf::net::http

--- a/libcaf_net/caf/net/http/client.test.cpp
+++ b/libcaf_net/caf/net/http/client.test.cpp
@@ -8,9 +8,12 @@
 #include "caf/test/scenario.hpp"
 
 #include "caf/net/fwd.hpp"
+#include "caf/net/http/method.hpp"
+#include "caf/net/http/response_header.hpp"
 #include "caf/net/multiplexer.hpp"
 #include "caf/net/octet_stream/transport.hpp"
 #include "caf/net/socket_id.hpp"
+#include "caf/net/socket_manager.hpp"
 #include "caf/net/stream_socket.hpp"
 
 #include "caf/async/promise.hpp"

--- a/libcaf_net/caf/net/http/client_factory.cpp
+++ b/libcaf_net/caf/net/http/client_factory.cpp
@@ -4,6 +4,9 @@
 
 #include "caf/net/http/client_factory.hpp"
 
+#include "caf/net/multiplexer.hpp"
+#include "caf/net/socket_manager.hpp"
+
 #include "caf/detail/assert.hpp"
 
 namespace caf::net::http {

--- a/libcaf_net/caf/net/http/server.cpp
+++ b/libcaf_net/caf/net/http/server.cpp
@@ -1,208 +1,276 @@
 #include "caf/net/http/server.hpp"
 
+#include "caf/net/fwd.hpp"
+#include "caf/net/http/request_header.hpp"
+#include "caf/net/http/status.hpp"
+#include "caf/net/http/upper_layer.hpp"
+#include "caf/net/http/v1.hpp"
 #include "caf/net/octet_stream/lower_layer.hpp"
+#include "caf/net/octet_stream/upper_layer.hpp"
+#include "caf/net/receive_policy.hpp"
+#include "caf/net/socket_manager.hpp"
 
+#include "caf/byte_span.hpp"
 #include "caf/detail/format.hpp"
+#include "caf/error.hpp"
 #include "caf/log/net.hpp"
 
+#include <algorithm>
+
 namespace caf::net::http {
+
+namespace {
+
+/// Implements the server part for the HTTP Protocol as defined in RFC 7231.
+class server_impl : public http::server {
+public:
+  // -- member types -----------------------------------------------------------
+
+  enum class mode {
+    read_header,
+    read_payload,
+    read_chunks,
+  };
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  explicit server_impl(upper_layer_ptr up) : up_(std::move(up)) {
+    // nop
+  }
+
+  // -- properties -------------------------------------------------------------
+
+  size_t max_request_size() const noexcept override {
+    return max_request_size_;
+  }
+
+  void max_request_size(size_t value) noexcept override {
+    if (value > 0)
+      max_request_size_ = value;
+  }
+
+  // -- http::lower_layer implementation ---------------------------------------
+
+  socket_manager* manager() noexcept override {
+    return down_->manager();
+  }
+
+  bool can_send_more() const noexcept override {
+    return down_->can_send_more();
+  }
+
+  bool is_reading() const noexcept override {
+    return down_->is_reading();
+  }
+
+  void write_later() override {
+    down_->write_later();
+  }
+
+  void shutdown() override {
+    down_->shutdown();
+  }
+
+  void request_messages() override {
+    if (!down_->is_reading())
+      down_->configure_read(receive_policy::up_to(max_request_size_));
+  }
+
+  void suspend_reading() override {
+    down_->configure_read(receive_policy::stop());
+  }
+
+  void begin_header(status code) override {
+    down_->begin_output();
+    v1::begin_response_header(code, down_->output_buffer());
+  }
+
+  void add_header_field(std::string_view key, std::string_view val) override {
+    v1::add_header_field(key, val, down_->output_buffer());
+  }
+
+  bool end_header() override {
+    return v1::end_header(down_->output_buffer()) && down_->end_output();
+  }
+
+  bool send_payload(const_byte_span bytes) override {
+    down_->begin_output();
+    auto& buf = down_->output_buffer();
+    buf.insert(buf.end(), bytes.begin(), bytes.end());
+    down_->end_output();
+    return true;
+  }
+
+  bool send_chunk(const_byte_span bytes) override {
+    down_->begin_output();
+    auto& buf = down_->output_buffer();
+    auto size_str = detail::format("{:X}\r\n", bytes.size());
+    std::transform(size_str.begin(), size_str.end(), std::back_inserter(buf),
+                   [](auto c) { return static_cast<std::byte>(c); });
+    buf.insert(buf.end(), bytes.begin(), bytes.end());
+    buf.emplace_back(std::byte{'\r'});
+    buf.emplace_back(std::byte{'\n'});
+    return down_->end_output();
+  }
+
+  bool send_end_of_chunks() override {
+    std::string_view str = "0\r\n\r\n";
+    auto bytes = as_bytes(make_span(str));
+    down_->begin_output();
+    auto& buf = down_->output_buffer();
+    buf.insert(buf.end(), bytes.begin(), bytes.end());
+    return down_->end_output();
+  }
+
+  void
+  switch_protocol(std::unique_ptr<octet_stream::upper_layer> next) override {
+    down_->switch_protocol(std::move(next));
+  }
+
+  // -- octet_stream::upper_layer implementation -------------------------------
+
+  error start(octet_stream::lower_layer* down) override {
+    down_ = down;
+    return up_->start(this);
+  }
+
+  void abort(const error& reason) override {
+    up_->abort(reason);
+  }
+
+  void prepare_send() override {
+    up_->prepare_send();
+  }
+
+  bool done_sending() override {
+    return up_->done_sending();
+  }
+
+  ptrdiff_t consume(byte_span input, byte_span) override {
+    auto lg = log::net::trace("bytes = {}", input.size());
+    ptrdiff_t consumed = 0;
+    for (;;) {
+      switch (mode_) {
+        case mode::read_header: {
+          auto [hdr, remainder] = v1::split_header(input);
+          if (hdr.empty()) {
+            if (input.size() >= max_request_size_) {
+              up_->abort(
+                make_error(sec::protocol_error, "header exceeds maximum size"));
+              write_response(status::request_header_fields_too_large,
+                             "Header exceeds maximum size.");
+              return -1;
+            } else {
+              return consumed;
+            }
+          } else if (!handle_header(hdr)) {
+            // Note: handle_header already calls up_->abort().
+            return -1;
+          } else {
+            // Prepare for next loop iteration.
+            consumed += static_cast<ptrdiff_t>(hdr.size());
+            input = remainder;
+            // Transition to the next mode.
+            if (hdr_.chunked_transfer_encoding()) {
+              mode_ = mode::read_chunks;
+            } else if (auto len = hdr_.content_length()) {
+              // Protect against payloads that exceed the maximum size.
+              if (*len >= max_request_size_) {
+                up_->abort(make_error(sec::protocol_error,
+                                      "payload exceeds maximum size"));
+                write_response(status::payload_too_large,
+                               "Payload exceeds maximum size.");
+                return -1;
+              }
+              // Transition to read_payload mode and continue.
+              payload_len_ = *len;
+              mode_ = mode::read_payload;
+            } else {
+              // TODO: we may *still* have a payload since HTTP can omit the
+              //       Content-Length field and simply close the connection
+              //       after the payload.
+              if (!invoke_upper_layer(const_byte_span{}))
+                return -1;
+            }
+          }
+          break;
+        }
+        case mode::read_payload: {
+          if (input.size() >= payload_len_) {
+            if (!invoke_upper_layer(input.subspan(0, payload_len_)))
+              return -1;
+            consumed += static_cast<ptrdiff_t>(payload_len_);
+            mode_ = mode::read_header;
+          } else {
+            // Wait for more data.
+            return consumed;
+          }
+          break;
+        }
+        case mode::read_chunks: {
+          // TODO: implement me
+          write_response(status::not_implemented,
+                         "Chunked transfer not implemented yet.");
+          return -1;
+        }
+      }
+    }
+  }
+
+private:
+  // -- utility functions ------------------------------------------------------
+
+  void write_response(status code, std::string_view content) {
+    down_->begin_output();
+    v1::write_response(code, "text/plain", content, down_->output_buffer());
+    down_->end_output();
+  }
+
+  bool invoke_upper_layer(const_byte_span payload) {
+    return up_->consume(hdr_, payload) >= 0;
+  }
+
+  bool handle_header(std::string_view http) {
+    // Parse the header and reject invalid inputs.
+    auto [code, msg] = hdr_.parse(http);
+    if (code != status::ok) {
+      log::net::debug("received malformed header");
+      up_->abort(make_error(sec::protocol_error, "received malformed header"));
+      write_response(code, msg);
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  octet_stream::lower_layer* down_;
+
+  upper_layer_ptr up_;
+
+  /// Buffer for re-using memory.
+  request_header hdr_;
+
+  /// Stores whether we are currently waiting for the payload.
+  mode mode_ = mode::read_header;
+
+  /// Stores the expected payload size when in read_payload mode.
+  size_t payload_len_ = 0;
+
+  /// Maximum size for incoming HTTP requests.
+  size_t max_request_size_ = caf::defaults::net::http_max_request_size;
+};
+} // namespace
 
 // -- factories ----------------------------------------------------------------
 
 std::unique_ptr<server> server::make(upper_layer_ptr up) {
-  return std::make_unique<server>(std::move(up));
+  return std::make_unique<server_impl>(std::move(up));
 }
 
-// -- http::lower_layer implementation -----------------------------------------
+// -- constructors, destructors, and assignment operators --------------------
 
-socket_manager* server::manager() noexcept {
-  return down_->manager();
-}
-
-bool server::can_send_more() const noexcept {
-  return down_->can_send_more();
-}
-
-bool server::is_reading() const noexcept {
-  return down_->is_reading();
-}
-
-void server::write_later() {
-  down_->write_later();
-}
-
-void server::shutdown() {
-  down_->shutdown();
-}
-
-void server::request_messages() {
-  if (!down_->is_reading())
-    down_->configure_read(receive_policy::up_to(max_request_size_));
-}
-
-void server::suspend_reading() {
-  down_->configure_read(receive_policy::stop());
-}
-
-void server::begin_header(status code) {
-  down_->begin_output();
-  v1::begin_response_header(code, down_->output_buffer());
-}
-
-void server::add_header_field(std::string_view key, std::string_view val) {
-  v1::add_header_field(key, val, down_->output_buffer());
-}
-
-bool server::end_header() {
-  return v1::end_header(down_->output_buffer()) && down_->end_output();
-}
-
-bool server::send_payload(const_byte_span bytes) {
-  down_->begin_output();
-  auto& buf = down_->output_buffer();
-  buf.insert(buf.end(), bytes.begin(), bytes.end());
-  down_->end_output();
-  return true;
-}
-
-bool server::send_chunk(const_byte_span bytes) {
-  down_->begin_output();
-  auto& buf = down_->output_buffer();
-  auto size_str = detail::format("{:X}\r\n", bytes.size());
-  std::transform(size_str.begin(), size_str.end(), std::back_inserter(buf),
-                 [](auto c) { return static_cast<std::byte>(c); });
-  buf.insert(buf.end(), bytes.begin(), bytes.end());
-  buf.emplace_back(std::byte{'\r'});
-  buf.emplace_back(std::byte{'\n'});
-  return down_->end_output();
-}
-
-bool server::send_end_of_chunks() {
-  std::string_view str = "0\r\n\r\n";
-  auto bytes = as_bytes(make_span(str));
-  down_->begin_output();
-  auto& buf = down_->output_buffer();
-  buf.insert(buf.end(), bytes.begin(), bytes.end());
-  return down_->end_output();
-}
-
-void server::switch_protocol(std::unique_ptr<octet_stream::upper_layer> next) {
-  down_->switch_protocol(std::move(next));
-}
-
-// -- octet_stream::upper_layer implementation ---------------------------------
-
-error server::start(octet_stream::lower_layer* down) {
-  down_ = down;
-  return up_->start(this);
-}
-
-void server::abort(const error& reason) {
-  up_->abort(reason);
-}
-
-void server::prepare_send() {
-  up_->prepare_send();
-}
-
-bool server::done_sending() {
-  return up_->done_sending();
-}
-
-ptrdiff_t server::consume(byte_span input, byte_span) {
-  auto lg = log::net::trace("bytes = {}", input.size());
-  ptrdiff_t consumed = 0;
-  for (;;) {
-    switch (mode_) {
-      case mode::read_header: {
-        auto [hdr, remainder] = v1::split_header(input);
-        if (hdr.empty()) {
-          if (input.size() >= max_request_size_) {
-            up_->abort(
-              make_error(sec::protocol_error, "header exceeds maximum size"));
-            write_response(status::request_header_fields_too_large,
-                           "Header exceeds maximum size.");
-            return -1;
-          } else {
-            return consumed;
-          }
-        } else if (!handle_header(hdr)) {
-          // Note: handle_header already calls up_->abort().
-          return -1;
-        } else {
-          // Prepare for next loop iteration.
-          consumed += static_cast<ptrdiff_t>(hdr.size());
-          input = remainder;
-          // Transition to the next mode.
-          if (hdr_.chunked_transfer_encoding()) {
-            mode_ = mode::read_chunks;
-          } else if (auto len = hdr_.content_length()) {
-            // Protect against payloads that exceed the maximum size.
-            if (*len >= max_request_size_) {
-              up_->abort(make_error(sec::protocol_error,
-                                    "payload exceeds maximum size"));
-              write_response(status::payload_too_large,
-                             "Payload exceeds maximum size.");
-              return -1;
-            }
-            // Transition to read_payload mode and continue.
-            payload_len_ = *len;
-            mode_ = mode::read_payload;
-          } else {
-            // TODO: we may *still* have a payload since HTTP can omit the
-            //       Content-Length field and simply close the connection
-            //       after the payload.
-            if (!invoke_upper_layer(const_byte_span{}))
-              return -1;
-          }
-        }
-        break;
-      }
-      case mode::read_payload: {
-        if (input.size() >= payload_len_) {
-          if (!invoke_upper_layer(input.subspan(0, payload_len_)))
-            return -1;
-          consumed += static_cast<ptrdiff_t>(payload_len_);
-          mode_ = mode::read_header;
-        } else {
-          // Wait for more data.
-          return consumed;
-        }
-        break;
-      }
-      case mode::read_chunks: {
-        // TODO: implement me
-        write_response(status::not_implemented,
-                       "Chunked transfer not implemented yet.");
-        return -1;
-      }
-    }
-  }
-}
-
-// -- utility functions ------------------------------------------------------
-
-void server::write_response(status code, std::string_view content) {
-  down_->begin_output();
-  v1::write_response(code, "text/plain", content, down_->output_buffer());
-  down_->end_output();
-}
-
-bool server::invoke_upper_layer(const_byte_span payload) {
-  return up_->consume(hdr_, payload) >= 0;
-}
-
-bool server::handle_header(std::string_view http) {
-  // Parse the header and reject invalid inputs.
-  auto [code, msg] = hdr_.parse(http);
-  if (code != status::ok) {
-    log::net::debug("received malformed header");
-    up_->abort(make_error(sec::protocol_error, "received malformed header"));
-    write_response(code, msg);
-    return false;
-  } else {
-    return true;
-  }
+server::~server() {
+  // nop
 }
 
 } // namespace caf::net::http

--- a/libcaf_net/caf/net/http/server.hpp
+++ b/libcaf_net/caf/net/http/server.hpp
@@ -6,27 +6,10 @@
 
 #include "caf/net/fwd.hpp"
 #include "caf/net/http/lower_layer.hpp"
-#include "caf/net/http/request_header.hpp"
-#include "caf/net/http/status.hpp"
 #include "caf/net/http/upper_layer.hpp"
-#include "caf/net/http/v1.hpp"
-#include "caf/net/multiplexer.hpp"
 #include "caf/net/octet_stream/upper_layer.hpp"
-#include "caf/net/receive_policy.hpp"
-#include "caf/net/socket_manager.hpp"
 
-#include "caf/byte_span.hpp"
-#include "caf/defaults.hpp"
-#include "caf/detail/append_hex.hpp"
-#include "caf/detail/message_flow_bridge.hpp"
 #include "caf/detail/net_export.hpp"
-#include "caf/error.hpp"
-#include "caf/logger.hpp"
-#include "caf/pec.hpp"
-#include "caf/settings.hpp"
-#include "caf/unordered_flat_map.hpp"
-
-#include <algorithm>
 
 namespace caf::net::http {
 
@@ -36,109 +19,21 @@ class CAF_NET_EXPORT server : public octet_stream::upper_layer,
 public:
   // -- member types -----------------------------------------------------------
 
-  enum class mode {
-    read_header,
-    read_payload,
-    read_chunks,
-  };
-
   using upper_layer_ptr = std::unique_ptr<http::upper_layer::server>;
-
-  // -- constructors, destructors, and assignment operators --------------------
-
-  explicit server(upper_layer_ptr up) : up_(std::move(up)) {
-    // nop
-  }
 
   // -- factories --------------------------------------------------------------
 
   static std::unique_ptr<server> make(upper_layer_ptr up);
 
+  // -- constructors, destructors, and assignment operators --------------------
+
+  ~server() override;
+
   // -- properties -------------------------------------------------------------
 
-  auto& upper_layer() noexcept {
-    return *up_;
-  }
+  virtual size_t max_request_size() const noexcept = 0;
 
-  const auto& upper_layer() const noexcept {
-    return *up_;
-  }
-
-  size_t max_request_size() const noexcept {
-    return max_request_size_;
-  }
-
-  void max_request_size(size_t value) noexcept {
-    if (value > 0)
-      max_request_size_ = value;
-  }
-
-  // -- http::lower_layer implementation ---------------------------------------
-
-  socket_manager* manager() noexcept override;
-
-  bool can_send_more() const noexcept override;
-
-  bool is_reading() const noexcept override;
-
-  void write_later() override;
-
-  void shutdown() override;
-
-  void request_messages() override;
-
-  void suspend_reading() override;
-
-  void begin_header(status code) override;
-
-  void add_header_field(std::string_view key, std::string_view val) override;
-
-  bool end_header() override;
-
-  bool send_payload(const_byte_span bytes) override;
-
-  bool send_chunk(const_byte_span bytes) override;
-
-  bool send_end_of_chunks() override;
-
-  void switch_protocol(std::unique_ptr<octet_stream::upper_layer>) override;
-
-  // -- octet_stream::upper_layer implementation -------------------------------
-
-  error start(octet_stream::lower_layer* down) override;
-
-  void abort(const error& reason) override;
-
-  void prepare_send() override;
-
-  bool done_sending() override;
-
-  ptrdiff_t consume(byte_span input, byte_span) override;
-
-private:
-  // -- utility functions ------------------------------------------------------
-
-  void write_response(status code, std::string_view content);
-
-  bool invoke_upper_layer(const_byte_span payload);
-
-  bool handle_header(std::string_view http);
-
-  octet_stream::lower_layer* down_;
-
-  upper_layer_ptr up_;
-
-  /// Buffer for re-using memory.
-  request_header hdr_;
-
-  /// Stores whether we are currently waiting for the payload.
-  mode mode_ = mode::read_header;
-
-  /// Stores the expected payload size when in read_payload mode.
-  size_t payload_len_ = 0;
-
-  /// Maximum size for incoming HTTP requests.
-  size_t max_request_size_ = caf::defaults::net::http_max_request_size;
+  virtual void max_request_size(size_t value) noexcept = 0;
 };
 
 } // namespace caf::net::http

--- a/libcaf_net/caf/net/http/server.test.cpp
+++ b/libcaf_net/caf/net/http/server.test.cpp
@@ -8,9 +8,11 @@
 #include "caf/test/suite.hpp"
 
 #include "caf/net/fwd.hpp"
+#include "caf/net/http/request_header.hpp"
 #include "caf/net/multiplexer.hpp"
 #include "caf/net/octet_stream/transport.hpp"
 #include "caf/net/socket_id.hpp"
+#include "caf/net/socket_manager.hpp"
 #include "caf/net/stream_socket.hpp"
 
 #include "caf/async/promise.hpp"

--- a/libcaf_net/caf/net/lp/client_factory.hpp
+++ b/libcaf_net/caf/net/lp/client_factory.hpp
@@ -7,7 +7,9 @@
 #include "caf/net/checked_socket.hpp"
 #include "caf/net/dsl/client_factory_base.hpp"
 #include "caf/net/lp/config.hpp"
+#include "caf/net/lp/frame.hpp"
 #include "caf/net/lp/framing.hpp"
+#include "caf/net/socket_manager.hpp"
 #include "caf/net/ssl/connection.hpp"
 #include "caf/net/tcp_stream_socket.hpp"
 

--- a/libcaf_net/caf/net/lp/framing.cpp
+++ b/libcaf_net/caf/net/lp/framing.cpp
@@ -1,157 +1,194 @@
 #include "caf/net/lp/framing.hpp"
 
+#include "caf/net/lp/upper_layer.hpp"
 #include "caf/net/octet_stream/lower_layer.hpp"
 #include "caf/net/receive_policy.hpp"
 
+#include "caf/byte_span.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/detail/network_order.hpp"
 #include "caf/error.hpp"
 #include "caf/log/net.hpp"
 #include "caf/sec.hpp"
 
+#include <cstdint>
+#include <cstring>
+#include <memory>
+
 namespace caf::net::lp {
 
-// -- factories ----------------------------------------------------------------
+namespace {
 
-std::unique_ptr<framing> framing::make(upper_layer_ptr up) {
-  return std::make_unique<framing>(std::move(up));
-}
-
-// -- implementation of octet_stream::upper_layer ------------------------------
-
-error framing::start(octet_stream::lower_layer* down) {
-  down_ = down;
-  return up_->start(this);
-}
-
-void framing::abort(const error& reason) {
-  up_->abort(reason);
-}
-
-ptrdiff_t framing::consume(byte_span input, byte_span) {
-  auto lg = log::net::trace("got {} bytes\n", input.size());
-  if (input.size() < sizeof(uint32_t)) {
-    log::net::error("received too few bytes from underlying transport");
-    up_->abort(make_error(sec::logic_error,
-                          "received too few bytes from underlying transport"));
-    return -1;
-  } else if (input.size() == hdr_size) {
-    auto u32_size = uint32_t{0};
-    memcpy(&u32_size, input.data(), sizeof(uint32_t));
-    auto msg_size = static_cast<size_t>(detail::from_network_order(u32_size));
-    if (msg_size == 0) {
-      // Ignore empty messages.
-      log::net::error("received empty message");
-      up_->abort(make_error(sec::logic_error,
-                            "received empty buffer from stream layer"));
-      return -1;
-    } else if (msg_size > max_message_length) {
-      log::net::debug("exceeded maximum message size");
-      up_->abort(
-        make_error(sec::protocol_error, "exceeded maximum message size"));
-      return -1;
-    } else {
-      log::net::debug("wait for payload of size {}", msg_size);
-      down_->configure_read(receive_policy::exactly(hdr_size + msg_size));
-      return 0;
-    }
-  } else {
-    auto [msg_size, msg] = split(input);
-    if (msg_size == msg.size() && msg_size + hdr_size == input.size()) {
-      log::net::debug("got message of size {}", msg_size);
-      if (up_->consume(msg) >= 0) {
-        if (down_->is_reading())
-          down_->configure_read(receive_policy::exactly(hdr_size));
-        return static_cast<ptrdiff_t>(input.size());
-      } else {
-        return -1;
-      }
-    } else {
-      log::net::debug("received malformed message");
-      up_->abort(make_error(sec::protocol_error, "received malformed message"));
-      return -1;
-    }
-  }
-}
-
-void framing::prepare_send() {
-  up_->prepare_send();
-}
-
-bool framing::done_sending() {
-  return up_->done_sending();
-}
-
-// -- implementation of lp::lower_layer ----------------------------------------
-
-socket_manager* framing::manager() noexcept {
-  return down_->manager();
-}
-
-bool framing::can_send_more() const noexcept {
-  return down_->can_send_more();
-}
-
-void framing::suspend_reading() {
-  down_->configure_read(receive_policy::stop());
-}
-
-bool framing::is_reading() const noexcept {
-  return down_->is_reading();
-}
-
-void framing::write_later() {
-  down_->write_later();
-}
-
-void framing::request_messages() {
-  if (!down_->is_reading())
-    down_->configure_read(receive_policy::exactly(hdr_size));
-}
-
-void framing::begin_message() {
-  down_->begin_output();
-  auto& buf = down_->output_buffer();
-  message_offset_ = buf.size();
-  buf.insert(buf.end(), 4, std::byte{0});
-}
-
-byte_buffer& framing::message_buffer() {
-  return down_->output_buffer();
-}
-
-bool framing::end_message() {
-  using detail::to_network_order;
-  auto& buf = down_->output_buffer();
-  CAF_ASSERT(message_offset_ < buf.size());
-  auto msg_begin = buf.begin() + static_cast<ptrdiff_t>(message_offset_);
-  auto msg_size = std::distance(msg_begin + 4, buf.end());
-  if (msg_size > 0 && static_cast<size_t>(msg_size) < max_message_length) {
-    auto u32_size = to_network_order(static_cast<uint32_t>(msg_size));
-    memcpy(std::addressof(*msg_begin), &u32_size, 4);
-    down_->end_output();
-    return true;
-  } else {
-    if (msg_size == 0)
-      log::net::debug("logic error: message of size 0");
-    if (msg_size != 0)
-      log::net::debug("maximum message size exceeded");
-    return false;
-  }
-}
-
-void framing::shutdown() {
-  down_->shutdown();
-}
-
-// -- utility functions ------------------------------------------------------
-
-std::pair<size_t, byte_span> framing::split(byte_span buffer) noexcept {
+std::pair<size_t, byte_span> split(byte_span buffer) noexcept {
   CAF_ASSERT(buffer.size() >= sizeof(uint32_t));
   auto u32_size = uint32_t{0};
   memcpy(&u32_size, buffer.data(), sizeof(uint32_t));
   auto msg_size = static_cast<size_t>(detail::from_network_order(u32_size));
   return std::make_pair(msg_size, buffer.subspan(sizeof(uint32_t)));
+}
+
+class framing_impl : public framing {
+public:
+  // -- member types -----------------------------------------------------------
+
+  using upper_layer_ptr = std::unique_ptr<lp::upper_layer>;
+
+  // -- constants --------------------------------------------------------------
+
+  static constexpr size_t hdr_size = sizeof(uint32_t);
+
+  static constexpr size_t max_message_length = INT32_MAX - sizeof(uint32_t);
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  explicit framing_impl(upper_layer_ptr up) : up_(std::move(up)) {
+    // nop
+  }
+
+  // -- implementation of octet_stream::upper_layer ----------------------------
+
+  error start(octet_stream::lower_layer* down) override {
+    down_ = down;
+    return up_->start(this);
+  }
+
+  void abort(const error& reason) override {
+    up_->abort(reason);
+  }
+
+  ptrdiff_t consume(byte_span input, byte_span) override {
+    auto lg = log::net::trace("got {} bytes\n", input.size());
+    if (input.size() < sizeof(uint32_t)) {
+      log::net::error("received too few bytes from underlying transport");
+      up_->abort(make_error(
+        sec::logic_error, "received too few bytes from underlying transport"));
+      return -1;
+    } else if (input.size() == hdr_size) {
+      auto u32_size = uint32_t{0};
+      memcpy(&u32_size, input.data(), sizeof(uint32_t));
+      auto msg_size = static_cast<size_t>(detail::from_network_order(u32_size));
+      if (msg_size == 0) {
+        // Ignore empty messages.
+        log::net::error("received empty message");
+        up_->abort(make_error(sec::logic_error,
+                              "received empty buffer from stream layer"));
+        return -1;
+      } else if (msg_size > max_message_length) {
+        log::net::debug("exceeded maximum message size");
+        up_->abort(
+          make_error(sec::protocol_error, "exceeded maximum message size"));
+        return -1;
+      } else {
+        log::net::debug("wait for payload of size {}", msg_size);
+        down_->configure_read(receive_policy::exactly(hdr_size + msg_size));
+        return 0;
+      }
+    } else {
+      auto [msg_size, msg] = split(input);
+      if (msg_size == msg.size() && msg_size + hdr_size == input.size()) {
+        log::net::debug("got message of size {}", msg_size);
+        if (up_->consume(msg) >= 0) {
+          if (down_->is_reading())
+            down_->configure_read(receive_policy::exactly(hdr_size));
+          return static_cast<ptrdiff_t>(input.size());
+        } else {
+          return -1;
+        }
+      } else {
+        log::net::debug("received malformed message");
+        up_->abort(
+          make_error(sec::protocol_error, "received malformed message"));
+        return -1;
+      }
+    }
+  }
+
+  void prepare_send() override {
+    up_->prepare_send();
+  }
+
+  bool done_sending() override {
+    return up_->done_sending();
+  }
+
+  // -- implementation of lp::lower_layer --------------------------------------
+
+  socket_manager* manager() noexcept override {
+    return down_->manager();
+  }
+
+  bool can_send_more() const noexcept override {
+    return down_->can_send_more();
+  }
+
+  void suspend_reading() override {
+    down_->configure_read(receive_policy::stop());
+  }
+
+  bool is_reading() const noexcept override {
+    return down_->is_reading();
+  }
+
+  void write_later() override {
+    down_->write_later();
+  }
+
+  void request_messages() override {
+    if (!down_->is_reading())
+      down_->configure_read(receive_policy::exactly(hdr_size));
+  }
+
+  void begin_message() override {
+    down_->begin_output();
+    auto& buf = down_->output_buffer();
+    message_offset_ = buf.size();
+    buf.insert(buf.end(), 4, std::byte{0});
+  }
+
+  byte_buffer& message_buffer() override {
+    return down_->output_buffer();
+  }
+
+  bool end_message() override {
+    using detail::to_network_order;
+    auto& buf = down_->output_buffer();
+    CAF_ASSERT(message_offset_ < buf.size());
+    auto msg_begin = buf.begin() + static_cast<ptrdiff_t>(message_offset_);
+    auto msg_size = std::distance(msg_begin + 4, buf.end());
+    if (msg_size > 0 && static_cast<size_t>(msg_size) < max_message_length) {
+      auto u32_size = to_network_order(static_cast<uint32_t>(msg_size));
+      memcpy(std::addressof(*msg_begin), &u32_size, 4);
+      down_->end_output();
+      return true;
+    } else {
+      if (msg_size == 0)
+        log::net::debug("logic error: message of size 0");
+      if (msg_size != 0)
+        log::net::debug("maximum message size exceeded");
+      return false;
+    }
+  }
+
+  void shutdown() override {
+    down_->shutdown();
+  }
+
+private:
+  // -- member variables -------------------------------------------------------
+
+  octet_stream::lower_layer* down_;
+
+  upper_layer_ptr up_;
+
+  size_t message_offset_ = 0;
+};
+
+} // namespace
+
+// -- factories ----------------------------------------------------------------
+
+std::unique_ptr<framing> framing::make(upper_layer_ptr up) {
+  return std::make_unique<framing_impl>(std::move(up));
 }
 
 } // namespace caf::net::lp

--- a/libcaf_net/caf/net/lp/framing.hpp
+++ b/libcaf_net/caf/net/lp/framing.hpp
@@ -4,24 +4,13 @@
 
 #pragma once
 
-#include "caf/net/lp/default_trait.hpp"
-#include "caf/net/lp/frame.hpp"
 #include "caf/net/lp/lower_layer.hpp"
 #include "caf/net/lp/upper_layer.hpp"
-#include "caf/net/middleman.hpp"
 #include "caf/net/octet_stream/upper_layer.hpp"
 
-#include "caf/actor_system.hpp"
-#include "caf/async/spsc_buffer.hpp"
-#include "caf/byte_span.hpp"
-#include "caf/cow_tuple.hpp"
 #include "caf/detail/net_export.hpp"
-#include "caf/disposable.hpp"
 
-#include <cstdint>
-#include <cstring>
 #include <memory>
-#include <type_traits>
 
 namespace caf::net::lp {
 
@@ -37,66 +26,9 @@ public:
 
   using upper_layer_ptr = std::unique_ptr<lp::upper_layer>;
 
-  // -- constants --------------------------------------------------------------
-
-  static constexpr size_t hdr_size = sizeof(uint32_t);
-
-  static constexpr size_t max_message_length = INT32_MAX - sizeof(uint32_t);
-
-  // -- constructors, destructors, and assignment operators --------------------
-
-  explicit framing(upper_layer_ptr up) : up_(std::move(up)) {
-    // nop
-  }
-
   // -- factories --------------------------------------------------------------
 
   static std::unique_ptr<framing> make(upper_layer_ptr up);
-
-  // -- implementation of octet_stream::upper_layer ----------------------------
-
-  error start(octet_stream::lower_layer* down) override;
-
-  void abort(const error& reason) override;
-
-  ptrdiff_t consume(byte_span buffer, byte_span delta) override;
-
-  void prepare_send() override;
-
-  bool done_sending() override;
-
-  // -- implementation of lp::lower_layer ----------------------------------
-
-  socket_manager* manager() noexcept override;
-
-  bool can_send_more() const noexcept override;
-
-  void request_messages() override;
-
-  void suspend_reading() override;
-
-  bool is_reading() const noexcept override;
-
-  void write_later() override;
-
-  void begin_message() override;
-
-  byte_buffer& message_buffer() override;
-
-  bool end_message() override;
-
-  void shutdown() override;
-
-  // -- utility functions ------------------------------------------------------
-
-  static std::pair<size_t, byte_span> split(byte_span buffer) noexcept;
-
-private:
-  // -- member variables -------------------------------------------------------
-
-  octet_stream::lower_layer* down_;
-  upper_layer_ptr up_;
-  size_t message_offset_ = 0;
 };
 
 } // namespace caf::net::lp

--- a/libcaf_net/caf/net/lp/framing.test.cpp
+++ b/libcaf_net/caf/net/lp/framing.test.cpp
@@ -8,6 +8,7 @@
 
 #include "caf/net/fwd.hpp"
 #include "caf/net/lp/with.hpp"
+#include "caf/net/middleman.hpp"
 #include "caf/net/multiplexer.hpp"
 #include "caf/net/octet_stream/transport.hpp"
 #include "caf/net/socket_id.hpp"

--- a/libcaf_net/caf/net/lp/with.hpp
+++ b/libcaf_net/caf/net/lp/with.hpp
@@ -11,6 +11,7 @@
 #include "caf/net/dsl/has_context.hpp"
 #include "caf/net/lp/client_factory.hpp"
 #include "caf/net/lp/config.hpp"
+#include "caf/net/lp/default_trait.hpp"
 #include "caf/net/lp/server_factory.hpp"
 #include "caf/net/multiplexer.hpp"
 #include "caf/net/ssl/context.hpp"

--- a/libcaf_net/caf/net/web_socket/client.cpp
+++ b/libcaf_net/caf/net/web_socket/client.cpp
@@ -121,4 +121,10 @@ std::unique_ptr<client> client::make(handshake_ptr hs, upper_layer_ptr up_ptr) {
   return std::make_unique<client_impl>(std::move(hs), std::move(up_ptr));
 }
 
+// -- constructors, destructors, and assignment operators --------------------
+
+client::~client() {
+  // nop
+}
+
 } // namespace caf::net::web_socket

--- a/libcaf_net/caf/net/web_socket/client.cpp
+++ b/libcaf_net/caf/net/web_socket/client.cpp
@@ -12,92 +12,112 @@
 
 #include "caf/byte_span.hpp"
 #include "caf/detail/assert.hpp"
-#include "caf/detail/base64.hpp"
-#include "caf/detail/message_flow_bridge.hpp"
 #include "caf/error.hpp"
-#include "caf/hash/sha1.hpp"
 #include "caf/log/net.hpp"
-#include "caf/pec.hpp"
-#include "caf/settings.hpp"
-
-#include <algorithm>
 
 namespace caf::net::web_socket {
+
+namespace {
+
+class client_impl : public client {
+public:
+  // -- constructors, destructors, and assignment operators --------------------
+
+  client_impl(handshake_ptr hs, upper_layer_ptr up)
+    : hs_(std::move(hs)), up_(std::move(up)) {
+    // nop
+  }
+
+  // -- implementation of octet_stream::upper_layer ----------------------------
+
+  error start(octet_stream::lower_layer* down) override {
+    CAF_ASSERT(hs_ != nullptr);
+    if (!hs_->has_mandatory_fields())
+      return make_error(
+        sec::runtime_error,
+        "WebSocket client_impl received an incomplete handshake");
+    if (!hs_->has_valid_key())
+      hs_->randomize_key();
+    down_ = down;
+    down_->begin_output();
+    hs_->write_http_1_request(down_->output_buffer());
+    down_->end_output();
+    down_->configure_read(receive_policy::up_to(handshake::max_http_size));
+    return none;
+  }
+
+  void abort(const error& reason) override {
+    CAF_ASSERT(up_);
+    up_->abort(reason);
+  }
+
+  ptrdiff_t consume(byte_span buffer, byte_span) override {
+    auto lg = log::net::trace("buffer = {}", buffer.size());
+    // Check whether we have received the HTTP header or else wait for more
+    // data. Abort when exceeding the maximum size.
+    auto [hdr, remainder] = http::v1::split_header(buffer);
+    if (hdr.empty()) {
+      if (buffer.size() >= handshake::max_http_size) {
+        log::net::error("server response exceeded the maximum header size");
+        up_->abort(make_error(sec::protocol_error, "server response exceeded "
+                                                   "the maximum header size"));
+        return -1;
+      }
+      // Wait for more data.
+      return 0;
+    }
+    if (!handle_header(hdr)) {
+      // Note: handle_header() already calls upper_layer().abort().
+      return -1;
+    }
+    // We only care about the header here. The framing layer is responsible for
+    // any remaining data.
+    return static_cast<ptrdiff_t>(hdr.size());
+  }
+
+  void prepare_send() override {
+    // nop
+  }
+
+  bool done_sending() override {
+    return true;
+  }
+
+private:
+  // -- HTTP response processing -----------------------------------------------
+
+  bool handle_header(std::string_view http) {
+    CAF_ASSERT(hs_ != nullptr);
+    auto http_ok = hs_->is_valid_http_1_response(http);
+    hs_.reset();
+    if (http_ok) {
+      down_->switch_protocol(framing::make_client(std::move(up_)));
+      return true;
+    }
+    log::net::debug("received an invalid WebSocket handshake");
+    up_->abort(make_error(sec::protocol_error,
+                          "received an invalid WebSocket handshake"));
+    return false;
+  }
+
+  // -- member variables -------------------------------------------------------
+
+  /// Points to the transport layer below.
+  octet_stream::lower_layer* down_;
+
+  /// Stores the WebSocket handshake data until the handshake completed.
+  handshake_ptr hs_;
+
+  /// Next layer in the processing chain.
+  upper_layer_ptr up_;
+};
+
+} // namespace
 
 // -- factories ----------------------------------------------------------------
 
 std::unique_ptr<client> client::make(handshake_ptr hs, upper_layer_ptr up_ptr) {
-  return std::make_unique<client>(std::move(hs), std::move(up_ptr));
-}
-
-// -- implementation of octet_stream::upper_layer ------------------------------
-
-error client::start(octet_stream::lower_layer* down) {
-  CAF_ASSERT(hs_ != nullptr);
-  if (!hs_->has_mandatory_fields())
-    return make_error(sec::runtime_error,
-                      "WebSocket client received an incomplete handshake");
-  if (!hs_->has_valid_key())
-    hs_->randomize_key();
-  down_ = down;
-  down_->begin_output();
-  hs_->write_http_1_request(down_->output_buffer());
-  down_->end_output();
-  down_->configure_read(receive_policy::up_to(handshake::max_http_size));
-  return none;
-}
-
-void client::abort(const error& reason) {
-  CAF_ASSERT(up_);
-  up_->abort(reason);
-}
-
-ptrdiff_t client::consume(byte_span buffer, byte_span) {
-  auto lg = log::net::trace("buffer = {}", buffer.size());
-  // Check whether we have received the HTTP header or else wait for more
-  // data. Abort when exceeding the maximum size.
-  auto [hdr, remainder] = http::v1::split_header(buffer);
-  if (hdr.empty()) {
-    if (buffer.size() >= handshake::max_http_size) {
-      log::net::error("server response exceeded the maximum header size");
-      up_->abort(make_error(sec::protocol_error, "server response exceeded "
-                                                 "the maximum header size"));
-      return -1;
-    }
-    // Wait for more data.
-    return 0;
-  }
-  if (!handle_header(hdr)) {
-    // Note: handle_header() already calls upper_layer().abort().
-    return -1;
-  }
-  // We only care about the header here. The framing layer is responsible for
-  // any remaining data.
-  return static_cast<ptrdiff_t>(hdr.size());
-}
-
-void client::prepare_send() {
-  // nop
-}
-
-bool client::done_sending() {
-  return true;
-}
-
-// -- HTTP response processing -------------------------------------------------
-
-bool client::handle_header(std::string_view http) {
-  CAF_ASSERT(hs_ != nullptr);
-  auto http_ok = hs_->is_valid_http_1_response(http);
-  hs_.reset();
-  if (http_ok) {
-    down_->switch_protocol(framing::make_client(std::move(up_)));
-    return true;
-  }
-  log::net::debug("received an invalid WebSocket handshake");
-  up_->abort(
-    make_error(sec::protocol_error, "received an invalid WebSocket handshake"));
-  return false;
+  return std::make_unique<client_impl>(std::move(hs), std::move(up_ptr));
 }
 
 } // namespace caf::net::web_socket

--- a/libcaf_net/caf/net/web_socket/client.cpp
+++ b/libcaf_net/caf/net/web_socket/client.cpp
@@ -6,6 +6,7 @@
 
 #include "caf/net/fwd.hpp"
 #include "caf/net/http/v1.hpp"
+#include "caf/net/octet_stream/lower_layer.hpp"
 #include "caf/net/receive_policy.hpp"
 #include "caf/net/web_socket/framing.hpp"
 #include "caf/net/web_socket/handshake.hpp"

--- a/libcaf_net/caf/net/web_socket/client.hpp
+++ b/libcaf_net/caf/net/web_socket/client.hpp
@@ -22,6 +22,10 @@ public:
 
   using upper_layer_ptr = std::unique_ptr<web_socket::upper_layer>;
 
+  // -- constructors, destructors, and assignment operators --------------------
+
+  ~client() override;
+
   // -- factories --------------------------------------------------------------
 
   static std::unique_ptr<client> make(handshake_ptr hs, upper_layer_ptr up);

--- a/libcaf_net/caf/net/web_socket/client.hpp
+++ b/libcaf_net/caf/net/web_socket/client.hpp
@@ -5,22 +5,8 @@
 #pragma once
 
 #include "caf/net/fwd.hpp"
-#include "caf/net/http/v1.hpp"
 #include "caf/net/octet_stream/upper_layer.hpp"
-#include "caf/net/receive_policy.hpp"
-#include "caf/net/web_socket/framing.hpp"
 #include "caf/net/web_socket/handshake.hpp"
-
-#include "caf/byte_span.hpp"
-#include "caf/detail/base64.hpp"
-#include "caf/detail/message_flow_bridge.hpp"
-#include "caf/error.hpp"
-#include "caf/hash/sha1.hpp"
-#include "caf/logger.hpp"
-#include "caf/pec.hpp"
-#include "caf/settings.hpp"
-
-#include <algorithm>
 
 namespace caf::net::web_socket {
 
@@ -36,13 +22,6 @@ public:
 
   using upper_layer_ptr = std::unique_ptr<web_socket::upper_layer>;
 
-  // -- constructors, destructors, and assignment operators --------------------
-
-  client(handshake_ptr hs, upper_layer_ptr up)
-    : hs_(std::move(hs)), up_(std::move(up)) {
-    // nop
-  }
-
   // -- factories --------------------------------------------------------------
 
   static std::unique_ptr<client> make(handshake_ptr hs, upper_layer_ptr up);
@@ -50,34 +29,6 @@ public:
   static std::unique_ptr<client> make(handshake&& hs, upper_layer_ptr up) {
     return make(std::make_unique<handshake>(std::move(hs)), std::move(up));
   }
-
-  // -- implementation of octet_stream::upper_layer ----------------------------
-
-  error start(octet_stream::lower_layer* down) override;
-
-  void abort(const error& reason) override;
-
-  ptrdiff_t consume(byte_span buffer, byte_span delta) override;
-
-  void prepare_send() override;
-
-  bool done_sending() override;
-
-private:
-  // -- HTTP response processing -----------------------------------------------
-
-  bool handle_header(std::string_view http);
-
-  // -- member variables -------------------------------------------------------
-
-  /// Points to the transport layer below.
-  octet_stream::lower_layer* down_;
-
-  /// Stores the WebSocket handshake data until the handshake completed.
-  handshake_ptr hs_;
-
-  /// Next layer in the processing chain.
-  upper_layer_ptr up_;
 };
 
 } // namespace caf::net::web_socket

--- a/libcaf_net/caf/net/web_socket/framing.cpp
+++ b/libcaf_net/caf/net/web_socket/framing.cpp
@@ -474,4 +474,10 @@ std::unique_ptr<framing> framing::make_server(upper_layer_ptr up) {
   return res;
 }
 
+// -- constructors, destructors, and assignment operators --------------------
+
+framing::~framing() {
+  // nop
+}
+
 } // namespace caf::net::web_socket

--- a/libcaf_net/caf/net/web_socket/framing.cpp
+++ b/libcaf_net/caf/net/web_socket/framing.cpp
@@ -4,10 +4,24 @@
 
 #include "caf/net/web_socket/framing.hpp"
 
-#include "caf/net/http/v1.hpp"
+#include "caf/net/fwd.hpp"
+#include "caf/net/octet_stream/lower_layer.hpp"
+#include "caf/net/receive_policy.hpp"
+#include "caf/net/web_socket/lower_layer.hpp"
+#include "caf/net/web_socket/status.hpp"
+#include "caf/net/web_socket/upper_layer.hpp"
 
+#include "caf/byte_span.hpp"
 #include "caf/detail/rfc3629.hpp"
+#include "caf/detail/rfc6455.hpp"
 #include "caf/log/net.hpp"
+#include "caf/sec.hpp"
+#include "caf/span.hpp"
+
+#include <memory>
+#include <random>
+#include <string_view>
+#include <vector>
 
 namespace caf::net::web_socket {
 
@@ -24,11 +38,11 @@ bool payload_valid(const_byte_span payload, size_t& offset) noexcept {
   return offset == payload.size() || incomplete;
 }
 
-} // namespace
-
-// -- static utility functions -------------------------------------------------
-
-error framing::validate_closing_payload(const_byte_span payload) {
+/// Checks whether the payload of a closing frame contains a valid status code
+/// and an UTF-8 formatted message.
+/// @returns A default constructed `error` if the payload is valid, error kind
+///          otherwise.
+error validate_closing_payload(const_byte_span payload) {
   if (payload.empty())
     return {};
   if (payload.size() == 1)
@@ -65,305 +79,399 @@ error framing::validate_closing_payload(const_byte_span payload) {
                     "invalid status code in closing payload");
 }
 
-// -- octet_stream::upper_layer implementation ---------------------------------
+class framing_impl : public framing {
+public:
+  // -- member types -----------------------------------------------------------
 
-error framing::start(octet_stream::lower_layer* down) {
-  std::random_device rd;
-  rng_.seed(rd());
-  down_ = down;
-  return up_->start(this);
-}
+  using binary_buffer = std::vector<std::byte>;
 
-void framing::abort(const error& reason) {
-  up_->abort(reason);
-}
+  // -- constants --------------------------------------------------------------
 
-ptrdiff_t framing::consume(byte_span buffer, byte_span delta) {
-  if (!hdr_.valid()) {
-    auto hdr_bytes = consume_header(buffer, delta);
-    if (hdr_bytes <= 0)
+  /// Restricts the size of received frames (including header).
+  static constexpr size_t max_frame_size = INT32_MAX;
+
+  /// Default receive policy for a new frame.
+  static constexpr auto default_receive_policy = receive_policy::up_to(2048);
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  explicit framing_impl(upper_layer_ptr up) : up_(std::move(up)) {
+    // nop
+  }
+
+  /// When set to true, causes the layer to mask all outgoing frames with a
+  /// randomly chosen masking key (cf. RFC 6455, Section 5.3). Servers may set
+  /// this to false, whereas clients are required to always mask according to
+  /// the standard.
+  bool mask_outgoing_frames = true;
+
+  // -- octet_stream::upper_layer implementation -------------------------------
+
+  error start(octet_stream::lower_layer* down) override {
+    std::random_device rd;
+    rng_.seed(rd());
+    down_ = down;
+    return up_->start(this);
+  }
+
+  void abort(const error& reason) override {
+    up_->abort(reason);
+  }
+
+  ptrdiff_t consume(byte_span buffer, byte_span delta) override {
+    if (!hdr_.valid()) {
+      auto hdr_bytes = consume_header(buffer, delta);
+      if (hdr_bytes <= 0)
+        return hdr_bytes;
+      if (hdr_.payload_len == 0
+          && consume_payload(buffer.first(0), delta.first(0)) < 0)
+        return -1;
       return hdr_bytes;
-    if (hdr_.payload_len == 0
-        && consume_payload(buffer.first(0), delta.first(0)) < 0)
+    }
+    return consume_payload(buffer, delta);
+  }
+
+  void prepare_send() override {
+    up_->prepare_send();
+  }
+
+  bool done_sending() override {
+    return up_->done_sending();
+  }
+
+  // -- web_socket::lower_layer implementation ---------------------------------
+
+  using web_socket::lower_layer::shutdown;
+
+  socket_manager* manager() noexcept override {
+    return down_->manager();
+  }
+
+  bool can_send_more() const noexcept override {
+    return down_->can_send_more();
+  }
+
+  void suspend_reading() override {
+    down_->configure_read(receive_policy::stop());
+  }
+
+  bool is_reading() const noexcept override {
+    return down_->is_reading();
+  }
+
+  void write_later() override {
+    down_->write_later();
+  }
+
+  void shutdown(status code, std::string_view msg) override {
+    ship_closing_message(code, msg);
+    down_->shutdown();
+  }
+
+  void request_messages() override {
+    if (!down_->is_reading())
+      down_->configure_read(default_receive_policy);
+  }
+
+  void begin_binary_message() override {
+    // nop
+  }
+
+  byte_buffer& binary_message_buffer() override {
+    return binary_buf_;
+  }
+
+  bool end_binary_message() override {
+    ship_frame(binary_buf_);
+    return true;
+  }
+
+  void begin_text_message() override {
+    // nop
+  }
+
+  text_buffer& text_message_buffer() override {
+    return text_buf_;
+  }
+
+  bool end_text_message() override {
+    ship_frame(text_buf_);
+    return true;
+  }
+
+private:
+  // -- implementation details -------------------------------------------------
+
+  // Validate the protocol after consuming a header.
+  error validate_header(ptrdiff_t hdr_bytes) const noexcept {
+    auto make_error_with_log = [](const char* message) {
+      log::net::debug(message);
+      return make_error(sec::protocol_error, message);
+    };
+    if (detail::rfc6455::is_control_frame(hdr_.opcode)) {
+      // Control frames can have a payload up to 125 bytes and can't be
+      // fragmented.
+      if (hdr_.payload_len > 125)
+        return make_error_with_log(
+          "WebSocket control frame payload exceeds allowed size");
+      if (!hdr_.fin)
+        return make_error_with_log(
+          "Received a fragmented WebSocket control message");
+    } else {
+      // The opcode is either continuation, text of binary frame.
+      // Make sure the entire frame (including header) fits into max_frame_size.
+      if (hdr_.payload_len >= max_frame_size - static_cast<size_t>(hdr_bytes))
+        return make_error_with_log("WebSocket frame too large");
+      // Reject any message whose assembled payload size exceeds max_frame_size.
+      if (payload_buf_.size() + hdr_.payload_len > max_frame_size)
+        return make_error_with_log(
+          "Fragmented WebSocket payload exceeds maximum size");
+      if (hdr_.opcode != detail::rfc6455::continuation_frame
+          && opcode_ != detail::rfc6455::invalid_frame)
+        return make_error_with_log("Expected a WebSocket continuation_frame");
+      if (hdr_.opcode == detail::rfc6455::continuation_frame
+          && opcode_ == detail::rfc6455::invalid_frame)
+        return make_error_with_log(
+          "Received WebSocket continuation frame without prior opcode");
+    }
+    return none;
+  }
+
+  // Consume the header for the currently parsing frame. Returns the number of
+  // sonsumed bytes.
+  ptrdiff_t consume_header(byte_span buffer, byte_span) {
+    // Parse header.
+    auto hdr_bytes = detail::rfc6455::decode_header(buffer, hdr_);
+    if (hdr_bytes < 0) {
+      log::net::debug("decoded malformed data: hdr_bytes < 0");
+      abort_and_shutdown(sec::protocol_error,
+                         "negative header size on WebSocket connection");
       return -1;
+    }
+    // Wait for more input.
+    if (hdr_bytes == 0)
+      return 0;
+    if (auto err = validate_header(hdr_bytes); err) {
+      abort_and_shutdown(err);
+      return -1;
+    }
+    // Configure the buffer for the next call to consume_payload. In case of
+    // text messages, we validate the UTF-8 encoding on the go, hence the use of
+    // up_to.
+    if (hdr_.opcode == detail::rfc6455::text_frame
+        || (hdr_.opcode == detail::rfc6455::continuation_frame
+            && opcode_ == detail::rfc6455::text_frame))
+      down_->configure_read(receive_policy::up_to(hdr_.payload_len));
+    else
+      down_->configure_read(receive_policy::exactly(hdr_.payload_len));
     return hdr_bytes;
   }
-  return consume_payload(buffer, delta);
-}
 
-void framing::prepare_send() {
-  up_->prepare_send();
-}
-
-bool framing::done_sending() {
-  return up_->done_sending();
-}
-
-// -- web_socket::lower_layer implementation -----------------------------------
-
-socket_manager* framing::manager() noexcept {
-  return down_->manager();
-}
-
-bool framing::can_send_more() const noexcept {
-  return down_->can_send_more();
-}
-
-void framing::suspend_reading() {
-  down_->configure_read(receive_policy::stop());
-}
-
-bool framing::is_reading() const noexcept {
-  return down_->is_reading();
-}
-
-void framing::write_later() {
-  down_->write_later();
-}
-
-void framing::shutdown(status code, std::string_view msg) {
-  ship_closing_message(code, msg);
-  down_->shutdown();
-}
-
-void framing::request_messages() {
-  if (!down_->is_reading())
-    down_->configure_read(default_receive_policy);
-}
-
-void framing::begin_binary_message() {
-  // nop
-}
-
-byte_buffer& framing::binary_message_buffer() {
-  return binary_buf_;
-}
-
-bool framing::end_binary_message() {
-  ship_frame(binary_buf_);
-  return true;
-}
-
-void framing::begin_text_message() {
-  // nop
-}
-
-text_buffer& framing::text_message_buffer() {
-  return text_buf_;
-}
-
-bool framing::end_text_message() {
-  ship_frame(text_buf_);
-  return true;
-}
-
-// -- implementation details ---------------------------------------------------
-
-error framing::validate_header(ptrdiff_t hdr_bytes) const noexcept {
-  auto make_error_with_log = [](const char* message) {
-    log::net::debug(message);
-    return make_error(sec::protocol_error, message);
-  };
-  if (detail::rfc6455::is_control_frame(hdr_.opcode)) {
-    // Control frames can have a payload up to 125 bytes and can't be
-    // fragmented.
-    if (hdr_.payload_len > 125)
-      return make_error_with_log(
-        "WebSocket control frame payload exceeds allowed size");
-    if (!hdr_.fin)
-      return make_error_with_log(
-        "Received a fragmented WebSocket control message");
-  } else {
-    // The opcode is either continuation, text of binary frame.
-    // Make sure the entire frame (including header) fits into max_frame_size.
-    if (hdr_.payload_len >= max_frame_size - static_cast<size_t>(hdr_bytes))
-      return make_error_with_log("WebSocket frame too large");
-    // Reject any message whose assembled payload size exceeds max_frame_size.
-    if (payload_buf_.size() + hdr_.payload_len > max_frame_size)
-      return make_error_with_log(
-        "Fragmented WebSocket payload exceeds maximum size");
-    if (hdr_.opcode != detail::rfc6455::continuation_frame
-        && opcode_ != detail::rfc6455::invalid_frame)
-      return make_error_with_log("Expected a WebSocket continuation_frame");
-    if (hdr_.opcode == detail::rfc6455::continuation_frame
-        && opcode_ == detail::rfc6455::invalid_frame)
-      return make_error_with_log(
-        "Received WebSocket continuation frame without prior opcode");
-  }
-  return none;
-}
-
-ptrdiff_t framing::consume_header(byte_span buffer, byte_span) {
-  // Parse header.
-  auto hdr_bytes = detail::rfc6455::decode_header(buffer, hdr_);
-  if (hdr_bytes < 0) {
-    log::net::debug("decoded malformed data: hdr_bytes < 0");
-    abort_and_shutdown(sec::protocol_error,
-                       "negative header size on WebSocket connection");
-    return -1;
-  }
-  // Wait for more input.
-  if (hdr_bytes == 0)
-    return 0;
-  if (auto err = validate_header(hdr_bytes); err) {
-    abort_and_shutdown(err);
-    return -1;
-  }
-  // Configure the buffer for the next call to consume_payload. In case of text
-  // messages, we validate the UTF-8 encoding on the go, hence the use of up_to.
-  if (hdr_.opcode == detail::rfc6455::text_frame
-      || (hdr_.opcode == detail::rfc6455::continuation_frame
-          && opcode_ == detail::rfc6455::text_frame))
-    down_->configure_read(receive_policy::up_to(hdr_.payload_len));
-  else
-    down_->configure_read(receive_policy::exactly(hdr_.payload_len));
-  return hdr_bytes;
-}
-
-ptrdiff_t framing::consume_payload(byte_span buffer, byte_span delta) {
-  // Calculate at what point of the received buffer the delta payload begins.
-  auto offset = static_cast<ptrdiff_t>(buffer.size() - delta.size());
-  // Unmask the arrived data.
-  if (hdr_.mask_key != 0)
-    detail::rfc6455::mask_data(hdr_.mask_key, buffer, offset);
-  // Control frames may not me fragmented and can arrive between regular message
-  // fragments.
-  if (detail::rfc6455::is_control_frame(hdr_.opcode))
-    return handle(hdr_.opcode, buffer, hdr_.payload_len);
-  // Handle the fragmentation logic of text and binary messages.
-  if (hdr_.opcode == detail::rfc6455::text_frame
-      || opcode_ == detail::rfc6455::text_frame) {
-    // For text messages we validate the UTF-8 encoding on the go. Only text
-    // messages can arrive with incomplete payload.
-    if (hdr_.opcode == detail::rfc6455::text_frame && hdr_.fin) {
-      if (!payload_valid(buffer, validation_offset_)) {
-        abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
-        return -1;
-      }
-    } else {
-      payload_buf_.insert(payload_buf_.end(), buffer.begin() + offset,
-                          buffer.end());
-      if (!payload_valid(payload_buf_, validation_offset_)) {
-        abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
-        return -1;
-      }
-    }
-    // Wait for more data if necessary.
-    if (buffer.size() < hdr_.payload_len)
-      return 0;
-  } else if ((hdr_.opcode == detail::rfc6455::binary_frame && !hdr_.fin)
-             || opcode_ == detail::rfc6455::binary_frame) {
-    payload_buf_.insert(payload_buf_.end(), buffer.begin(), buffer.end());
-  }
-  // Handle the completed frame.
-  if (hdr_.fin) {
-    if (opcode_ == detail::rfc6455::invalid_frame) {
-      if (hdr_.opcode == detail::rfc6455::text_frame
-          && validation_offset_ != buffer.size()) {
-        abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
-        return -1;
-      }
-      // Call upper layer.
-      validation_offset_ = 0;
+  // Consume the payload for the currently parsing frame. Returns the number of
+  // consumed bytes.
+  ptrdiff_t consume_payload(byte_span buffer, byte_span delta) {
+    // Calculate at what point of the received buffer the delta payload begins.
+    auto offset = static_cast<ptrdiff_t>(buffer.size() - delta.size());
+    // Unmask the arrived data.
+    if (hdr_.mask_key != 0)
+      detail::rfc6455::mask_data(hdr_.mask_key, buffer, offset);
+    // Control frames may not me fragmented and can arrive between regular
+    // message fragments.
+    if (detail::rfc6455::is_control_frame(hdr_.opcode))
       return handle(hdr_.opcode, buffer, hdr_.payload_len);
+    // Handle the fragmentation logic of text and binary messages.
+    if (hdr_.opcode == detail::rfc6455::text_frame
+        || opcode_ == detail::rfc6455::text_frame) {
+      // For text messages we validate the UTF-8 encoding on the go. Only text
+      // messages can arrive with incomplete payload.
+      if (hdr_.opcode == detail::rfc6455::text_frame && hdr_.fin) {
+        if (!payload_valid(buffer, validation_offset_)) {
+          abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
+          return -1;
+        }
+      } else {
+        payload_buf_.insert(payload_buf_.end(), buffer.begin() + offset,
+                            buffer.end());
+        if (!payload_valid(payload_buf_, validation_offset_)) {
+          abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
+          return -1;
+        }
+      }
+      // Wait for more data if necessary.
+      if (buffer.size() < hdr_.payload_len)
+        return 0;
+    } else if ((hdr_.opcode == detail::rfc6455::binary_frame && !hdr_.fin)
+               || opcode_ == detail::rfc6455::binary_frame) {
+      payload_buf_.insert(payload_buf_.end(), buffer.begin(), buffer.end());
     }
-    // End of fragmented input.
-    if (opcode_ == detail::rfc6455::text_frame
-        && validation_offset_ != payload_buf_.size()) {
-      abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
-      return -1;
-    }
-    auto result = handle(opcode_, payload_buf_, hdr_.payload_len);
-    opcode_ = detail::rfc6455::invalid_frame;
-    payload_buf_.clear();
-    validation_offset_ = 0;
-    return result;
-  }
-  if (opcode_ == detail::rfc6455::invalid_frame)
-    opcode_ = hdr_.opcode;
-  // Clean up the state since we finished processing this frame
-  down_->configure_read(default_receive_policy);
-  hdr_.opcode = detail::rfc6455::invalid_frame;
-  return static_cast<ptrdiff_t>(hdr_.payload_len);
-}
-
-ptrdiff_t framing::handle(uint8_t opcode, byte_span payload,
-                          size_t frame_size) {
-  // opcodes are checked for validity when decoding the header
-  switch (opcode) {
-    case detail::rfc6455::connection_close_frame:
-      if (auto err = validate_closing_payload(payload); err) {
-        abort_and_shutdown(err);
+    // Handle the completed frame.
+    if (hdr_.fin) {
+      if (opcode_ == detail::rfc6455::invalid_frame) {
+        if (hdr_.opcode == detail::rfc6455::text_frame
+            && validation_offset_ != buffer.size()) {
+          abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
+          return -1;
+        }
+        // Call upper layer.
+        validation_offset_ = 0;
+        return handle(hdr_.opcode, buffer, hdr_.payload_len);
+      }
+      // End of fragmented input.
+      if (opcode_ == detail::rfc6455::text_frame
+          && validation_offset_ != payload_buf_.size()) {
+        abort_and_shutdown(sec::malformed_message, "Invalid UTF-8 sequence");
         return -1;
       }
-      abort_and_shutdown(sec::connection_closed);
-      return -1;
-    case detail::rfc6455::text_frame: {
-      std::string_view text{reinterpret_cast<const char*>(payload.data()),
-                            payload.size()};
-      if (up_->consume_text(text) < 0)
-        return -1;
-      break;
+      auto result = handle(opcode_, payload_buf_, hdr_.payload_len);
+      opcode_ = detail::rfc6455::invalid_frame;
+      payload_buf_.clear();
+      validation_offset_ = 0;
+      return result;
     }
-    case detail::rfc6455::binary_frame:
-      if (up_->consume_binary(payload) < 0)
+    if (opcode_ == detail::rfc6455::invalid_frame)
+      opcode_ = hdr_.opcode;
+    // Clean up the state since we finished processing this frame
+    down_->configure_read(default_receive_policy);
+    hdr_.opcode = detail::rfc6455::invalid_frame;
+    return static_cast<ptrdiff_t>(hdr_.payload_len);
+  }
+
+  // Returns `frame_size` on success and -1 on error.
+  ptrdiff_t handle(uint8_t opcode, byte_span payload, size_t frame_size) {
+    // opcodes are checked for validity when decoding the header
+    switch (opcode) {
+      case detail::rfc6455::connection_close_frame:
+        if (auto err = validate_closing_payload(payload); err) {
+          abort_and_shutdown(err);
+          return -1;
+        }
+        abort_and_shutdown(sec::connection_closed);
         return -1;
-      break;
-    case detail::rfc6455::ping_frame:
-      ship_pong(payload);
-      break;
-    default: //  detail::rfc6455::pong
-      // nop
-      break;
+      case detail::rfc6455::text_frame: {
+        std::string_view text{reinterpret_cast<const char*>(payload.data()),
+                              payload.size()};
+        if (up_->consume_text(text) < 0)
+          return -1;
+        break;
+      }
+      case detail::rfc6455::binary_frame:
+        if (up_->consume_binary(payload) < 0)
+          return -1;
+        break;
+      case detail::rfc6455::ping_frame:
+        ship_pong(payload);
+        break;
+      default: //  detail::rfc6455::pong
+        // nop
+        break;
+    }
+    // Clean up the state since we finished processing this frame
+    down_->configure_read(default_receive_policy);
+    hdr_.opcode = detail::rfc6455::invalid_frame;
+    return static_cast<ptrdiff_t>(frame_size);
   }
-  // Clean up the state since we finished processing this frame
-  down_->configure_read(default_receive_policy);
-  hdr_.opcode = detail::rfc6455::invalid_frame;
-  return static_cast<ptrdiff_t>(frame_size);
+
+  void ship_pong(byte_span payload) {
+    uint32_t mask_key = 0;
+    if (mask_outgoing_frames) {
+      mask_key = static_cast<uint32_t>(rng_());
+      detail::rfc6455::mask_data(mask_key, payload);
+    }
+    down_->begin_output();
+    detail::rfc6455::assemble_frame(detail::rfc6455::pong_frame, mask_key,
+                                    payload, down_->output_buffer());
+    down_->end_output();
+  }
+
+  template <class T>
+  void ship_frame(std::vector<T>& buf) {
+    uint32_t mask_key = 0;
+    if (mask_outgoing_frames) {
+      mask_key = static_cast<uint32_t>(rng_());
+      detail::rfc6455::mask_data(mask_key, buf);
+    }
+    down_->begin_output();
+    detail::rfc6455::assemble_frame(mask_key, buf, down_->output_buffer());
+    down_->end_output();
+    buf.clear();
+  }
+
+  // Sends closing message, can be error status, or closing handshake
+  void ship_closing_message(status code, std::string_view msg) {
+    auto code_val = static_cast<uint16_t>(code);
+    uint32_t mask_key = 0;
+    byte_buffer payload;
+    payload.reserve(msg.size() + 2);
+    payload.push_back(static_cast<std::byte>((code_val & 0xFF00) >> 8));
+    payload.push_back(static_cast<std::byte>(code_val & 0x00FF));
+    auto* first = reinterpret_cast<const std::byte*>(msg.data());
+    payload.insert(payload.end(), first, first + msg.size());
+    if (mask_outgoing_frames) {
+      mask_key = static_cast<uint32_t>(rng_());
+      detail::rfc6455::mask_data(mask_key, payload);
+    }
+    down_->begin_output();
+    detail::rfc6455::assemble_frame(detail::rfc6455::connection_close_frame,
+                                    mask_key, payload, down_->output_buffer());
+    down_->end_output();
+  }
+
+  // Signal abort to the upper layer and shutdown to the lower layer,
+  // with closing message
+  template <class... Ts>
+  void abort_and_shutdown(sec reason, Ts&&... xs) {
+    abort_and_shutdown(make_error(reason, std::forward<Ts>(xs)...));
+  }
+
+  void abort_and_shutdown(const error& err) {
+    up_->abort(err);
+    shutdown(err);
+  }
+
+  // -- member variables -------------------------------------------------------
+
+  /// Points to the transport layer below.
+  octet_stream::lower_layer* down_ = nullptr;
+
+  /// Buffer for assembling binary frames.
+  binary_buffer binary_buf_;
+
+  /// Buffer for assembling text frames.
+  text_buffer text_buf_;
+
+  /// A 32-bit random number generator.
+  std::mt19937 rng_;
+
+  /// Header of the currently parsing frame.
+  detail::rfc6455::header hdr_;
+
+  /// Caches the opcode while decoding.
+  uint8_t opcode_ = detail::rfc6455::invalid_frame;
+
+  /// Assembles fragmented payloads.
+  binary_buffer payload_buf_;
+
+  /// Stores where to resume the UTF-8 input validation.
+  size_t validation_offset_ = 0;
+
+  /// Next layer in the processing chain.
+  upper_layer_ptr up_;
+};
+
+} // namespace
+
+// -- factories ----------------------------------------------------------------
+
+std::unique_ptr<framing> framing::make_client(upper_layer_ptr up) {
+  return std::make_unique<framing_impl>(std::move(up));
 }
 
-void framing::ship_pong(byte_span payload) {
-  uint32_t mask_key = 0;
-  if (mask_outgoing_frames) {
-    mask_key = static_cast<uint32_t>(rng_());
-    detail::rfc6455::mask_data(mask_key, payload);
-  }
-  down_->begin_output();
-  detail::rfc6455::assemble_frame(detail::rfc6455::pong_frame, mask_key,
-                                  payload, down_->output_buffer());
-  down_->end_output();
-}
-
-template <class T>
-void framing::ship_frame(std::vector<T>& buf) {
-  uint32_t mask_key = 0;
-  if (mask_outgoing_frames) {
-    mask_key = static_cast<uint32_t>(rng_());
-    detail::rfc6455::mask_data(mask_key, buf);
-  }
-  down_->begin_output();
-  detail::rfc6455::assemble_frame(mask_key, buf, down_->output_buffer());
-  down_->end_output();
-  buf.clear();
-}
-
-void framing::ship_closing_message(status code, std::string_view msg) {
-  auto code_val = static_cast<uint16_t>(code);
-  uint32_t mask_key = 0;
-  byte_buffer payload;
-  payload.reserve(msg.size() + 2);
-  payload.push_back(static_cast<std::byte>((code_val & 0xFF00) >> 8));
-  payload.push_back(static_cast<std::byte>(code_val & 0x00FF));
-  auto* first = reinterpret_cast<const std::byte*>(msg.data());
-  payload.insert(payload.end(), first, first + msg.size());
-  if (mask_outgoing_frames) {
-    mask_key = static_cast<uint32_t>(rng_());
-    detail::rfc6455::mask_data(mask_key, payload);
-  }
-  down_->begin_output();
-  detail::rfc6455::assemble_frame(detail::rfc6455::connection_close_frame,
-                                  mask_key, payload, down_->output_buffer());
-  down_->end_output();
+std::unique_ptr<framing> framing::make_server(upper_layer_ptr up) {
+  // A server MUST NOT mask any frames that it sends to the client.
+  // See RFC 6455, Section 5.1.
+  auto res = std::make_unique<framing_impl>(std::move(up));
+  res->mask_outgoing_frames = false;
+  return res;
 }
 
 } // namespace caf::net::web_socket

--- a/libcaf_net/caf/net/web_socket/framing.hpp
+++ b/libcaf_net/caf/net/web_socket/framing.hpp
@@ -21,6 +21,10 @@ public:
 
   using upper_layer_ptr = std::unique_ptr<web_socket::upper_layer>;
 
+  // -- constructors, destructors, and assignment operators --------------------
+
+  ~framing() override;
+
   // -- factories --------------------------------------------------------------
 
   /// Creates a new framing protocol for client mode.

--- a/libcaf_net/caf/net/web_socket/framing.hpp
+++ b/libcaf_net/caf/net/web_socket/framing.hpp
@@ -5,22 +5,11 @@
 #pragma once
 
 #include "caf/net/fwd.hpp"
-#include "caf/net/octet_stream/lower_layer.hpp"
 #include "caf/net/octet_stream/upper_layer.hpp"
-#include "caf/net/receive_policy.hpp"
 #include "caf/net/web_socket/lower_layer.hpp"
-#include "caf/net/web_socket/status.hpp"
 #include "caf/net/web_socket/upper_layer.hpp"
 
-#include "caf/byte_span.hpp"
-#include "caf/detail/rfc6455.hpp"
-#include "caf/sec.hpp"
-#include "caf/span.hpp"
-
 #include <memory>
-#include <random>
-#include <string_view>
-#include <vector>
 
 namespace caf::net::web_socket {
 
@@ -30,177 +19,15 @@ class CAF_NET_EXPORT framing : public octet_stream::upper_layer,
 public:
   // -- member types -----------------------------------------------------------
 
-  using binary_buffer = std::vector<std::byte>;
-
   using upper_layer_ptr = std::unique_ptr<web_socket::upper_layer>;
 
-  // -- constants --------------------------------------------------------------
-
-  /// Restricts the size of received frames (including header).
-  static constexpr size_t max_frame_size = INT32_MAX;
-
-  /// Default receive policy for a new frame.
-  static constexpr auto default_receive_policy = receive_policy::up_to(2048);
-
-  // -- static utility functions -----------------------------------------------
-
-  /// Checks whether the payload of a closing frame contains a valid status
-  /// code and an UTF-8 formatted message.
-  /// @returns A default constructed `error` if the payload is valid, error kind
-  ///          otherwise.
-  static error validate_closing_payload(const_byte_span payload);
-
-  // -- constructors, destructors, and assignment operators --------------------
+  // -- factories --------------------------------------------------------------
 
   /// Creates a new framing protocol for client mode.
-  static std::unique_ptr<framing> make_client(upper_layer_ptr up) {
-    return std::unique_ptr<framing>{new framing(std::move(up))};
-  }
+  static std::unique_ptr<framing> make_client(upper_layer_ptr up);
 
   /// Creates a new framing protocol for server mode.
-  static std::unique_ptr<framing> make_server(upper_layer_ptr up) {
-    // > A server MUST NOT mask any frames that it sends to the client.
-    // See RFC 6455, Section 5.1.
-    auto res = std::unique_ptr<framing>{new framing(std::move(up))};
-    res->mask_outgoing_frames = false;
-    return res;
-  }
-
-  // -- properties -------------------------------------------------------------
-
-  auto& up() noexcept {
-    return *up_;
-  }
-
-  const auto& up() const noexcept {
-    return *up_;
-  }
-
-  auto& down() noexcept {
-    return *down_;
-  }
-
-  const auto& down() const noexcept {
-    return *down_;
-  }
-
-  /// When set to true, causes the layer to mask all outgoing frames with a
-  /// randomly chosen masking key (cf. RFC 6455, Section 5.3). Servers may set
-  /// this to false, whereas clients are required to always mask according to
-  /// the standard.
-  bool mask_outgoing_frames = true;
-
-  // -- octet_stream::upper_layer implementation -------------------------------
-
-  error start(octet_stream::lower_layer* down) override;
-
-  void abort(const error& reason) override;
-
-  ptrdiff_t consume(byte_span input, byte_span) override;
-
-  void prepare_send() override;
-
-  bool done_sending() override;
-
-  // -- web_socket::lower_layer implementation ---------------------------------
-
-  using web_socket::lower_layer::shutdown;
-
-  socket_manager* manager() noexcept override;
-
-  bool can_send_more() const noexcept override;
-
-  void suspend_reading() override;
-
-  bool is_reading() const noexcept override;
-
-  void write_later() override;
-
-  void shutdown(status code, std::string_view desc) override;
-
-  void request_messages() override;
-
-  void begin_binary_message() override;
-
-  byte_buffer& binary_message_buffer() override;
-
-  bool end_binary_message() override;
-
-  void begin_text_message() override;
-
-  text_buffer& text_message_buffer() override;
-
-  bool end_text_message() override;
-
-private:
-  // -- implementation details -------------------------------------------------
-
-  explicit framing(upper_layer_ptr up) : up_(std::move(up)) {
-    // nop
-  }
-
-  // Validate the protocol after consuming a header.
-  error validate_header(ptrdiff_t hdr_bytes) const noexcept;
-
-  // Consume the header for the currently parsing frame. Returns the number of
-  // sonsumed bytes.
-  ptrdiff_t consume_header(byte_span input, byte_span);
-
-  // Consume the payload for the currently parsing frame. Returns the number of
-  // consumed bytes.
-  ptrdiff_t consume_payload(byte_span buffer, byte_span delta);
-
-  // Returns `frame_size` on success and -1 on error.
-  ptrdiff_t handle(uint8_t opcode, byte_span payload, size_t frame_size);
-
-  void ship_pong(byte_span payload);
-
-  template <class T>
-  void ship_frame(std::vector<T>& buf);
-
-  // Sends closing message, can be error status, or closing handshake
-  void ship_closing_message(status code, std::string_view desc);
-
-  // Signal abort to the upper layer and shutdown to the lower layer,
-  // with closing message
-  template <class... Ts>
-  void abort_and_shutdown(sec reason, Ts&&... xs) {
-    abort_and_shutdown(make_error(reason, std::forward<Ts>(xs)...));
-  }
-
-  void abort_and_shutdown(const error& err) {
-    up_->abort(err);
-    shutdown(err);
-  }
-
-  // -- member variables -------------------------------------------------------
-
-  /// Points to the transport layer below.
-  octet_stream::lower_layer* down_ = nullptr;
-
-  /// Buffer for assembling binary frames.
-  binary_buffer binary_buf_;
-
-  /// Buffer for assembling text frames.
-  text_buffer text_buf_;
-
-  /// A 32-bit random number generator.
-  std::mt19937 rng_;
-
-  /// Header of the currently parsing frame.
-  detail::rfc6455::header hdr_;
-
-  /// Caches the opcode while decoding.
-  uint8_t opcode_ = detail::rfc6455::invalid_frame;
-
-  /// Assembles fragmented payloads.
-  binary_buffer payload_buf_;
-
-  /// Stores where to resume the UTF-8 input validation.
-  size_t validation_offset_ = 0;
-
-  /// Next layer in the processing chain.
-  upper_layer_ptr up_;
+  static std::unique_ptr<framing> make_server(upper_layer_ptr up);
 };
 
 } // namespace caf::net::web_socket

--- a/libcaf_net/caf/net/web_socket/server.cpp
+++ b/libcaf_net/caf/net/web_socket/server.cpp
@@ -4,99 +4,139 @@
 
 #include "caf/net/web_socket/server.hpp"
 
+#include "caf/net/fwd.hpp"
+#include "caf/net/http/method.hpp"
+#include "caf/net/http/request_header.hpp"
+#include "caf/net/http/status.hpp"
+#include "caf/net/http/v1.hpp"
+#include "caf/net/receive_policy.hpp"
+#include "caf/net/web_socket/framing.hpp"
+#include "caf/net/web_socket/handshake.hpp"
+#include "caf/net/web_socket/upper_layer.hpp"
+
+#include "caf/byte_span.hpp"
+#include "caf/detail/net_export.hpp"
+#include "caf/error.hpp"
 #include "caf/log/net.hpp"
 
 namespace caf::net::web_socket {
 
-// -- octet_stream::upper_layer implementation ---------------------------------
+namespace {
 
-error server::start(octet_stream::lower_layer* down) {
-  down_ = down;
-  down_->configure_read(receive_policy::up_to(handshake::max_http_size));
-  return none;
-}
+class server_impl : public server {
+public:
+  // -- constructors, destructors, and assignment operators --------------------
 
-void server::abort(const error& err) {
-  up_->abort(err);
-}
+  explicit server_impl(upper_layer_ptr up) : up_(std::move(up)) {
+    // nop
+  }
 
-ptrdiff_t server::consume(byte_span input, byte_span) {
-  using namespace std::literals;
-  auto lg = log::net::trace("bytes.size = {}", input.size());
-  // Check whether we received an HTTP header or else wait for more data.
-  // Abort when exceeding the maximum size.
-  auto [hdr, remainder] = http::v1::split_header(input);
-  if (hdr.empty()) {
-    if (input.size() >= handshake::max_http_size) {
-      down_->begin_output();
-      http::v1::write_response(http::status::request_header_fields_too_large,
-                               "text/plain"sv, "Header exceeds maximum size."sv,
-                               down_->output_buffer());
-      down_->end_output();
+  // -- octet_stream::upper_layer implementation -------------------------------
+
+  error start(octet_stream::lower_layer* down) override {
+    down_ = down;
+    down_->configure_read(receive_policy::up_to(handshake::max_http_size));
+    return none;
+  }
+
+  void abort(const error& err) override {
+    up_->abort(err);
+  }
+
+  ptrdiff_t consume(byte_span input, byte_span) override {
+    using namespace std::literals;
+    auto lg = log::net::trace("bytes.size = {}", input.size());
+    // Check whether we received an HTTP header or else wait for more data.
+    // Abort when exceeding the maximum size.
+    auto [hdr, remainder] = http::v1::split_header(input);
+    if (hdr.empty()) {
+      if (input.size() >= handshake::max_http_size) {
+        down_->begin_output();
+        http::v1::write_response(http::status::request_header_fields_too_large,
+                                 "text/plain"sv,
+                                 "Header exceeds maximum size."sv,
+                                 down_->output_buffer());
+        down_->end_output();
+        return -1;
+      } else {
+        return 0;
+      }
+    } else if (!handle_header(hdr)) {
       return -1;
     } else {
-      return 0;
+      return static_cast<ptrdiff_t>(hdr.size());
     }
-  } else if (!handle_header(hdr)) {
-    return -1;
-  } else {
-    return static_cast<ptrdiff_t>(hdr.size());
   }
-}
 
-void server::prepare_send() {
-  // nop
-}
-
-bool server::done_sending() {
-  return true;
-}
-
-// -- HTTP request processing ------------------------------------------------
-
-void server::write_response(http::status code, std::string_view msg) {
-  down_->begin_output();
-  http::v1::write_response(code, "text/plain", msg, down_->output_buffer());
-  down_->end_output();
-}
-
-bool server::handle_header(std::string_view http) {
-  using namespace std::literals;
-  // Parse the header and reject invalid inputs.
-  http::request_header hdr;
-  auto [code, msg] = hdr.parse(http);
-  if (code != http::status::ok) {
-    write_response(code, msg);
-    return false;
+  void prepare_send() override {
+    // nop
   }
-  if (hdr.method() != http::method::get) {
-    write_response(http::status::bad_request,
-                   "Expected a WebSocket handshake.");
-    return false;
+
+  bool done_sending() override {
+    return true;
   }
-  // Check whether the mandatory fields exist.
-  auto sec_key = hdr.field("Sec-WebSocket-Key");
-  if (sec_key.empty()) {
-    auto descr = "Mandatory field Sec-WebSocket-Key missing or invalid."s;
-    write_response(http::status::bad_request, descr);
-    log::net::debug("received invalid WebSocket handshake");
-    return false;
+
+private:
+  // -- HTTP request processing ------------------------------------------------
+
+  void write_response(http::status code, std::string_view msg) {
+    down_->begin_output();
+    http::v1::write_response(code, "text/plain", msg, down_->output_buffer());
+    down_->end_output();
   }
-  // Kindly ask the upper layer to accept a new WebSocket connection.
-  if (auto err = up_->accept(hdr)) {
-    write_response(http::status::bad_request, to_string(err));
-    return false;
+
+  bool handle_header(std::string_view http) {
+    using namespace std::literals;
+    // Parse the header and reject invalid inputs.
+    http::request_header hdr;
+    auto [code, msg] = hdr.parse(http);
+    if (code != http::status::ok) {
+      write_response(code, msg);
+      return false;
+    }
+    if (hdr.method() != http::method::get) {
+      write_response(http::status::bad_request,
+                     "Expected a WebSocket handshake.");
+      return false;
+    }
+    // Check whether the mandatory fields exist.
+    auto sec_key = hdr.field("Sec-WebSocket-Key");
+    if (sec_key.empty()) {
+      auto descr = "Mandatory field Sec-WebSocket-Key missing or invalid."s;
+      write_response(http::status::bad_request, descr);
+      log::net::debug("received invalid WebSocket handshake");
+      return false;
+    }
+    // Kindly ask the upper layer to accept a new WebSocket connection.
+    if (auto err = up_->accept(hdr)) {
+      write_response(http::status::bad_request, to_string(err));
+      return false;
+    }
+    // Finalize the WebSocket handshake.
+    handshake hs;
+    hs.assign_key(sec_key);
+    down_->begin_output();
+    hs.write_http_1_response(down_->output_buffer());
+    down_->end_output();
+    // All done. Switch to the framing protocol.
+    log::net::debug("completed WebSocket handshake");
+    down_->switch_protocol(framing::make_server(std::move(up_)));
+    return true;
   }
-  // Finalize the WebSocket handshake.
-  handshake hs;
-  hs.assign_key(sec_key);
-  down_->begin_output();
-  hs.write_http_1_response(down_->output_buffer());
-  down_->end_output();
-  // All done. Switch to the framing protocol.
-  log::net::debug("completed WebSocket handshake");
-  down_->switch_protocol(framing::make_server(std::move(up_)));
-  return true;
+
+  /// Points to the transport layer below.
+  octet_stream::lower_layer* down_;
+
+  /// We store this only to pass it to the framing layer after the handshake.
+  upper_layer_ptr up_;
+};
+
+} // namespace
+
+// -- factories ----------------------------------------------------------------
+
+std::unique_ptr<server> server::make(upper_layer_ptr up) {
+  return std::make_unique<server_impl>(std::move(up));
 }
 
 } // namespace caf::net::web_socket

--- a/libcaf_net/caf/net/web_socket/server.cpp
+++ b/libcaf_net/caf/net/web_socket/server.cpp
@@ -9,6 +9,7 @@
 #include "caf/net/http/request_header.hpp"
 #include "caf/net/http/status.hpp"
 #include "caf/net/http/v1.hpp"
+#include "caf/net/octet_stream/lower_layer.hpp"
 #include "caf/net/receive_policy.hpp"
 #include "caf/net/web_socket/framing.hpp"
 #include "caf/net/web_socket/handshake.hpp"

--- a/libcaf_net/caf/net/web_socket/server.cpp
+++ b/libcaf_net/caf/net/web_socket/server.cpp
@@ -140,4 +140,10 @@ std::unique_ptr<server> server::make(upper_layer_ptr up) {
   return std::make_unique<server_impl>(std::move(up));
 }
 
+// -- constructors, destructors, and assignment operators --------------------
+
+server::~server() {
+  // nop
+}
+
 } // namespace caf::net::web_socket

--- a/libcaf_net/caf/net/web_socket/server.hpp
+++ b/libcaf_net/caf/net/web_socket/server.hpp
@@ -5,30 +5,10 @@
 #pragma once
 
 #include "caf/net/fwd.hpp"
-#include "caf/net/http/method.hpp"
-#include "caf/net/http/request_header.hpp"
-#include "caf/net/http/status.hpp"
-#include "caf/net/http/v1.hpp"
-#include "caf/net/multiplexer.hpp"
 #include "caf/net/octet_stream/upper_layer.hpp"
-#include "caf/net/receive_policy.hpp"
-#include "caf/net/socket_manager.hpp"
-#include "caf/net/web_socket/framing.hpp"
-#include "caf/net/web_socket/handshake.hpp"
-#include "caf/net/web_socket/lower_layer.hpp"
-#include "caf/net/web_socket/status.hpp"
 #include "caf/net/web_socket/upper_layer.hpp"
 
-#include "caf/byte_span.hpp"
-#include "caf/detail/message_flow_bridge.hpp"
 #include "caf/detail/net_export.hpp"
-#include "caf/error.hpp"
-#include "caf/logger.hpp"
-#include "caf/pec.hpp"
-#include "caf/settings.hpp"
-#include "caf/string_algorithms.hpp"
-
-#include <algorithm>
 
 namespace caf::net::web_socket {
 
@@ -42,42 +22,9 @@ public:
 
   using upper_layer_ptr = std::unique_ptr<web_socket::upper_layer::server>;
 
-  // -- constructors, destructors, and assignment operators --------------------
-
-  explicit server(upper_layer_ptr up) : up_(std::move(up)) {
-    // nop
-  }
-
   // -- factories --------------------------------------------------------------
 
-  static std::unique_ptr<server> make(upper_layer_ptr up) {
-    return std::make_unique<server>(std::move(up));
-  }
-
-  // -- octet_stream::upper_layer implementation -------------------------------
-
-  error start(octet_stream::lower_layer* down) override;
-
-  void abort(const error& reason) override;
-
-  ptrdiff_t consume(byte_span input, byte_span) override;
-
-  void prepare_send() override;
-
-  bool done_sending() override;
-
-private:
-  // -- HTTP request processing ------------------------------------------------
-
-  void write_response(http::status code, std::string_view msg);
-
-  bool handle_header(std::string_view http);
-
-  /// Points to the transport layer below.
-  octet_stream::lower_layer* down_;
-
-  /// We store this only to pass it to the framing layer after the handshake.
-  upper_layer_ptr up_;
+  static std::unique_ptr<server> make(upper_layer_ptr up);
 };
 
 } // namespace caf::net::web_socket

--- a/libcaf_net/caf/net/web_socket/server.hpp
+++ b/libcaf_net/caf/net/web_socket/server.hpp
@@ -22,6 +22,10 @@ public:
 
   using upper_layer_ptr = std::unique_ptr<web_socket::upper_layer::server>;
 
+  // -- constructors, destructors, and assignment operators --------------------
+
+  ~server() override;
+
   // -- factories --------------------------------------------------------------
 
   static std::unique_ptr<server> make(upper_layer_ptr up);

--- a/libcaf_net/caf/net/web_socket/switch_protocol.hpp
+++ b/libcaf_net/caf/net/web_socket/switch_protocol.hpp
@@ -7,9 +7,12 @@
 #include "caf/net/http/route.hpp"
 #include "caf/net/web_socket/acceptor.hpp"
 #include "caf/net/web_socket/default_trait.hpp"
-#include "caf/net/web_socket/server_factory.hpp"
+#include "caf/net/web_socket/framing.hpp"
+#include "caf/net/web_socket/handshake.hpp"
 
+#include "caf/async/blocking_producer.hpp"
 #include "caf/detail/assert.hpp"
+#include "caf/detail/ws_flow_bridge.hpp"
 #include "caf/type_list.hpp"
 
 #include <memory>


### PR DESCRIPTION
As agreed, the low hanging classes from `caf::net` are now interfaces, with imlementation hidden in the translation units. One commit per class and no functional changes. 

Open question to consider as a followup are:
- classes `octest_stream::transport` and `ssl::transport`, 
- `net::socket_manager` could probably be hidden as well with some effort. 

Relates #1254.