### PR TITLE
Add version header and ABI version token

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,36 @@
 cmake_minimum_required(VERSION 3.13..3.27 FATAL_ERROR)
-project(CAF CXX)
+project(CAF VERSION 1.0.0 LANGUAGES CXX)
+
+# -- version boilerplate -------------------------------------------------------
+
+# Individual components of the version number.
+set(CAF_VERSION_MAJOR ${PROJECT_VERSION_MAJOR}
+    CACHE INTERNAL "The major version of CAF" FORCE)
+set(CAF_VERSION_MINOR ${PROJECT_VERSION_MINOR}
+    CACHE INTERNAL "The minor version of CAF" FORCE)
+set(CAF_VERSION_PATCH ${PROJECT_VERSION_PATCH}
+    CACHE INTERNAL "The patch version of CAF" FORCE)
+
+# The full version number as human-readable string.
+set(CAF_VERSION "${CAF_VERSION_MAJOR}.${CAF_VERSION_MINOR}.${CAF_VERSION_PATCH}"
+    CACHE INTERNAL "The full CAF version string" FORCE)
+
+# The full version number as integer.
+if(CAF_VERSION_MAJOR LESS 1)
+  set(CAF_VERSION_INT ${CAF_VERSION_MAJOR})
+else()
+  set(CAF_VERSION_INT "")
+endif()
+if(CAF_VERSION_MINOR LESS 10)
+  set(CAF_VERSION_INT ${CAF_VERSION_INT}0${CAF_VERSION_MINOR})
+else()
+  set(CAF_VERSION_INT ${CAF_VERSION_INT}${CAF_VERSION_MINOR})
+endif()
+if(CAF_VERSION_PATCH LESS 10)
+  set(CAF_VERSION_INT ${CAF_VERSION_INT}0${CAF_VERSION_PATCH})
+else()
+  set(CAF_VERSION_INT ${CAF_VERSION_INT}${CAF_VERSION_PATCH})
+endif()
 
 # -- includes ------------------------------------------------------------------
 
@@ -154,28 +185,6 @@ add_library(CAF::internal ALIAS caf_internal)
 
 install(TARGETS caf_internal EXPORT CAFTargets)
 
-# -- get CAF version -----------------------------------------------------------
-
-# Get line containing the version from config.hpp and extract version number.
-file(READ "libcaf_core/caf/config.hpp" CAF_CONFIG_HPP)
-string(REGEX MATCH "#define CAF_VERSION [0-9]+" CAF_VERSION_LINE "${CAF_CONFIG_HPP}")
-string(REGEX MATCH "[0-9]+" CAF_VERSION_INT "${CAF_VERSION_LINE}")
-# Calculate major, minor, and patch version.
-math(EXPR CAF_VERSION_MAJOR "${CAF_VERSION_INT} / 10000")
-math(EXPR CAF_VERSION_MINOR "( ${CAF_VERSION_INT} / 100) % 100")
-math(EXPR CAF_VERSION_PATCH "${CAF_VERSION_INT} % 100")
-# Create full version string.
-set(CAF_VERSION "${CAF_VERSION_MAJOR}.${CAF_VERSION_MINOR}.${CAF_VERSION_PATCH}"
-  CACHE INTERNAL "The full CAF version string")
-# Set the library version for our shared library targets.
-if(CMAKE_HOST_SYSTEM_NAME MATCHES "OpenBSD")
-  set(CAF_LIB_VERSION "${CAF_VERSION_MAJOR}.${CAF_VERSION_MINOR}"
-      CACHE INTERNAL "The version string used for shared library objects")
-else()
-  set(CAF_LIB_VERSION "${CAF_VERSION}"
-      CACHE INTERNAL "The version string used for shared library objects")
-endif()
-
 # -- create the libcaf_test target ahead of time for caf_core ------------------
 
 add_library(libcaf_test)
