### PR TITLE
Refactor floating point comparisons with approx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - New flow operators: `buffer`, `sample`, `start_with`,
   `on_backpressure_buffer`, `on_error_return`, `on_error_return_item`, and
   `on_error_complete`.
+- The unit test framework now offers the new utility (template) class
+  `caf::test::approx` for approximate comparisons.
 
 ### Fixed
 
@@ -94,6 +96,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   altogether.
 - Event-based actors can now handle types like `exit_msg` and `error` in their
   regular behavior.
+- The `check_eq` and `require_eq` functions in the unit test framework now
+  prohibit comparing floating-point numbers with `==`. Instead, users should use
+  new `approx` utility class.
 
 ### Deprecated
 
@@ -127,6 +132,10 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Special-purpose handlers for messages like `exit_msg` and `error` are now
   deprecated. Instead, users should handle these messages in their regular
   behavior.
+- The legacy testing framework in `caf/test/unit_test.hpp` is now deprecated and
+  the header (as well as headers that build on top it such as
+  `caf/test/dsl.hpp`) will be removed in the next major release. Users should
+  migrate to the new testing framework.
 
 ## [0.19.5] - 2024-01-08
 

--- a/libcaf_core/caf/actor_system_config.test.cpp
+++ b/libcaf_core/caf/actor_system_config.test.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/actor_system_config.hpp"
 
+#include "caf/test/approx.hpp"
 #include "caf/test/scenario.hpp"
 #include "caf/test/test.hpp"
 
