### PR TITLE
Add tests to improve coverage

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -220,6 +220,7 @@ caf_add_component(
     caf/event_based_actor.cpp
     caf/event_based_actor.test.cpp
     caf/event_based_mail.test.cpp
+    caf/exit_reason.test.cpp
     caf/expected.test.cpp
     caf/flow/byte.test.cpp
     caf/flow/concat_map.test.cpp
@@ -265,6 +266,7 @@ caf_add_component(
     caf/hash/sha1.cpp
     caf/hash/sha1.test.cpp
     caf/init_global_meta_objects.cpp
+    caf/inspector_access_type.test.cpp
     caf/intrusive/lifo_inbox.test.cpp
     caf/intrusive/linked_list.test.cpp
     caf/intrusive/stack.test.cpp
@@ -308,6 +310,7 @@ caf_add_component(
     caf/message_builder.cpp
     caf/message_builder.test.cpp
     caf/message_handler.cpp
+    caf/message_handler.test.cpp
     caf/message_id.test.cpp
     caf/message_lifetime.test.cpp
     caf/messaging.test.cpp
@@ -318,8 +321,10 @@ caf_add_component(
     caf/mtl.test.cpp
     caf/node_id.cpp
     caf/node_id.test.cpp
+    caf/none.test.cpp
     caf/or_else.test.cpp
     caf/parser_state.cpp
+    caf/pec.test.cpp
     caf/policy/select_all.test.cpp
     caf/policy/select_any.test.cpp
     caf/proxy_registry.cpp
@@ -343,6 +348,7 @@ caf_add_component(
     caf/serial_reply.test.cpp
     caf/serialization.test.cpp
     caf/serializer.cpp
+    caf/serializer.test.cpp
     caf/settings.cpp
     caf/settings.test.cpp
     caf/skip.cpp

--- a/libcaf_core/caf/action.test.cpp
+++ b/libcaf_core/caf/action.test.cpp
@@ -110,6 +110,26 @@ SCENARIO("actions wrap function calls") {
   }
 }
 
+SCENARIO("actions can increase and decrease reference count") {
+  GIVEN("an action with default_action_impl") {
+    WHEN("ref or deref is called") {
+      THEN("reference count is updated") {
+        auto fn = [] {};
+        using impl_t = detail::default_action_impl<decltype(fn), true>;
+        auto uut = action{make_counted<impl_t>(std::move(fn))};
+        check_eq(uut.as_intrusive_ptr()->subtype(),
+                 resumable::subtype_t::function_object);
+        auto impl_ptr = dynamic_cast<impl_t*>(uut.as_intrusive_ptr().get());
+        check(impl_ptr->unique());
+        impl_ptr->ref_resumable();
+        check(!impl_ptr->unique());
+        impl_ptr->deref_resumable();
+        check(impl_ptr->unique());
+      }
+    }
+  }
+}
+
 WITH_FIXTURE(test::fixture::deterministic) {
 
 SCENARIO("actors run actions that they receive") {

--- a/libcaf_core/caf/behavior.test.cpp
+++ b/libcaf_core/caf/behavior.test.cpp
@@ -7,6 +7,7 @@
 #include "caf/test/test.hpp"
 
 #include "caf/cow_string.hpp"
+#include "caf/message_handler.hpp"
 
 using namespace caf;
 using namespace std::literals;
@@ -249,6 +250,35 @@ TEST("message handlers with const arguments never force a detach or copy") {
     f(msg_copy);
     check_eq(msg_copy.cptr(), msg.cptr());
     check(called);
+  }
+}
+
+TEST("behaviors may be assigned after construction") {
+  auto f = behavior{
+    [](int x) { return x + 1; },
+  };
+  SECTION("assigned with another behavior") {
+    auto g = behavior{
+      [](int x) { return x + 2; },
+    };
+    f.assign(g);
+    check_eq(res_of(f, m1), 3);
+    check_eq(res_of(f, m2), std::nullopt);
+    check_eq(res_of(f, m3), std::nullopt);
+    check_eq(res_of(g, m1), 3);
+    check_eq(res_of(g, m2), std::nullopt);
+    check_eq(res_of(g, m3), std::nullopt);
+  }
+  SECTION("assigned with another message_handler") {
+    auto g = [] {
+      return message_handler{
+        [](int x) { return x + 2; },
+      };
+    };
+    f.assign(g());
+    check_eq(res_of(f, m1), 3);
+    check_eq(res_of(f, m2), std::nullopt);
+    check_eq(res_of(f, m3), std::nullopt);
   }
 }
 

--- a/libcaf_core/caf/config_option.test.cpp
+++ b/libcaf_core/caf/config_option.test.cpp
@@ -149,4 +149,17 @@ TEST("config options with storage sync their value with the storage") {
   }
 }
 
+TEST("negated config options") {
+  auto negated_value = false;
+  auto true_option = config_value{true};
+  const auto negated_option = make_negated_config_option(negated_value, "foo",
+                                                         "bar", "baz");
+  check(negated_option.is_flag());
+  check_eq(negated_option.type_name(), "bool");
+  check_eq(negated_option.category(), "foo");
+  check_eq(negated_option.long_name(), "bar");
+  check_eq(negated_option.short_names(), "");
+  check_eq(negated_option.sync(true_option), error{});
+}
+
 } // namespace

--- a/libcaf_core/caf/exit_reason.test.cpp
+++ b/libcaf_core/caf/exit_reason.test.cpp
@@ -1,0 +1,55 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/exit_reason.hpp"
+
+#include "caf/test/test.hpp"
+
+#include "caf/actor_system.hpp"
+#include "caf/actor_system_config.hpp"
+#include "caf/binary_deserializer.hpp"
+#include "caf/binary_serializer.hpp"
+
+using namespace caf;
+
+namespace {
+
+struct fixture {
+  actor_system_config cfg;
+  actor_system sys{cfg};
+
+  template <class T>
+  T roundtrip(T x) {
+    byte_buffer buf;
+    binary_serializer sink(sys, buf);
+    if (!sink.apply(x))
+      test::runnable::current().fail("serialization failed: {}",
+                                     sink.get_error());
+    binary_deserializer source(sys, make_span(buf));
+    T y;
+    if (!source.apply(y))
+      test::runnable::current().fail("deserialization failed: {}",
+                                     source.get_error());
+    return y;
+  }
+};
+
+#define CHECK_SERIALIZATION(error_code)                                        \
+  check_eq(error_code, roundtrip(error_code))
+
+WITH_FIXTURE(fixture) {
+
+TEST("exit_reason values are serializable") {
+  CHECK_SERIALIZATION(exit_reason::kill);
+  CHECK_SERIALIZATION(exit_reason::normal);
+  CHECK_SERIALIZATION(exit_reason::out_of_workers);
+  CHECK_SERIALIZATION(exit_reason::remote_link_unreachable);
+  CHECK_SERIALIZATION(exit_reason::unreachable);
+  CHECK_SERIALIZATION(exit_reason::unknown);
+  CHECK_SERIALIZATION(exit_reason::user_shutdown);
+}
+
+} // WITH_FIXTURE(fixture)
+
+} // namespace

--- a/libcaf_core/caf/inspector_access_type.hpp
+++ b/libcaf_core/caf/inspector_access_type.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "caf/allowed_unsafe_message_type.hpp"
 #include "caf/detail/is_complete.hpp"
 #include "caf/detail/type_traits.hpp"
 #include "caf/fwd.hpp"

--- a/libcaf_core/caf/inspector_access_type.test.cpp
+++ b/libcaf_core/caf/inspector_access_type.test.cpp
@@ -1,0 +1,61 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/inspector_access_type.hpp"
+
+#include "caf/test/test.hpp"
+
+#include "caf/action.hpp"
+#include "caf/binary_serializer.hpp"
+#include "caf/inspector_access_base.hpp"
+
+#include <vector>
+
+using namespace caf;
+using namespace std::literals;
+
+namespace {
+
+TEST("inspect_access_type") {
+  check(
+    std::is_same_v<decltype(inspect_access_type<caf::binary_serializer, int>()),
+                   inspector_access_type::builtin>);
+  check(std::is_same_v<decltype(inspect_access_type<caf::binary_serializer,
+                                                    std::array<int, 5>>()),
+                       inspector_access_type::tuple>);
+  check(std::is_same_v<decltype(inspect_access_type<caf::binary_serializer,
+                                                    std::optional<int>>()),
+                       inspector_access_type::specialization>);
+  check(
+    std::is_same_v<
+      decltype(inspect_access_type<caf::binary_serializer, std::vector<int>>()),
+      inspector_access_type::list>);
+  check(std::is_same_v<decltype(inspect_access_type<caf::binary_serializer,
+                                                    std::map<int, int>>()),
+                       inspector_access_type::map>);
+  check(std::is_same_v<
+        decltype(inspect_access_type<caf::binary_serializer, int*>()),
+        inspector_access_type::none>);
+  check(std::is_same_v<
+        decltype(inspect_access_type<caf::binary_serializer, int[]>()),
+        inspector_access_type::tuple>);
+  check(std::is_same_v<
+        decltype(inspect_access_type<caf::binary_serializer, std::string>()),
+        inspector_access_type::builtin>);
+  check(std::is_same_v<
+        decltype(inspect_access_type<caf::binary_serializer, int const[]>()),
+        inspector_access_type::tuple>);
+  check(
+    std::is_same_v<
+      decltype(inspect_access_type<caf::binary_serializer, std::false_type>()),
+      inspector_access_type::empty>);
+  check(std::is_same_v<
+        decltype(inspect_access_type<caf::binary_serializer, error>()),
+        inspector_access_type::inspect>);
+  check(std::is_same_v<
+        decltype(inspect_access_type<caf::binary_serializer, action>()),
+        inspector_access_type::unsafe>);
+}
+
+} // namespace

--- a/libcaf_core/caf/ipv6_subnet.test.cpp
+++ b/libcaf_core/caf/ipv6_subnet.test.cpp
@@ -34,6 +34,18 @@ TEST("contains") {
   auto local = ipv6_address{{0xbebe, 0xbebe}, {}} / 32;
   check(local.contains(ipv6_address({0xbebe, 0xbebe, 0xbebe}, {})));
   check(!local.contains(ipv6_address({0xbebe, 0xbebf}, {})));
+  check(local.contains(
+    ipv6_subnet(ipv6_address({0xbebe, 0xbebe, 0xbebe}, {}), 64)));
+  check(local.contains(
+    ipv6_subnet(ipv6_address({0xbebe, 0xbebe, 0xbebe}, {}), 32)));
+  check(!local.contains(ipv6_subnet(ipv6_address({0xbebe, 0xbebe}, {}), 16)));
+  auto local_embed_v4 = ipv6_subnet{make_ipv4_address(127, 0, 0, 1), 8};
+  check(local_embed_v4.contains(make_ipv4_address(127, 127, 127, 1)));
+  check(!local_embed_v4.contains(make_ipv4_address(128, 0, 0, 1)));
+  check(local_embed_v4.contains(
+    ipv4_subnet{make_ipv4_address(127, 127, 0, 1), 16}));
+  check(!local_embed_v4.contains(
+    ipv4_subnet{make_ipv4_address(128, 127, 0, 1), 16}));
 }
 
 TEST("embedding") {
@@ -41,6 +53,14 @@ TEST("embedding") {
   ipv6_subnet local{v4_local};
   check(local.embeds_v4());
   check_eq(local.prefix_length(), 104u);
+}
+
+TEST("serializing") {
+  auto local = ipv6_address{{0xbebe, 0xbebe}, {}} / 32;
+  check_eq(to_string(local), "bebe:bebe::/32");
+  ipv4_subnet v4_local{make_ipv4_address(127, 0, 0, 1), 8};
+  ipv6_subnet local_embed_v4{v4_local};
+  check_eq(to_string(local_embed_v4), "127.0.0.0/8");
 }
 
 } // namespace

--- a/libcaf_core/caf/message_handler.test.cpp
+++ b/libcaf_core/caf/message_handler.test.cpp
@@ -1,0 +1,52 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/test/fixture/deterministic.hpp"
+#include "caf/test/test.hpp"
+
+#include "caf/actor_system.hpp"
+#include "caf/actor_system_config.hpp"
+#include "caf/event_based_actor.hpp"
+#include "caf/response_handle.hpp"
+#include "caf/scoped_actor.hpp"
+
+using namespace caf;
+using namespace std::literals;
+
+namespace {
+
+message_handler handle_a() {
+  return {
+    [](int) { return "a"; },
+  };
+}
+
+message_handler handle_b() {
+  return {
+    [](int) { return "b"; },
+  };
+}
+
+WITH_FIXTURE(test::fixture::deterministic) {
+
+TEST("message handler may be assigned") {
+  scoped_actor self{sys};
+  auto received = std::make_shared<bool>(false);
+  auto handler = handle_a();
+  handler.assign(handle_b());
+  auto testee = sys.spawn([=]() { return handler; });
+  self->mail(int{1}).send(testee);
+  dispatch_messages();
+  self->receive([this, received](const std::string& str) {
+    *received = true;
+    check_eq(str, "b");
+  });
+  self->send_exit(testee, exit_reason::user_shutdown);
+  dispatch_messages();
+  require(*received);
+}
+
+} // WITH_FIXTURE(test::fixture::deterministic)
+
+} // namespace

--- a/libcaf_core/caf/none.test.cpp
+++ b/libcaf_core/caf/none.test.cpp
@@ -1,0 +1,27 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/none.hpp"
+
+#include "caf/test/test.hpp"
+
+#include "caf/actor_system.hpp"
+#include "caf/actor_system_config.hpp"
+#include "caf/binary_deserializer.hpp"
+#include "caf/binary_serializer.hpp"
+
+using namespace caf;
+
+namespace {
+
+TEST("none is serializable") {
+  check_eq(to_string(none), "none");
+}
+
+TEST("none is comparable") {
+  check(!none);
+  check_eq(none.compare(none), 0);
+}
+
+} // namespace

--- a/libcaf_core/caf/pec.test.cpp
+++ b/libcaf_core/caf/pec.test.cpp
@@ -1,0 +1,71 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/pec.hpp"
+
+#include "caf/test/test.hpp"
+
+#include "caf/actor_system.hpp"
+#include "caf/actor_system_config.hpp"
+#include "caf/binary_deserializer.hpp"
+#include "caf/binary_serializer.hpp"
+
+using namespace caf;
+
+namespace {
+
+struct fixture {
+  actor_system_config cfg;
+  actor_system sys{cfg};
+
+  template <class T>
+  T roundtrip(T x) {
+    byte_buffer buf;
+    binary_serializer sink(sys, buf);
+    if (!sink.apply(x))
+      test::runnable::current().fail("serialization failed: {}",
+                                     sink.get_error());
+    binary_deserializer source(sys, make_span(buf));
+    T y;
+    if (!source.apply(y))
+      test::runnable::current().fail("deserialization failed: {}",
+                                     source.get_error());
+    return y;
+  }
+};
+
+#define CHECK_SERIALIZATION(error_code)                                        \
+  check_eq(error_code, roundtrip(error_code))
+
+WITH_FIXTURE(fixture) {
+
+TEST("pec values are serializable") {
+  CHECK_SERIALIZATION(pec::exponent_overflow);
+  CHECK_SERIALIZATION(pec::exponent_underflow);
+  CHECK_SERIALIZATION(pec::fractional_timespan);
+  CHECK_SERIALIZATION(pec::integer_overflow);
+  CHECK_SERIALIZATION(pec::integer_underflow);
+  CHECK_SERIALIZATION(pec::invalid_argument);
+  CHECK_SERIALIZATION(pec::invalid_category);
+  CHECK_SERIALIZATION(pec::invalid_escape_sequence);
+  CHECK_SERIALIZATION(pec::invalid_field_name);
+  CHECK_SERIALIZATION(pec::invalid_range_expression);
+  CHECK_SERIALIZATION(pec::invalid_state);
+  CHECK_SERIALIZATION(pec::missing_argument);
+  CHECK_SERIALIZATION(pec::missing_field);
+  CHECK_SERIALIZATION(pec::nested_too_deeply);
+  CHECK_SERIALIZATION(pec::not_an_option);
+  CHECK_SERIALIZATION(pec::repeated_field_name);
+  CHECK_SERIALIZATION(pec::success);
+  CHECK_SERIALIZATION(pec::type_mismatch);
+  CHECK_SERIALIZATION(pec::trailing_character);
+  CHECK_SERIALIZATION(pec::too_many_characters);
+  CHECK_SERIALIZATION(pec::unexpected_character);
+  CHECK_SERIALIZATION(pec::unexpected_eof);
+  CHECK_SERIALIZATION(pec::unexpected_newline);
+}
+
+} // WITH_FIXTURE(fixture)
+
+} // namespace

--- a/libcaf_core/caf/serializer.test.cpp
+++ b/libcaf_core/caf/serializer.test.cpp
@@ -1,0 +1,172 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/serializer.hpp"
+
+#include "caf/test/test.hpp"
+
+#include "caf/actor_system.hpp"
+#include "caf/actor_system_config.hpp"
+
+#include <vector>
+
+using namespace caf;
+
+namespace {
+
+class test_serializer : public serializer {
+  // -- constructors, destructors, and assignment operators --------------------
+public:
+  using super = serializer;
+
+  test_serializer(actor_system& sys, bool state) : super(sys), state_(state) {
+    // nop
+  }
+
+  ~test_serializer() override {
+    // nop
+  }
+
+  // -- interface functions ----------------------------------------------------
+
+  bool begin_object(type_id_t, std::string_view) override {
+    return state_;
+  };
+
+  bool end_object() override {
+    return state_;
+  };
+
+  bool begin_field(std::string_view) override {
+    return state_;
+  };
+
+  bool begin_field(std::string_view, bool) override {
+    return state_;
+  };
+
+  bool begin_field(std::string_view, span<const type_id_t>, size_t) override {
+    return state_;
+  };
+
+  bool begin_field(std::string_view, bool, span<const type_id_t>,
+                   size_t) override {
+    return state_;
+  };
+
+  bool end_field() override {
+    return state_;
+  };
+
+  bool begin_tuple(size_t) override {
+    return state_;
+  };
+
+  bool end_tuple() override {
+    return state_;
+  };
+
+  bool begin_sequence(size_t size) override {
+    return size % 2 == 0;
+  };
+
+  bool end_sequence() override {
+    return state_;
+  };
+
+  bool value(std::byte) override {
+    return state_;
+  };
+
+  bool value(bool) override {
+    return state_;
+  };
+
+  bool value(int8_t) override {
+    return state_;
+  };
+
+  bool value(uint8_t) override {
+    return state_;
+  };
+
+  bool value(int16_t) override {
+    return state_;
+  };
+
+  bool value(uint16_t) override {
+    return state_;
+  };
+
+  bool value(int32_t) override {
+    return state_;
+  };
+
+  bool value(uint32_t) override {
+    return state_;
+  };
+
+  bool value(int64_t) override {
+    return state_;
+  };
+
+  bool value(uint64_t) override {
+    return state_;
+  };
+
+  bool value(float) override {
+    return state_;
+  };
+
+  bool value(double) override {
+    return state_;
+  };
+
+  bool value(long double) override {
+    return state_;
+  };
+
+  bool value(std::string_view) override {
+    return state_;
+  };
+
+  bool value(const std::u16string&) override {
+    return state_;
+  };
+
+  bool value(const std::u32string&) override {
+    return state_;
+  };
+
+  bool value(span<const std::byte>) override {
+    return state_;
+  };
+
+private:
+  bool state_ = false;
+};
+
+TEST("base serializer") {
+  auto cfg = actor_system_config{};
+  auto sys = actor_system{cfg};
+  SECTION("failing serializer") {
+    auto serializer = test_serializer{sys, false};
+    check(!serializer.begin_associative_array(3));
+    check(!serializer.end_associative_array());
+    check(!serializer.begin_key_value_pair());
+    check(!serializer.end_key_value_pair());
+    check(!serializer.list(std::vector<bool>{true, false}));
+  }
+  SECTION("successful serializer") {
+    auto serializer = test_serializer{sys, true};
+    check(serializer.begin_associative_array(4));
+    check(serializer.end_associative_array());
+    check(serializer.begin_key_value_pair());
+    check(serializer.end_key_value_pair());
+    check(!serializer.list(std::vector<bool>{true, false, true}));
+    check(serializer.list(std::vector<bool>{true, false}));
+  }
+}
+
+} // namespace

--- a/libcaf_core/caf/stream.test.cpp
+++ b/libcaf_core/caf/stream.test.cpp
@@ -49,6 +49,20 @@ TEST("default-constructed streams are invalid") {
   check_eq(uut, serialization_roundtrip(uut));
 }
 
+TEST("streams are comparable") {
+  auto dummy = sys.spawn([] { return behavior{[](int) {}}; });
+  auto dummy_guard = make_actor_scope_guard(dummy);
+  auto uut = stream{actor_cast<strong_actor_ptr>(dummy), type_id_v<int32_t>,
+                    "foo", 42};
+  check_eq(uut.compare(uut), 0);
+  auto uut2 = stream{actor_cast<strong_actor_ptr>(dummy), type_id_v<int32_t>,
+                     "foo", 43};
+  check_eq(uut.compare(uut2), -1);
+  auto uut3 = stream{actor_cast<strong_actor_ptr>(dummy), type_id_v<int32_t>,
+                     "foo", 41};
+  check_eq(uut.compare(uut3), 1);
+}
+
 TEST("streams are serializable") {
   auto dummy = sys.spawn([] { return behavior{[](int) {}}; });
   // Note: we need to terminate the dummy actor manually because the registry


### PR DESCRIPTION
Tests have been added for the following files to increase coverage

- config_option_set.cpp
- ipv6_subnet.cpp
- message_handler.cpp
- pec.hpp
- make_config_option.cpp
- inspector_access_type.hpp
- exit_reason.hpp
- action.cpp
- behavior.cpp
- stream.cpp
- serializer.cpp
- none.hpp
- message_handler.cpp