### PR TITLE
Minor API additions for use cases at Interance

### DIFF
--- a/libcaf_core/caf/intrusive/linked_list.hpp
+++ b/libcaf_core/caf/intrusive/linked_list.hpp
@@ -115,6 +115,18 @@ public:
     return result;
   }
 
+  /// Transfers all elements from `other` into this list.
+  void splice(linked_list& other) noexcept {
+    if (other.empty()) {
+      return;
+    }
+    tail_.next->next = other.head_.next;
+    other.tail_.next->next = &tail_;
+    tail_.next = other.tail_.next;
+    size_ += other.size_;
+    other.init();
+  }
+
   // -- iterator access --------------------------------------------------------
 
   /// Returns an iterator to the dummy before the first element.

--- a/libcaf_core/caf/intrusive/linked_list.test.cpp
+++ b/libcaf_core/caf/intrusive/linked_list.test.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/intrusive/linked_list.hpp"
 
+#include "caf/test/scenario.hpp"
 #include "caf/test/test.hpp"
 
 #include "caf/intrusive/singly_linked.hpp"
@@ -155,6 +156,77 @@ TEST("pop_front removes the oldest element of a list and returns it") {
   if (check_eq(uut.size(), 1u))
     check_eq(uut.pop_front()->value, 3);
   check(uut.empty());
+}
+
+SCENARIO("splice transfers all elements from one list to another") {
+  GIVEN("and empty source list and an empty target list") {
+    list_type src;
+    list_type dst;
+    WHEN("splicing the source into the target") {
+      THEN("both lists remain empty") {
+        dst.splice(src);
+        check(src.empty());
+        check(dst.empty());
+      }
+    }
+  }
+  GIVEN("a source list with one element and an empty target list") {
+    list_type src;
+    fill(src, 1);
+    list_type dst;
+    WHEN("splicing the source into the target") {
+      THEN("the target list contains the element") {
+        dst.splice(src);
+        check(src.empty());
+        check_eq(dst.size(), 1u);
+        check_eq(dst.front()->value, 1);
+      }
+    }
+  }
+  GIVEN("a source list with three elements and an empty target list") {
+    list_type src;
+    fill(src, 1, 2, 3);
+    list_type dst;
+    WHEN("splicing the source into the target") {
+      THEN("the target list contains the elements") {
+        dst.splice(src);
+        check(src.empty());
+        check_eq(dst.size(), 3u);
+        check_eq(dst.front()->value, 1);
+        check_eq(dst.back()->value, 3);
+      }
+    }
+  }
+  GIVEN("a source list with one element and a non-empty target list") {
+    list_type src;
+    fill(src, 4);
+    list_type dst;
+    fill(dst, 1, 2, 3);
+    WHEN("splicing the source into the target") {
+      THEN("the target list contains the original elements and the new one") {
+        dst.splice(src);
+        check(src.empty());
+        check_eq(dst.size(), 4u);
+        check_eq(dst.front()->value, 1);
+        check_eq(dst.back()->value, 4);
+      }
+    }
+  }
+  GIVEN("a source list with three elements and a non-empty target list") {
+    list_type src;
+    fill(src, 4, 5, 6);
+    list_type dst;
+    fill(dst, 1, 2, 3);
+    WHEN("splicing the source into the target") {
+      THEN("the target list contains the original elements and the new ones") {
+        dst.splice(src);
+        check(src.empty());
+        check_eq(dst.size(), 6u);
+        check_eq(dst.front()->value, 1);
+        check_eq(dst.back()->value, 6);
+      }
+    }
+  }
 }
 
 } // namespace

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -668,6 +668,15 @@ public:
            || !stream_sources_.empty() || !stream_bridges_.empty();
   }
 
+  /// Checks whether the actor is currently waiting for an external event, i.e.,
+  /// a response message or external flow activity.
+  /// @private
+  [[nodiscard]] bool awaits_external_event() const noexcept {
+    return !awaited_responses_.empty() || !multiplexed_responses_.empty()
+           || !watched_disposables_.empty() || !stream_sources_.empty()
+           || !stream_bridges_.empty();
+  }
+
   /// Runs all pending actions.
   void run_actions() override;
 

--- a/libcaf_core/caf/sec.hpp
+++ b/libcaf_core/caf/sec.hpp
@@ -175,6 +175,9 @@ enum class sec : uint8_t {
   invalid_utf8,
   /// A downstream operator failed to process inputs on time.
   backpressure_overflow,
+  /// Signals that a supervisor failed to start a new worker because too many
+  /// workers failed in a short period of time.
+  too_many_worker_failures = 80,
 };
 // --(rst-sec-end)--
 


### PR DESCRIPTION
- `splice` for intrusive lists, similar to `std::list::splice`, except that it will always insert at the end
- `awaits_external_event` in combination with the `blocked` flag on the mailbox gives us a way to detect actors that are currently completely idle
- `too_many_worker_failures` is a new error code meant for supervisors that automatically restart workers but terminate once there are too many errors in a given time frame