### PR TITLE
Hide the implementation of net::socket_manager

### DIFF
--- a/libcaf_net/caf/net/http/with.hpp
+++ b/libcaf_net/caf/net/http/with.hpp
@@ -20,6 +20,7 @@
 #include "caf/net/ssl/context.hpp"
 #include "caf/net/tcp_accept_socket.hpp"
 
+#include "caf/extend.hpp"
 #include "caf/fwd.hpp"
 
 #include <cstdint>

--- a/libcaf_net/caf/net/lp/with.hpp
+++ b/libcaf_net/caf/net/lp/with.hpp
@@ -17,6 +17,7 @@
 #include "caf/net/ssl/context.hpp"
 #include "caf/net/tcp_accept_socket.hpp"
 
+#include "caf/extend.hpp"
 #include "caf/fwd.hpp"
 
 #include <cstdint>

--- a/libcaf_net/caf/net/socket_manager.cpp
+++ b/libcaf_net/caf/net/socket_manager.cpp
@@ -4,267 +4,383 @@
 
 #include "caf/net/socket_manager.hpp"
 
-#include "caf/net/actor_shell.hpp"
+#include "caf/net/fwd.hpp"
 #include "caf/net/multiplexer.hpp"
+#include "caf/net/socket.hpp"
+#include "caf/net/socket_event_layer.hpp"
 
 #include "caf/action.hpp"
-#include "caf/config.hpp"
+#include "caf/actor_system.hpp"
 #include "caf/detail/assert.hpp"
+#include "caf/disposable.hpp"
+#include "caf/error.hpp"
+#include "caf/flow/coordinated.hpp"
+#include "caf/flow/coordinator.hpp"
+#include "caf/fwd.hpp"
 #include "caf/log/net.hpp"
 #include "caf/make_counted.hpp"
