### PR TITLE
Fix sphinx build for the manual

### DIFF
--- a/manual/conf.py
+++ b/manual/conf.py
@@ -27,27 +27,24 @@ conf_dir = pathlib.Path(__file__).parent.absolute()
 root_dir = conf_dir.parent.absolute()
 
 # Fetch the CAF version.
-with open(os.path.join(root_dir, "libcaf_core/caf/config.hpp")) as f:
-    match = re.search('^#define CAF_VERSION ([0-9]+)$', f.read(), re.MULTILINE)
+with open(os.path.join(root_dir, "CMakeLists.txt")) as f:
+    match = re.search('^project.CAF VERSION ([0-9.]+) ', f.read(), re.MULTILINE)
     if match is None:
-        raise RuntimeError("unable to locate CAF_VERSION string in config.hpp")
-    raw_version = int(match.group(1))
-    major = int(raw_version / 10000)
-    minor = int(raw_version / 100) % 100
-    patch = raw_version % 100
-    version = '{}.{}.{}'.format(major, minor, patch)
+        raise RuntimeError("unable to locate CAF version string in CMakeLists.txt")
+    version = match.group(1)
 
 # We're building a stable release if the last commit message is
 # "Change version to <version>".
 repo = git.Repo(root_dir)
-is_stable = False
 
 # We're building a stable release if this version has a release date.
-with open(os.path.join(root_dir, "CHANGELOG.md")) as f:
-    match = re.search('^## \[' + version + '\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$',
-                      f.read(), re.MULTILINE)
-    if match != None:
-        is_stable = True
+def has_release_date():
+    with open(os.path.join(root_dir, "CHANGELOG.md")) as f:
+        for line in f:
+            if line.startswith("## [" + version + "]"):
+                return True
+    return False
+is_stable = has_release_date()
 
 # Generate the full version, including alpha/beta/rc tags. For stable releases,
 # this is always the same as the CAF version.


### PR DESCRIPTION
I broke the manual build recently when moving the version information out of `config.hpp`.