@@ -219,7 +228,7 @@ function(caf_export_and_install_lib component)
   set_target_properties(libcaf_${component} PROPERTIES
                         EXPORT_NAME ${component}
                         SOVERSION ${CAF_VERSION}
-                        VERSION ${CAF_LIB_VERSION}
+                        VERSION ${CAF_VERSION_MAJOR}
                         OUTPUT_NAME caf_${component})
   install(TARGETS libcaf_${component}
           EXPORT CAFTargets
@@ -442,7 +451,7 @@ install(EXPORT CAFTargets
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/CAFConfigVersion.cmake"
   VERSION ${CAF_VERSION}
-  COMPATIBILITY ExactVersion)
+  COMPATIBILITY SameMajorVersion)
 
 configure_package_config_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CAFConfig.cmake.in"

--- a/cmake/build_config.hpp.in
+++ b/cmake/build_config.hpp.in
@@ -6,6 +6,23 @@
 
 #define CAF_LOG_LEVEL CAF_LOG_LEVEL_@CAF_LOG_LEVEL@
 
+/// Denotes the version of CAF in the format {MAJOR}{MINOR}{PATCH}, whereas
+/// minor and patch versions use two-digit decimal numbers (but without leading
+/// zeros), e.g. 900 is version 0.9.0 and 10000 is version 1.0.0.
+#define CAF_VERSION @CAF_VERSION_INT@
+
+/// Denotes version of CAF as a string in the format "{MAJOR}.{MINOR}.{PATCH}".
+#define CAF_VERSION_STR "@CAF_VERSION@"
+
+/// Defined to the major version number of CAF.
+#define CAF_VERSION_MAJOR @CAF_VERSION_MAJOR@
+
+/// Defined to the minor version number of CAF.
+#define CAF_VERSION_MINOR @CAF_VERSION_MINOR@
+
+/// Defined to the patch version number of CAF.
+#define CAF_VERSION_PATCH @CAF_VERSION_PATCH@
+
 #cmakedefine CAF_ENABLE_RUNTIME_CHECKS
 
 #cmakedefine CAF_ENABLE_EXCEPTIONS
@@ -13,3 +30,8 @@
 #cmakedefine CAF_ENABLE_ACTOR_PROFILER
 
 #cmakedefine CAF_USE_STD_FORMAT
