### PR TITLE
Fix image reference for the buffer operator

### DIFF
--- a/manual/DataFlows.rst
+++ b/manual/DataFlows.rst
@@ -193,7 +193,7 @@ The operator also takes an optional second argument that specifies the maximum
 time period between two items before the buffer is emitted regardless of its
 size.
 
-.. image:: op/concat.svg
+.. image:: op/buffer.svg
 
 Concat
 ++++++


### PR DESCRIPTION
I've noted that we show the wrong image for the `buffer` operator.