### PR TITLE
Add retry flow operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## Unreleased
 
+### Added
+
+- New flow operator: `retry`.
+
 ### Fixed
 
 - Fix build error in `caf-net` when building with C++23 (#1919).

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -252,6 +252,7 @@ caf_add_component(
     caf/flow/op/prefix_and_tail.test.cpp
     caf/flow/op/publish.test.cpp
     caf/flow/op/pullable.cpp
+    caf/flow/op/retry.test.cpp
     caf/flow/op/sample.test.cpp
     caf/flow/op/ucast.test.cpp
     caf/flow/op/zip_with.test.cpp

--- a/libcaf_core/caf/flow/observable_decl.hpp
+++ b/libcaf_core/caf/flow/observable_decl.hpp
@@ -215,6 +215,11 @@ public:
   /// Emits the most recent item of the input observable once per interval.
   observable<T> sample(timespan period);
 
+  /// Re-subscribes to the input observable on error for as long as the
+  /// predicate returns true.
+  template <class Predicate>
+  observable<T> retry(Predicate predicate);
+
   // -- combining --------------------------------------------------------------
 
   /// Combines the output of multiple @ref observable objects into one by

--- a/libcaf_core/caf/flow/op/retry.hpp
+++ b/libcaf_core/caf/flow/op/retry.hpp
@@ -1,0 +1,172 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#pragma once
+
+#include "caf/config.hpp"
+#include "caf/detail/assert.hpp"
+#include "caf/flow/backpressure_overflow_strategy.hpp"
+#include "caf/flow/observer.hpp"
+#include "caf/flow/op/hot.hpp"
+#include "caf/flow/subscription.hpp"
+
+#include <deque>
+#include <utility>
+
+namespace caf::flow::op {
+
+template <class T, class Predicate>
+class retry_sub : public subscription::impl_base, public observer_impl<T> {
+public:
+  // -- constructors, destructors, and assignment operators --------------------
+
+  retry_sub(coordinator* parent, observer<T> out, Predicate predicate,
+            observable<T> in)
+    : parent_(parent),
+      out_(std::move(out)),
+      in_(std::move(in)),
+      predicate_(std::move(predicate)) {
+    // nop
+  }
+
+  // -- implementation of subscription -----------------------------------------
+
+  coordinator* parent() const noexcept override {
+    return parent_;
+  }
+
+  bool disposed() const noexcept override {
+    return !out_;
+  }
+
+  void request(size_t new_demand) override {
+    if (new_demand == 0)
+      return;
+    demand_ += new_demand;
+    if (sub_)
+      sub_.request(new_demand);
+  }
+
+  // -- implementation of observer_impl ----------------------------------------
+
+  void ref_coordinated() const noexcept override {
+    ref();
+  }
+
+  void deref_coordinated() const noexcept override {
+    deref();
+  }
+
+  void on_subscribe(subscription sub) override {
+    if (sub_) {
+      sub_.cancel();
+      sub_.release_later();
+    }
+    sub_ = std::move(sub);
+    if (demand_ > 0)
+      sub_.request(demand_);
+  }
+
+  void on_next(const T& item) override {
+    if (!out_)
+      return;
+    if (demand_ > 0) {
+      --demand_;
+      out_.on_next(item);
+    }
+  }
+
+  void on_complete() override {
+    if (!out_)
+      return;
+    sub_.release_later();
+    out_.on_complete();
+  }
+
+  void on_error(const error& what) override {
+    if (!out_)
+      return;
+    sub_.release_later();
+    if (predicate_(what))
+      parent()->delay_fn([this]() { in_.subscribe(this->as_observer()); });
+    else
+      out_.on_error(what);
+  }
+
+private:
+  void do_dispose(bool from_external) override {
+    if (!out_)
+      return;
+    sub_.cancel();
+    if (from_external)
+      out_.on_error(make_error(sec::disposed));
+  }
+
+  size_t demand_ = 0u;
+
+  /// Stores the context (coordinator) that runs this flow.
+  coordinator* parent_;
+
+  /// Stores a handle to the subscribed observer.
+  observer<T> out_;
+
+  /// Stores a handle to the subscribed observable.
+  observable<T> in_;
+
+  /// Stores the subscription to the input observable.
+  subscription sub_;
+
+  /// Stores the number of retries remaining.
+  Predicate predicate_;
+};
+
+/// An observable that retry calls any callbacks on its
+/// subscribers.
+template <class T, class Predicate>
+class retry : public hot<T> {
+public:
+  using trait = detail::get_callable_trait_t<Predicate>;
+
+  using arg_type
+    = std::decay_t<caf::detail::tl_head_t<typename trait::arg_types>>;
+
+  static_assert(std::is_convertible_v<typename trait::result_type, bool>,
+                "predicates must return a boolean value");
+
+  static_assert(trait::num_args == 1,
+                "predicates must take exactly one argument");
+
+  static_assert(std::is_same_v<arg_type, caf::error>,
+                "predicates must take only error as argument");
+
+  // -- member types -----------------------------------------------------------
+
+  using super = hot<T>;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  retry(coordinator* parent, observable<T> in, Predicate predicate)
+    : super(parent), in_(std::move(in)), predicate_(std::move(predicate)) {
+    // nop
+  }
+
+  // -- implementation of observable_impl<T> -----------------------------------
+
+  disposable subscribe(observer<T> out) override {
+    CAF_ASSERT(out.valid());
+    using sub_t = retry_sub<T, Predicate>;
+    auto ptr = super::parent_->add_child(std::in_place_type<sub_t>, out,
+                                         predicate_, in_);
+    out.on_subscribe(subscription{ptr});
+    in_.subscribe(ptr->as_observer());
+    return disposable{ptr->as_disposable()};
+  }
+
+private:
+  observable<T> in_;
+
+  Predicate predicate_;
+};
+
+} // namespace caf::flow::op

--- a/libcaf_core/caf/flow/op/retry.test.cpp
+++ b/libcaf_core/caf/flow/op/retry.test.cpp
@@ -1,0 +1,237 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/master/LICENSE.
+
+#include "caf/test/fixture/deterministic.hpp"
+#include "caf/test/fixture/flow.hpp"
+#include "caf/test/scenario.hpp"
+#include "caf/test/test.hpp"
+
+#include "caf/log/test.hpp"
+
+using namespace caf;
+
+namespace {
+
+struct fixture : test::fixture::deterministic, test::fixture::flow {
+  // Similar to retry::subscribe, but returns a retry_sub pointer instead of
+  // type-erasing it into a disposable.
+  template <class T = int, class Predicate>
+  auto raw_sub(caf::flow::observable<int> in, caf::flow::observer<int> out,
+               Predicate predicate) {
+    using sub_t = caf::flow::op::retry_sub<T, Predicate>;
+    auto ptr = make_counted<sub_t>(coordinator(), out, std::move(predicate),
+                                   in);
+    out.on_subscribe(caf::flow::subscription{ptr});
+    return ptr;
+  }
+};
+
+WITH_FIXTURE(fixture) {
+
+SCENARIO("the retry operator re-subscribes observables on error") {
+  const int max_retry_count = 3;
+  int retry_count = 0;
+  auto retry_predicate = [&retry_count,
+                          &max_retry_count](const caf::error& what) {
+    if (what == sec::invalid_request && retry_count < max_retry_count) {
+      ++retry_count;
+      return true;
+    } else
+      return false;
+  };
+  GIVEN("an observable that always fails") {
+    WHEN("calling retry") {
+      THEN("the observer receives an error after retrying 3 times") {
+        auto outputs = std::make_shared<std::vector<int>>();
+        auto err = std::make_shared<error>();
+        auto input = std::vector{1, 2, 3, 4};
+        make_observable()
+          .from_container(input)
+          .concat(make_observable().fail<int32_t>(sec::invalid_request))
+          .retry(retry_predicate)
+          .do_on_error([err](const error& what) { *err = what; })
+          .for_each([outputs](const int& xs) { outputs->emplace_back(xs); });
+        run_flows();
+        check_eq(outputs->size(), 16u);
+        check_eq(retry_count, 3);
+        check_eq(*err, error{sec::invalid_request});
+      }
+    }
+  }
+  GIVEN("an observable that always completes") {
+    WHEN("calling retry") {
+      THEN("the observer completes without retrying") {
+        auto outputs = std::make_shared<std::vector<int>>();
+        auto err = std::make_shared<error>();
+        auto completed = std::make_shared<bool>(false);
+        auto input = std::vector{1, 2, 3, 4};
+        make_observable()
+          .from_container(input)
+          .retry(retry_predicate)
+          .do_on_error([err](const error& what) { *err = what; })
+          .do_on_complete([completed]() { *completed = true; })
+          .for_each([outputs](const int& xs) { outputs->emplace_back(xs); });
+        run_flows();
+        check_eq(outputs->size(), 4u);
+        check_eq(retry_count, 0);
+        check_eq(*err, error{}); // no error
+        check(*completed);
+      }
+    }
+  }
+}
+
+SCENARIO("the retry operator can complete flows despite errors") {
+  auto retry_predicate = [](const caf::error& what) {
+    return what == sec::runtime_error;
+  };
+  GIVEN("an observable that is retried on `runtime_error`") {
+    auto snk = flow::make_passive_observer<int>();
+    auto uut = raw_sub(make_observable().never<int>(), snk->as_observer(),
+                       retry_predicate);
+    snk->request(42);
+    run_flows();
+    WHEN("calling on_error with runtime_error once") {
+      THEN("the flow completes without error") {
+        uut->on_next(1);
+        uut->on_next(2);
+        run_flows();
+        uut->on_error(sec::runtime_error);
+        run_flows();
+        uut->on_next(1);
+        uut->on_complete();
+        run_flows();
+        check_eq(snk->buf, std::vector<int>{1, 2, 1});
+        check(snk->completed());
+      }
+    }
+    WHEN("calling on_error with runtime_error twice") {
+      THEN("the flow completes without error") {
+        uut->on_next(1);
+        uut->on_next(2);
+        run_flows();
+        uut->on_error(sec::runtime_error);
+        run_flows();
+        uut->on_next(1);
+        uut->on_error(sec::runtime_error);
+        run_flows();
+        uut->on_next(1);
+        uut->on_next(2);
+        uut->on_complete();
+        run_flows();
+        check_eq(snk->buf, std::vector<int>{1, 2, 1, 1, 2});
+        check(snk->completed());
+      }
+    }
+    WHEN("calling on_error on operator with unexpected_message") {
+      THEN("the flow aborts with an error") {
+        uut->on_next(1);
+        uut->on_next(2);
+        run_flows();
+        uut->on_error(sec::unexpected_message);
+        run_flows();
+        check_eq(snk->buf, std::vector<int>{1, 2});
+        check(snk->aborted());
+      }
+    }
+    WHEN("calling on_error on operator after the flow is completed") {
+      THEN("the items are not emitted") {
+        uut->on_next(1);
+        run_flows();
+        uut->on_complete();
+        run_flows();
+        check_eq(snk->buf, std::vector<int>{1});
+        check(snk->completed());
+        uut->on_next(3);
+        run_flows();
+        check_eq(snk->buf, std::vector<int>{1});
+      }
+    }
+    WHEN("calling on_error on operator after the flow is aborted") {
+      THEN("the items are not emitted") {
+        uut->on_next(1);
+        run_flows();
+        uut->on_error(sec::unexpected_message);
+        run_flows();
+        check_eq(snk->buf, std::vector<int>{1});
+        check(snk->aborted());
+        uut->on_next(3);
+        run_flows();
+        check_eq(snk->buf, std::vector<int>{1});
+      }
+    }
+  }
+}
+
+SCENARIO("disposing a retry operator aborts the flow") {
+  auto retry_predicate = [](const caf::error& what) {
+    return what == sec::runtime_error;
+  };
+  GIVEN("an observable that is retried on `runtime_error`") {
+    WHEN("disposing the subscription of the operator") {
+      THEN("the observer receives an on_error event") {
+        auto snk = flow::make_passive_observer<int>();
+        auto uut = raw_sub(make_observable().never<int>(), snk->as_observer(),
+                           retry_predicate);
+        snk->request(42);
+        run_flows();
+        uut->dispose();
+        run_flows();
+        check(snk->aborted());
+      }
+    }
+  }
+}
+
+SCENARIO("retry operators discard items when there is no demand") {
+  GIVEN("an observable that is retried on `runtime_error`") {
+    WHEN("the demand is met") {
+      THEN("the observer stops receiving new items") {
+        auto snk = flow::make_passive_observer<int>();
+        auto uut = raw_sub(make_observable().never<int>(), snk->as_observer(),
+                           [](const caf::error&) { return true; });
+        snk->request(2);
+        uut->on_next(1);
+        uut->on_next(2);
+        uut->on_next(3);
+        uut->on_complete();
+        run_flows();
+        check_eq(snk->buf, std::vector<int>{1, 2});
+        check(snk->completed());
+      }
+    }
+  }
+}
+
+SCENARIO("retry operators forwards existing demand on retry") {
+  GIVEN("an observable that is retried on `runtime_error`") {
+    WHEN("on_error is called on the operator") {
+      THEN("the observable forwards existing demand") {
+        auto snk = flow::make_passive_observer<int>();
+        auto uut = raw_sub(make_observable().never<int>(), snk->as_observer(),
+                           [](const caf::error&) { return true; });
+        snk->request(4);
+        uut->on_next(1);
+        uut->on_next(2);
+        run_flows();
+        uut->on_error(sec::runtime_error);
+        uut->on_next(3);
+        uut->on_next(4);
+        uut->on_next(5);
+        run_flows();
+        check_eq(snk->buf, std::vector<int>{1, 2, 3, 4});
+        snk->request(2);
+        uut->on_next(6);
+        uut->on_complete();
+        run_flows();
+        check_eq(snk->buf, std::vector<int>{1, 2, 3, 4, 6});
+        check(snk->completed());
+      }
+    }
+  }
+}
+
+} // WITH_FIXTURE(fixture)
+
+} // namespace


### PR DESCRIPTION
Relates https://github.com/actor-framework/actor-framework/issues/1389

Adds retry operator that retries only when the predicate returns true. The predicate should accept one argument of type caf::error.