### PR TITLE
Refactor print statements in examples

### DIFF
--- a/examples/config/read-json.cpp
+++ b/examples/config/read-json.cpp
@@ -7,7 +7,6 @@
 #include "caf/type_id.hpp"
 
 #include <fstream>
-#include <iostream>
 #include <string>
 #include <string_view>
 
@@ -49,34 +48,31 @@ int caf_main(caf::actor_system& sys) {
   auto& cfg = sys.config();
   auto remainder = cfg.remainder();
   if (remainder.size() != 1) {
-    std::cerr
-      << "*** expected one positional argument: path to a JSON file\n"
-      << "\n\nNote: expected a JSON list of user objects. For example:\n"
-      << example_input << '\n';
+    sys.println(
+      "*** expected one positional argument: path to a JSON file\n\n\nNote: "
+      "expected a JSON list of user objects. For example:\n{}",
+      example_input);
     return EXIT_FAILURE;
   }
   auto& file_path = remainder[0];
   // Read JSON-formatted file.
   caf::json_reader reader;
   if (!reader.load_file(file_path)) {
-    std::cerr << "*** failed to parse JSON file: "
-              << to_string(reader.get_error()) << '\n';
+    sys.println("*** failed to parse JSON file: {}\n", reader.get_error());
     return EXIT_FAILURE;
   }
   // Deserialize our user list from the parsed JSON.
   user_list users;
   if (!reader.apply(users)) {
-    std::cerr
-      << "*** failed to deserialize the user list: "
-      << to_string(reader.get_error())
-      << "\n\nNote: expected a JSON list of user objects. For example:\n"
-      << example_input << '\n';
+    sys.println("*** failed to deserialize the user list: {}\n\n Note: "
+                "expected a JSON list of user objects. For example: {}\n",
+                reader.get_error(), example_input);
     return EXIT_FAILURE;
   }
   // Print the list in "CAF format".
-  std::cout << "Entries loaded from file:\n";
+  sys.println("Entries loaded from file:\n");
   for (auto& entry : users)
-    std::cout << "- " << caf::deep_to_string(entry) << '\n';
+    sys.println("- {}", entry);
   return EXIT_SUCCESS;
 }
 

--- a/examples/custom_type/custom_types_1.cpp
+++ b/examples/custom_type/custom_types_1.cpp
@@ -8,7 +8,6 @@
 #include "caf/type_id.hpp"
 
 #include <cassert>
-#include <iostream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -26,7 +25,6 @@ CAF_BEGIN_TYPE_ID_BLOCK(custom_types_1, first_custom_type_id)
 CAF_END_TYPE_ID_BLOCK(custom_types_1)
 // --(rst-type-id-block-end)--
 
-using std::cerr;
 using std::endl;
 
 using namespace caf;
@@ -103,15 +101,13 @@ void caf_main(actor_system& sys) {
   // write f1 to buffer
   binary_serializer sink{sys, buf};
   if (!sink.apply(f1)) {
-    std::cerr << "*** failed to serialize foo2: " << to_string(sink.get_error())
-              << '\n';
+    sys.println("*** failed to serialize foo2: {}", sink.get_error());
     return;
   }
   // read f2 back from buffer
   binary_deserializer source{sys, buf};
   if (!source.apply(f2)) {
-    std::cerr << "*** failed to deserialize foo2: "
-              << to_string(source.get_error()) << '\n';
+    sys.println("*** failed to deserialize foo2: {}", source.get_error());
     return;
   }
   // must be equal

--- a/examples/flow/iota.cpp
+++ b/examples/flow/iota.cpp
@@ -5,8 +5,6 @@
 #include "caf/event_based_actor.hpp"
 #include "caf/scheduled_actor/flow.hpp"
 
-#include <iostream>
-
 namespace {
 
 constexpr size_t default_num_values = 10;
@@ -36,7 +34,7 @@ void caf_main(caf::actor_system& sys, const config& cfg) {
       // Only take the requested number of items from the infinite sequence.
       .take(n)
       // Print each integer.
-      .for_each([](int x) { std::cout << x << std::endl; });
+      .for_each([self](int x) { self->println("{}", x); });
   });
 }
 // --(rst-main-end)--

--- a/examples/flow/spsc-buffer-resource.cpp
+++ b/examples/flow/spsc-buffer-resource.cpp
@@ -8,8 +8,6 @@
 #include "caf/event_based_actor.hpp"
 #include "caf/scheduled_actor/flow.hpp"
 
