### PR TITLE
Move former CAFcademy gems to the manual

### DIFF
--- a/manual/CopyOnWriteTypes.rst
+++ b/manual/CopyOnWriteTypes.rst
@@ -1,0 +1,63 @@
+.. _copy-on-write-types:
+
+Copy-on-Write Types
+===================
+
+Copy-on-write (COW) is an optimization technique that makes copies cheap by
+implicitly sharing data between the original and the copy until one of them is
+modified. This makes it convenient and cheap to pass values around while also
+making sure that the data is only copied when necessary.
+
+CAF uses copy-on-write for its ``message`` type, which basically is a
+type-erased tuple.  CAF also includes ``cow_tuple`` which wraps a ``std::tuple``
+and allows users to pass e expensive data (like strings and lists) as a single
+unit that can be passed around cheaply. This is particularly useful when
+emitting tuples in a flow, where the tuples are frequently buffered and passed
+around.
+
+Here is a small example to illustrate the API:
+
+.. code-block:: C++
+
+  auto addr = [](auto& tup) {
+    return reinterpret_cast<intptr_t>(std::addressof(tup.data()));
+  };
+  auto xs = caf::make_cow_tuple(1, 2, 3);
+  auto ys = xs;
+  sys.println("After initializing:");
+  sys.println("xs: {} ({:#x})", xs, addr(xs));
+  sys.println("ys: {} ({:#x})", ys, addr(ys));
+  ys.unshared() = std::tuple{4, 5, 6};
+  sys.println("After assigning to ys:");
+  sys.println("xs: {} ({:#x})", xs, addr(xs));
+  sys.println("ys: {} ({:#x})", ys, addr(ys));
+
+An example output of this program is:
+
+.. code-block:: text
+
+  After initializing:
+  xs: [1, 2, 3] (0x10a001d30)
+  ys: [1, 2, 3] (0x10a001d30)
+  After assigning to ys:
+  xs: [1, 2, 3] (0x10a001d30)
+  ys: [4, 5, 6] (0x10a001d00)
+
+By default, ``cow_tuple`` only grants ``const`` access to its elements. With
+``get<I>(xs)``, users can get access to a single value of ``xs`` at the index
+``I``. With ``xs.data()``, users get a ``const`` reference to the internally
+stored ``std::tuple``.
+
+In order to gain mutable access, users may call ``unshared()`` to get a mutable
+reference to the ``std::tuple``. This function makes a deep copy of the data if
+there is more than one reference to the data at the moment. In our example
+above, ``ys`` initially points to the same data as ``xs``. After calling
+``unshared()`` on ``ys``, however, the two tuples point to different data.
+
+Especially when using the flow API, it is important to use values that are
+cheap to copy. For this reason, CAF includes a few convenience types that wrap
+their standard equivalent:
+
+- ``cow_string``: A copy-on-write string that wraps ``std::string``.
+- ``cow_vector``: A copy-on-write vector that wraps ``std::vector``.
+- ``cow_tuple``: A copy-on-write tuple that wraps ``std::tuple``.

--- a/manual/CopyOnWriteTypes.rst
+++ b/manual/CopyOnWriteTypes.rst
@@ -10,7 +10,7 @@ making sure that the data is only copied when necessary.
 
 CAF uses copy-on-write for its ``message`` type, which basically is a
 type-erased tuple.  CAF also includes ``cow_tuple`` which wraps a ``std::tuple``
-and allows users to pass e expensive data (like strings and lists) as a single
+and allows users to pass expensive data (like strings and lists) as a single
 unit that can be passed around cheaply. This is particularly useful when
 emitting tuples in a flow, where the tuples are frequently buffered and passed
 around.

--- a/manual/Hashing.rst
+++ b/manual/Hashing.rst
@@ -1,0 +1,72 @@
+.. _hashing:
+
+Hashing
+=======
+
+Writing an ``inspect`` overload (see :ref:`type-inspection`), for a custom type
+not only enables CAF to serialize and deserialize it, but also to generate hash
+values for it.
+
+Consider this simple POD type with an ``inspect`` overload:
+
+.. code-block:: C++
+
+  struct point_3d {
+    int32_t x;
+    int32_t y;
+    int32_t z;
+  };
+
+  template<class Inspector>
+  bool inspect(Inspector& f, point_3d& point) {
+    return f.object(point).fields(f.field("x", point.x),
+                                  f.field("y", point.y),
+                                  f.field("z", point.z));
+  }
+
+The common algorithm of choice for generating hash values is the FNV_ algorithm,
+which is designed for hash tables and fast. Because this algorithm is so common,
+CAF ships an inspector that implements it: ``caf::hash::fnv`` (include
+``caf/hash/fnv.hpp``).
+
+The FNV algorithm chooses a different prime number as the seed value based on
+whether you are generating a 32-bit hash value or a 64-bit hash value. In CAF,
+you choose the seed implicitly by instantiating the inspector with ``uint32_t``,
+``uint64_t``, or ``size_t``.
+
+Because applying any value to the inspector always results in an integer value,
+``caf::hash::fnv`` has a static member function called ``compute`` that takes any
+number of inspectable values. This means generating a hash boils down to a
+one-liner!
+
+It also makes it very convenient to specialize ``std::hash``. For our
+``point_3d``, the implementation boils down to this:
+
+.. code-block:: C++
+
+  namespace std {
+
+  template <>
+  struct hash<point_3d> {
+    size_t operator()(const point_3d& point) const noexcept {
+      return caf::hash::fnv<size_t>::compute(point);
+    }
+  };
+
+  } // namespace std
+
+Under the hood, the inspector uses the ``inspect`` overload to traverse the
+object. Hash inspectors ignore type names, field names, etc. So passing a
+``point_3d`` to the inspector results in the same result as passing ``x``, ``y``
+and ``z`` individually:
+
+.. code-block:: C++
+
+  using hasher = caf::hash::fnv<uint32_t>;
+  sys.println("hash of (1, 2, 3): {}", hasher::compute(1, 2, 3));
+  sys.println("hash of point_3d(1, 2, 3): {}", hasher::compute(point_3d{1, 2, 3}));
+
+In the code above, the result of both calls to ``hasher::compute`` will be the
+FNV hash value of the sequence ``1, 2, 3``, i.e., ``2034659765``.
+
+.. _FNV: https://en.wikipedia.org/wiki/FNV_hash_function

