### PR TITLE
Fix errors when using std::format 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 ### Fixed
 
 - Fix a compiler error when using `spawn_client` on the I/O middleman (#1900).
+- An unfortunate bug prevented the auto-detection of `std::format` when building
+  CAF with C++20 or later. This bug has been fixed, alongside issues with the
+  actual `std::format`-based implementation. However, since selecting a
+  different backend for `println` and the log output generation breaks the ABI,
+  we have decided to ship the `std::format`-based implementation only as opt-in
+  at this point. Users can enable it by setting the CMake option
+  `CAF_USE_STD_FORMAT`.
 
 ## [1.0.0] - 2024-06-26
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ option(CAF_ENABLE_PROTOBUF_EXAMPLES "Build examples with Google Protobuf" OFF)
 option(CAF_ENABLE_QT6_EXAMPLES "Build examples with the Qt6 framework" OFF)
 option(CAF_ENABLE_ROBOT_TESTS "Add the Robot tests to CTest " OFF)
 option(CAF_ENABLE_RUNTIME_CHECKS "Build CAF with extra runtime assertions" OFF)
+option(CAF_USE_STD_FORMAT "Enable std::format support" OFF)
 
 # -- CAF options that are on by default ----------------------------------------
 
@@ -145,24 +146,6 @@ endif()
 
 if(CAF_ENABLE_TESTING)
   enable_testing()
-endif()
-
-# -- check whether we can use std::format --------------------------------------
-
-if(NOT DEFINED CAF_USE_STD_FORMAT)
-  set(CAF_USE_STD_FORMAT OFF CACHE BOOL "Enable std::format support" FORCE)
-  if(NOT CMAKE_CROSSCOMPILING)
-    set(snippet "#include <format>
-                 #include <iostream>
-                 int main() { std::cout << std::format(\"{}\", \"ok\"); }")
-    check_cxx_source_runs("${snippet}" snippet_output)
-    if("${snippet_output}" STREQUAL "ok")
-      message(STATUS "Enable std::format support")
-      set(CAF_USE_STD_FORMAT ON CACHE BOOL "Enable std::format support" FORCE)
-    else()
-      message(STATUS "Disable std::format support: NOT available")
-    endif()
-  endif()
 endif()
 
 # -- export internal target (may be useful for re-using compiler flags) --------

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,6 +79,7 @@ config = [
             extraBuildFlags: [
                 'CMAKE_CXX_FLAGS:STRING=-Werror -Wno-maybe-uninitialized -Wno-uninitialized -Wno-array-bounds -Wno-free-nonheap-object',
                 'CAF_CXX_VERSION:STRING=23',
+                'CAF_USE_STD_FORMAT:BOOL=ON',
             ],
         ]],
         ['ubuntu-20.04', [ // April 2025

--- a/libcaf_core/caf/chunked_string.hpp
+++ b/libcaf_core/caf/chunked_string.hpp
@@ -158,7 +158,7 @@ private:
 namespace std {
 
 template <>
-struct std::formatter<caf::chunked_string, char> {
+struct formatter<caf::chunked_string, char> {
   bool quoted = false;
 
   template <class ParseContext>

--- a/libcaf_core/caf/detail/format.test.cpp
+++ b/libcaf_core/caf/detail/format.test.cpp
@@ -6,6 +6,8 @@
 
 #include "caf/test/test.hpp"
 
+#include <vector>
+
 #if !defined(CAF_USE_STD_FORMAT) && !defined(CAF_USE_SYSTEM_LIBFMT)
 #  define CAF_MINIMAL_FORMATTING
 #endif
@@ -14,6 +16,23 @@ using namespace caf;
 using namespace std::literals;
 
 namespace {
+
+#ifdef CAF_USE_STD_FORMAT
+
+using caf::detail::fmt_fwd;
+// Types that have a formatter overload are forwarded as is.
+static_assert(std::is_same_v<decltype(fmt_fwd(std::declval<char>())), char&&>);
+static_assert(std::is_same_v<decltype(fmt_fwd(std::declval<int>())), int&&>);
+static_assert(
+  std::is_same_v<decltype(fmt_fwd(std::declval<const char&>())), const char&>);
+static_assert(
+  std::is_same_v<decltype(fmt_fwd(std::declval<const int&>())), const int&>);
+// Types without a formatter overload are forwarded as std::string.
+static_assert(
+  std::is_same_v<decltype(fmt_fwd(std::declval<std::vector<int>>())),
+                 std::string>);
+
+#endif
 
 TEST("format strings without placeholders copies verbatim") {
   check_eq(detail::format("hello world"), "hello world");

--- a/libcaf_test/caf/test/reporter.cpp
+++ b/libcaf_test/caf/test/reporter.cpp
@@ -37,7 +37,7 @@ namespace {
 /// - $C(cyan text)
 /// - $0 turns off coloring completely (enter verbatim mode)
 struct colorizing_iterator {
-  using difference_type = void;
+  using difference_type = int;
   using value_type = void;
   using pointer = void;
   using reference = void;


### PR DESCRIPTION
This was reported in the community chatroom. 
We want to use the same C++ version when detecting std::format support as when compiling our targets.