### PR TITLE
Simplify the socket_manager virtual interface

### DIFF
--- a/libcaf_net/caf/net/make_actor_shell.hpp
+++ b/libcaf_net/caf/net/make_actor_shell.hpp
@@ -1,7 +1,7 @@
 #include "caf/net/actor_shell.hpp"
 #include "caf/net/fwd.hpp"
+#include "caf/net/multiplexer.hpp"
 #include "caf/net/socket_manager.hpp"
-#include "caf/net/typed_actor_shell.hpp"
 
 #include "caf/actor_system.hpp"
 
@@ -16,7 +16,7 @@ actor_shell_ptr_t<Handle> make_actor_shell(socket_manager* mgr) {
   };
   using ptr_type = actor_shell_ptr_t<Handle>;
   using impl_type = typename ptr_type::element_type;
-  auto hdl = mgr->system().spawn<impl_type>(mgr);
+  auto hdl = mgr->mpx().system().spawn<impl_type>(mgr);
   auto ptr = ptr_type{actor_cast<strong_actor_ptr>(std::move(hdl))};
   ptr->set_fallback(std::move(f));
   return ptr;

--- a/libcaf_net/caf/net/socket_manager.cpp
+++ b/libcaf_net/caf/net/socket_manager.cpp
@@ -69,27 +69,6 @@ public:
     return fd_;
   }
 
-  /// @private
-  void handle(socket new_handle) override {
-    fd_ = new_handle;
-  }
-
-  /// Returns a reference to the hosting @ref actor_system instance.
-  actor_system& system() noexcept override {
-    CAF_ASSERT(mpx_ != nullptr);
-    return mpx_->system();
-  }
-
-  /// Returns the owning @ref multiplexer instance.
-  multiplexer& mpx() noexcept override {
-    return *mpx_;
-  }
-
-  /// Returns the owning @ref multiplexer instance.
-  const multiplexer& mpx() const noexcept override {
-    return *mpx_;
-  }
-
   /// Returns a pointer to the owning @ref multiplexer instance.
   multiplexer* mpx_ptr() noexcept override {
     return mpx_;
@@ -298,8 +277,6 @@ public:
   void deref_disposable() const noexcept override {
     deref();
   }
-
-  // -- disambiguation ---------------------------------------------------------
 
 private:
   // -- utility functions ------------------------------------------------------

--- a/libcaf_net/caf/net/socket_manager.cpp
+++ b/libcaf_net/caf/net/socket_manager.cpp
@@ -70,12 +70,7 @@ public:
   }
 
   /// Returns a pointer to the owning @ref multiplexer instance.
-  multiplexer* mpx_ptr() noexcept override {
-    return mpx_;
-  }
-
-  /// Returns a pointer to the owning @ref multiplexer instance.
-  const multiplexer* mpx_ptr() const noexcept override {
+  multiplexer* mpx_ptr() const noexcept override {
     return mpx_;
   }
 

--- a/libcaf_net/caf/net/socket_manager.hpp
+++ b/libcaf_net/caf/net/socket_manager.hpp
@@ -45,22 +45,13 @@ public:
   virtual socket handle() const = 0;
 
   /// Returns the owning @ref multiplexer instance.
-  multiplexer& mpx() {
-    CAF_ASSERT(mpx_ptr());
-    return *mpx_ptr();
-  }
-
-  /// Returns the owning @ref multiplexer instance.
-  const multiplexer& mpx() const {
+  multiplexer& mpx() const {
     CAF_ASSERT(mpx_ptr());
     return *mpx_ptr();
   }
 
   /// Returns a pointer to the owning @ref multiplexer instance.
-  virtual multiplexer* mpx_ptr() noexcept = 0;
-
-  /// Returns a pointer to the owning @ref multiplexer instance.
-  virtual const multiplexer* mpx_ptr() const noexcept = 0;
+  virtual multiplexer* mpx_ptr() const noexcept = 0;
 
   /// Queries whether the manager is registered for reading.
   virtual bool is_reading() const noexcept = 0;

--- a/libcaf_net/caf/net/socket_manager.hpp
+++ b/libcaf_net/caf/net/socket_manager.hpp
@@ -44,17 +44,17 @@ public:
   /// Returns the handle for the managed socket.
   virtual socket handle() const = 0;
 
-  /// @private
-  virtual void handle(socket new_handle) = 0;
-
-  /// Returns a reference to the hosting @ref actor_system instance.
-  virtual actor_system& system() noexcept = 0;
+  /// Returns the owning @ref multiplexer instance.
+  multiplexer& mpx() {
+    CAF_ASSERT(mpx_ptr());
+    return *mpx_ptr();
+  }
 
   /// Returns the owning @ref multiplexer instance.
-  virtual multiplexer& mpx() noexcept = 0;
-
-  /// Returns the owning @ref multiplexer instance.
-  virtual const multiplexer& mpx() const noexcept = 0;
+  const multiplexer& mpx() const {
+    CAF_ASSERT(mpx_ptr());
+    return *mpx_ptr();
+  }
 
   /// Returns a pointer to the owning @ref multiplexer instance.
   virtual multiplexer* mpx_ptr() noexcept = 0;


### PR DESCRIPTION
After giving the `socket_manager` another look, one of the `handle` functions wasn't used. We can also inline some functions to make it simpler. 