+#include "caf/sec.hpp"
+
+#include <type_traits>
 
 namespace caf::net {
 
-// -- constructors, destructors, and assignment operators ----------------------
+namespace {
 
-socket_manager::socket_manager(multiplexer* mpx, event_handler_ptr handler)
-  : fd_(handler->handle()),
-    mpx_(mpx),
-    handler_(std::move(handler)),
-    disposed_(false) {
-  CAF_ASSERT(fd_ != invalid_socket);
-  CAF_ASSERT(mpx_ != nullptr);
-  CAF_ASSERT(handler_ != nullptr);
-}
+class socket_manager_impl : public socket_manager {
+public:
+  // -- constructors, destructors, and assignment operators --------------------
 
-socket_manager::~socket_manager() {
-  // Note: may not call cleanup since it calls the multiplexer via deregister().
-  handler_.reset();
-  if (fd_) {
-    close(fd_);
-    fd_ = invalid_socket;
+  /// @pre `handle != invalid_socket`
+  /// @pre `mpx!= nullptr`
+  socket_manager_impl(multiplexer* mpx, event_handler_ptr handler)
+    : fd_(handler->handle()),
+      mpx_(mpx),
+      handler_(std::move(handler)),
+      disposed_(false) {
+    CAF_ASSERT(fd_ != invalid_socket);
+    CAF_ASSERT(mpx_ != nullptr);
+    CAF_ASSERT(handler_ != nullptr);
   }
-  if (!cleanup_listeners_.empty()) {
-    for (auto& f : cleanup_listeners_)
-      mpx_->schedule(std::move(f));
-    cleanup_listeners_.clear();
+
+  ~socket_manager_impl() override {
+    // Note: may not call cleanup since it calls the multiplexer via
+    // deregister().
+    handler_.reset();
+    if (fd_) {
+      close(fd_);
+      fd_ = invalid_socket;
+    }
+    if (!cleanup_listeners_.empty()) {
+      for (auto& f : cleanup_listeners_)
+        mpx_->schedule(std::move(f));
+      cleanup_listeners_.clear();
+    }
   }
-}
+
+  socket_manager_impl(const socket_manager_impl&) = delete;
+
+  socket_manager_impl& operator=(const socket_manager_impl&) = delete;
+
+  // -- properties -------------------------------------------------------------
+
+  /// Returns the handle for the managed socket.
+  socket handle() const override {
+    return fd_;
+  }
+
+  /// @private
+  void handle(socket new_handle) override {
+    fd_ = new_handle;
+  }
+
+  /// Returns a reference to the hosting @ref actor_system instance.
+  actor_system& system() noexcept override {
+    CAF_ASSERT(mpx_ != nullptr);
+    return mpx_->system();
+  }
+
+  /// Returns the owning @ref multiplexer instance.
+  multiplexer& mpx() noexcept override {
+    return *mpx_;
+  }
+
+  /// Returns the owning @ref multiplexer instance.
+  const multiplexer& mpx() const noexcept override {
+    return *mpx_;
+  }
+
+  /// Returns a pointer to the owning @ref multiplexer instance.
+  multiplexer* mpx_ptr() noexcept override {
+    return mpx_;
+  }
+
+  /// Returns a pointer to the owning @ref multiplexer instance.
+  const multiplexer* mpx_ptr() const noexcept override {
+    return mpx_;
+  }
+
+  /// Queries whether the manager is registered for reading.
+  bool is_reading() const noexcept override {
+    return mpx_->is_reading(this);
+  }
+
+  /// Queries whether the manager is registered for writing.
+  bool is_writing() const noexcept override {
+    return mpx_->is_writing(this);
+  }
+
+  // -- event loop management --------------------------------------------------
+
+  /// Registers the manager for read operations.
+  void register_reading() override {
+    mpx_->register_reading(this);
+  }
+
+  /// Registers the manager for write operations.
+  void register_writing() override {
+    mpx_->register_writing(this);
+  }
+
+  /// Deregisters the manager from read operations.
+  void deregister_reading() override {
+    mpx_->deregister_reading(this);
+  }
+
+  /// Deregisters the manager from write operations.
+  void deregister_writing() override {
+    mpx_->deregister_writing(this);
+  }
+
+  /// Deregisters the manager from both read and write operations.
+  void deregister() override {
+    mpx_->deregister(this);
+  }
+
+  /// Schedules a call to `fn` on the multiplexer when this socket manager
+  /// cleans up its state.
+  /// @note Must be called before `start`.
+  void add_cleanup_listener(action fn) override {
+    cleanup_listeners_.push_back(std::move(fn));
+  }
+
+  // -- callbacks for the handler ----------------------------------------------
+
+  /// Schedules a call to `do_handover` on the handler.
+  void schedule_handover() override {
+    deregister();
+    mpx_->schedule_fn([ptr = strong_this()] {
+      event_handler_ptr next;
+      if (ptr->handler_->do_handover(next)) {
+        ptr->handler_.swap(next);
+      }
+    });
+  }
+
+  /// Shuts down this socket manager.
+  void shutdown() override {
+    auto lg = log::net::trace("");
+    if (!shutting_down_) {
+      shutting_down_ = true;
+      dispose();
+    } else {
+      // This usually only happens after disposing the manager if the handler
+      // still had data to send.
+      mpx_->schedule_fn([ptr = strong_this()] { //
+        ptr->cleanup();
+      });
+    }
+  }
+
+  // -- callbacks for the multiplexer ------------------------------------------
+
+  /// Starts the manager and its all of its processing layers.
+  error start() override {
+    auto lg = log::net::trace("");
+    if (auto err = nonblocking(fd_, true)) {
+      log::net::error("failed to set nonblocking flag in socket: {}", err);
+      handler_->abort(err);
+      cleanup();
+      return err;
+    }
+    if (auto err = handler_->start(this); err) {
+      log::net::debug("failed to initialize handler: {}", err);
+      cleanup();
+      return err;
+    }
+    run_delayed_actions();
+    return none;
+  }
+
+  /// Called whenever the socket received new data.
+  void handle_read_event() override {
+    if (handler_) {
+      handler_->handle_read_event();
+      run_delayed_actions();
+      return;
+    }
+    deregister();
+  }
+
+  /// Called whenever the socket is allowed to send data.
+  void handle_write_event() override {
+    if (handler_) {
+      handler_->handle_write_event();
+      run_delayed_actions();
+      return;
+    }
+    deregister();
+  }
+
+  /// Called when the remote side becomes unreachable due to an error or after
+  /// calling @ref dispose.
+  /// @param code The error code as reported by the operating system or
+  ///             @ref sec::disposed.
+  void handle_error(sec code) override {
+    auto lg = log::net::trace("");
+    if (!disposed_)
+      disposed_ = true;
+    if (handler_) {
+      if (!shutting_down_) {
+        handler_->abort(make_error(code));
+        shutting_down_ = true;
+        run_delayed_actions();
+      }
+      if (code == sec::disposed && !handler_->finalized()) {
+        // When disposing the manger, the transport is still allowed to send
+        // any pending data and it will call shutdown() later to trigger
+        // cleanup().
+        deregister_reading();
+      } else {
+        cleanup();
+      }
+    }
+  }
+
+  // -- implementation of coordinator ------------------------------------------
+
+  void ref_execution_context() const noexcept override {
+    ref();
+  }
+
+  void deref_execution_context() const noexcept override {
+    deref();
+  }
+
+  void schedule(action what) override {
+    mpx_->schedule_fn([ptr = strong_this(), f = std::move(what)]() mutable { //
+      ptr->exec(f);
+    });
+  }
+
+  void watch(disposable what) override {
+    watched_.push_back(std::move(what));
+  }
+
+  void release_later(flow::coordinated_ptr& child) override {
+    trash_.push_back(std::move(child));
+  }
+
+  steady_time_point steady_time() override {
+    return std::chrono::steady_clock::now();
+  }
+
+  void delay(action what) override {
+    delayed_.push_back(std::move(what));
+  }
+
+  disposable delay_until(steady_time_point abs_time, action what) override {
+    auto callback = make_single_shot_action(
+      [ptr = strong_this(), f = std::move(what)]() mutable { ptr->exec(f); });
+    mpx_->schedule(abs_time, callback);
+    return std::move(callback).as_disposable();
+  }
+
+  // -- implementation of disposable_impl --------------------------------------
+
+  void dispose() override {
+    bool expected = false;
+    if (disposed_.compare_exchange_strong(expected, true)) {
+      mpx_->schedule_fn([ptr = strong_this()] { //
+        ptr->handle_error(sec::disposed);
+      });
+    }
+  }
+
+  bool disposed() const noexcept override {
+    return disposed_.load();
+  }
+
+  void ref_disposable() const noexcept override {
+    ref();
+  }
+
+  void deref_disposable() const noexcept override {
+    deref();
+  }
+
+  // -- disambiguation ---------------------------------------------------------
+
+private:
+  // -- utility functions ------------------------------------------------------
+
+  void exec(action& f) {
+    f.run();
+    run_delayed_actions();
+  }
+
+  void run_delayed_actions() override {
+    while (!delayed_.empty()) {
+      auto next = std::move(delayed_.front());
+      delayed_.pop_front();
+      next.run();
+    }
+    trash_.clear();
+    disposable::erase_disposed(watched_);
+  }
+
+  void cleanup() {
+    deregister();
+    handler_.reset();
+    if (fd_) {
+      close(fd_);
+      fd_ = invalid_socket;
+    }
+    if (!cleanup_listeners_.empty()) {
+      for (auto& f : cleanup_listeners_)
+        mpx_->schedule(std::move(f));
+      cleanup_listeners_.clear();
+    }
+  }
+
+  intrusive_ptr<socket_manager_impl> strong_this() {
+    return intrusive_ptr<socket_manager_impl>{this};
+  }
+
+  // -- member variables -------------------------------------------------------
+
+  /// Stores the socket file descriptor. The socket manager automatically closes
+  /// the socket in its destructor.
+  socket fd_;
+
+  /// Points to the multiplexer that executes this manager. Note: we do not need
+  /// to increase the reference count for the multiplexer, because the
+  /// multiplexer owns all managers in the sense that calling any member
+  /// function on a socket manager may not occur if the actor system has shut
+  /// down (and the multiplexer is part of the actor system).
+  multiplexer* mpx_;
+
+  /// Stores the event handler that operators on the socket file descriptor.
+  event_handler_ptr handler_;
+
+  /// Stores whether `shutdown` has been called.
+  bool shutting_down_ = false;
+
+  /// Stores whether the manager has been either explicitly disposed or shut
+  /// down by demand of the application.
+  std::atomic<bool> disposed_;
+
+  /// Callbacks to run when calling `cleanup`.
+  std::vector<action> cleanup_listeners_;
+
+  /// Stores watched disposables.
+  std::vector<disposable> watched_;
+
+  /// Stores actions that should run at the next opportunity.
+  std::deque<action> delayed_;
+
+  /// Stores flow children that should be released at the next opportunity.
+  std::vector<flow::coordinated_ptr> trash_;
+};
+
+} // namespace
 
 // -- factories ----------------------------------------------------------------
 
 socket_manager_ptr socket_manager::make(multiplexer* mpx,
                                         event_handler_ptr handler) {
   CAF_ASSERT(mpx != nullptr);
-  return make_counted<socket_manager>(std::move(mpx), std::move(handler));
-}
-
-// -- properties ---------------------------------------------------------------
-
-actor_system& socket_manager::system() noexcept {
-  CAF_ASSERT(mpx_ != nullptr);
-  return mpx_->system();
-}
-
-bool socket_manager::is_reading() const noexcept {
-  return mpx_->is_reading(this);
-}
-
-bool socket_manager::is_writing() const noexcept {
-  return mpx_->is_writing(this);
-}
-
-// -- event loop management ----------------------------------------------------
-
-void socket_manager::register_reading() {
-  mpx_->register_reading(this);
-}
-
-void socket_manager::register_writing() {
-  mpx_->register_writing(this);
-}
-
-void socket_manager::deregister_reading() {
-  mpx_->deregister_reading(this);
-}
-
-void socket_manager::deregister_writing() {
-  mpx_->deregister_writing(this);
-}
-
-void socket_manager::deregister() {
-  mpx_->deregister(this);
-}
-
-// -- callbacks for the handler ------------------------------------------------
-
-void socket_manager::schedule_handover() {
-  deregister();
-  mpx_->schedule_fn([ptr = strong_this()] {
-    event_handler_ptr next;
-    if (ptr->handler_->do_handover(next)) {
-      ptr->handler_.swap(next);
-    }
-  });
-}
-
-void socket_manager::shutdown() {
-  auto lg = log::net::trace("");
-  if (!shutting_down_) {
-    shutting_down_ = true;
-    dispose();
-  } else {
-    // This usually only happens after disposing the manager if the handler
-    // still had data to send.
-    mpx_->schedule_fn([ptr = strong_this()] { //
-      ptr->cleanup();
-    });
-  }
-}
-
-// -- callbacks for the multiplexer --------------------------------------------
-
-error socket_manager::start() {
-  auto lg = log::net::trace("");
-  if (auto err = nonblocking(fd_, true)) {
-    log::net::error("failed to set nonblocking flag in socket: {}", err);
-    handler_->abort(err);
-    cleanup();
-    return err;
-  }
-  if (auto err = handler_->start(this); err) {
-    log::net::debug("failed to initialize handler: {}", err);
-    cleanup();
-    return err;
-  }
-  run_delayed_actions();
-  return none;
-}
-
-void socket_manager::handle_read_event() {
-  if (handler_) {
-    handler_->handle_read_event();
-    run_delayed_actions();
-    return;
-  }
-  deregister();
-}
-
-void socket_manager::handle_write_event() {
-  if (handler_) {
-    handler_->handle_write_event();
-    run_delayed_actions();
-    return;
-  }
-  deregister();
-}
-
-void socket_manager::handle_error(sec code) {
-  auto lg = log::net::trace("");
-  if (!disposed_)
-    disposed_ = true;
-  if (handler_) {
-    if (!shutting_down_) {
-      handler_->abort(make_error(code));
-      shutting_down_ = true;
-      run_delayed_actions();
-    }
-    if (code == sec::disposed && !handler_->finalized()) {
-      // When disposing the manger, the transport is still allowed to send any
-      // pending data and it will call shutdown() later to trigger cleanup().
-      deregister_reading();
-    } else {
-      cleanup();
-    }
-  }
-}
-
-// -- implementation of coordinator --------------------------------------------
-
-void socket_manager::ref_execution_context() const noexcept {
-  ref();
-}
-
-void socket_manager::deref_execution_context() const noexcept {
-  deref();
-}
-
-void socket_manager::schedule(action what) {
-  mpx_->schedule_fn([ptr = strong_this(), f = std::move(what)]() mutable { //
-    ptr->exec(f);
-  });
-}
-
-void socket_manager::watch(disposable what) {
-  watched_.push_back(std::move(what));
-}
-
-void socket_manager::release_later(flow::coordinated_ptr& child) {
-  trash_.push_back(std::move(child));
-}
-
-socket_manager::steady_time_point socket_manager::steady_time() {
-  return std::chrono::steady_clock::now();
-}
-
-void socket_manager::delay(action what) {
-  delayed_.push_back(std::move(what));
-}
-
-disposable socket_manager::delay_until(steady_time_point abs_time,
-                                       action what) {
-  auto callback = make_single_shot_action(
-    [ptr = strong_this(), f = std::move(what)]() mutable { ptr->exec(f); });
-  mpx_->schedule(abs_time, callback);
-  return std::move(callback).as_disposable();
-}
-
-// -- implementation of disposable_impl ----------------------------------------
-
-void socket_manager::dispose() {
-  bool expected = false;
-  if (disposed_.compare_exchange_strong(expected, true)) {
-    mpx_->schedule_fn([ptr = strong_this()] { //
-      ptr->handle_error(sec::disposed);
-    });
-  }
-}
-
-bool socket_manager::disposed() const noexcept {
-  return disposed_.load();
-}
-
-void socket_manager::ref_disposable() const noexcept {
-  ref();
-}
-
-void socket_manager::deref_disposable() const noexcept {
-  deref();
-}
-
-// -- utility functions --------------------------------------------------------
-
-void socket_manager::exec(action& f) {
-  f.run();
-  run_delayed_actions();
-}
-
-void socket_manager::run_delayed_actions() {
-  while (!delayed_.empty()) {
-    auto next = std::move(delayed_.front());
-    delayed_.pop_front();
-    next.run();
-  }
-  trash_.clear();
-  disposable::erase_disposed(watched_);
-}
-
-void socket_manager::cleanup() {
-  deregister();
-  handler_.reset();
-  if (fd_) {
-    close(fd_);
-    fd_ = invalid_socket;
-  }
-  if (!cleanup_listeners_.empty()) {
-    for (auto& f : cleanup_listeners_)
-      mpx_->schedule(std::move(f));
-    cleanup_listeners_.clear();
-  }
-}
-
-socket_manager_ptr socket_manager::strong_this() {
-  return socket_manager_ptr{this};
+  return make_counted<socket_manager_impl>(std::move(mpx), std::move(handler));
 }
 
 // -- free functions -----------------------------------------------------------

--- a/libcaf_net/caf/net/socket_manager.hpp
+++ b/libcaf_net/caf/net/socket_manager.hpp
@@ -4,22 +4,16 @@
 
 #pragma once
 
-#include "caf/net/actor_shell.hpp"
 #include "caf/net/fwd.hpp"
 #include "caf/net/socket.hpp"
 #include "caf/net/socket_event_layer.hpp"
-#include "caf/net/typed_actor_shell.hpp"
 
 #include "caf/action.hpp"
-#include "caf/actor.hpp"
 #include "caf/actor_system.hpp"
-#include "caf/callback.hpp"
 #include "caf/detail/atomic_ref_counted.hpp"
-#include "caf/detail/infer_actor_shell_ptr_type.hpp"
 #include "caf/detail/net_export.hpp"
 #include "caf/disposable.hpp"
 #include "caf/error.hpp"
-#include "caf/flow/coordinated.hpp"
 #include "caf/flow/coordinator.hpp"
 #include "caf/fwd.hpp"
 #include "caf/sec.hpp"
@@ -41,18 +35,6 @@ public:
 
   using event_handler_ptr = std::unique_ptr<socket_event_layer>;
 
-  // -- constructors, destructors, and assignment operators --------------------
-
-  /// @pre `handle != invalid_socket`
-  /// @pre `mpx!= nullptr`
-  socket_manager(multiplexer* mpx, event_handler_ptr handler);
-
-  ~socket_manager() override;
-
-  socket_manager(const socket_manager&) = delete;
-
-  socket_manager& operator=(const socket_manager&) = delete;
-
   // -- factories --------------------------------------------------------------
 
   static socket_manager_ptr make(multiplexer* mpx, event_handler_ptr handler);
@@ -60,168 +42,81 @@ public:
   // -- properties -------------------------------------------------------------
 
   /// Returns the handle for the managed socket.
-  socket handle() const {
-    return fd_;
-  }
+  virtual socket handle() const = 0;
 
   /// @private
-  void handle(socket new_handle) {
-    fd_ = new_handle;
-  }
+  virtual void handle(socket new_handle) = 0;
 
   /// Returns a reference to the hosting @ref actor_system instance.
-  actor_system& system() noexcept;
+  virtual actor_system& system() noexcept = 0;
 
   /// Returns the owning @ref multiplexer instance.
-  multiplexer& mpx() noexcept {
-    return *mpx_;
-  }
+  virtual multiplexer& mpx() noexcept = 0;
 
   /// Returns the owning @ref multiplexer instance.
-  const multiplexer& mpx() const noexcept {
-    return *mpx_;
-  }
+  virtual const multiplexer& mpx() const noexcept = 0;
 
   /// Returns a pointer to the owning @ref multiplexer instance.
-  multiplexer* mpx_ptr() noexcept {
-    return mpx_;
-  }
+  virtual multiplexer* mpx_ptr() noexcept = 0;
 
   /// Returns a pointer to the owning @ref multiplexer instance.
-  const multiplexer* mpx_ptr() const noexcept {
-    return mpx_;
-  }
+  virtual const multiplexer* mpx_ptr() const noexcept = 0;
 
   /// Queries whether the manager is registered for reading.
-  bool is_reading() const noexcept;
+  virtual bool is_reading() const noexcept = 0;
 
   /// Queries whether the manager is registered for writing.
-  bool is_writing() const noexcept;
+  virtual bool is_writing() const noexcept = 0;
 
   // -- event loop management --------------------------------------------------
 
   /// Registers the manager for read operations.
-  void register_reading();
+  virtual void register_reading() = 0;
 
   /// Registers the manager for write operations.
-  void register_writing();
+  virtual void register_writing() = 0;
 
   /// Deregisters the manager from read operations.
-  void deregister_reading();
+  virtual void deregister_reading() = 0;
 
   /// Deregisters the manager from write operations.
-  void deregister_writing();
+  virtual void deregister_writing() = 0;
 
   /// Deregisters the manager from both read and write operations.
-  void deregister();
+  virtual void deregister() = 0;
 
   /// Schedules a call to `fn` on the multiplexer when this socket manager
   /// cleans up its state.
   /// @note Must be called before `start`.
-  void add_cleanup_listener(action fn) {
-    cleanup_listeners_.push_back(std::move(fn));
-  }
+  virtual void add_cleanup_listener(action fn) = 0;
 
   // -- callbacks for the handler ----------------------------------------------
 
   /// Schedules a call to `do_handover` on the handler.
-  void schedule_handover();
+  virtual void schedule_handover() = 0;
 
   /// Shuts down this socket manager.
-  void shutdown();
+  virtual void shutdown() = 0;
 
   // -- callbacks for the multiplexer ------------------------------------------
 
   /// Starts the manager and its all of its processing layers.
-  error start();
+  virtual error start() = 0;
 
   /// Called whenever the socket received new data.
-  void handle_read_event();
+  virtual void handle_read_event() = 0;
 
   /// Called whenever the socket is allowed to send data.
-  void handle_write_event();
+  virtual void handle_write_event() = 0;
 
   /// Called when the remote side becomes unreachable due to an error or after
   /// calling @ref dispose.
   /// @param code The error code as reported by the operating system or
   ///             @ref sec::disposed.
-  void handle_error(sec code);
-
-  // -- implementation of coordinator ------------------------------------------
-
-  void ref_execution_context() const noexcept override;
-
-  void deref_execution_context() const noexcept override;
-
-  void schedule(action what) override;
-
-  void watch(disposable what) override;
-
-  void release_later(flow::coordinated_ptr& child) override;
-
-  steady_time_point steady_time() override;
-
-  void delay(action what) override;
-
-  disposable delay_until(steady_time_point abs_time, action what) override;
-
-  // -- implementation of disposable_impl --------------------------------------
-
-  void dispose() override;
-
-  bool disposed() const noexcept override;
-
-  void ref_disposable() const noexcept override;
-
-  void deref_disposable() const noexcept override;
-
-  // -- disambiguation ---------------------------------------------------------
+  virtual void handle_error(sec code) = 0;
 
 private:
-  // -- utility functions ------------------------------------------------------
-
-  void exec(action& f);
-
-  void run_delayed_actions();
-
-  void cleanup();
-
-  socket_manager_ptr strong_this();
-
-  // -- member variables -------------------------------------------------------
-
-  /// Stores the socket file descriptor. The socket manager automatically closes
-  /// the socket in its destructor.
-  socket fd_;
-
-  /// Points to the multiplexer that executes this manager. Note: we do not need
-  /// to increase the reference count for the multiplexer, because the
-  /// multiplexer owns all managers in the sense that calling any member
-  /// function on a socket manager may not occur if the actor system has shut
-  /// down (and the multiplexer is part of the actor system).
-  multiplexer* mpx_;
-
-  /// Stores the event handler that operators on the socket file descriptor.
-  event_handler_ptr handler_;
-
-  /// Stores whether `shutdown` has been called.
-  bool shutting_down_ = false;
-
-  /// Stores whether the manager has been either explicitly disposed or shut
-  /// down by demand of the application.
-  std::atomic<bool> disposed_;
-
-  /// Callbacks to run when calling `cleanup`.
-  std::vector<action> cleanup_listeners_;
-
-  /// Stores watched disposables.
-  std::vector<disposable> watched_;
-
-  /// Stores actions that should run at the next opportunity.
-  std::deque<action> delayed_;
-
-  /// Stores flow children that should be released at the next opportunity.
-  std::vector<flow::coordinated_ptr> trash_;
+  virtual void run_delayed_actions() = 0;
 };
 
 // -- related free functions ---------------------------------------------------

--- a/libcaf_net/caf/net/web_socket/with.hpp
+++ b/libcaf_net/caf/net/web_socket/with.hpp
@@ -16,6 +16,7 @@
 #include "caf/net/web_socket/default_trait.hpp"
 #include "caf/net/web_socket/has_on_request.hpp"
 
+#include "caf/extend.hpp"
 #include "caf/fwd.hpp"
 
 #include <cstdint>


### PR DESCRIPTION
As discussed, this hides the `net::socket_manager`. 
Relates #1254. 