### PR TITLE
Fix begin_sequence to handle arrays inside struct

### DIFF
--- a/libcaf_core/caf/json_builder.cpp
+++ b/libcaf_core/caf/json_builder.cpp
@@ -229,9 +229,8 @@ bool json_builder::begin_sequence(size_t) {
       err_ = make_error(sec::runtime_error, "unexpected begin_sequence");
       return false;
     case type::element: {
-      auto* val = top_ptr();
-      val->assign_array(storage_);
-      push(val, type::array);
+      top_ptr()->assign_array(storage_);
+      stack_.back().t = type::array;
       return true;
     }
     case type::array: {


### PR DESCRIPTION
begin_sequence previously pushed a new value to the stack which was causing a bug when attempting to pop member from the stack. This has been fixed by replacing the stack value instead of pushing new value.
Additionally, a test has been added to test this scenario.
Closes https://github.com/actor-framework/actor-framework/issues/1889