### PR TITLE
Add text-client example with robot test

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -97,6 +97,7 @@ add_net_example(length_prefix_framing chat-client)
 add_net_example(length_prefix_framing chat-server)
 
 add_net_example(octet_stream key-value-store)
+add_net_example(octet_stream text-client)
 
 add_net_example(web_socket echo)
 add_net_example(web_socket hello-client)

--- a/examples/octet_stream/text-client.cpp
+++ b/examples/octet_stream/text-client.cpp
@@ -9,6 +9,7 @@
 #include "caf/async/spsc_buffer.hpp"
 #include "caf/caf_main.hpp"
 #include "caf/flow/byte.hpp"
+#include "caf/flow/string.hpp"
 #include "caf/json_reader.hpp"
 #include "caf/scheduled_actor/flow.hpp"
 
@@ -41,79 +42,22 @@ struct config : caf::actor_system_config {
     auto result = actor_system_config::dump_content();
     caf::put_missing(result, "host", default_host);
     caf::put_missing(result, "port", default_port);
-    caf::put_missing(result, "enable", false);
     return result;
   }
 };
 
 // -- main ---------------------------------------------------------------------
 
-namespace {
-
-std::atomic<bool> shutdown_flag;
-
-void set_shutdown_flag(int) {
-  shutdown_flag = true;
-}
-
-void worker(caf::event_based_actor* self,
-            caf::async::consumer_resource<std::byte> pull,
-            caf::async::consumer_resource<std::byte> input_consumer,
-            caf::async::producer_resource<std::byte> push) {
-  auto producer = caf::async::make_blocking_producer(push);
-  self->make_observable()
-    .from_resource(std::move(pull))
-    .transform(caf::flow::byte::split_as_utf8_at('\n'))
-    .do_on_error([self](const caf::error& err) {
-      self->println("*** connection error: {}", err);
-      self->quit();
-    })
-    .do_finally([self] {
-      self->println("*** lost connection to server -> quit\n*** use "
-                    "CTRL+D or CTRL+C to terminate");
-      self->quit();
-    })
-    .for_each([self](const caf::cow_string& line) {
-      self->println("reply: {}", line.str());
-    });
-  self->make_observable()
-    .from_resource(std::move(input_consumer))
-    .transform(caf::flow::byte::split_as_utf8_at('\n'))
-    .do_on_error([self](const caf::error& err) {
-      self->println(
-        "*** input error: {}\n*** use CTRL+D or CTRL+C to terminate", err);
-      self->quit();
-    })
-    .do_finally([self] {
-      self->println("*** lost connection to input -> quit\n*** use "
-                    "CTRL+D or CTRL+C to terminate");
-      self->quit();
-    })
-    .for_each(
-      [producer = std::move(producer)](const caf::cow_string& line) mutable {
-        assert(producer);
-        std::string message = line.str() + '\n';
-        producer->push(caf::as_bytes(caf::make_span(message)));
-      });
-}
-
-} // namespace
-
 int caf_main(caf::actor_system& sys, const config& cfg) {
   namespace ssl = caf::net::ssl;
-  // Do a regular shutdown for CTRL+C and SIGTERM.
-  auto default_term = signal(SIGTERM, set_shutdown_flag);
-  auto default_sint = signal(SIGINT, set_shutdown_flag);
   // Read the configuration.
-  auto use_tls = caf::get_or(cfg, "tls.enable", false);
   auto port = caf::get_or(cfg, "port", default_port);
   auto host = caf::get_or(cfg, "host", default_host);
+  auto use_tls = caf::get_or(cfg, "tls.enable", false);
   auto ca_file = caf::get_as<std::string>(cfg, "tls.ca-file");
-  auto input_resource = caf::async::make_spsc_buffer_resource<std::byte>();
-  auto& input_consumer_resource = input_resource.first;
-  auto& input_producer_resource = input_resource.second;
-  auto input_producer
-    = caf::async::make_blocking_producer(input_producer_resource);
+  // Connect to the server.
+  auto [line_producer, line_pull]
+    = caf::async::make_blocking_producer<caf::cow_string>();
   auto conn
     = caf::net::octet_stream::with(sys)
         // Optionally enable TLS.
@@ -126,30 +70,43 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
         .retry_delay(1s)
         .max_retry_count(9)
         // After connecting, spin up a worker that prints received inputs.
-        .start([&sys, input_consumer_resource](auto pull, auto push) {
-          sys.spawn<caf::detached>(worker, std::move(pull),
-                                   std::move(input_consumer_resource),
-                                   std::move(push));
+        .start([&sys, lpull = line_pull](auto pull, auto push) {
+          sys.spawn([lpull, pull, push](caf::event_based_actor* self) {
+            // Print each line received from the server.
+            pull.observe_on(self)
+              .do_on_error([self](const caf::error& err) {
+                self->println("*** connection error: {}", err);
+                self->quit();
+              })
+              .do_finally([self] {
+                self->println("*** lost connection to server");
+                self->quit();
+              })
+              .transform(caf::flow::byte::split_as_utf8_at('\n'))
+              .for_each([self](const caf::cow_string& line) {
+                self->println("reply: {}", line.str());
+              });
+            // Read what the users types and send it to the server.
+            lpull.observe_on(self)
+              .do_finally([self] { self->quit(); })
+              .transform(caf::flow::string::to_chars("\n"))
+              .map([](char ch) { return static_cast<std::byte>(ch); })
+              .subscribe(push);
+          });
         });
   // Report any error to the user.
   if (!conn) {
     sys.println("*** unable to run at port {}: {}", port, conn.error());
     return EXIT_FAILURE;
   }
-  // Wait for CTRL+C or SIGTERM.
-  sys.println("*** Client is running, press CTRL+C to stop");
+  // Send each line to the server and stop if stdin closes or on an empty line.
+  sys.println("*** server is running, enter an empty line (or CTRL+D) to stop");
   auto line = std::string{};
   while (std::getline(std::cin, line)) {
-    line = line + '\n';
-    input_producer->push(caf::as_bytes(caf::make_span(line)));
+    sys.println("line: {}", line);
+    line_producer.push(caf::cow_string{line});
     line.clear();
   }
-  while (!shutdown_flag)
-    std::this_thread::sleep_for(250ms);
-  // Restore the default handlers.
-  signal(SIGTERM, default_term);
-  signal(SIGINT, default_sint);
-  // Shut down the client.
   sys.println("*** shutting down");
   return EXIT_SUCCESS;
 }

--- a/examples/octet_stream/text-client.cpp
+++ b/examples/octet_stream/text-client.cpp
@@ -1,0 +1,157 @@
+// A client for a line-based text protocol over TCP.
+
+#include "caf/net/middleman.hpp"
+#include "caf/net/octet_stream/with.hpp"
+
+#include "caf/actor_from_state.hpp"
+#include "caf/anon_mail.hpp"
+#include "caf/async/blocking_producer.hpp"
+#include "caf/async/spsc_buffer.hpp"
+#include "caf/caf_main.hpp"
+#include "caf/flow/byte.hpp"
+#include "caf/json_reader.hpp"
+#include "caf/scheduled_actor/flow.hpp"
+
+#include <csignal>
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+using namespace std::literals;
+
+// -- constants ----------------------------------------------------------------
+
+static constexpr uint16_t default_port = 7788;
+
+static constexpr std::string_view default_host = "localhost";
+
+// -- configuration setup ------------------------------------------------------
+
+struct config : caf::actor_system_config {
+  config() {
+    opt_group{custom_options_, "global"} //
+      .add<std::string>("host,h", "server host")
+      .add<uint16_t>("port,p", "port to listen for incoming connections");
+    opt_group{custom_options_, "tls"} //
+      .add<bool>("enable,t", "enables encryption via TLS")
+      .add<std::string>("ca-file", "CA file for trusted servers");
+  }
+
+  caf::settings dump_content() const override {
+    auto result = actor_system_config::dump_content();
+    caf::put_missing(result, "host", default_host);
+    caf::put_missing(result, "port", default_port);
+    caf::put_missing(result, "enable", false);
+    return result;
+  }
+};
+
+// -- main ---------------------------------------------------------------------
+
+namespace {
+
+std::atomic<bool> shutdown_flag;
+
+void set_shutdown_flag(int) {
+  shutdown_flag = true;
+}
+
+void worker(caf::event_based_actor* self,
+            caf::async::consumer_resource<std::byte> pull,
+            caf::async::consumer_resource<std::byte> input_consumer,
+            caf::async::producer_resource<std::byte> push) {
+  auto producer = caf::async::make_blocking_producer(push);
+  self->make_observable()
+    .from_resource(std::move(pull))
+    .transform(caf::flow::byte::split_as_utf8_at('\n'))
+    .do_on_error([self](const caf::error& err) {
+      self->println("*** connection error: {}", err);
+      self->quit();
+    })
+    .do_finally([self] {
+      self->println("*** lost connection to server -> quit\n*** use "
+                    "CTRL+D or CTRL+C to terminate");
+      self->quit();
+    })
+    .for_each([self](const caf::cow_string& line) {
+      self->println("reply: {}", line.str());
+    });
+  self->make_observable()
+    .from_resource(std::move(input_consumer))
+    .transform(caf::flow::byte::split_as_utf8_at('\n'))
+    .do_on_error([self](const caf::error& err) {
+      self->println(
+        "*** input error: {}\n*** use CTRL+D or CTRL+C to terminate", err);
+      self->quit();
+    })
+    .do_finally([self] {
+      self->println("*** lost connection to input -> quit\n*** use "
+                    "CTRL+D or CTRL+C to terminate");
+      self->quit();
+    })
+    .for_each(
+      [producer = std::move(producer)](const caf::cow_string& line) mutable {
+        assert(producer);
+        std::string message = line.str() + '\n';
+        producer->push(caf::as_bytes(caf::make_span(message)));
+      });
+}
+
+} // namespace
+
+int caf_main(caf::actor_system& sys, const config& cfg) {
+  namespace ssl = caf::net::ssl;
+  // Do a regular shutdown for CTRL+C and SIGTERM.
+  auto default_term = signal(SIGTERM, set_shutdown_flag);
+  auto default_sint = signal(SIGINT, set_shutdown_flag);
+  // Read the configuration.
+  auto use_tls = caf::get_or(cfg, "tls.enable", false);
+  auto port = caf::get_or(cfg, "port", default_port);
+  auto host = caf::get_or(cfg, "host", default_host);
+  auto ca_file = caf::get_as<std::string>(cfg, "tls.ca-file");
+  auto input_resource = caf::async::make_spsc_buffer_resource<std::byte>();
+  auto& input_consumer_resource = input_resource.first;
+  auto& input_producer_resource = input_resource.second;
+  auto input_producer
+    = caf::async::make_blocking_producer(input_producer_resource);
+  auto conn
+    = caf::net::octet_stream::with(sys)
+        // Optionally enable TLS.
+        .context(ssl::context::enable(use_tls)
+                   .and_then(ssl::emplace_client(ssl::tls::v1_2))
+                   .and_then(ssl::load_verify_file_if(ca_file)))
+        // Connect to "$host:$port".
+        .connect(host, port)
+        // If we don't succeed at first, try up to 10 times with 1s delay.
+        .retry_delay(1s)
+        .max_retry_count(9)
+        // After connecting, spin up a worker that prints received inputs.
+        .start([&sys, input_consumer_resource](auto pull, auto push) {
+          sys.spawn<caf::detached>(worker, std::move(pull),
+                                   std::move(input_consumer_resource),
+                                   std::move(push));
+        });
+  // Report any error to the user.
+  if (!conn) {
+    sys.println("*** unable to run at port {}: {}", port, conn.error());
+    return EXIT_FAILURE;
+  }
+  // Wait for CTRL+C or SIGTERM.
+  sys.println("*** Client is running, press CTRL+C to stop");
+  auto line = std::string{};
+  while (std::getline(std::cin, line)) {
+    line = line + '\n';
+    input_producer->push(caf::as_bytes(caf::make_span(line)));
+    line.clear();
+  }
+  while (!shutdown_flag)
+    std::this_thread::sleep_for(250ms);
+  // Restore the default handlers.
+  signal(SIGTERM, default_term);
+  signal(SIGINT, default_sint);
+  // Shut down the client.
+  sys.println("*** shutting down");
+  return EXIT_SUCCESS;
+}
+
+CAF_MAIN(caf::net::middleman)

--- a/libcaf_core/caf/actor_system.cpp
+++ b/libcaf_core/caf/actor_system.cpp
@@ -338,7 +338,9 @@ public:
       };
     } else {
       do_print_ = [](void* out, term, const char* buf, size_t len) {
-        fwrite(buf, 1, len, reinterpret_cast<FILE*>(out));
+        auto* fhdl = reinterpret_cast<FILE*>(out);
+        fwrite(buf, 1, len, fhdl);
+        fflush(fhdl);
       };
     }
   }

