### PR TITLE
Rename shutdown to abort_and_shutdown in http::router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 - When disposing a connection acceptor, CAF no longer generates a log event with
   severity `error`. Instead, it will log the event with severity `debug`.
+- The `http::router` member function `shutdown` has been deprecated and renamed to
+  `abort_and_shutdown` to better reflect its functionality.
 
 ## [1.0.0] - 2024-06-26
 

--- a/libcaf_net/caf/net/http/router.cpp
+++ b/libcaf_net/caf/net/http/router.cpp
@@ -61,8 +61,7 @@ request router::lift(responder&& res) {
 }
 
 void router::shutdown(const error& err) {
-  abort(err);
-  down_->shutdown(err);
+  abort_and_shutdown(err);
 }
 
 void router::abort_and_shutdown(const error& err) {

--- a/libcaf_net/caf/net/http/router.cpp
+++ b/libcaf_net/caf/net/http/router.cpp
@@ -65,6 +65,11 @@ void router::shutdown(const error& err) {
   down_->shutdown(err);
 }
 
+void router::abort_and_shutdown(const error& err) {
+  abort(err);
+  down_->shutdown(err);
+}
+
 // -- http::upper_layer implementation -----------------------------------------
 
 void router::prepare_send() {

--- a/libcaf_net/caf/net/http/router.hpp
+++ b/libcaf_net/caf/net/http/router.hpp
@@ -59,7 +59,10 @@ public:
   /// processing of the HTTP request.
   request lift(responder&& res);
 
+  [[deprecated("use abort_and_shutdown instead")]]
   void shutdown(const error& err);
+
+  void abort_and_shutdown(const error& err);
 
   // -- http::upper_layer implementation ---------------------------------------
 

--- a/libcaf_net/caf/net/http/server_factory.cpp
+++ b/libcaf_net/caf/net/http/server_factory.cpp
@@ -154,7 +154,7 @@ expected<disposable> do_start_impl(Config& cfg, Acceptor acc,
     auto new_route = make_route([producer](responder& res) {
       if (!producer->push(responder{res}.to_request())) {
         auto err = make_error(sec::runtime_error, "flow disconnected");
-        res.router()->shutdown(err);
+        res.router()->abort_and_shutdown(err);
       }
     });
     if (!new_route) {


### PR DESCRIPTION
Other uses for `abort` and `shutdown` are OK, this is the only fix. 
Relates #1908. 