### PR TITLE
Change values for log levels

### DIFF
--- a/libcaf_core/caf/detail/log_level.hpp
+++ b/libcaf_core/caf/detail/log_level.hpp
@@ -8,16 +8,16 @@
 #define CAF_LOG_LEVEL_QUIET 0
 
 /// Integer value for the ERROR log level.
-#define CAF_LOG_LEVEL_ERROR 3
+#define CAF_LOG_LEVEL_ERROR 200
 
 /// Integer value for the WARNING log level.
-#define CAF_LOG_LEVEL_WARNING 6
+#define CAF_LOG_LEVEL_WARNING 300
 
 /// Integer value for the INFO log level.
-#define CAF_LOG_LEVEL_INFO 9
+#define CAF_LOG_LEVEL_INFO 400
 
 /// Integer value for the DEBUG log level.
-#define CAF_LOG_LEVEL_DEBUG 12
+#define CAF_LOG_LEVEL_DEBUG 500
 
 /// Integer value for the TRACE log level.
-#define CAF_LOG_LEVEL_TRACE 15
+#define CAF_LOG_LEVEL_TRACE 600

--- a/libcaf_core/caf/logger.cpp
+++ b/libcaf_core/caf/logger.cpp
@@ -114,33 +114,24 @@ public:
     plain_text_field,
   };
 
-  /// Combines various logging-related flags and parameters into a bitfield.
+  /// Combines various logging-related flags and parameters.
   struct config {
     /// Stores `max(file_verbosity, console_verbosity)`.
-    unsigned verbosity : 4;
+    unsigned verbosity = CAF_LOG_LEVEL;
 
     /// Configures the verbosity for file output.
-    unsigned file_verbosity : 4;
+    unsigned file_verbosity = CAF_LOG_LEVEL;
 
     /// Configures the verbosity for console output.
-    unsigned console_verbosity : 4;
+    unsigned console_verbosity = CAF_LOG_LEVEL;
 
     /// Configures whether the logger immediately writes its output in the
     /// calling thread, bypassing its queue. Use this option only in
     /// single-threaded test environments.
-    bool inline_output : 1;
+    bool inline_output = false;
 
     /// Configures whether the logger generates colored output.
-    bool console_coloring : 1;
-
-    config()
-      : verbosity(CAF_LOG_LEVEL),
-        file_verbosity(CAF_LOG_LEVEL),
-        console_verbosity(CAF_LOG_LEVEL),
-        inline_output(false),
-        console_coloring(false) {
-      // nop
-    }
+    bool console_coloring = false;
   };
 
   /// Represents a single format string field.


### PR DESCRIPTION
This sets the values for our log levels to the same values Log4j uses, giving users much more space for custom log levels. The logger already allows passing custom log levels to `log`, so this wraps up this topic (aside from documentation).

Closes #1066.