### PR TITLE
Deprecate `after(...)` for event-based actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   that can be used to cancel the monitoring. This mechanism replaces the old
   approach that relied on `down_msg` handlers in event-based actors (nothing
   changes for blocking actors).
+- Event-based actors can now set an idle timeout via `set_idle_handler`. The
+  timeout fires when the actor receives no messages for a specified duration.
+  This new feature replaces the `after(...) >> ...` syntax and allows actors to
+  specify what kind of reference CAF will hold to that actor while it is waiting
+  for the timeout (strong or weak) and whether to trigger the timeout once or
+  repeatedly.
+
 
 ### Fixed
 
@@ -99,6 +106,10 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   `monitor`: please use the new `monitor` API with a callback instead.
 - The spawn flag `monitored` is deprecated as well and users should call
   `monitor` directly instead.
+- Constructing a behavior with `after(...) >> ...` has been deprecated in favor
+  of the new `set_idle_handler` function. Note that blocking actors may still
+  pass a timeout via `after(...)` to `receive` functions. The deprecation only
+  targets event-based actors.
 
 ## [0.19.5] - 2024-01-08
 

--- a/libcaf_core/caf/timeout_definition.hpp
+++ b/libcaf_core/caf/timeout_definition.hpp
@@ -55,6 +55,9 @@ struct is_timeout_definition : std::false_type {};
 template <class T>
 struct is_timeout_definition<timeout_definition<T>> : std::true_type {};
 
+template <class T>
+constexpr bool is_timeout_definition_v = is_timeout_definition<T>::value;
+
 using generic_timeout_definition = timeout_definition<std::function<void()>>;
 
 } // namespace caf


### PR DESCRIPTION
The blocking actors use the internal `make_behavior` free function. Hence, we can simply deprecate passing a timeout from `after(...) >> ...` to the constructor of `behavior` or `behavior::assign`.

Relates #1800.