### PR TITLE
Fix cleanup in the consumer adapter if pull fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   we have decided to ship the `std::format`-based implementation only as opt-in
   at this point. Users can enable it by setting the CMake option
   `CAF_USE_STD_FORMAT`.
+- Fix cleanup in the consumer adapter. This component connects actors to SPSC
+  buffers. If the SPSC buffer was closed by the producer, the consumer adapter
+  failed to properly dispose pending actions.
 
 ## [1.0.0] - 2024-06-26
 

--- a/libcaf_core/caf/async/consumer_adapter.hpp
+++ b/libcaf_core/caf/async/consumer_adapter.hpp
@@ -57,6 +57,8 @@ public:
         auto [again, n] = buf_->pull(policy, 1u, *this);
         if (!again) {
           buf_ = nullptr;
+          do_wakeup_.dispose();
+          do_wakeup_ = nullptr;
         }
         if (n == 1) {
           return read_result::ok;


### PR DESCRIPTION
Fix cleanup in the consumer adapter. This component connects actors to SPSC buffers. If the SPSC buffer was closed by the producer, the consumer adapter failed to properly dispose pending actions.