### PR TITLE
Fix heap use after free in blocking actor

### DIFF
--- a/libcaf_core/caf/blocking_actor.cpp
+++ b/libcaf_core/caf/blocking_actor.cpp
@@ -132,13 +132,13 @@ public:
     rsn = self_->fail_state();
 #endif
     self_->cleanup(std::move(rsn), ctx);
-    intrusive_ptr_release(self_->ctrl());
+    [[maybe_unused]] auto id = self_->id();
     auto& sys = self_->system();
+    intrusive_ptr_release(self_->ctrl());
     sys.release_private_thread(thread_);
     if (!hidden_) {
       [[maybe_unused]] auto count = sys.registry().dec_running();
-      log::system::debug("actor {} decreased running count to {}", self_->id(),
-                         count);
+      log::system::debug("actor {} decreased running count to {}", id, count);
     }
     return resumable::done;
   }


### PR DESCRIPTION
Closes #1894 
From the traces, `self_->system()` seams to be the issue, with `intrusive_ptr_release(self_->ctrl());` freeing the memory (guess the ref count fell to 0). I've added the `id` line so we don't reference `self_` after the release line. 

I don't understand why doesn't this fail in the test consistently.      