### PR TITLE
Change handling of special messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,11 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - The use case for `function_view` is covered by the new feature on blocking
   actors that allows calling `receive` with no arguments. Hence, `function_view`
   becomes obsolete and is deprecated.
+- The `set_default_handler` member function on event-based actors is now
+  deprecated. Instead, users should use a handler for `message` in their
+  behavior as a catch-all. For skipping messages, CAF now includes a new
+  `mail_cache` class that allows explicitly stashing messages for later
+  processing.
 
 ## [0.19.5] - 2024-01-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Passing a class to `spawn_inactive` is now optional and defaults to
   `event_based_actor`. The next major release will remove the class parameter
   altogether.
+- Event-based actors can now handle types like `exit_msg` and `error` in their
+  regular behavior.
 
 ### Deprecated
 
@@ -122,6 +124,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   behavior as a catch-all. For skipping messages, CAF now includes a new
   `mail_cache` class that allows explicitly stashing messages for later
   processing.
+- Special-purpose handlers for messages like `exit_msg` and `error` are now
+  deprecated. Instead, users should handle these messages in their regular
+  behavior.
 
 ## [0.19.5] - 2024-01-08
 

--- a/examples/dynamic_behavior/skip_messages.cpp
+++ b/examples/dynamic_behavior/skip_messages.cpp
@@ -2,32 +2,46 @@
 // messages in the mailbox until an actor switches to another behavior that can
 // handle them.
 
+#include "caf/actor_from_state.hpp"
 #include "caf/actor_ostream.hpp"
 #include "caf/actor_system.hpp"
 #include "caf/caf_main.hpp"
 #include "caf/event_based_actor.hpp"
+#include "caf/fwd.hpp"
+#include "caf/mail_cache.hpp"
 #include "caf/scoped_actor.hpp"
 
 using namespace caf;
 using namespace std::literals;
 
