### PR TITLE
Apply the pimpl idiom to http::request

### DIFF
--- a/libcaf_net/caf/net/http/request.cpp
+++ b/libcaf_net/caf/net/http/request.cpp
@@ -4,11 +4,73 @@
 
 #include "caf/net/http/request.hpp"
 
+#include <utility>
+
 using namespace std::literals;
 
 // TODO: reduce number of memory allocations for producing the response.
 
 namespace caf::net::http {
+
+class request::impl : public ref_counted {
+public:
+  impl(request_header hdr, std::vector<std::byte> body,
+       async::promise<response> prom)
+    : hdr(std::move(hdr)), body(std::move(body)), prom(std::move(prom)) {
+    // nop
+  }
+
+  request_header hdr;
+  std::vector<std::byte> body;
+  async::promise<response> prom;
+};
+
+request::request(request&& other) noexcept : impl_(other.impl_) {
+  if (impl_) {
+    other.impl_ = nullptr;
+  }
+}
+
+request::request(const request& other) noexcept {
+  if (other.impl_ != nullptr) {
+    impl_ = other.impl_;
+    impl_->ref();
+  }
+}
+
+request::request(request_header hdr, std::vector<std::byte> body,
+                 async::promise<response> prom) {
+  impl_ = new impl(std::move(hdr), std::move(body), std::move(prom));
+}
+
+request& request::operator=(request&& other) noexcept {
+  std::swap(impl_, other.impl_);
+  return *this;
+}
+
+request& request::operator=(const request& other) noexcept {
+  request tmp{other};
+  std::swap(impl_, tmp.impl_);
+  return *this;
+}
+
+request::~request() {
+  if (impl_ != nullptr) {
+    impl_->deref();
+  }
+}
+
+const request_header& request::header() const {
+  return impl_->hdr;
+}
+
+const_byte_span request::body() const {
+  return make_span(impl_->body);
+}
+
+const_byte_span request::payload() const {
+  return make_span(impl_->body);
+}
 
 void request::respond(status code, std::string_view content_type,
                       const_byte_span content) const {
@@ -17,7 +79,7 @@ void request::respond(status code, std::string_view content_type,
   fields.emplace("Content-Type"sv, content_type);
   fields.emplace("Content-Length"sv, content_size);
   auto body = std::vector<std::byte>{content.begin(), content.end()};
-  pimpl_->prom.set_value(response{code, std::move(fields), std::move(body)});
+  impl_->prom.set_value(response{code, std::move(fields), std::move(body)});
 }
 
 } // namespace caf::net::http

--- a/libcaf_net/caf/net/http/request.hpp
+++ b/libcaf_net/caf/net/http/request.hpp
@@ -14,7 +14,6 @@
 #include "caf/detail/net_export.hpp"
 
 #include <cstdint>
-#include <memory>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -25,39 +24,32 @@ namespace caf::net::http {
 /// promise for the HTTP response.
 class CAF_NET_EXPORT request {
 public:
-  struct impl {
-    request_header hdr;
-    std::vector<std::byte> body;
-    async::promise<response> prom;
-  };
+  friend class router;
 
-  request() = default;
-  request(request&&) = default;
-  request(const request&) = default;
-  request& operator=(request&&) = default;
-  request& operator=(const request&) = default;
+  class impl;
 
-  /// @private
-  explicit request(std::shared_ptr<impl> pimpl) : pimpl_(std::move(pimpl)) {
-    // nop
-  }
+  request() noexcept = default;
+
+  request(request&& other) noexcept;
+
+  request(const request& other) noexcept;
+
+  request& operator=(request&& other) noexcept;
+
+  request& operator=(const request& other) noexcept;
+
+  ~request();
 
   /// Returns the HTTP header for the request.
   /// @pre `valid()`
-  const request_header& header() const {
-    return pimpl_->hdr;
-  }
+  const request_header& header() const;
 
   /// Returns the HTTP body (payload) for the request.
   /// @pre `valid()`
-  const_byte_span body() const {
-    return make_span(pimpl_->body);
-  }
+  const_byte_span body() const;
 
   /// @copydoc body
-  const_byte_span payload() const {
-    return make_span(pimpl_->body);
-  }
+  const_byte_span payload() const;
 
   /// Sends an HTTP response message to the client. Automatically sets the
   /// `Content-Type` and `Content-Length` header fields.
@@ -74,7 +66,10 @@ public:
   }
 
 private:
-  std::shared_ptr<impl> pimpl_;
+  request(request_header hdr, std::vector<std::byte> body,
+          async::promise<response> prom);
+
+  impl* impl_ = nullptr;
 };
 
 } // namespace caf::net::http

--- a/libcaf_net/caf/net/http/router.cpp
+++ b/libcaf_net/caf/net/http/router.cpp
@@ -38,8 +38,7 @@ request router::lift(responder&& res) {
   auto prom = async::promise<response>();
   auto fut = prom.get_future();
   auto buf = std::vector<std::byte>{res.payload().begin(), res.payload().end()};
-  auto impl = request::impl{res.header(), std::move(buf), std::move(prom)};
-  auto lifted = request{std::make_shared<request::impl>(std::move(impl))};
+  auto lifted = request{res.header(), std::move(buf), std::move(prom)};
   auto request_id = request_id_++;
   auto hdl = fut.bind_to(down_->mpx())
                .then(


### PR DESCRIPTION
I've found another instance where we can-and should-apply the pimpl idiom.