--- a/manual/MessagePassing.rst
+++ b/manual/MessagePassing.rst
@@ -20,9 +20,10 @@ when using the message passing API.
 Copy on Write
 -------------
 
-A ``message`` is a copy-on-write (COW) type. This means that copying a message
-is cheap because it only copies the reference to the message content. The actual
-copying of the content only happens when one of the copies is modified.
+A ``message`` in CAF is a copy-on-write (COW) type (see
+:ref:`copy-on-write-types`). This means that copying a message is cheap because
+it only copies the reference to the message content. The actual copying of the
+content only happens when one of the copies is modified.
 
 This allows sending the same message to multiple receivers without copying
 overhead, as long as all receivers only read the content of the message.
@@ -331,4 +332,3 @@ signature ``void (error&)`` or ``void (scheduled_actor*, error&)``.
 Additionally, ``request`` accepts an error handler as second argument to handle
 errors for a particular request (see :ref:`error-response`). The default handler
 is used as fallback if ``request`` is used without error handler.
-

--- a/manual/TypedMessageView.rst
+++ b/manual/TypedMessageView.rst
@@ -1,0 +1,53 @@
+.. _typed-message-view:
+
+Typed Message View
+==================
+
+For the most part, users can write CAF applications without knowing about
+``message``. When sending messages between actors, CAF automatically wraps the
+content for the message into this type-erased container and then matches each
+incoming message against the message handlers.
+
+However, there are use cases for ``message`` outside of the dispatching logic in
+CAF. For example, actors can store messages that they currently don't want to
+(or cannot) process in some cache for processing them later. Or an application
+could read messages from custom data sources and then deploy on their run-time
+type.
+
+For such use cases, CAF includes typed message views. On construction, a view
+performs the necessary type checking. On a match, users can then query
+individual elements from the view via ``get<Index>(x)``, much like the interface
+offered by ``std::tuple``.
+
+Internally, messages use copy-on-write (see :ref:`copy-on-write-types`). Hence,
+there are two flavors of typed message views: ``const`` views that represent
+read-only access and views with mutable access. The latter forces the message to
+perform a deep copy of its data if there is more to one reference to the data.
+To cut a long story short, we recommend sticking to the ``const`` version
+whenever possible.
+
+For both view types, the simplest way of using them is to construct a view
+object and then check whether it is valid. The ``const`` version is called
+``const_typed_message_view``:
+
+.. code-block:: C++
+
+  auto msg1 = caf::make_message("hello", "world");
+  auto msg2 = msg1;
+  if (auto v = caf::const_typed_message_view<std::string, std::string>{msg1})
+    sys.println("v: {}, {}", caf::get<0>(v), caf::get<1>(v));
+  // Both messages still point to the same data.
+  assert(msg1.cptr() == msg2.cptr());
+
+The mutable version is simply called ``typed_message_view``, but otherwise has a
+similar interface:
+
+.. code-block:: C++
+  auto msg1 = caf::make_message("hello", "world");
+  auto msg2 = msg1;
+  if (auto v = caf::typed_message_view<std::string, std::string>{msg1}) {
+    caf::get<0>(v) = "bye";
+    sys.println("v: {}, {}", caf::get<0>(v), caf::get<1>(v));
+  }
+  // The messages no longer point to the same data.
+  assert(msg1.cptr() != msg2.cptr());

--- a/manual/index.rst
+++ b/manual/index.rst
@@ -14,6 +14,7 @@ Contents
    Overview
    MessagePassing
    TypeInspection
+   Hashing
    MessageHandlers
    Actors
    Scheduler
@@ -21,6 +22,8 @@ Contents
    ReferenceCounting
    Error
    ConfiguringActorApplications
+   CopyOnWriteTypes
+   TypedMessageView
    DataFlows
    Testing
    Metrics

--- a/manual/net/LengthPrefixFraming.rst
+++ b/manual/net/LengthPrefixFraming.rst
@@ -25,7 +25,7 @@ The simplest way to start a length-prefix framing server is by using the
 high-level factory DSL. The entry point for this API is calling the
 ``caf::net::lp::with`` function:
 
-.. code-block:: cpp
+.. code-block:: C++
 
     caf::net::lp::with(sys)
 


### PR DESCRIPTION
The line between a manual entry and a CAFcademy gem always was a bit fuzzy. Ultimately, the manual seems the more natural place to discuss individual features.