+
+// Backwards compatibility macros.
+#define CAF_MAJOR_VERSION @CAF_VERSION_MAJOR@
+#define CAF_MINOR_VERSION @CAF_VERSION_MINOR@
+#define CAF_PATCH_VERSION @CAF_VERSION_PATCH@

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -388,6 +388,8 @@ caf_add_component(
     caf/uri_builder.cpp
     caf/uuid.cpp
     caf/uuid.test.cpp
+    caf/version.cpp
+    caf/version.test.cpp
   LEGACY_TEST_SOURCES
     tests/legacy/core-test.cpp
   LEGACY_TEST_SUITES

--- a/libcaf_core/caf/actor_system.cpp
+++ b/libcaf_core/caf/actor_system.cpp
@@ -590,14 +590,18 @@ actor_system::networking_module::~networking_module() {
 
 namespace {} // namespace
 
-actor_system::actor_system(actor_system_config& cfg)
-  : actor_system(cfg, nullptr, nullptr) {
+actor_system::actor_system(actor_system_config& cfg, version::abi_token token)
+  : actor_system(cfg, nullptr, nullptr, token) {
   // nop
 }
 
 actor_system::actor_system(actor_system_config& cfg,
                            custom_setup_fn custom_setup,
-                           void* custom_setup_data) {
+                           void* custom_setup_data, version::abi_token token) {
+  // Make sure the ABI token matches the expected version.
+  if (static_cast<int>(token) != CAF_VERSION_MAJOR) {
+    CAF_CRITICAL("CAF ABI token mismatch");
+  }
   // This is a convoluted way to construct the implementation, but we cannot
   // just use new and delete here. The `custom_setup` function might call member
   // functions on this actor system when constructing `impl`, which requires us

--- a/libcaf_core/caf/actor_system.cpp
+++ b/libcaf_core/caf/actor_system.cpp
@@ -588,8 +588,6 @@ actor_system::networking_module::~networking_module() {
   // nop
 }
 
-namespace {} // namespace
-
 actor_system::actor_system(actor_system_config& cfg, version::abi_token token)
   : actor_system(cfg, nullptr, nullptr, token) {
   // nop

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -24,6 +24,7 @@
 #include "caf/string_algorithms.hpp"
 #include "caf/term.hpp"
 #include "caf/type_id.hpp"
+#include "caf/version.hpp"
 
 #include <cstddef>
 #include <memory>
@@ -208,7 +209,8 @@ public:
 
   /// @warning The system stores a reference to `cfg`, which means the
   ///          config object must outlive the actor system.
-  explicit actor_system(actor_system_config& cfg);
+  explicit actor_system(actor_system_config& cfg,
+                        version::abi_token = make_abi_token());
 
   virtual ~actor_system();
 
@@ -622,7 +624,7 @@ public:
   using custom_setup_fn = void (*)(actor_system&, actor_system_config&, void*);
 
   actor_system(actor_system_config& cfg, custom_setup_fn custom_setup,
-               void* custom_setup_data);
+               void* custom_setup_data, version::abi_token = make_abi_token());
 
   /// @endcond
 

--- a/libcaf_core/caf/actor_system_config.hpp
+++ b/libcaf_core/caf/actor_system_config.hpp
@@ -108,9 +108,10 @@ public:
     return add_actor_factory(std::move(name), make_actor_factory(std::move(f)));
   }
 
-  /// Loads module `T` with optional template parameters `Ts...`.
+  /// Loads module `T`.
   template <class T>
-  actor_system_config& load() {
+  actor_system_config& load(version::abi_token token = make_abi_token()) {
+    T::check_abi_compatibility(token);
     T::add_module_options(*this);
     add_module_factory([](actor_system& sys) -> actor_system_module* { //
       return T::make(sys);

--- a/libcaf_core/caf/config.hpp
+++ b/libcaf_core/caf/config.hpp
@@ -19,20 +19,6 @@
 //   - denotes the amount of logging, ranging from error messages only (0)
 //     to complete traces (4)
 
-/// Denotes version of CAF in the format {MAJOR}{MINOR}{PATCH},
-/// whereas each number is a two-digit decimal number without
-/// leading zeros (e.g. 900 is version 0.9.0).
-#define CAF_VERSION 1905
-
-/// Defined to the major version number of CAF.
-#define CAF_MAJOR_VERSION (CAF_VERSION / 10000)
-
-/// Defined to the minor version number of CAF.
-#define CAF_MINOR_VERSION ((CAF_VERSION / 100) % 100)
-
-/// Defined to the patch version number of CAF.
-#define CAF_PATCH_VERSION (CAF_VERSION % 100)
-
 // This compiler-specific block defines:
 // - CAF_PUSH_WARNINGS/CAF_POP_WARNINGS to surround "noisy" header includes
 // - CAF_COMPILER_VERSION to retrieve the compiler version in CAF_VERSION format

--- a/libcaf_core/caf/version.cpp
+++ b/libcaf_core/caf/version.cpp
@@ -26,10 +26,10 @@ const char* version::c_str() noexcept {
   return CAF_VERSION_STR;
 }
 
-inline namespace CAF_PP_PASTE(abi_, CAF_VERSION_MAJOR) {
+inline namespace CAF_ABI_NAMESPACE {
 version::abi_token make_abi_token() noexcept {
   return static_cast<version::abi_token>(CAF_VERSION_MAJOR);
 }
-} // namespace CAF_PP_PASTE(abi_,CAF_VERSION_MAJOR)
+} // namespace CAF_ABI_NAMESPACE
 
 } // namespace caf

--- a/libcaf_core/caf/version.cpp
+++ b/libcaf_core/caf/version.cpp
@@ -1,0 +1,35 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/version.hpp"
+
+namespace caf {
+
+int version::get_major() noexcept {
+  return CAF_VERSION_MAJOR;
+}
+
+int version::get_minor() noexcept {
+  return CAF_VERSION_MINOR;
+}
+
+int version::get_patch() noexcept {
+  return CAF_VERSION_PATCH;
+}
+
+std::string_view version::str() noexcept {
+  return CAF_VERSION_STR;
+}
+
+const char* version::c_str() noexcept {
+  return CAF_VERSION_STR;
+}
+
+inline namespace CAF_PP_PASTE(abi_, CAF_VERSION_MAJOR) {
+version::abi_token make_abi_token() noexcept {
+  return static_cast<version::abi_token>(CAF_VERSION_MAJOR);
+}
+} // namespace CAF_PP_PASTE(abi_,CAF_VERSION_MAJOR)
+
+} // namespace caf

--- a/libcaf_core/caf/version.hpp
+++ b/libcaf_core/caf/version.hpp
@@ -1,0 +1,42 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/config.hpp"
+#include "caf/detail/core_export.hpp"
+#include "caf/detail/pp.hpp"
+
+#include <string_view>
+
+namespace caf {
+
+/// Provides version information for CAF.
+class CAF_CORE_EXPORT version {
+public:
+  /// Returns the major version number of CAF.
+  static int get_major() noexcept;
+
+  /// Returns the minor version number of CAF.
+  static int get_minor() noexcept;
+
+  /// Returns the patch version number of CAF.
+  static int get_patch() noexcept;
+
+  /// Returns the full version number of CAF as human-readable string.
+  static std::string_view str() noexcept;
+
+  /// Returns the full version number of CAF as human-readable string.
+  static const char* c_str() noexcept;
+
+  /// An opaque token that represents the ABI version of CAF.
+  enum class abi_token {};
+};
+
+inline namespace CAF_PP_PASTE(abi_, CAF_VERSION_MAJOR) {
+/// Returns an token that represents the ABI version of CAF.
+CAF_CORE_EXPORT version::abi_token make_abi_token() noexcept;
+} // namespace CAF_PP_PASTE(abi_,CAF_VERSION_MAJOR)
+
+} // namespace caf

--- a/libcaf_core/caf/version.hpp
+++ b/libcaf_core/caf/version.hpp
@@ -10,6 +10,8 @@
 
 #include <string_view>
 
+#define CAF_ABI_NAMESPACE CAF_PP_PASTE(abi_, CAF_VERSION_MAJOR)
+
 namespace caf {
 
 /// Provides version information for CAF.
@@ -32,11 +34,15 @@ public:
 
   /// An opaque token that represents the ABI version of CAF.
   enum class abi_token {};
+
+  /// Checks whether the ABI token is compatible with the current version of
+  /// CAF. Otherwise, calls `abort`.
+  static void check_abi_compatibility(abi_token token) noexcept;
 };
 
-inline namespace CAF_PP_PASTE(abi_, CAF_VERSION_MAJOR) {
+inline namespace CAF_ABI_NAMESPACE {
 /// Returns an token that represents the ABI version of CAF.
 CAF_CORE_EXPORT version::abi_token make_abi_token() noexcept;
-} // namespace CAF_PP_PASTE(abi_,CAF_VERSION_MAJOR)
+} // namespace CAF_ABI_NAMESPACE
 
 } // namespace caf

--- a/libcaf_core/caf/version.test.cpp
+++ b/libcaf_core/caf/version.test.cpp
@@ -1,0 +1,26 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/version.hpp"
+
+#include "caf/test/test.hpp"
+
+#include "caf/detail/format.hpp"
+
+using namespace caf;
+
+namespace {
+
+TEST("version functions must return the values from the build configuration") {
+  check_eq(version::get_major(), CAF_VERSION_MAJOR);
+  check_eq(version::get_minor(), CAF_VERSION_MINOR);
+  check_eq(version::get_patch(), CAF_VERSION_PATCH);
+  auto vstr = detail::format("{}.{}.{}", CAF_VERSION_MAJOR, CAF_VERSION_MINOR,
+                             CAF_VERSION_PATCH);
+  check_eq(version::str(), vstr);
+  check_eq(version::c_str(), vstr);
+  check_eq(static_cast<int>(make_abi_token()), CAF_VERSION_MAJOR);
+}
+
+} // namespace

--- a/libcaf_io/caf/io/middleman.cpp
+++ b/libcaf_io/caf/io/middleman.cpp
@@ -215,6 +215,12 @@ actor_system_module* middleman::make(actor_system& sys) {
   return new mm_impl<network::default_multiplexer>(sys);
 }
 
+void middleman::check_abi_compatibility(version::abi_token token) {
+  if (static_cast<int>(token) != CAF_VERSION_MAJOR) {
+    CAF_CRITICAL("CAF ABI token mismatch");
+  }
+}
+
 middleman::middleman(actor_system& sys) : system_(sys) {
   metric_singletons = make_metrics(sys.metrics());
 }

--- a/libcaf_io/caf/io/middleman.hpp
+++ b/libcaf_io/caf/io/middleman.hpp
@@ -18,6 +18,7 @@
 #include "caf/node_id.hpp"
 #include "caf/send.hpp"
 #include "caf/timespan.hpp"
+#include "caf/version.hpp"
 
 #include <chrono>
 #include <list>
@@ -248,8 +249,12 @@ public:
   /// Adds module-specific options to the config before loading the module.
   static void add_module_options(actor_system_config& cfg);
 
-  /// Returns a middleman using the default network backend.
+  /// Creates a new middleman instance.
   static actor_system_module* make(actor_system&);
+
+  /// Checks whether ghe ABI of the middleman is compatible with the CAF core.
+  /// Otherwise, calls `abort`.
+  static void check_abi_compatibility(version::abi_token token);
 
   /// @private
   actor get_named_broker(const std::string& name) {

--- a/libcaf_io/caf/io/middleman.hpp
+++ b/libcaf_io/caf/io/middleman.hpp
@@ -252,7 +252,7 @@ public:
   /// Creates a new middleman instance.
   static actor_system_module* make(actor_system&);
 
-  /// Checks whether ghe ABI of the middleman is compatible with the CAF core.
+  /// Checks whether the ABI of the middleman is compatible with the CAF core.
   /// Otherwise, calls `abort`.
   static void check_abi_compatibility(version::abi_token token);
 

--- a/libcaf_net/caf/net/middleman.cpp
+++ b/libcaf_net/caf/net/middleman.cpp
@@ -140,10 +140,6 @@ void* middleman::subtype_ptr() {
   return this;
 }
 
-actor_system_module* middleman::make(actor_system& sys) {
-  return new middleman(sys);
-}
-
 void middleman::add_module_options(actor_system_config& cfg) {
   config_option_adder{cfg.custom_options(), "caf.net.prometheus-http"}
     .add<uint16_t>("port", "listening port for incoming scrapes")
@@ -151,6 +147,16 @@ void middleman::add_module_options(actor_system_config& cfg) {
   config_option_adder{cfg.custom_options(), "caf.net.prometheus-http.tls"}
     .add<std::string>("key-file", "path to the Promehteus private key file")
     .add<std::string>("cert-file", "path to the Promehteus private cert file");
+}
+
+actor_system_module* middleman::make(actor_system& sys) {
+  return new middleman(sys);
+}
+
+void middleman::check_abi_compatibility(version::abi_token token) {
+  if (static_cast<int>(token) != CAF_VERSION_MAJOR) {
+    CAF_CRITICAL("CAF ABI token mismatch");
+  }
 }
 
 } // namespace caf::net

--- a/libcaf_net/caf/net/middleman.hpp
+++ b/libcaf_net/caf/net/middleman.hpp
@@ -65,7 +65,7 @@ public:
   /// Creates a new middleman instance.
   static actor_system_module* make(actor_system& sys);
 
-  /// Checks whether ghe ABI of the middleman is compatible with the CAF core.
+  /// Checks whether the ABI of the middleman is compatible with the CAF core.
   /// Otherwise, calls `abort`.
   static void check_abi_compatibility(version::abi_token token);
 

--- a/libcaf_net/caf/net/middleman.hpp
+++ b/libcaf_net/caf/net/middleman.hpp
@@ -12,6 +12,7 @@
 #include "caf/detail/net_export.hpp"
 #include "caf/fwd.hpp"
 #include "caf/type_list.hpp"
+#include "caf/version.hpp"
 
 #include <thread>
 
@@ -58,10 +59,15 @@ public:
 
   // -- factory functions ------------------------------------------------------
 
-  static actor_system_module* make(actor_system& sys);
-
   /// Adds module-specific options to the config before loading the module.
   static void add_module_options(actor_system_config& cfg);
+
+  /// Creates a new middleman instance.
+  static actor_system_module* make(actor_system& sys);
+
+  /// Checks whether ghe ABI of the middleman is compatible with the CAF core.
+  /// Otherwise, calls `abort`.
+  static void check_abi_compatibility(version::abi_token token);
 
   // -- properties -------------------------------------------------------------
 

--- a/libcaf_openssl/caf/openssl/manager.cpp
+++ b/libcaf_openssl/caf/openssl/manager.cpp
@@ -173,6 +173,12 @@ actor_system_module* manager::make(actor_system& sys) {
   return new manager(sys);
 }
 
+void manager::check_abi_compatibility(version::abi_token token) {
+  if (static_cast<int>(token) != CAF_VERSION_MAJOR) {
+    CAF_CRITICAL("CAF ABI token mismatch");
+  }
+}
+
 void manager::init_global_meta_objects() {
   // nop
 }

--- a/libcaf_openssl/caf/openssl/manager.hpp
+++ b/libcaf_openssl/caf/openssl/manager.hpp
@@ -60,7 +60,7 @@ public:
   ///         default network backend.
   static actor_system_module* make(actor_system&);
 
-  /// Checks whether ghe ABI of the middleman is compatible with the CAF core.
+  /// Checks whether the ABI of the middleman is compatible with the CAF core.
   /// Otherwise, calls `abort`.
   static void check_abi_compatibility(version::abi_token token);
 

--- a/libcaf_openssl/caf/openssl/manager.hpp
+++ b/libcaf_openssl/caf/openssl/manager.hpp
@@ -8,6 +8,7 @@
 
 #include "caf/actor_system.hpp"
 #include "caf/detail/openssl_export.hpp"
+#include "caf/version.hpp"
 
 #include <set>
 #include <string>
@@ -58,6 +59,10 @@ public:
   /// @throws `logic_error` if the middleman is not loaded or is not using the
   ///         default network backend.
   static actor_system_module* make(actor_system&);
+
+  /// Checks whether ghe ABI of the middleman is compatible with the CAF core.
+  /// Otherwise, calls `abort`.
+  static void check_abi_compatibility(version::abi_token token);
 
   /// Adds message types of the OpenSSL module to the global meta object table.
   static void init_global_meta_objects();


### PR DESCRIPTION
Relates #1254.

- shift the version information to CMake
- auto-generate CAF's version macros from CMake
- add a new version.hpp header to get versions from CAF at run-time
- add an ABI token to the `actor_system` constructor

The latter will force a call to `caf::version::make_abi_token()` for all instances where a user constructs an actor system. Since probably every CAF application (at least 99.999%) will construct an actor system at some point, this injects a call to `make_abi_token` into client code. The function lives in an inline namespace that will change with each major release. Hence, an application will fail to load a CAF library with the wrong ABI version. Additionally, the actor system also checks the value of the ABI token at run-time as an additional safeguard.

The new set of version functions in the namespace `caf::version` allows users to detect at run-time what version of CAF they have loaded. Users can also obtain the CAF version as a string now.

@riemass I thought about the inline namespaces a bit more. Introducing something like `caf::v1` is quite intrusive and would force us to use macros to open up the namespaces. So it would spread through the entire code base. This approach is much less intrusive. We only use an inline namespace in one place and basically make sure that CAF application will have to call this ABI-versioned function (by sneaking the call into client code when constructing an `actor_system`). That way, I think we still get the ABI "version check" to make sure applications can't accidentally load an incompatible CAF version. The only TODO item for this would be to add the ABI token calls when loading modules. Let me know what you think about this approach.