### PR TITLE
Always install a default logger when running tests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   leaving `main` right after setting up the connection, even when starting an
   actor in `start`. This was due to CAF not holding onto a strong reference to
   the connection object (and thus the actor) at all times (#1918).
+- When using log statements in unit tests, e.g. `log::test::debug`, the output
+  will now be rendered by default even when not using the deterministic fixture.
 
 ## [1.0.1] - 2024-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   no user-info at all.
 - The parser for reading JSON and configuration files now properly handles
   Windows-style line endings (#1850).
-- Calling `force_utc` on a `caf::chrono::dateime` object now properly applies
+- Calling `force_utc` on a `caf::chrono::datetime` object now properly applies
   the UTC offset. Previously, the function would shift the time into the wrong
   direction (#1860).
 - Fix a regression in the work-stealing scheduler that prevented workers from

--- a/libcaf_core/caf/chrono.test.cpp
+++ b/libcaf_core/caf/chrono.test.cpp
@@ -409,7 +409,7 @@ OUTLINE("two timestamps with the same time point are equal") {
   )__";
 }
 
-OUTLINE("force_utc coverts a dateime object to UTC") {
+OUTLINE("force_utc coverts a datetime object to UTC") {
   GIVEN("the timestamp <timestamp>") {
     auto maybe_ts = datetime::from_string(block_parameters<std::string>());
     require(maybe_ts.has_value());

--- a/libcaf_test/caf/test/reporter.hpp
+++ b/libcaf_test/caf/test/reporter.hpp
@@ -122,6 +122,9 @@ public:
 
   /// Creates a default reporter that writes to the standard output.
   static std::unique_ptr<reporter> make_default();
+
+  /// Creates a logger that forwards events to the current reporter.
+  static intrusive_ptr<logger> make_logger();
 };
 
 } // namespace caf::test

--- a/libcaf_test/caf/test/runner.cpp
+++ b/libcaf_test/caf/test/runner.cpp
@@ -144,6 +144,7 @@ runner::runner() : suites_(caf::test::registry::suites()) {
 int runner::run(int argc, char** argv) {
   auto default_reporter = reporter::make_default();
   reporter::instance(default_reporter.get());
+  auto default_logger = reporter::make_logger();
   if (auto [ok, help_printed] = parse_cli(argc, argv); !ok) {
     return EXIT_FAILURE;
   } else if (help_printed) {
@@ -178,6 +179,7 @@ int runner::run(int argc, char** argv) {
       std::unique_ptr<runnable> def;
       try {
         do {
+          logger::current_logger(default_logger.get());
           default_reporter->begin_test(state, test_name);
           def = factory_instance->make(state);
           def->run();


### PR DESCRIPTION
When using the deterministic fixture, we install a logger that forwards all messages to the reporter. However, when not using the fixture, logs are silently discarded because no logger exists. Since we offer a log component specifically for testing, e.g. via `log::test::debug`, this is not what a user can reasonably expect.

This patch moves the logger implementation from the deterministic fixture to the reporter and always installs an instance of that logger as default.