### PR TITLE
Temporarily disable caf-robot-lp-communication

### DIFF
--- a/robot/CMakeLists.txt
+++ b/robot/CMakeLists.txt
@@ -130,10 +130,11 @@ if(TARGET CAF::net AND CAF_ENABLE_EXAMPLES)
     client
     --variable BINARY_PATH:$<TARGET_FILE:client>)
 
-  add_robot_test(
-    lp
-    communication
-    --variable SERVER_PATH:$<TARGET_FILE:chat-server>
-    --variable CLIENT_PATH:$<TARGET_FILE:chat-client>)
+  # Temporary disabled: https://github.com/actor-framework/actor-framework/issues/1864
+  # add_robot_test(
+  #   lp
+  #   communication
+  #   --variable SERVER_PATH:$<TARGET_FILE:chat-server>
+  #   --variable CLIENT_PATH:$<TARGET_FILE:chat-client>)
 
 endif()


### PR DESCRIPTION
Due to the frequent CI run failures, `caf-robot-lp-communication` is disabled until we get to the bottom of why this test is unstable.