### PR TITLE
Set receive policy in WS framing layer

### DIFF
--- a/libcaf_net/caf/net/web_socket/framing.cpp
+++ b/libcaf_net/caf/net/web_socket/framing.cpp
@@ -111,6 +111,7 @@ public:
     std::random_device rd;
     rng_.seed(rd());
     down_ = down;
+    down_->configure_read(default_receive_policy);
     return up_->start(this);
   }
 


### PR DESCRIPTION
The receive policy gets reset automatically after calling switch protocol in our `WebSocket` implementation. 
Fixes #1918.