-behavior server(event_based_actor* self) {
-  // Setting the default handler to `skip` will keep all unmatched messages in
-  // the mailbox until we switch to another behavior that handles them. This
-  // allows us to receive idle and ping messages in any order but process them
-  // in alternating order.
-  self->set_default_handler(skip);
-  return {
-    [self](idle_atom, const actor& worker) {
-      // Passing keep_behavior allows us to return to this behavior later on by
-      // calling `self->unbecome()`.
-      self->become(keep_behavior, [self, worker](ping_atom atm) {
-        self->delegate(worker, atm);
-        self->unbecome();
-      });
-    },
-  };
-}
+struct server_state {
+  server_state(event_based_actor* selfptr) : self(selfptr), cache(self, 10) {
+    // nop
+  }
+
+  behavior make_behavior() {
+    return {
+      [this](idle_atom, const actor& worker) {
+        // Passing keep_behavior allows us to return to this behavior later on
+        // by calling `self->unbecome()`.
+        self->become(keep_behavior, [this, worker](ping_atom) {
+          // Switch back to our default behavior, put all messages from the
+          // cache back to the mailbox and delegate 'ping' to the worker.
+          self->unbecome();
+          cache.unstash();
+          return self->mail(ping_atom_v).delegate(worker);
+        });
+      },
+      [this](message msg) {
+        // Stash all messages until we receive an `idle_atom`.
+        cache.stash(std::move(msg));
+      },
+    };
+  }
+
+  event_based_actor* self;
+  mail_cache cache;
+};
 
 behavior client(event_based_actor* self, const actor& serv) {
   self->link_to(serv);
@@ -41,7 +55,7 @@ behavior client(event_based_actor* self, const actor& serv) {
 }
 
 void caf_main(actor_system& sys) {
-  auto serv = sys.spawn(server);
+  auto serv = sys.spawn(actor_from_state<server_state>);
   auto worker = sys.spawn(client, serv);
   scoped_actor self{sys};
   self->mail(ping_atom_v)

--- a/libcaf_core/caf/detail/type_list.hpp
+++ b/libcaf_core/caf/detail/type_list.hpp
@@ -228,6 +228,35 @@ struct tl_at<type_list<E...>, N> {
 template <class List, size_t N>
 using tl_at_t = typename tl_at<List, N>::type;
 
+// list remove(list, value)
+
+template <class Input, class Value, class Output>
+struct tl_remove_impl;
+
+template <class Value, class... Out>
+struct tl_remove_impl<empty_type_list, Value, type_list<Out...>> {
+  using type = type_list<Out...>;
+};
+
+template <class T, class... Ts, class Value, class... Out>
+struct tl_remove_impl<type_list<T, Ts...>, Value, type_list<Out...>> {
+  using type = std::conditional_t<
+    std::is_same_v<T, Value>,
+    typename tl_remove_impl<type_list<Ts...>, Value, type_list<Out...>>::type,
+    typename tl_remove_impl<type_list<Ts...>, Value,
+                            type_list<Out..., T>>::type>;
+};
+
+template <class List, class T>
+struct tl_remove;
+
+template <class... Ts, class T>
+struct tl_remove<type_list<Ts...>, T>
+  : tl_remove_impl<type_list<Ts...>, T, type_list<>> {};
+
+template <class List, class T>
+using tl_remove_t = typename tl_remove<List, T>::type;
+
 // list filter(list, predicate)
 
 template <class Input, class Selection, class Output>

--- a/libcaf_core/caf/interface_mismatch.hpp
+++ b/libcaf_core/caf/interface_mismatch.hpp
@@ -4,85 +4,53 @@
 
 #pragma once
 
+#include "caf/detail/type_list.hpp"
 #include "caf/fwd.hpp"
+#include "caf/timeout_definition.hpp"
 #include "caf/type_list.hpp"
 
 namespace caf::detail {
 
-// imi = interface_mismatch_implementation
-// Precondition: Pos == 0 && len(Xs) == len(Ys) && len(Zs) == 0
-// Iterate over Xs to find a match in Ys; Zs is used as temporary storage
-// to iterate over Ys. On a match, the element is removed from Xs and Ys and
-// Zs are prepended to Ys again for next iteration.
-// Evaluates to:
-// * len(Xs) if interface check succeeds
-// * Pos on a mismatch (incremented per iteration to reflect position in Xs)
-template <int Pos, class Xs, class Ys, class Zs>
-struct imi;
-
-// end of recursion: success (consumed both lists)
-template <int Pos>
-struct imi<Pos, type_list<>, type_list<>, type_list<>> {
+template <int Pos, class Xs, class Ys>
+struct imi_result {
   static constexpr int value = Pos;
-  using xs = type_list<>;
-  using ys = type_list<>;
+  using xs = Xs;
+  using ys = Ys;
 };
 
-// end of recursion: success (consumed both lists, except the timeout)
-template <int Pos, class X>
-struct imi<Pos, type_list<timeout_definition<X>>, type_list<>, type_list<>> {
-  static constexpr int value = Pos + 1; // count timeout def. as consumed
-  using xs = type_list<>;
-  using ys = type_list<>;
-};
+template <int Pos, class... Ys>
+constexpr auto match_interface(type_list<>, type_list<Ys...>) {
+  return imi_result<(sizeof...(Ys) == 0 ? Pos : -1), type_list<>,
+                    type_list<Ys...>>{};
+}
 
-// end of recursion: failure (consumed all Xs but not all Ys)
-template <int Pos, class Yin, class Yout, class... Ys>
-struct imi<Pos, type_list<>, type_list<Yout(Yin), Ys...>, type_list<>> {
-  static constexpr int value = -1;
-  using xs = type_list<>;
-  using ys = type_list<Yout(Yin), Ys...>;
-};
+template <class Signature>
+struct is_special_handler : std::false_type {};
 
-// end of recursion: failure (consumed all Ys but not all Xs)
-template <int Pos, class Xin, class Xout, class... Xs>
-struct imi<Pos, type_list<Xout(Xin), Xs...>, type_list<>, type_list<>> {
-  static constexpr int value = -2;
-  using xs = type_list<Xout(Xin), Xs...>;
-  using ys = type_list<>;
-};
+template <>
+struct is_special_handler<result<void>(down_msg)> : std::true_type {};
 
-// end of recursion: failure (consumed all Ys except timeout but not all Xs)
-template <int Pos, class X, class Y, class... Ys>
-struct imi<Pos, type_list<timeout_definition<X>>, type_list<Y, Ys...>,
-           type_list<>> {
-  static constexpr int value = -2;
-  using xs = type_list<>;
-  using ys = type_list<Y, Ys...>;
-};
+template <>
+struct is_special_handler<result<void>(exit_msg)> : std::true_type {};
 
-// case #1a: exact match
-template <int Pos, class Out, class... In, class... Xs, class... Ys,
-          class... Zs>
-struct imi<Pos, type_list<Out(In...), Xs...>, type_list<Out(In...), Ys...>,
-           type_list<Zs...>>
-  : imi<Pos + 1, type_list<Xs...>, type_list<Zs..., Ys...>, type_list<>> {};
+template <>
+struct is_special_handler<result<void>(error)> : std::true_type {};
 
-// case #2: no match at position
-template <int Pos, class Xout, class... Xin, class... Xs, class Yout,
-          class... Yin, class... Ys, class... Zs>
-struct imi<Pos, type_list<Xout(Xin...), Xs...>, type_list<Yout(Yin...), Ys...>,
-           type_list<Zs...>>
-  : imi<Pos, type_list<Xout(Xin...), Xs...>, type_list<Ys...>,
-        type_list<Zs..., Yout(Yin...)>> {};
+template <>
+struct is_special_handler<result<void>(node_down_msg)> : std::true_type {};
 
-// case #3: no match (error)
-template <int Pos, class X, class... Xs, class... Zs>
-struct imi<Pos, type_list<X, Xs...>, type_list<>, type_list<Zs...>> {
-  static constexpr int value = Pos;
-  using xs = type_list<X, Xs...>;
-  using ys = type_list<Zs...>;
-};
+template <int Pos, class X, class... Xs, class Ys>
+constexpr auto match_interface(type_list<X, Xs...>, Ys) {
+  if constexpr (is_special_handler<X>::value) {
+    return match_interface<Pos + 1>(type_list_v<Xs...>, Ys{});
+  } else if constexpr (tl_contains_v<Ys, X>) {
+    return match_interface<Pos + 1>(type_list_v<Xs...>, tl_remove_t<Ys, X>{});
+  } else if constexpr (is_timeout_definition_v<X> && sizeof...(Xs) == 0) {
+    return match_interface<Pos + 1>(type_list_v<Xs...>, Ys{});
+  } else {
+    return imi_result<Pos, type_list<X, Xs...>, Ys>{};
+  }
+}
 
 } // namespace caf::detail
 
@@ -92,6 +60,7 @@ namespace caf {
 /// first mismatch. Returns the number of elements on a match.
 /// @pre len(Found) == len(Expected)
 template <class Found, class Expected>
-using interface_mismatch_t = detail::imi<0, Found, Expected, type_list<>>;
+using interface_mismatch_t
+  = decltype(detail::match_interface<0>(Found{}, Expected{}));
 
 } // namespace caf

--- a/libcaf_core/caf/mixin/sender.test.cpp
+++ b/libcaf_core/caf/mixin/sender.test.cpp
@@ -89,9 +89,12 @@ TEST("exceptions while processing a message will send error to the sender") {
     };
   });
   dispatch_messages();
-  auto client = sys.spawn([worker](event_based_actor*) -> behavior {
-    return [](message) { //
-      test::runnable::current().fail("unexpected handler called");
+  auto client = sys.spawn([](event_based_actor* self) -> behavior {
+    return {
+      [self](error what) { self->quit(std::move(what)); },
+      [](message) {
+        test::runnable::current().fail("unexpected handler called");
+      },
     };
   });
   inject().with(42).from(client).to(worker);

--- a/libcaf_core/caf/monitor.test.cpp
+++ b/libcaf_core/caf/monitor.test.cpp
@@ -15,8 +15,9 @@ namespace {
 WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("monitoring another actor") {
-  auto client_spawn = [](event_based_actor*) {
+  auto client_spawn = [](event_based_actor* self) {
     return behavior{
+      [self](const exit_msg& msg) { self->quit(msg.reason); },
       [](message) {},
     };
   };

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -339,7 +339,7 @@ void scheduled_actor::quit(error x) {
   down_handler_ = silently_ignore<down_msg>;
   set_error_handler(silently_ignore<error>);
   // Drop future messages and produce sec::request_receiver_down for requests.
-  set_default_handler(drop_after_quit);
+  default_handler_ = drop_after_quit;
   // Make sure we're not waiting for flows or stream anymore.
   cancel_flows_and_streams();
 }

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -278,6 +278,7 @@ public:
   }
 
   /// Sets a custom handler for error messages.
+  [[deprecated("use a handler for 'error' instead")]]
   void set_error_handler(error_handler fun) {
     if (fun)
       error_handler_ = std::move(fun);
@@ -287,6 +288,7 @@ public:
 
   /// Sets a custom handler for error messages.
   template <class F>
+  [[deprecated("use a handler for 'error' instead")]]
   std::enable_if_t<std::is_invocable_v<F, error&>> set_error_handler(F fun) {
     error_handler_ = [fn{std::move(fun)}](scheduled_actor*, error& x) mutable {
       fn(x);
@@ -311,6 +313,7 @@ public:
   }
 
   /// Sets a custom handler for node down messages.
+  [[deprecated("use a handler for 'node_down_msg' instead")]]
   void set_node_down_handler(node_down_handler fun) {
     if (fun)
       node_down_handler_ = std::move(fun);
@@ -320,6 +323,7 @@ public:
 
   /// Sets a custom handler for down messages.
   template <class F>
+  [[deprecated("use a handler for 'node_down_msg' instead")]]
   std::enable_if_t<std::is_invocable_v<F, node_down_msg&>>
   set_node_down_handler(F fun) {
     node_down_handler_ = [fn{std::move(fun)}](scheduled_actor*,
@@ -329,6 +333,7 @@ public:
   }
 
   /// Sets a custom handler for error messages.
+  [[deprecated("use a handler for 'exit_msg' instead")]]
   void set_exit_handler(exit_handler fun) {
     if (fun)
       exit_handler_ = std::move(fun);
@@ -338,6 +343,7 @@ public:
 
   /// Sets a custom handler for exit messages.
   template <class F>
+  [[deprecated("use a handler for 'exit_msg' instead")]]
   std::enable_if_t<std::is_invocable_v<F, exit_msg&>> set_exit_handler(F fun) {
     exit_handler_ = [fn{std::move(fun)}](scheduled_actor*,
                                          exit_msg& x) mutable { fn(x); };

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -258,6 +258,7 @@ public:
   // -- event handlers ---------------------------------------------------------
 
   /// Sets a custom handler for unexpected messages.
+  [[deprecated("use a handler for 'message' instead")]]
   void set_default_handler(default_handler fun) {
     if (fun)
       default_handler_ = std::move(fun);
@@ -267,6 +268,7 @@ public:
 
   /// Sets a custom handler for unexpected messages.
   template <class F>
+  [[deprecated("use a handler for 'message' instead")]]
   std::enable_if_t<std::is_invocable_r_v<skippable_result, F, message&>>
   set_default_handler(F fun) {
     default_handler_ = [fn{std::move(fun)}](scheduled_actor*,

--- a/libcaf_core/caf/typed_event_based_actor.test.cpp
+++ b/libcaf_core/caf/typed_event_based_actor.test.cpp
@@ -409,6 +409,29 @@ TEST("check signature") {
   check_eq(dispatch_messages(), 2u);
 }
 
+TEST("special-purpose types are automatically part of the interface") {
+  auto impl = []() -> int_actor::behavior_type {
+    return {
+      [](const down_msg&) {
+        // nop
+      },
+      [](const exit_msg&) {
+        // nop
+      },
+      [](const error&) {
+        // nop
+      },
+      [](const node_down_msg&) {
+        // nop
+      },
+      [](int x) { return x * x; },
+    };
+  };
+  auto aut = sys.spawn(impl);
+  anon_mail(3).send(aut);
+  expect<int>().with(3).to(aut);
+}
+
 SCENARIO("state classes may use typed pointers") {
   GIVEN("a state class for a statically typed actor type") {
     using foo_type = typed_actor<result<int32_t>(get_atom)>;

--- a/libcaf_io/caf/io/middleman_actor_impl.cpp
+++ b/libcaf_io/caf/io/middleman_actor_impl.cpp
@@ -29,10 +29,7 @@ namespace caf::io {
 middleman_actor_impl::middleman_actor_impl(actor_config& cfg,
                                            actor default_broker)
   : middleman_actor::base(cfg), broker_(std::move(default_broker)) {
-  set_exit_handler([=](exit_msg&) {
-    // ignored, the MM links group nameservers
-    // to this actor for proper shutdown ordering
-  });
+  // nop
 }
 
 void middleman_actor_impl::on_exit() {
@@ -170,6 +167,10 @@ auto middleman_actor_impl::make_behavior() -> behavior_type {
       auto lg = log::io::trace("");
       delegate(broker_, get_atom_v, std::move(nid));
       return {};
+    },
+    [](const exit_msg&) {
+      // Ignore exit messages. The middleman only links group nameservers to
+      // this actor for proper shutdown ordering.
     },
   };
   // Note: needed to sneak the extra `delete_atom` handler into the behavior.


### PR DESCRIPTION
- Event-based actors can now handle types like `exit_msg` and `error` in their regular behavior.
- The `set_default_handler` member function on event-based actors is now deprecated. Instead, users should use a handler for `message` in their behavior as a catch-all. For skipping messages, CAF now includes a new `mail_cache` class that allows explicitly stashing messages for later processing.
- Special-purpose handlers for messages like `exit_msg` and `error` are now deprecated. Instead, users should handle these messages in their regular behavior.

Closes #1800.