### PR TITLE
Fix an example in the testing manual section

### DIFF
--- a/manual/Testing.rst
+++ b/manual/Testing.rst
@@ -250,7 +250,7 @@ a ``std::tuple``:
         auto result = x + y;
         THEN("the result should be <sum>") {
           auto sum = block_parameters<double>();
-          check_eq(result, sum);
+          check_eq(result, caf::test::approx{sum});
         }
       }
     }


### PR DESCRIPTION
Our `adding two numbers` example for the test outlines currently runs into a static assertion (trying to compare `double` using `operator==`). We simply forgot to use `approx` here when making adding that assertion.