### PR TITLE
Add missing tests to improve coverage

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -153,6 +153,7 @@ caf_add_component(
     caf/detail/base64.cpp
     caf/detail/base64.test.cpp
     caf/detail/beacon.cpp
+    caf/detail/beacon.test.cpp
     caf/detail/behavior_impl.cpp
     caf/detail/behavior_stack.cpp
     caf/detail/blocking_behavior.cpp

--- a/libcaf_core/caf/detail/beacon.test.cpp
+++ b/libcaf_core/caf/detail/beacon.test.cpp
@@ -1,0 +1,38 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/detail/beacon.hpp"
+
+#include "caf/test/fixture/deterministic.hpp"
+#include "caf/test/scenario.hpp"
+
+#include "caf/event_based_actor.hpp"
+#include "caf/flow/scoped_coordinator.hpp"
+#include "caf/scheduled_actor/flow.hpp"
+
+using namespace caf;
+using namespace std::literals;
+
+namespace {
+
+SCENARIO("beacons can be disposed") {
+  auto disposable_beacon = detail::beacon{};
+  GIVEN("a beacon") {
+    WHEN("dispose() is not called") {
+      THEN("the beacon is in a scheduled state") {
+        check_eq(disposable_beacon.current_state(), action::state::scheduled);
+        check(!disposable_beacon.disposed());
+      }
+    }
+    WHEN("dispose() is called") {
+      disposable_beacon.dispose();
+      THEN("the beacon is in a disposed state") {
+        check_eq(disposable_beacon.current_state(), action::state::disposed);
+        check(disposable_beacon.disposed());
+      }
+    }
+  }
+}
+
+} // namespace

--- a/libcaf_core/caf/ipv4_subnet.test.cpp
+++ b/libcaf_core/caf/ipv4_subnet.test.cpp
@@ -4,7 +4,13 @@
 
 #include "caf/ipv4_subnet.hpp"
 
+#include "caf/test/fixture/deterministic.hpp"
 #include "caf/test/test.hpp"
+
+#include "caf/actor_system.hpp"
+#include "caf/actor_system_config.hpp"
+#include "caf/binary_deserializer.hpp"
+#include "caf/binary_serializer.hpp"
 
 using namespace caf;
 
@@ -50,5 +56,19 @@ TEST("ordering") {
   check_lt(addr(192, 168, 167, 0) / 24, addr(192, 168, 168, 0) / 24);
   check_lt(addr(192, 168, 168, 0) / 24, addr(192, 168, 168, 0) / 25);
 }
+
+WITH_FIXTURE(test::fixture::deterministic) {
+
+#define CHECK_SERIALIZATION(subn) check_eq(subn, serialization_roundtrip(subn))
+
+TEST("serialization") {
+  CHECK_SERIALIZATION(addr(192, 168, 168, 1) / 16);
+  CHECK_SERIALIZATION(addr(192, 168, 168, 1) / 24);
+  CHECK_SERIALIZATION(addr(192, 168, 168, 1) / 31);
+  CHECK_SERIALIZATION(addr(255, 255, 255, 1) / 8);
+  CHECK_SERIALIZATION(addr(127, 0, 0, 1) / 24);
+}
+
+} // WITH_FIXTURE(test::fixture::deterministic)
 
 } // namespace

--- a/libcaf_core/caf/ipv6_subnet.test.cpp
+++ b/libcaf_core/caf/ipv6_subnet.test.cpp
@@ -4,7 +4,13 @@
 
 #include "caf/ipv6_subnet.hpp"
 
+#include "caf/test/fixture/deterministic.hpp"
 #include "caf/test/test.hpp"
+
+#include "caf/actor_system.hpp"
+#include "caf/actor_system_config.hpp"
+#include "caf/binary_deserializer.hpp"
+#include "caf/binary_serializer.hpp"
 
 using namespace caf;
 
@@ -62,5 +68,22 @@ TEST("serializing") {
   ipv6_subnet local_embed_v4{v4_local};
   check_eq(to_string(local_embed_v4), "127.0.0.0/8");
 }
+
+WITH_FIXTURE(test::fixture::deterministic) {
+
+#define CHECK_SERIALIZATION(subn) check_eq(subn, serialization_roundtrip(subn))
+
+TEST("serialization") {
+  CHECK_SERIALIZATION((ipv6_address{{0xbebe}, {}} / 128));
+  CHECK_SERIALIZATION((ipv6_address{{0xbebe}, {}} / 32));
+  CHECK_SERIALIZATION((ipv6_address{{0xbebe}, {0xbebe}} / 32));
+  CHECK_SERIALIZATION((ipv6_address{{0xbebe}, {0xbebe}} / 64));
+  CHECK_SERIALIZATION((ipv6_address{{}, {0xbebe}} / 16));
+  CHECK_SERIALIZATION((ipv6_address{{}, {0xbebe}} / 32));
+  CHECK_SERIALIZATION((ipv6_address{{}, {0xbebe, 0xbebe}} / 32));
+  CHECK_SERIALIZATION((ipv6_address{{}, {0xbebe, 0xbebe}} / 64));
+}
+
+} // WITH_FIXTURE(test::fixture::deterministic)
 
 } // namespace

--- a/libcaf_core/caf/unit.test.cpp
+++ b/libcaf_core/caf/unit.test.cpp
@@ -54,4 +54,11 @@ TEST("unit_results") {
   }
 }
 
+TEST("actor_address") {
+  actor_system_config cfg;
+  actor_system sys{cfg};
+  scoped_actor self{sys};
+  check_ne(self.address().id(), 0u);
+}
+
 } // namespace


### PR DESCRIPTION
Tests have been added for the following
- beacon
- ipv4_subnet
- ipv6_subnet
- scoped_actor
- make_config_option

The following functions have been removed from settings as they have not been referenced in any public function
- `expected<std::string> get_or(const settings& xs, std::string_view name, const char* fallback)`
- `config_value& put_impl(settings& dict, const std::vector<std::string_view>& path, config_value& value)`