@@ -28,9 +29,15 @@ using namespace std::literals;
   do {                                                                         \
     using ref_value_type = std::decay_t<decltype(var)>;                        \
     ref_value_type value{__VA_ARGS__};                                         \
-    check_eq(var, value);                                                      \
+    if constexpr (std::is_arithmetic_v<decltype(var)>)                         \
+      check_eq(var, test::approx{value});                                      \
+    else                                                                       \
+      check_eq(var, value);                                                    \
     if (auto maybe_val = get_as<decltype(var)>(cfg, #var)) {                   \
-      check_eq(*maybe_val, value);                                             \
+      if constexpr (std::is_arithmetic_v<decltype(var)>)                       \
+        check_eq(*maybe_val, test::approx{value});                             \
+      else                                                                     \
+        check_eq(*maybe_val, value);                                           \
     } else {                                                                   \
       auto cv = get_if(std::addressof(cfg.content), #var);                     \
       fail("expected type {}, got {}",                                         \

--- a/libcaf_core/caf/config_option_set.test.cpp
+++ b/libcaf_core/caf/config_option_set.test.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/config_option_set.hpp"
 
+#include "caf/test/approx.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/log/test.hpp"
@@ -133,7 +134,7 @@ TEST("parse with ref syncing") {
       fail("parser stopped at: {}", *res.second);
     log::test::debug("verify referenced values");
     check_eq(foo_i, 42);
-    check_eq(foo_f, 1e2);
+    check_eq(foo_f, caf::test::approx{1e2});
     check_eq(foo_b, true);
     check_eq(bar_s, "hello");
     check_eq(bar_l, ls({"hello", "world"}));

--- a/libcaf_core/caf/detail/ieee_754.test.cpp
+++ b/libcaf_core/caf/detail/ieee_754.test.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/detail/ieee_754.hpp"
 
+#include "caf/test/approx.hpp"
 #include "caf/test/test.hpp"
 
 #include <limits>
@@ -22,7 +23,7 @@ using flimits = std::numeric_limits<float>;
 
 using dlimits = std::numeric_limits<double>;
 
-#define CHECK_RT(value) check_eq(roundtrip(value), value)
+#define CHECK_RT(value) check_eq(roundtrip(value), caf::test::approx{value})
 
 #define CHECK_PRED_RT(pred, value) check(pred(roundtrip(value)))
 

--- a/libcaf_core/caf/json_array.test.cpp
+++ b/libcaf_core/caf/json_array.test.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/json_array.hpp"
 
+#include "caf/test/approx.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/binary_deserializer.hpp"
@@ -81,7 +82,7 @@ TEST("from non-empty array") {
   require_eq(vals.size(), 3u);
   check_eq(vals[0].to_integer(), 1);
   check_eq(vals[1].to_string(), "two");
-  check_eq(vals[2].to_double(), 3.0);
+  check_eq(vals[2].to_double(), test::approx{3.0});
   check_eq(to_string(arr), R"_([1, "two", 3])_");
   check_eq(printed(arr), "[\n  1,\n  \"two\",\n  3\n]");
   check_eq(deep_copy(arr), arr);

--- a/libcaf_core/caf/json_builder.test.cpp
+++ b/libcaf_core/caf/json_builder.test.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/json_builder.hpp"
 
+#include "caf/test/approx.hpp"
 #include "caf/test/scenario.hpp"
 #include "caf/test/test.hpp"
 
@@ -138,7 +139,7 @@ TEST("float") {
     check(builder.value(4.2f));
     auto val = builder.seal();
     check(val.is_double());
-    check_eq(val.to_double(), 4.2f);
+    check_eq(val.to_double(), test::approx{4.2f});
   }
   SECTION("array") {
     auto xs = std::vector{4.2f, 4.2f, 4.2f};
@@ -153,14 +154,14 @@ TEST("double") {
   check(builder.value(4.2));
   auto val = builder.seal();
   check(val.is_double());
-  check_eq(val.to_double(), 4.2);
+  check_eq(val.to_double(), test::approx{4.2});
 }
 
 TEST("long double") {
   check(builder.value(4.2l));
   auto val = builder.seal();
   check(val.is_double());
-  check_eq(val.to_double(), 4.2);
+  check_eq(val.to_double(), test::approx{4.2});
 }
 
 TEST("byte") {

--- a/libcaf_core/caf/json_reader.test.cpp
+++ b/libcaf_core/caf/json_reader.test.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/json_reader.hpp"
 
+#include "caf/test/approx.hpp"
 #include "caf/test/scenario.hpp"
 #include "caf/test/test.hpp"
 
@@ -222,6 +223,8 @@ struct fixture {
       if (res) {
         if constexpr (std::is_same_v<T, message>)
           res = this_test.check_eq(to_string(tmp), to_string(obj));
+        else if constexpr (std::is_arithmetic_v<T>)
+          res = this_test.check_eq(tmp, test::approx{obj});
         else
           res = this_test.check_eq(tmp, obj);
       }

--- a/libcaf_core/caf/json_value.test.cpp
+++ b/libcaf_core/caf/json_value.test.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/json_value.hpp"
 
+#include "caf/test/approx.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/binary_deserializer.hpp"
@@ -67,7 +68,7 @@ TEST("default-constructed") {
   check(!val.is_object());
   check_eq(val.to_integer(), 0);
   check_eq(val.to_unsigned(), 0u);
-  check_eq(val.to_double(), 0.0);
+  check_eq(val.to_double(), test::approx{0.0});
   check_eq(val.to_bool(), false);
   check_eq(val.to_string(), ""sv);
   check_eq(val.to_object().size(), 0u);
@@ -90,7 +91,7 @@ TEST("from undefined") {
   check(!val.is_object());
   check_eq(val.to_integer(), 0);
   check_eq(val.to_unsigned(), 0u);
-  check_eq(val.to_double(), 0.0);
+  check_eq(val.to_double(), test::approx{0.0});
   check_eq(val.to_bool(), false);
   check_eq(val.to_string(), ""sv);
   check_eq(val.to_object().size(), 0u);
@@ -113,7 +114,7 @@ TEST("from negative integer") {
   check(!val.is_object());
   check_eq(val.to_integer(), -1);
   check_eq(val.to_unsigned(), 0u);
-  check_eq(val.to_double(), -1.0);
+  check_eq(val.to_double(), test::approx{-1.0});
   check_eq(val.to_bool(), false);
   check_eq(val.to_string(), ""sv);
   check_eq(val.to_object().size(), 0u);
@@ -137,7 +138,7 @@ TEST("from small integer") {
   check(!val.is_object());
   check_eq(val.to_integer(), 42);
   check_eq(val.to_unsigned(), 42u);
-  check_eq(val.to_double(), 42.0);
+  check_eq(val.to_double(), test::approx{42.0});
   check_eq(val.to_bool(), false);
   check_eq(val.to_string(), ""sv);
   check_eq(val.to_object().size(), 0u);
@@ -160,7 +161,7 @@ TEST("from UINT64_MAX") {
   check(!val.is_object());
   check_eq(val.to_integer(), 0);
   check_eq(val.to_unsigned(), UINT64_MAX);
-  check_eq(val.to_double(), static_cast<double>(UINT64_MAX));
+  check_eq(val.to_double(), test::approx{static_cast<double>(UINT64_MAX)});
   check_eq(val.to_bool(), false);
   check_eq(val.to_string(), ""sv);
   check_eq(val.to_object().size(), 0u);
@@ -182,7 +183,7 @@ TEST("from double") {
   check(!val.is_object());
   check_eq(val.to_integer(), 42);
   check_eq(val.to_unsigned(), 42u);
-  check_eq(val.to_double(), 42.0);
+  check_eq(val.to_double(), test::approx{42.0});
   check_eq(val.to_bool(), false);
   check_eq(val.to_string(), ""sv);
   check_eq(val.to_object().size(), 0u);
@@ -204,7 +205,7 @@ TEST("from bool") {
   check(!val.is_object());
   check_eq(val.to_integer(), 0);
   check_eq(val.to_unsigned(), 0u);
-  check_eq(val.to_double(), 0.0);
+  check_eq(val.to_double(), test::approx{0.0});
   check_eq(val.to_bool(), true);
   check_eq(val.to_string(), ""sv);
   check_eq(val.to_object().size(), 0u);
@@ -226,7 +227,7 @@ TEST("from string") {
   check(!val.is_object());
   check_eq(val.to_integer(), 0);
   check_eq(val.to_unsigned(), 0u);
-  check_eq(val.to_double(), 0.0);
+  check_eq(val.to_double(), test::approx{0.0});
   check_eq(val.to_bool(), false);
   check_eq(val.to_string(), "Hello, world!"sv);
   check_eq(val.to_object().size(), 0u);
@@ -248,7 +249,7 @@ TEST("from empty array") {
   check(!val.is_object());
   check_eq(val.to_integer(), 0);
   check_eq(val.to_unsigned(), 0u);
-  check_eq(val.to_double(), 0.0);
+  check_eq(val.to_double(), test::approx{0.0});
   check_eq(val.to_bool(), false);
   check_eq(val.to_string(), ""sv);
   check_eq(val.to_array().size(), 0u);
@@ -271,7 +272,7 @@ TEST("from array of size 1") {
   check(!val.is_object());
   check_eq(val.to_integer(), 0);
   check_eq(val.to_unsigned(), 0u);
-  check_eq(val.to_double(), 0.0);
+  check_eq(val.to_double(), test::approx{0.0});
   check_eq(val.to_bool(), false);
   check_eq(val.to_string(), ""sv);
   check_eq(val.to_array().size(), 1u);
@@ -294,7 +295,7 @@ TEST("from array of size 3") {
   check(!val.is_object());
   check_eq(val.to_integer(), 0);
   check_eq(val.to_unsigned(), 0u);
-  check_eq(val.to_double(), 0.0);
+  check_eq(val.to_double(), test::approx{0.0});
   check_eq(val.to_bool(), false);
   check_eq(val.to_string(), ""sv);
   check_eq(val.to_array().size(), 3u);
@@ -317,7 +318,7 @@ TEST("from empty object") {
   check(val.is_object());
   check_eq(val.to_integer(), 0);
   check_eq(val.to_unsigned(), 0u);
-  check_eq(val.to_double(), 0.0);
+  check_eq(val.to_double(), test::approx{0.0});
   check_eq(val.to_bool(), false);
   check_eq(val.to_string(), ""sv);
   check_eq(val.to_object().size(), 0u);
@@ -339,7 +340,7 @@ TEST("from non-empty object") {
   check(val.is_object());
   check_eq(val.to_integer(), 0);
   check_eq(val.to_unsigned(), 0u);
-  check_eq(val.to_double(), 0.0);
+  check_eq(val.to_double(), test::approx{0.0});
   check_eq(val.to_bool(), false);
   check_eq(val.to_string(), ""sv);
   check_eq(val.to_object().size(), 1u);

--- a/libcaf_core/caf/message.test.cpp
+++ b/libcaf_core/caf/message.test.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/message.hpp"
 
+#include "caf/test/approx.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/init_global_meta_objects.hpp"
@@ -87,7 +88,7 @@ TEST("messages allow index-based access") {
   check_eq(msg.types(), (make_type_id_list<std::string, uint32_t, double>()));
   check_eq(msg.get_as<std::string>(0), "abc");
   check_eq(msg.get_as<uint32_t>(1), 10u);
-  check_eq(msg.get_as<double>(2), 20.0);
+  check_eq(msg.get_as<double>(2), test::approx{20.0});
   check_eq(msg.cdata().get_reference_count(), 1u);
 }
 

--- a/libcaf_core/caf/serialization.test.cpp
+++ b/libcaf_core/caf/serialization.test.cpp
@@ -2,6 +2,7 @@
 // the main distribution directory for license terms and copyright or visit
 // https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
 
+#include "caf/test/approx.hpp"
 #include "caf/test/fixture/deterministic.hpp"
 #include "caf/test/outline.hpp"
 #include "caf/test/runnable.hpp"
@@ -702,7 +703,11 @@ OUTLINE("serializing and then deserializing primitive values") {
             using lhs_t = std::decay_t<decltype(lhs)>;
             using rhs_t = std::decay_t<decltype(rhs)>;
             if constexpr (std::is_same_v<lhs_t, rhs_t>) {
-              check_eq(lhs, rhs);
+              if constexpr (std::is_arithmetic_v<lhs_t>
+                            || std::is_arithmetic_v<rhs_t>)
+                check_eq(lhs, test::approx{rhs});
+              else
+                check_eq(lhs, rhs);
             } else {
               fail("type mismatch");
             }

--- a/libcaf_core/caf/telemetry/counter.test.cpp
+++ b/libcaf_core/caf/telemetry/counter.test.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/telemetry/counter.hpp"
 
+#include "caf/test/approx.hpp"
 #include "caf/test/test.hpp"
 
 using namespace caf;
@@ -14,15 +15,15 @@ TEST("counters can only increment") {
   SECTION("double counters") {
     telemetry::dbl_counter c;
     SECTION("counters start at 0") {
-      check_eq(c.value(), 0.0);
+      check_eq(c.value(), test::approx{0.0});
     }
     SECTION("counters are incrementable") {
       c.inc();
       c.inc(2.0);
-      check_eq(c.value(), 3.0);
+      check_eq(c.value(), test::approx{3.0});
     }
     SECTION("users can create counters with custom start values") {
-      check_eq(telemetry::dbl_counter{42.0}.value(), 42.0);
+      check_eq(telemetry::dbl_counter{42.0}.value(), test::approx{42.0});
     }
   }
   SECTION("integer counters") {

--- a/libcaf_core/caf/telemetry/gauge.test.cpp
+++ b/libcaf_core/caf/telemetry/gauge.test.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/telemetry/gauge.hpp"
 
+#include "caf/test/approx.hpp"
 #include "caf/test/test.hpp"
 
 using namespace caf;
@@ -14,24 +15,24 @@ TEST("gauges can increment and decrement") {
   SECTION("double gauges") {
     telemetry::dbl_gauge g;
     SECTION("gauges start at 0") {
-      check_eq(g.value(), 0.0);
+      check_eq(g.value(), test::approx{0.0});
     }
     SECTION("gauges are incrementable") {
       g.inc();
       g.inc(2.0);
-      check_eq(g.value(), 3.0);
+      check_eq(g.value(), test::approx{3.0});
     }
     SECTION("gauges are decrementable") {
       g.dec();
       g.dec(5.0);
-      check_eq(g.value(), -6.0);
+      check_eq(g.value(), test::approx{-6.0});
     }
     SECTION("gauges allow setting values") {
       g.value(42.0);
-      check_eq(g.value(), 42.0);
+      check_eq(g.value(), test::approx{42.0});
     }
     SECTION("users can create gauges with custom start values") {
-      check_eq(telemetry::dbl_gauge{42.0}.value(), 42.0);
+      check_eq(telemetry::dbl_gauge{42.0}.value(), test::approx{42.0});
     }
   }
   SECTION("integer gauges") {

--- a/libcaf_core/caf/telemetry/histogram.test.cpp
+++ b/libcaf_core/caf/telemetry/histogram.test.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/telemetry/histogram.hpp"
 
+#include "caf/test/approx.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/telemetry/gauge.hpp"
@@ -19,9 +20,9 @@ namespace {
 TEST("double histograms use infinity for the last bucket") {
   dbl_histogram h1{.1, .2, .4, .8};
   check_eq(h1.buckets().size(), 5u);
-  check_eq(h1.buckets().front().upper_bound, .1);
+  check_eq(h1.buckets().front().upper_bound, test::approx{.1});
   check(std::isinf(h1.buckets().back().upper_bound));
-  check_eq(h1.sum(), 0.0);
+  check_eq(h1.sum(), test::approx{0.0});
 }
 
 TEST("integer histograms use int_max for the last bucket") {

--- a/libcaf_core/caf/typed_event_based_actor.test.cpp
+++ b/libcaf_core/caf/typed_event_based_actor.test.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/typed_event_based_actor.hpp"
 
+#include "caf/test/approx.hpp"
 #include "caf/test/fixture/deterministic.hpp"
 #include "caf/test/scenario.hpp"
 #include "caf/test/test.hpp"
@@ -347,7 +348,7 @@ behavior foo2(event_based_actor* self) {
 float_actor::behavior_type float_fun(float_actor::pointer self) {
   return {
     [=](float a) {
-      test::runnable::current().check_eq(a, 1.0f);
+      test::runnable::current().check_eq(a, test::approx{1.0f});
       self->quit(exit_reason::user_shutdown);
     },
   };

--- a/libcaf_core/caf/typed_spawn.test.cpp
+++ b/libcaf_core/caf/typed_spawn.test.cpp
@@ -2,6 +2,7 @@
 // the main distribution directory for license terms and copyright or visit
 // https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
 
+#include "caf/test/approx.hpp"
 #include "caf/test/fixture/deterministic.hpp"
 #include "caf/test/scenario.hpp"
 #include "caf/test/test.hpp"
@@ -266,7 +267,7 @@ behavior foo2(event_based_actor* self) {
 float_actor::behavior_type float_fun(float_actor::pointer self) {
   return {
     [=](float a) {
-      test::runnable::current().check_eq(a, 1.0f);
+      test::runnable::current().check_eq(a, test::approx{1.0f});
       self->quit(exit_reason::user_shutdown);
     },
   };

--- a/libcaf_test/caf/test/approx.hpp
+++ b/libcaf_test/caf/test/approx.hpp
@@ -1,0 +1,41 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include <limits>
+
+namespace caf::test {
+
+/// Allows comparing a value of type `T` with a configurable precision.
+template <class T>
+class approx {
+public:
+  explicit approx(T value) : value_(value) {
+  }
+
+  approx epsilon(T eps) const {
+    auto copy = *this;
+    copy.epsilon_ = eps;
+    return copy;
+  }
+
+  friend bool operator==(T lhs, approx<T> rhs) {
+    return lhs >= rhs.min_value() && lhs <= rhs.max_value();
+  }
+
+private:
+  T min_value() {
+    return value_ - epsilon_;
+  }
+
+  T max_value() {
+    return value_ + epsilon_;
+  }
+
+  T value_;
+  T epsilon_ = std::numeric_limits<T>::epsilon();
+};
+
+} // namespace caf::test

--- a/libcaf_test/caf/test/outline.test.cpp
+++ b/libcaf_test/caf/test/outline.test.cpp
@@ -4,6 +4,8 @@
 
 #include "caf/test/outline.hpp"
 
+#include "caf/test/approx.hpp"
+
 #include "caf/log/test.hpp"
 
 #include <numeric>
@@ -39,7 +41,7 @@ OUTLINE("adding two numbers") {
       auto result = x + y;
       THEN("the result should be <sum>") {
         auto sum = block_parameters<double>();
-        check_eq(result, sum);
+        check_eq(result, caf::test::approx{sum});
       }
     }
   }

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -65,6 +65,9 @@ public:
                 const detail::source_location& location
                 = detail::source_location::current()) {
     assert_save_comparison<T0, T1>();
+    static_assert(
+      !(std::is_floating_point_v<T0> && std::is_floating_point_v<T1>),
+      "comparing floating points using operator== is unsafe, use approx");
     if (lhs == rhs) {
       reporter::instance().pass(location);
       return true;

--- a/manual/Testing.rst
+++ b/manual/Testing.rst
@@ -49,6 +49,25 @@ writing checks that depend on other checks. For example:
     check_eq(xs.back(), 42);
   }
 
+Approximate Comparisons
+-----------------------
+
+When working with floating point numbers, comparing for equality is generally
+unsafe due to rounding errors and limited precision. To account for this, the
+testing framework includes the template class ``caf::test::approx`` for
+approximate comparisons. The class provides a constructor that takes a value and
+when passing ``approx`` to ``check_eq`` or ``require_eq``, the comparison will
+accept the value if it is within a certain range of the expected value.
+
+By default, the allowed deviation is ``std::numeric_limits<T>::epsilon()``.
+Users can change the deviation by using the ``epsilon`` member function. For
+example:
+
+.. code-block:: C++
+
+  check_eq(my_fn(), approx{3.117}); // uses the default epsilon
+  check_eq(my_fn(), approx{3.117}.epsilon(0.001)); // allows 3.116 <= x <= 3.118
+
 Requirements
 ------------
 


### PR DESCRIPTION
Refactor tests to use `approx` class with adjustable epsilon to compare floating points, instead of comparing floating point with equal operator.