### PR TITLE
Improve convenience for typed actors

### DIFF
--- a/libcaf_core/caf/type_list.hpp
+++ b/libcaf_core/caf/type_list.hpp
@@ -12,6 +12,9 @@ struct type_list {
   constexpr type_list() {
     // nop
   }
+
+  template <class... Us>
+  using append = type_list<Ts..., Us...>;
 };
 
 template <class... Ts>

--- a/libcaf_core/caf/typed_actor_view.hpp
+++ b/libcaf_core/caf/typed_actor_view.hpp
@@ -261,6 +261,20 @@ public:
     return self_->run_delayed_weak(delay, std::move(what));
   }
 
+  // -- printing ---------------------------------------------------------------
+
+  /// Adds a new line to stdout.
+  template <class... Args>
+  void println(std::string_view fmt, Args&&... args) {
+    system().println(fmt, std::forward<Args>(args)...);
+  }
+
+  /// Adds a new line to stdout.
+  template <class... Args>
+  void println(term color, std::string_view fmt, Args&&... args) {
+    system().println(color, fmt, std::forward<Args>(args)...);
+  }
+
   // -- miscellaneous actor operations -----------------------------------------
 
   void quit(exit_reason reason = exit_reason::normal) {


### PR DESCRIPTION
- add missing `println` member function typed actor views
- add `type_list::append` to make extending signature lists simpler

Here's a motivating example for the `append` utility:

```c++
struct compute_unit_trait {
  using signatures = caf::type_list<
    caf::result<int32_t>(caf::add_atom, int32_t, int32_t),
    caf::result<int32_t>(caf::sub_atom, int32_t, int32_t)
  >;
};

using compute_unit_actor = caf::typed_actor<compute_unit_trait>;

struct compute_service_trait {
  using signatures = compute_unit_trait::signatures::append<
    caf::result<void>(caf::spawn_atom, int32_t)
  >;
};

using compute_service_actor = caf::typed_actor<compute_service_trait>;
```