--- a/libcaf_core/caf/async/blocking_producer.hpp
+++ b/libcaf_core/caf/async/blocking_producer.hpp
@@ -195,4 +195,11 @@ make_blocking_producer(producer_resource<T> res) {
   }
 }
 
+/// @relates blocking_producer
+template <class T>
+std::pair<blocking_producer<T>, consumer_resource<T>> make_blocking_producer() {
+  auto [pull, push] = caf::async::make_spsc_buffer_resource<T>();
+  return {make_blocking_producer(push.try_open()), std::move(pull)};
+}
+
 } // namespace caf::async

--- a/robot/CMakeLists.txt
+++ b/robot/CMakeLists.txt
@@ -126,6 +126,12 @@ if(TARGET CAF::net AND CAF_ENABLE_EXAMPLES)
     --variable SSL_PATH:${CMAKE_CURRENT_SOURCE_DIR})
 
   add_robot_test(
+    stream
+    octet
+    --variable SERVER_PATH:$<TARGET_FILE:key-value-store>
+    --variable CLIENT_PATH:$<TARGET_FILE:text-client>)
+
+  add_robot_test(
     http
     client
     --variable BINARY_PATH:$<TARGET_FILE:client>)

--- a/robot/stream/octet.robot
+++ b/robot/stream/octet.robot
@@ -1,0 +1,81 @@
+*** Settings ***
+Documentation       A test suite for examples/octet_stream/key-value-store 
+
+Library             Process
+Library             String
+Library             OperatingSystem
+
+Test Setup          Start Key Value Store Server
+Test Teardown       Stop Server And Clients
+
+
+*** Variables ***
+${SERVER_HOST}      localhost
+${SERVER_PORT}      55520
+${SERVER_PATH}      /path/to/the/server
+${CLIENT_PATH}      /path/to/the/client
+
+${FIRST_CLIENT_INPUT}         { "type": "put", "key": "A", "value": "26" }\n{ "type": "get", "key": "A" }\n{ "type": "del", "key": "A" }\n{ "type": "get", "key": "A" }     
+${FIRST_CLIENT_BASELINE}      reply: \nreply: 26\nreply: 26\nreply: {"error":"no_such_key"}
+${SECOND_CLIENT_INPUT}        { "type": "get", "key": "A" }\n{ "type": "put", "key": "B", "value": "27" }\n{ "type": "get", "key": "B" }\n{ "type": "del", "key": "B" }\n{ "type": "get", "key": "B" }      
+${SECOND_CLIENT_BASELINE}     reply: {"error":"no_such_key"}\nreply: \nreply: 27\nreply: 27\nreply: {"error":"no_such_key"}    
+
+
+*** Test Cases ***
+Server stores key values for client independently
+    Start Text Client  ${FIRST_CLIENT_INPUT}
+    Wait For Client    ${1}
+    Wait Until Contains Baseline  ${FIRST_CLIENT_BASELINE}  text-store.out
+    Start Text Client  ${SECOND_CLIENT_INPUT}
+    Wait For Client    ${2}
+    Wait Until Contains Baseline  ${SECOND_CLIENT_BASELINE}  text-store.out
+
+
+*** Keywords ***
+Start Key Value Store Server
+    Start Process
+    ...  ${SERVER_PATH}
+    ...  -p    ${SERVER_PORT}
+    ...  --caf.logger.file.path  server.log
+    ...  stdout=server.out
+    ...  stderr=server.err
+    Wait For Server Startup
+
+Start Text Client
+    [Arguments]   ${stdin}
+    Start Process
+    ...  ${CLIENT_PATH}
+    ...  -p    ${SERVER_PORT}
+    ...  --caf.logger.file.path  text-store.log
+    ...  stdin=${stdin}
+    ...  stdout=text-store.out
+    ...  stderr=text-store.err
+
+Has Baseline
+    [Arguments]     ${baseline}   ${file_path}
+    ${output}       Get File      ${file_path}
+    Should Contain  ${output}     ${baseline}
+
+Wait Until Contains Baseline
+    [Arguments]     ${baseline}   ${file_path}
+    Wait Until Keyword Succeeds    5s    125ms    Has Baseline    ${baseline}   ${file_path}
+
+Count Connected Clients
+    [Arguments]     ${client_count}
+    ${output}=      Grep File        server.out    accepted new connection
+    ${lc}=          Get Line Count   ${output}
+    Should Be True  ${lc} >= ${client_count}
+
+Wait For Client
+    [Arguments]    ${client_count}
+    Wait Until Keyword Succeeds    5s    125ms    Count Connected Clients    ${client_count}
+
+Has Server Started
+    ${output}=      Grep File        server.out    server is running
+    Should Not Be Empty  ${output}
+
+Wait For Server Startup
+    Wait Until Keyword Succeeds    5s    125ms    Has Server Started
+
+Stop Server And Clients
+    Run Keyword And Ignore Error    Terminate All Processes


### PR DESCRIPTION
An example `text-client` that utilizes `octet_stream` and the `key-value-store` example to store/retrieve simple string in server.
Additionally, a robot test has been added to test the examples and the expected functionality. 