### PR TITLE
Remove unused network socket functions

### DIFF
--- a/libcaf_net/caf/net/network_socket.cpp
+++ b/libcaf_net/caf/net/network_socket.cpp
@@ -169,16 +169,4 @@ expected<uint16_t> remote_port(network_socket x) {
   return ntohs(port_of(reinterpret_cast<sockaddr&>(st)));
 }
 
-void shutdown_read(network_socket x) {
-  ::shutdown(x.id, 0);
-}
-
-void shutdown_write(network_socket x) {
-  ::shutdown(x.id, 1);
-}
-
-void shutdown(network_socket x) {
-  ::shutdown(x.id, 2);
-}
-
 } // namespace caf::net

--- a/libcaf_net/caf/net/network_socket.hpp
+++ b/libcaf_net/caf/net/network_socket.hpp
@@ -58,16 +58,4 @@ expected<uint16_t> CAF_NET_EXPORT remote_port(network_socket x);
 /// @relates network_socket
 expected<std::string> CAF_NET_EXPORT remote_addr(network_socket x);
 
-/// Closes the read channel for a socket.
-/// @relates network_socket
-void CAF_NET_EXPORT shutdown_read(network_socket x);
-
-/// Closes the write channel for a socket.
-/// @relates network_socket
-void CAF_NET_EXPORT shutdown_write(network_socket x);
-
-/// Closes the both read and write channel for a socket.
-/// @relates network_socket
-void CAF_NET_EXPORT shutdown(network_socket x);
-
 } // namespace caf::net


### PR DESCRIPTION
We no longer have use for closing individual channels of sockets, so these unused functions should go.