### PR TITLE
Fix mailbox creation when spawning child actors

### DIFF
--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -129,6 +129,7 @@ public:
   template <class T, spawn_options Os = no_spawn_options, class... Ts>
   infer_handle_from_class_t<T> spawn(Ts&&... xs) {
     actor_config cfg{context(), this};
+    cfg.mbox_factory = system().mailbox_factory();
     return eval_opts(Os, system().spawn_class<T, make_unbound(Os)>(
                            cfg, std::forward<Ts>(xs)...));
   }
@@ -150,6 +151,7 @@ public:
     static_assert(spawnable,
                   "cannot spawn function-based actor with given arguments");
     actor_config cfg{context(), this};
+    cfg.mbox_factory = system().mailbox_factory();
     static constexpr spawn_options unbound = make_unbound(Os);
     std::bool_constant<spawnable> enabled;
     return eval_opts(Os, system().spawn_functor<unbound>(

--- a/libcaf_core/caf/typed_event_based_actor.test.cpp
+++ b/libcaf_core/caf/typed_event_based_actor.test.cpp
@@ -407,7 +407,7 @@ TEST("check signature") {
     };
   };
   auto x = sys.spawn(bar_action);
-  check_eq(dispatch_messages(), 1u);
+  check_eq(dispatch_messages(), 2u);
 }
 
 SCENARIO("state classes may use typed pointers") {


### PR DESCRIPTION
When spawning an actor from another actor, we must make sure to pass in the proper mailbox factory. Otherwise, we break setups such as our deterministic test fixture.