-#include <iostream>
-
 namespace {
 
 constexpr size_t default_num_values = 100;
@@ -39,7 +37,7 @@ void sink(caf::event_based_actor* self, caf::async::consumer_resource<int> in) {
     // Lift the input to an observable flow.
     .from_resource(std::move(in))
     // Print each integer.
-    .for_each([](int x) { std::cout << x << std::endl; });
+    .for_each([self](int x) { self->println("{}", x); });
 }
 // --(rst-sink-end)--
 

--- a/examples/http/rest.cpp
+++ b/examples/http/rest.cpp
@@ -20,7 +20,6 @@
 #include <atomic>
 #include <cctype>
 #include <csignal>
-#include <iostream>
 #include <string>
 #include <utility>
 
@@ -117,7 +116,7 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
   auto max_request_size = caf::get_or(
     cfg, "max-request-size", caf::defaults::net::http_max_request_size);
   if (!key_file != !cert_file) {
-    std::cerr << "*** inconsistent TLS config: declare neither file or both\n";
+    sys.println("*** inconsistent TLS config: declare neither file or both");
     return EXIT_FAILURE;
   }
   // Spin up our key-value store actor.
@@ -199,14 +198,13 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
         .start();
   // Report any error to the user.
   if (!server) {
-    std::cerr << "*** unable to run at port " << port << ": "
-              << to_string(server.error()) << '\n';
+    sys.println("*** unable to run at port {}: {}", port, server.error());
     return EXIT_FAILURE;
   }
   // Wait for CTRL+C or SIGTERM.
   while (!shutdown_flag)
     std::this_thread::sleep_for(250ms);
-  std::cerr << "*** shutting down\n";
+  sys.println("*** shutting down");
   server->dispose();
   return EXIT_SUCCESS;
 }

--- a/examples/http/time-server.cpp
+++ b/examples/http/time-server.cpp
@@ -85,7 +85,7 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
   // start actors, we need to block on something else.
   sys.println("Server is up and running. Press <enter> to shut down.");
   getchar();
-  sys.println("Terminating.\n");
+  sys.println("Terminating.");
   return EXIT_SUCCESS;
 }
 // --(rst-main-end)--

--- a/examples/http/time-server.cpp
+++ b/examples/http/time-server.cpp
@@ -10,7 +10,6 @@
 #include "caf/event_based_actor.hpp"
 #include "caf/scheduled_actor/flow.hpp"
 
-#include <iostream>
 #include <string>
 #include <utility>
 
@@ -54,7 +53,7 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
   auto max_connections = caf::get_or(cfg, "max-connections",
                                      default_max_connections);
   if (!key_file != !cert_file) {
-    std::cerr << "*** inconsistent TLS config: declare neither file or both\n";
+    sys.println("*** inconsistent TLS config: declare neither file or both");
     return EXIT_FAILURE;
   }
   // Open up a TCP port for incoming connections and start the server.
@@ -79,16 +78,14 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
         .start();
   // Report any error to the user.
   if (!server) {
-    std::cerr << "*** unable to run at port " << port << ": "
-              << to_string(server.error()) << '\n';
+    sys.println("*** unable to run at port {}: {}", port, server.error());
     return EXIT_FAILURE;
   }
   // Note: the actor system will only wait for actors on default. Since we don't
   // start actors, we need to block on something else.
-  std::cout << "Server is up and running. Press <enter> to shut down."
-            << std::endl;
+  sys.println("Server is up and running. Press <enter> to shut down.");
   getchar();
-  std::cout << "Terminating.\n";
+  sys.println("Terminating.\n");
   return EXIT_SUCCESS;
 }
 // --(rst-main-end)--

--- a/examples/qtsupport/qt_group_chat.cpp
+++ b/examples/qtsupport/qt_group_chat.cpp
@@ -15,7 +15,6 @@
 #include <time.h>
 
 #include <cstdlib>
-#include <iostream>
 #include <map>
 #include <set>
 #include <sstream>
