### PR TITLE
Fix math in chrono::datetime::force_utc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   no user-info at all.
 - The parser for reading JSON and configuration files now properly handles
   Windows-style line endings (#1850).
+- Calling `force_utc` on a `caf::chrono::dateime` object now properly applies
+  the UTC offset. Previously, the function would shift the time into the wrong
+  direction (#1860).
 
 ### Removed
 

--- a/libcaf_core/caf/chrono.cpp
+++ b/libcaf_core/caf/chrono.cpp
@@ -259,7 +259,7 @@ void datetime::force_utc() {
   auto offset = *utc_offset;
   utc_offset = 0;
   auto ts = to_time_t();
-  assign_utc_secs(ts + offset);
+  assign_utc_secs(ts - offset);
 }
 
 void datetime::read_local_time(time_t secs, int nsecs) {


### PR DESCRIPTION
It's a one character fix, but I've used the opportunity to improve our unit tests as well.

Fixes #1860.