### PR TITLE
Remove logger factory from the config class

### DIFF
--- a/libcaf_core/caf/actor_system.cpp
+++ b/libcaf_core/caf/actor_system.cpp
@@ -436,7 +436,7 @@ public:
     }
     // Initialize the logger before any other module.
     if (!logger) {
-      logger = cfg.make_logger(*parent);
+      logger = logger::make(*parent);
       logger->init(cfg);
       CAF_SET_LOGGER_SYS(parent);
     }

--- a/libcaf_core/caf/actor_system_config.cpp
+++ b/libcaf_core/caf/actor_system_config.cpp
@@ -14,7 +14,6 @@
 #include "caf/detail/parser/read_config.hpp"
 #include "caf/detail/parser/read_string.hpp"
 #include "caf/format_to_error.hpp"
-#include "caf/logger.hpp"
 #include "caf/message_builder.hpp"
 #include "caf/pec.hpp"
 #include "caf/sec.hpp"
@@ -84,7 +83,6 @@ constexpr const char* default_config_file = "caf-application.conf";
 
 struct actor_system_config::fields {
   std::vector<std::string> paths;
-  std::unique_ptr<logger_factory_t> logger_factory;
   module_factory_list module_factories;
   actor_factory_dictionary actor_factories;
   thread_hook_list thread_hooks;
@@ -601,19 +599,6 @@ void actor_system_config::print_content() const {
   config_printer printer;
   printer(dump_content());
   std::cout << std::endl;
-}
-
-// -- logger factories ---------------------------------------------------------
-
-void actor_system_config::set_logger_factory(
-  std::unique_ptr<logger_factory_t> ptr) {
-  fields_->logger_factory = std::move(ptr);
-}
-
-intrusive_ptr<logger> actor_system_config::make_logger(actor_system& sys) {
-  if (auto& fn = fields_->logger_factory)
-    return (*fn)(sys);
-  return logger::make(sys);
 }
 
 // -- module factories ---------------------------------------------------------

--- a/libcaf_core/caf/actor_system_config.hpp
+++ b/libcaf_core/caf/actor_system_config.hpp
@@ -125,18 +125,6 @@ public:
     return *this;
   }
 
-  /// Overrides the default logger factory.
-  /// @pre `new_factory != nullptr`
-  template <class Factory>
-  actor_system_config& logger_factory(Factory new_factory) {
-    static_assert(
-      std::is_invocable_r_v<intrusive_ptr<logger>, Factory&, actor_system&>,
-      "Factory must have signature `intrusive_ptr<logger>(actor_system&)`");
-    using impl_t = callback_impl<Factory, intrusive_ptr<logger>(actor_system&)>;
-    set_logger_factory(std::make_unique<impl_t>(std::move(new_factory)));
-    return *this;
-  }
-
   // -- parser and CLI state ---------------------------------------------------
 
   /// Returns whether the help text was printed. If this function return `true`,
@@ -236,14 +224,6 @@ protected:
   config_option_set custom_options_;
 
 private:
-  // -- logger factories -------------------------------------------------------
-
-  using logger_factory_t = callback<intrusive_ptr<logger>(actor_system&)>;
-
-  void set_logger_factory(std::unique_ptr<logger_factory_t> ptr);
-
-  intrusive_ptr<logger> make_logger(actor_system& sys);
-
   // -- module factories -------------------------------------------------------
 
   using module_factory_fn = actor_system_module* (*) (actor_system&);


### PR DESCRIPTION
The logger is a central component of the actor system. Allowing users to override this component should be carefully considered. For now, we should rather play it safe and not introduce a major feature by accident that will make it hard to change central interfaces such as the logger or the scheduler later on.