### PR TITLE
Bump version and fix documentation for doxygen

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "C++ Actor Framework"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.19
+PROJECT_NUMBER         = 1.0.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/libcaf_core/caf/all.hpp
+++ b/libcaf_core/caf/all.hpp
@@ -85,7 +85,6 @@
 #include "caf/unit.hpp"
 #include "caf/uuid.hpp"
 
-///
 /// @mainpage CAF
 ///
 /// @section Intro Introduction


### PR DESCRIPTION
Closes https://github.com/actor-framework/actor-framework/issues/1916

The bug was a hard one to track. Doxygen 1.11.0 and upwards really didn't like the blank comment. 

I have also bumped the CAF version in doxygen for future release.