### PR TITLE
Add new module for background workers

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -161,6 +161,7 @@ caf_add_component(
     caf/detail/config_consumer.cpp
     caf/detail/config_consumer.test.cpp
     caf/detail/critical.cpp
+    caf/detail/daemons.cpp
     caf/detail/default_mailbox.cpp
     caf/detail/default_mailbox.test.cpp
     caf/detail/default_thread_count.cpp

--- a/libcaf_core/caf/actor_system.cpp
+++ b/libcaf_core/caf/actor_system.cpp
@@ -420,7 +420,7 @@ public:
       modules[mod_id].reset(mod_ptr);
     }
     // Let there be daemons.
-    modules[actor_system_module::daemons].reset(new detail::daemons);
+    modules[actor_system_module::daemons].reset(new detail::daemons(*parent));
     // Make sure meta objects are loaded.
     auto gmos = detail::global_meta_objects();
     if (gmos.size() < id_block::core_module::end

--- a/libcaf_core/caf/actor_system.cpp
+++ b/libcaf_core/caf/actor_system.cpp
@@ -11,8 +11,10 @@
 #include "caf/actor_registry.hpp"
 #include "caf/actor_system_config.hpp"
 #include "caf/defaults.hpp"
+#include "caf/detail/actor_system_access.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/detail/critical.hpp"
+#include "caf/detail/daemons.hpp"
 #include "caf/detail/meta_object.hpp"
 #include "caf/detail/private_thread_pool.hpp"
 #include "caf/detail/test_coordinator.hpp"
@@ -417,6 +419,8 @@ public:
       auto mod_id = mod_ptr->id();
       modules[mod_id].reset(mod_ptr);
     }
+    // Let there be daemons.
+    modules[actor_system_module::daemons].reset(new detail::daemons);
     // Make sure meta objects are loaded.
     auto gmos = detail::global_meta_objects();
     if (gmos.size() < id_block::core_module::end
@@ -889,3 +893,12 @@ void actor_system::set_node(node_id id) {
 }
 
 } // namespace caf
+
+namespace caf::detail {
+
+detail::daemons* actor_system_access::daemons() {
+  auto ptr = sys_->impl_->modules[actor_system_module::daemons].get();
+  return static_cast<detail::daemons*>(ptr);
+}
+
+} // namespace caf::detail