@@ -58,7 +57,7 @@ int caf_main(actor_system& sys, const config& cfg) {
   auto host = caf::get_or(cfg, "host", default_host);
   auto name = caf::get_or(cfg, "name", "");
   if (name.empty()) {
-    std::cerr << "*** mandatory parameter 'name' missing or empty\n";
+    sys.println("*** mandatory parameter 'name' missing or empty");
     return EXIT_FAILURE;
   }
   // Spin up Qt.
@@ -69,16 +68,15 @@ int caf_main(actor_system& sys, const config& cfg) {
   Ui::ChatWindow helper;
   helper.setupUi(&mw);
   // Connect to the server.
-  auto conn
-    = caf::net::lp::with(sys)
-        .connect(host, port)
-        .start([&](auto pull, auto push) {
-          std::cout << "*** connected to " << host << ":" << port << '\n';
-          helper.chatwidget->init(sys, name, std::move(pull), std::move(push));
-        });
+  auto conn = caf::net::lp::with(sys)
+                .connect(host, port)
+                .start([&](auto pull, auto push) {
+                  sys.println("*** connected to {}:{}", host, port);
+                  helper.chatwidget->init(sys, name, std::move(pull),
+                                          std::move(push));
+                });
   if (!conn) {
-    std::cerr << "*** unable to connect to " << host << ":" << port << ": "
-              << to_string(conn.error()) << '\n';
+    sys.println("*** unable to connect to {}:{}: {}", host, port, conn.error());
     mw.close();
     return app.exec();
   }

--- a/examples/web_socket/echo.cpp
+++ b/examples/web_socket/echo.cpp
@@ -12,7 +12,6 @@
 
 #include <atomic>
 #include <csignal>
-#include <iostream>
 #include <utility>
 
 using namespace std::literals;
@@ -71,7 +70,7 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
   auto max_connections = caf::get_or(cfg, "max-connections",
                                      default_max_connections);
   if (!key_file != !cert_file) {
-    std::cerr << "*** inconsistent TLS config: declare neither file or both\n";
+    sys.println("*** inconsistent TLS config: declare neither file or both");
     return EXIT_FAILURE;
   }
   // Open up a TCP port for incoming connections and start the server.
@@ -87,11 +86,11 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
         // Limit how many clients may be connected at any given time.
         .max_connections(max_connections)
         // Accept only requests for path "/".
-        .on_request([](ws::acceptor<>& acc) {
+        .on_request([&sys](ws::acceptor<>& acc) {
           // The header parameter contains fields from the WebSocket handshake
           // such as the path and HTTP header fields..
           auto path = acc.header().path();
-          std::cout << "*** new client request for path " << path << std::endl;
+          sys.println("*** new client request for path {}", path);
           // Accept the WebSocket connection only if the path is "/".
           if (path == "/") {
             // Calling `accept` causes the server to acknowledge the client and
@@ -118,22 +117,22 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
                 // ... that simply pushes data back to the sender.
                 auto [pull, push] = ev.data();
                 pull.observe_on(self)
-                  .do_on_error([](const caf::error& what) { //
-                    std::cout << "*** connection closed: " << to_string(what)
-                              << std::endl;
+                  .do_on_error([self](const caf::error& what) { //
+                    self->println("*** connection closed: {}", what);
                   })
-                  .do_on_complete([] { //
-                    std::cout << "*** connection closed" << std::endl;
+                  .do_on_complete([self] { //
+                    self->println("*** connection closed");
                   })
-                  .do_on_next([](const ws::frame& x) {
+                  .do_on_next([self](const ws::frame& x) {
                     if (x.is_binary()) {
-                      std::cout
-                        << "*** received a binary WebSocket frame of size "
-                        << x.size() << std::endl;
+                      self->println(
+                        "*** received a binary WebSocket frame of size "
+                        "{}",
+                        x.size());
                     } else {
-                      std::cout
-                        << "*** received a text WebSocket frame of size "
-                        << x.size() << std::endl;
+                      self->println(
+                        "*** received a text WebSocket frame of size {}",
+                        x.size());
                     }
                   })
                   .subscribe(push);
@@ -142,14 +141,13 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
         });
   // Report any error to the user.
   if (!server) {
-    std::cerr << "*** unable to run at port " << port << ": "
-              << to_string(server.error()) << '\n';
+    sys.println("*** unable to run at port {}: {}", port, server.error());
     return EXIT_FAILURE;
   }
   // Wait for CTRL+C or SIGTERM.
   while (!shutdown_flag)
     std::this_thread::sleep_for(250ms);
-  std::cerr << "*** shutting down\n";
+  sys.println("*** shutting down");
   server->dispose();
   return EXIT_SUCCESS;
 }

--- a/examples/web_socket/echo.cpp
+++ b/examples/web_socket/echo.cpp
@@ -126,8 +126,7 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
                   .do_on_next([self](const ws::frame& x) {
                     if (x.is_binary()) {
                       self->println(
-                        "*** received a binary WebSocket frame of size "
-                        "{}",
+                        "*** received a binary WebSocket frame of size {}",
                         x.size());
                     } else {
                       self->println(

--- a/examples/web_socket/hello-client.cpp
+++ b/examples/web_socket/hello-client.cpp
@@ -30,7 +30,7 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
   // Sanity checking.
   auto server = caf::get_as<caf::uri>(cfg, "server");
   if (!server) {
-    sys.println("*** mandatory argument server missing or invalid");
+    sys.println("*** mandatory argument 'server' missing or invalid");
     return EXIT_FAILURE;
   }
   // Ask the user for the hello message.

--- a/examples/web_socket/hello-client.cpp
+++ b/examples/web_socket/hello-client.cpp
@@ -30,7 +30,7 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
   // Sanity checking.
   auto server = caf::get_as<caf::uri>(cfg, "server");
   if (!server) {
-    std::cerr << "*** mandatory argument server missing or invalid\n";
+    sys.println("*** mandatory argument server missing or invalid");
     return EXIT_FAILURE;
   }
   // Ask the user for the hello message.
@@ -52,9 +52,9 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
             pull
               .observe_on(self)
               // Print errors to stderr.
-              .do_on_error([](const caf::error& what) {
-                std::cerr << "*** error while reading from the WebSocket: "
-                          << to_string(what) << std::endl;
+              .do_on_error([self](const caf::error& what) {
+                self->println("*** error while reading from the WebSocket: {}",
+                              what);
               })
               // Restrict how many messages we receive if the user configured
               // a limit.
@@ -66,16 +66,16 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
                 }
               })
               // Print a bye-bye message if the server closes the connection.
-              .do_on_complete([] { //
-                std::cout << "Server has closed the connection" << std::endl;
+              .do_on_complete([self] { //
+                self->println("Server has closed the connection");
               })
               // Print everything from the server to stdout.
-              .for_each([](const ws::frame& msg) {
+              .for_each([self](const ws::frame& msg) {
                 if (msg.is_text()) {
-                  std::cout << "Server: " << msg.as_text() << std::endl;
+                  self->println("Server: {}", msg.as_text());
                 } else if (msg.is_binary()) {
-                  std::cout << "Server: [binary message of size "
-                            << msg.as_binary().size() << "]" << std::endl;
+                  self->println("Server: [binary message of size {}]",
+                                msg.as_binary().size());
                 }
               });
             // Send our hello message and wait until the server closes the
@@ -88,8 +88,7 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
           });
         });
   if (!conn) {
-    std::cerr << "*** unable to connect to " << server->str() << ": "
-              << to_string(conn.error()) << std::endl;
+    sys.println("*** unable to connect to {}: {}", server->str(), conn.error());
     return EXIT_FAILURE;
   }
   // Note: the actor system will keep the application running for as long as the

--- a/examples/web_socket/quote-server.cpp
+++ b/examples/web_socket/quote-server.cpp
@@ -21,7 +21,6 @@
 #include <atomic>
 #include <cassert>
 #include <csignal>
-#include <iostream>
 #include <random>
 #include <utility>
 
@@ -157,7 +156,7 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
   auto max_connections = caf::get_or(cfg, "max-connections",
                                      default_max_connections);
   if (!key_file != !cert_file) {
-    std::cerr << "*** inconsistent TLS config: declare neither file or both\n";
+    sys.println("*** inconsistent TLS config: declare neither file or both");
     return EXIT_FAILURE;
   }
   // Open up a TCP port for incoming connections and start the server.
@@ -232,14 +231,13 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
         .start();
   // Report any error to the user.
   if (!server) {
-    std::cerr << "*** unable to run at port " << port << ": "
-              << to_string(server.error()) << '\n';
+    sys.println("*** unable to run at port {}: {}", port, server.error());
     return EXIT_FAILURE;
   }
   // Wait for CTRL+C or SIGTERM.
   while (!shutdown_flag)
     std::this_thread::sleep_for(250ms);
-  std::cerr << "*** shutting down\n";
+  sys.println("*** shutting down");
   server->dispose();
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Following examples have been updated with `println()` for writing to console.
- read-json.cpp
- custom_types_1
- iota
- spsc-buffer-resource
- rest
- time-server
- qt_group_chat
- echo
- hello-client
- quote-server
- stock-ticker