### PR TITLE
Fix how some type names are rendered in help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   the connection object (and thus the actor) at all times (#1918).
 - When using log statements in unit tests, e.g. `log::test::debug`, the output
   will now be rendered by default even when not using the deterministic fixture.
+- Registering a custom option of type `size_t` will no longer print
+  `<dictionary>` as type hint in the `--help` output. Instead, CAF will print
+  either `uint32_t` or `uint64_t`, depending on the platform.
 
 ## [1.0.1] - 2024-07-23
 

--- a/libcaf_core/caf/config_value.hpp
+++ b/libcaf_core/caf/config_value.hpp
@@ -9,6 +9,7 @@
 #include "caf/detail/bounds_checker.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/detail/parse.hpp"
+#include "caf/detail/squashed_int.hpp"
 #include "caf/detail/type_traits.hpp"
 #include "caf/dictionary.hpp"
 #include "caf/expected.hpp"
@@ -251,9 +252,10 @@ public:
 
   template <class T>
   static constexpr std::string_view mapped_type_name() {
-    if constexpr (detail::is_complete<caf::type_name<T>>) {
-      return caf::type_name_v<T>;
-    } else if constexpr (detail::is_list_like_v<T>) {
+    using type = detail::squash_if_int_t<T>;
+    if constexpr (detail::is_complete<caf::type_name<type>>) {
+      return caf::type_name_v<type>;
+    } else if constexpr (detail::is_list_like_v<type>) {
       return "list";
     } else {
       return "dictionary";


### PR DESCRIPTION
Fix a small issue in CAF with the help text. When adding a custom option of type `size_t`, CAF would display `<dictionary>` in the helptext as type hint.