--- a/libcaf_core/caf/actor_system_module.cpp
+++ b/libcaf_core/caf/actor_system_module.cpp
@@ -6,21 +6,27 @@
 
 namespace caf {
 
+namespace {
+
+const char* module_names[] = {
+  "middleman",
+  "openssl-manager",
+  "network-manager",
+  "daemons",
+};
+
+} // namespace
+
 actor_system_module::~actor_system_module() {
   // nop
 }
 
 const char* actor_system_module::name() const noexcept {
-  switch (id()) {
-    case middleman:
-      return "middleman";
-    case openssl_manager:
-      return "openssl-manager";
-    case network_manager:
-      return "network-manager";
-    default:
-      return "???";
+  auto index = static_cast<int>(id());
+  if (index < num_ids) {
+    return module_names[index];
   }
+  return "???";
 }
 
 } // namespace caf

--- a/libcaf_core/caf/actor_system_module.hpp
+++ b/libcaf_core/caf/actor_system_module.hpp
@@ -12,7 +12,7 @@ namespace caf {
 /// An (optional) component of the actor system.
 class CAF_CORE_EXPORT actor_system_module {
 public:
-  enum id_t { middleman, openssl_manager, network_manager, num_ids };
+  enum id_t { middleman, openssl_manager, network_manager, daemons, num_ids };
 
   virtual ~actor_system_module();
 

--- a/libcaf_core/caf/detail/actor_system_access.hpp
+++ b/libcaf_core/caf/detail/actor_system_access.hpp
@@ -9,6 +9,8 @@
 
 namespace caf::detail {
 
+class daemons;
+
 /// Utility to override internal components of an actor system.
 class CAF_CORE_EXPORT actor_system_access {
 public:
@@ -27,6 +29,8 @@ public:
   void node(node_id id);
 
   detail::mailbox_factory* mailbox_factory();
+
+  detail::daemons* daemons();
 
 private:
   actor_system* sys_;

--- a/libcaf_core/caf/detail/daemons.cpp
+++ b/libcaf_core/caf/detail/daemons.cpp
@@ -1,0 +1,96 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#include "caf/detail/daemons.hpp"
+
+#include <cstdint>
+#include <map>
+#include <mutex>
+#include <thread>
+
+namespace caf::detail {
+
+struct daemons::impl {
+  int64_t next_id() {
+    std::lock_guard guard{mtx};
+    if (id == 0)
+      return 0;
+    return id++;
+  }
+
+  struct state {
+    std::thread t;
+    std::function<void()> on_stop;
+  };
+
+  /// Protects other member variables.
+  mutable std::mutex mtx;
+
+  /// Next ID to assign to a background thread or 0 if the module is stopped.
+  int64_t id = 1;
+
+  /// Maps daemon IDs to their state.
+  std::map<int64_t, state> threads;
+};
+
+daemons::daemons() : impl_(new impl) {
+  // nop
+}
+
+daemons::~daemons() {
+  delete impl_;
+}
+
+void daemons::cleanup(int id) {
+  std::lock_guard guard{impl_->mtx};
+  auto i = impl_->threads.find(id);
+  auto& [t, on_stop] = i->second;
+  on_stop();
+  t.join();
+  impl_->threads.erase(i);
+}
+
+bool daemons::launch(std::function<void()> fn, std::function<void()> stop) {
+  auto id = impl_->next_id();
+  if (id == 0) {
+    return false;
+  }
+  auto t = std::thread{[fn = std::move(fn)] { fn(); }};
+  std::lock_guard guard{impl_->mtx};
+  auto& st = impl_->threads[id];
+  st.t = std::move(t);
+  st.on_stop = std::move(stop);
+  return true;
+}
+
+void daemons::start() {
+  // nop
+}
+
+void daemons::stop() {
+  std::map<int64_t, impl::state> threads;
+  {
+    std::lock_guard guard{impl_->mtx};
+    impl_->id = 0;
+    impl_->threads.swap(threads);
+  }
+  for (auto& [id, st] : threads) {
+    st.on_stop();
+    st.t.join();
+  }
+}
+
+void daemons::init(caf::actor_system_config&) {
+  // nop
+}
+
+caf::actor_system_module::id_t daemons::id() const {
+  return id_t::daemons;
+}
+
+void* daemons::subtype_ptr() {
+  return static_cast<caf::actor_system_module*>(this);
+}
+
+} // namespace caf::detail

--- a/libcaf_core/caf/detail/daemons.hpp
+++ b/libcaf_core/caf/detail/daemons.hpp
@@ -1,0 +1,47 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+#include "caf/actor_system_module.hpp"
+#include "caf/detail/core_export.hpp"
+
+#include <functional>
+
+namespace caf::detail {
+
+/// A module that starts and manages background threads.
+class CAF_CORE_EXPORT daemons : public caf::actor_system_module {
+public:
+  daemons();
+
+  daemons(const daemons&) = delete;
+
+  daemons& operator=(const daemons&) = delete;
+
+  ~daemons() override;
+
+  /// Removes the state associated with a stopped background thread.
+  void cleanup(int id);
+
+  bool launch(std::function<void()> fn, std::function<void()> stop);
+
+  // -- overrides --------------------------------------------------------------
+
+  void start() override;
+
+  void stop() override;
+
+  void init(caf::actor_system_config&) override;
+
+  id_t id() const override;
+
+  void* subtype_ptr() override;
+
+private:
+  struct impl;
+  impl* impl_;
+};
+
+} // namespace caf::detail

--- a/libcaf_core/caf/detail/daemons.hpp
+++ b/libcaf_core/caf/detail/daemons.hpp
@@ -4,17 +4,23 @@
 
 #pragma once
 
+#include "caf/actor.hpp"
+#include "caf/actor_system.hpp"
 #include "caf/actor_system_module.hpp"
 #include "caf/detail/core_export.hpp"
+#include "caf/settings.hpp"
+#include "caf/spawn_options.hpp"
+#include <caf/send.hpp>
 
 #include <functional>
+#include <tuple>
 
 namespace caf::detail {
 
 /// A module that starts and manages background threads.
-class CAF_CORE_EXPORT daemons : public caf::actor_system_module {
+class CAF_CORE_EXPORT daemons : public actor_system_module {
 public:
-  daemons();
+  daemons(actor_system& sys);
 
   daemons(const daemons&) = delete;
 
@@ -22,10 +28,29 @@ public:
 
   ~daemons() override;
 
-  /// Removes the state associated with a stopped background thread.
-  void cleanup(int id);
-
-  bool launch(std::function<void()> fn, std::function<void()> stop);
+  /// Launches a new hidden (and detached) background worker.
+  /// @param fn Function object that implements the worker actor.
+  /// @param do_stop Function object that stops the worker actor. The function
+  ///                object is called with the actor handle as argument to allow
+  ///                sending an exit message.
+  /// @param args Additional arguments forwarded to `fn`.
+  template <class Fn, class... Args>
+  actor launch(Fn fn, std::function<void(actor)> do_stop, Args&&... args) {
+    // Launches a new background worker. We need to this lazily to enable
+    // `do_launch` to atomically create the worker and add it to the internal
+    // map. If `stop()` has been called prior, we return an invalid actor handle
+    // and never call `do_spawn`.
+    auto do_spawn = [args = std::make_tuple(std::forward<Args>(args)...),
+                     fn = std::move(fn)](actor_system& sys) {
+      // TODO: simply capture args... in the lambda when we switch to C++20
+      return std::apply(
+        [&fn, &sys](auto&&... xs) {
+          return sys.spawn<hidden + detached>(std::move(fn), xs...);
+        },
+        std::move(args));
+    };
+    return do_launch(do_spawn, do_stop);
+  }
 
   // -- overrides --------------------------------------------------------------
 
@@ -33,13 +58,16 @@ public:
 
   void stop() override;
 
-  void init(caf::actor_system_config&) override;
+  void init(actor_system_config&) override;
 
   id_t id() const override;
 
   void* subtype_ptr() override;
 
 private:
+  actor do_launch(std::function<actor(actor_system&)> do_spawn,
+                  std::function<void(actor)> do_stop);
+
   struct impl;
   impl* impl_;
 };

--- a/libcaf_net/caf/net/http/client_factory.hpp
+++ b/libcaf_net/caf/net/http/client_factory.hpp
@@ -50,6 +50,15 @@ public:
   /// Add an additional HTTP header field to the request.
   client_factory& add_header_field(std::string key, std::string value);
 
+  /// Add an additional HTTP header fields to the request.
+  template <class KeyValueMap>
+  client_factory& add_header_fields(KeyValueMap&& kv_map) {
+    for (auto& [key, value] : kv_map) {
+      add_header_field(std::move(key), std::move(value));
+    }
+    return *this;
+  }
+
   /// Sends an HTTP GET message.
   expected<std::pair<async::future<response>, disposable>> get();
 


### PR DESCRIPTION
A new piece of infrastructure for running background tasks. We have a couple of those, like the Prometheus exporter, and use one-off solutions instead of having a dedicated API.

The class uses the PIMPL idiom to allow us to experiment with the implementation. I've also added a convenience function to `client_factory` which could technically go into a separate PR, but I happened to need that to test the new daemons module with some background task doing HTTP.