### PR TITLE
Always put tests into the anonymous namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## Unreleased
 
+### Changed
+
+- Tests, scenarios and outlines are now automatically put into the anonymous
+  namespace to avoid name clashes with other tests. This removes the need for
+  users to manually put their tests into an anonymous namespace.
+- The `SUITE` macro of the unit test framework can now be used multiple times in
+  a single compilation unit.
+
 ### Fixed
 
 - When using the HTTP client API, the client now properly closes the connection

--- a/libcaf_core/caf/action.test.cpp
+++ b/libcaf_core/caf/action.test.cpp
@@ -11,8 +11,6 @@
 
 using namespace caf;
 
-namespace {
-
 SCENARIO("actions wrap function calls") {
   GIVEN("an action wrapping a lambda") {
     WHEN("running the action") {
@@ -150,5 +148,3 @@ SCENARIO("actors run actions that they receive") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/actor_companion.test.cpp
+++ b/libcaf_core/caf/actor_companion.test.cpp
@@ -11,8 +11,6 @@
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("actor_companion forwards messages to a custom handler") {
@@ -38,5 +36,3 @@ TEST("actor_companion calls the on_exit handler on shutdown") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/actor_factory.test.cpp
+++ b/libcaf_core/caf/actor_factory.test.cpp
@@ -48,6 +48,8 @@ struct test_actor_one_arg : event_based_actor {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("fun_no_args") {
@@ -99,5 +101,3 @@ TEST("class_one_arg_valid") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/actor_from_state.test.cpp
+++ b/libcaf_core/caf/actor_from_state.test.cpp
@@ -21,8 +21,6 @@ behavior dummy_impl() {
   };
 }
 
-WITH_FIXTURE(test::fixture::deterministic) {
-
 struct cell_state {
   cell_state() = default;
 
@@ -59,6 +57,10 @@ struct typed_cell_state {
 
   int value = 0;
 };
+
+} // namespace
+
+WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("a default-constructed cell has value 0") {
   auto dummy = sys.spawn(dummy_impl);
@@ -124,6 +126,8 @@ TEST("actors can spawn stateful actors as children") {
   }
 }
 
+namespace {
+
 struct id_cell_state {
   explicit id_cell_state(event_based_actor* selfptr, uint64_t offset_init = 0)
     : self(selfptr), offset(offset_init) {
@@ -158,6 +162,8 @@ struct typed_id_cell_state {
   typed_id_cell_actor::pointer self;
   uint64_t offset;
 };
+
+} // namespace
 
 TEST("the state may take the self pointer as constructor argument") {
   auto dummy = sys.spawn(dummy_impl);
@@ -229,5 +235,3 @@ TEST("the state destructor may send messages") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/actor_pool.test.cpp
+++ b/libcaf_core/caf/actor_pool.test.cpp
@@ -68,6 +68,8 @@ struct fixture {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("round_robin_actor_pool") {
@@ -162,5 +164,3 @@ TEST("random_actor_pool") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/actor_registry.test.cpp
+++ b/libcaf_core/caf/actor_registry.test.cpp
@@ -21,6 +21,8 @@ behavior dummy() {
   return {[](int i) { return i; }};
 }
 
+} // namespace
+
 WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("erase") {
@@ -59,5 +61,3 @@ TEST("serialization roundtrips go through the registry") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/actor_system.test.cpp
+++ b/libcaf_core/caf/actor_system.test.cpp
@@ -15,8 +15,6 @@
 
 using namespace caf;
 
-namespace {
-
 using shared_bool_ptr = std::shared_ptr<bool>;
 
 TEST("spawn_inactive creates an actor without launching it") {
@@ -91,5 +89,3 @@ TEST("println renders its arguments to a text stream") {
   sys.await_all_actors_done();
   check_eq(*out, "line1\n<red>line2</red>\nline3\n<green>line4</green>\n");
 }
-
-} // namespace

--- a/libcaf_core/caf/actor_system_config.test.cpp
+++ b/libcaf_core/caf/actor_system_config.test.cpp
@@ -98,6 +98,8 @@ struct fixture {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("parsing - without CLI arguments") {
@@ -348,5 +350,3 @@ SCENARIO("config files allow both nested and dot-separated values") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/actor_termination.test.cpp
+++ b/libcaf_core/caf/actor_termination.test.cpp
@@ -41,6 +41,8 @@ struct fixture : test::fixture::deterministic {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("single multiplexed request") {
@@ -105,5 +107,3 @@ TEST("multiple awaited requests") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/anon_mail.test.cpp
+++ b/libcaf_core/caf/anon_mail.test.cpp
@@ -15,8 +15,6 @@
 using namespace caf;
 using namespace std::literals;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("send asynchronous message") {
@@ -151,5 +149,3 @@ TEST("explicit cancel of a delayed message") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/async/batch.test.cpp
+++ b/libcaf_core/caf/async/batch.test.cpp
@@ -30,6 +30,8 @@ auto to_list(span<const T> xs) {
   return std::list<T>{xs.begin(), xs.end()};
 }
 
+} // namespace
+
 SCENARIO("batches are constructible from a list of values") {
   GIVEN("an empty vector") {
     WHEN("passing it to make_batch") {
@@ -259,5 +261,3 @@ SCENARIO("serializing and then deserializing a batch makes a deep copy") {
     }
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/async/blocking_consumer.test.cpp
+++ b/libcaf_core/caf/async/blocking_consumer.test.cpp
@@ -35,6 +35,8 @@ void produce(async::producer_resource<int> push) {
     out.push(i);
 }
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("blocking consumers allow threads to receive data") {
@@ -75,5 +77,3 @@ SCENARIO("blocking consumers allow threads to receive data") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/async/blocking_producer.test.cpp
+++ b/libcaf_core/caf/async/blocking_producer.test.cpp
@@ -118,6 +118,8 @@ void receiver_impl(event_based_actor* self, pull_resource_t inputs,
     });
 }
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("blocking producers allow threads to generate data") {
@@ -148,5 +150,3 @@ SCENARIO("blocking producers allow threads to generate data") {
 TEST_INIT() {
   init_global_meta_objects<id_block::blocking_producer_test>();
 }
-
-} // namespace

--- a/libcaf_core/caf/async/consumer_adapter.test.cpp
+++ b/libcaf_core/caf/async/consumer_adapter.test.cpp
@@ -82,6 +82,8 @@ private:
   std::vector<int> values_;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("consumer adapters allow integrating consumers into event loops") {
@@ -107,5 +109,3 @@ SCENARIO("consumer adapters allow integrating consumers into event loops") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/async/file.test.cpp
+++ b/libcaf_core/caf/async/file.test.cpp
@@ -39,6 +39,8 @@ constexpr std::string_view quotes_numbered_lines = R"_(1:
 7:
 )_";
 
+} // namespace
+
 TEST("async text file I/O") {
   actor_system_config cfg;
   actor_system sys{cfg};
@@ -165,5 +167,3 @@ TEST("async binary file I/O") {
     check_eq(res.get(), expected<byte_buffer>{bytes});
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/async/producer_adapter.test.cpp
+++ b/libcaf_core/caf/async/producer_adapter.test.cpp
@@ -151,6 +151,8 @@ void receiver_impl(event_based_actor* self, pull_resource_t inputs,
     });
 }
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("producers adapters allow integrating producers into event loops") {
@@ -183,5 +185,3 @@ SCENARIO("producers adapters allow integrating producers into event loops") {
 TEST_INIT() {
   init_global_meta_objects<id_block::producer_adapter_test>();
 }
-
-} // namespace

--- a/libcaf_core/caf/async/promise.test.cpp
+++ b/libcaf_core/caf/async/promise.test.cpp
@@ -21,6 +21,8 @@ auto make_shared_val_ptr() {
   return std::make_shared<std::variant<none_t, T, error>>();
 }
 
+} // namespace
+
 SCENARIO("futures can actively wait on a promise") {
   auto uut = async::promise<int32_t>{};
   auto fut = uut.get_future();
@@ -234,5 +236,3 @@ SCENARIO("never setting a value or an error breaks the promises") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/async/publisher.test.cpp
+++ b/libcaf_core/caf/async/publisher.test.cpp
@@ -13,8 +13,6 @@
 
 using namespace caf;
 
-namespace {
-
 /*
 WITH_FIXTURE(test::fixture::flow) {
 
@@ -128,5 +126,3 @@ SCENARIO("publishers from terminated actors produce errors") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/async/spsc_buffer.test.cpp
+++ b/libcaf_core/caf/async/spsc_buffer.test.cpp
@@ -105,6 +105,8 @@ struct dummy_observer {
   error err;
 };
 
+} // namespace
+
 WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("resources may be copied") {
@@ -552,5 +554,3 @@ SCENARIO("SPSC buffers reject multiple consumers") {
 #endif // CAF_ENABLE_EXCEPTIONS
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/async_mail.test.cpp
+++ b/libcaf_core/caf/async_mail.test.cpp
@@ -18,8 +18,6 @@
 using namespace caf;
 using namespace std::literals;
 
-namespace {
-
 using dummy_actor = typed_actor<result<int>(int)>;
 
 using dummy_behavior = dummy_actor::behavior_type;
@@ -570,5 +568,3 @@ TEST("send asynchronous message as a typed actor") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/behavior.test.cpp
+++ b/libcaf_core/caf/behavior.test.cpp
@@ -49,6 +49,8 @@ struct fixture {
   message m3 = make_message(1, 2, 3);
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("a default-constructed behavior accepts no messages") {
@@ -291,5 +293,3 @@ TEST("behaviors may be assigned after construction") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/blocking_actor.test.cpp
+++ b/libcaf_core/caf/blocking_actor.test.cpp
@@ -22,6 +22,8 @@ struct fixture : test::fixture::deterministic {
   scoped_actor self{sys};
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("catch_all") {
@@ -61,5 +63,3 @@ TEST("spawn blocking actor") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/blocking_mail.test.cpp
+++ b/libcaf_core/caf/blocking_mail.test.cpp
@@ -33,6 +33,8 @@ struct fixture {
   actor_system sys{cfg};
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("send request message") {
@@ -403,5 +405,3 @@ TEST("receive response as an expected") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/chrono.test.cpp
+++ b/libcaf_core/caf/chrono.test.cpp
@@ -12,8 +12,6 @@
 
 using namespace caf;
 
-namespace {
-
 using datetime = chrono::datetime;
 
 TEST("a default constructed date and time is invalid") {
@@ -490,5 +488,3 @@ TEST("to_string prints fractional digits according to the precision") {
     check_eq(to_string(dt), dt.to_string());
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/chunked_string.test.cpp
+++ b/libcaf_core/caf/chunked_string.test.cpp
@@ -21,6 +21,8 @@ auto str(const node_type& head) {
   return chunked_string{&head};
 }
 
+} // namespace
+
 TEST("to_string") {
   auto world = node_type{"World!", nullptr};
   check_eq(to_string(str(world)), "World!");
@@ -87,5 +89,3 @@ TEST("builder") {
     check_eq(sizes, std::vector<size_t>{128, 128, 128, 128, 1});
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/config_option.test.cpp
+++ b/libcaf_core/caf/config_option.test.cpp
@@ -29,6 +29,8 @@ dummy_meta_state(std::string_view type_name = "dummy") {
   };
 }
 
+} // namespace
+
 OUTLINE("config options parse their parameters for long, short and env names") {
   using std::string;
   auto dummy = dummy_meta_state();
@@ -148,5 +150,3 @@ TEST("config options with storage sync their value with the storage") {
     check_eq(val, 0);
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/config_option_set.test.cpp
+++ b/libcaf_core/caf/config_option_set.test.cpp
@@ -61,6 +61,8 @@ struct fixture {
   std::string key = "value";
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("lookup") {
@@ -296,14 +298,10 @@ TEST("square brackets are optional on the command line") {
   check_eq(read<int_list>({"-v", "1, 2 , 3 , "}), int_list({1, 2, 3}));
 }
 
-#define SUBTEST(msg)                                                           \
-  opts.clear();                                                                \
-  if (true)
-
 TEST("CLI arguments override defaults") {
   using int_list = std::vector<int>;
   using string_list = std::vector<std::string>;
-  SUBTEST("with ref syncing") {
+  SECTION("with ref syncing") {
     settings cfg;
     int_list ints;
     string_list strings;
@@ -326,7 +324,7 @@ TEST("CLI arguments override defaults") {
     check_eq(strings, string_list({"hello", "world"}));
     check_eq(get_as<string_list>(cfg, "foo"), string_list({"hello", "world"}));
   }
-  SUBTEST("without ref syncing") {
+  SECTION("without ref syncing") {
     settings cfg;
     log::test::debug("add --foo and --bar options");
     opts.add<string_list>("global", "foo,f", "some list");
@@ -356,5 +354,3 @@ TEST("CLI arguments may use custom types") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/config_value.test.cpp
+++ b/libcaf_core/caf/config_value.test.cpp
@@ -109,6 +109,8 @@ struct fixture {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("default-constructed config values represent null") {
@@ -1012,5 +1014,3 @@ TEST("dictionary baseline testing") {
 TEST_INIT() {
   caf::init_global_meta_objects<caf::id_block::config_value_test>();
 }
-
-} // namespace

--- a/libcaf_core/caf/const_typed_message_view.test.cpp
+++ b/libcaf_core/caf/const_typed_message_view.test.cpp
@@ -13,8 +13,6 @@
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("const message views never detach their content") {
@@ -52,5 +50,3 @@ TEST("to_tuple can convert messages to tuples") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/constructor_attach.test.cpp
+++ b/libcaf_core/caf/constructor_attach.test.cpp
@@ -50,6 +50,8 @@ public:
   actor testee;
 };
 
+} // namespace
+
 WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("constructor attach") {
@@ -58,5 +60,3 @@ TEST("constructor attach") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/cow_string.test.cpp
+++ b/libcaf_core/caf/cow_string.test.cpp
@@ -14,8 +14,6 @@ using std::tuple;
 using namespace caf;
 using namespace std::literals;
 
-namespace {
-
 SCENARIO("default constructed COW strings are empty") {
   WHEN("default-constructing a COW tuple") {
     cow_string str;
@@ -91,5 +89,3 @@ SCENARIO("COW strings detach their content when becoming unshared") {
     }
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/cow_tuple.test.cpp
+++ b/libcaf_core/caf/cow_tuple.test.cpp
@@ -43,6 +43,8 @@ T roundtrip(const T& x) {
   return result;
 }
 
+} // namespace
+
 TEST("default_construction") {
   cow_tuple<string, string> x;
   check_eq(x.unique(), true);
@@ -128,5 +130,3 @@ TEST("serialization") {
   check_eq(y.unique(), true);
   check_ne(x.ptr(), y.ptr());
 }
-
-} // namespace

--- a/libcaf_core/caf/deep_to_string.test.cpp
+++ b/libcaf_core/caf/deep_to_string.test.cpp
@@ -10,43 +10,39 @@
 
 using namespace caf;
 
-#define CHECK_DEEP_TO_STRING(val, str) check_eq(deep_to_string(val), str)
-
-namespace {
-
 TEST("timespans use the highest unit available when printing") {
   check_eq(to_string(config_value{timespan{0}}), "0s");
-  CHECK_DEEP_TO_STRING(timespan{0}, "0s");
-  CHECK_DEEP_TO_STRING(timespan{1}, "1ns");
-  CHECK_DEEP_TO_STRING(timespan{1'000}, "1us");
-  CHECK_DEEP_TO_STRING(timespan{1'000'000}, "1ms");
-  CHECK_DEEP_TO_STRING(timespan{1'000'000'000}, "1s");
-  CHECK_DEEP_TO_STRING(timespan{60'000'000'000}, "1min");
+  check_eq(deep_to_string(timespan{0}), "0s");
+  check_eq(deep_to_string(timespan{1}), "1ns");
+  check_eq(deep_to_string(timespan{1'000}), "1us");
+  check_eq(deep_to_string(timespan{1'000'000}), "1ms");
+  check_eq(deep_to_string(timespan{1'000'000'000}), "1s");
+  check_eq(deep_to_string(timespan{60'000'000'000}), "1min");
 }
 
 TEST("lists use square brackets") {
   int i32_array[] = {1, 2, 3, 4};
   using i32_array_type = std::array<int, 4>;
-  CHECK_DEEP_TO_STRING(std::list<int>({1, 2, 3, 4}), "[1, 2, 3, 4]");
-  CHECK_DEEP_TO_STRING(std::vector<int>({1, 2, 3, 4}), "[1, 2, 3, 4]");
-  CHECK_DEEP_TO_STRING(std::set<int>({1, 2, 3, 4}), "[1, 2, 3, 4]");
-  CHECK_DEEP_TO_STRING(i32_array_type({{1, 2, 3, 4}}), "[1, 2, 3, 4]");
-  CHECK_DEEP_TO_STRING(i32_array, "[1, 2, 3, 4]");
+  check_eq(deep_to_string(std::list<int>({1, 2, 3, 4})), "[1, 2, 3, 4]");
+  check_eq(deep_to_string(std::vector<int>({1, 2, 3, 4})), "[1, 2, 3, 4]");
+  check_eq(deep_to_string(std::set<int>({1, 2, 3, 4})), "[1, 2, 3, 4]");
+  check_eq(deep_to_string(i32_array_type({{1, 2, 3, 4}})), "[1, 2, 3, 4]");
+  check_eq(deep_to_string(i32_array), "[1, 2, 3, 4]");
   bool bool_array[] = {false, true};
   using bool_array_type = std::array<bool, 2>;
-  CHECK_DEEP_TO_STRING(std::list<bool>({false, true}), "[false, true]");
-  CHECK_DEEP_TO_STRING(std::vector<bool>({false, true}), "[false, true]");
-  CHECK_DEEP_TO_STRING(std::set<bool>({false, true}), "[false, true]");
-  CHECK_DEEP_TO_STRING(bool_array_type({{false, true}}), "[false, true]");
-  CHECK_DEEP_TO_STRING(bool_array, "[false, true]");
+  check_eq(deep_to_string(std::list<bool>({false, true})), "[false, true]");
+  check_eq(deep_to_string(std::vector<bool>({false, true})), "[false, true]");
+  check_eq(deep_to_string(std::set<bool>({false, true})), "[false, true]");
+  check_eq(deep_to_string(bool_array_type({{false, true}})), "[false, true]");
+  check_eq(deep_to_string(bool_array), "[false, true]");
 }
 
 TEST("pointers and optionals use dereference syntax") {
   auto i = 42;
-  CHECK_DEEP_TO_STRING(&i, "*42");
-  CHECK_DEEP_TO_STRING(static_cast<int*>(nullptr), "null");
-  CHECK_DEEP_TO_STRING(std::optional<int>{}, "null");
-  CHECK_DEEP_TO_STRING(std::optional<int>{23}, "*23");
+  check_eq(deep_to_string(&i), "*42");
+  check_eq(deep_to_string(static_cast<int*>(nullptr)), "null");
+  check_eq(deep_to_string(std::optional<int>{}), "null");
+  check_eq(deep_to_string(std::optional<int>{23}), "*23");
 }
 
 TEST("buffers") {
@@ -64,5 +60,3 @@ TEST("buffers") {
   buf.push_back(16);
   check_eq(deep_to_string(buf), "[-1, 0, 127, 10, 16]");
 }
-
-} // namespace

--- a/libcaf_core/caf/delegate.test.cpp
+++ b/libcaf_core/caf/delegate.test.cpp
@@ -10,8 +10,6 @@
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("delegation moves responsibility for a request to another actor") {
@@ -74,5 +72,3 @@ TEST("delegation moves responsibility for a request to another actor") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/detached_actors.test.cpp
+++ b/libcaf_core/caf/detached_actors.test.cpp
@@ -11,8 +11,6 @@
 using namespace caf;
 using namespace std::literals;
 
-namespace {
-
 SCENARIO("an actor system shuts down after the last actor terminates") {
   GIVEN("an actor system and a detached actor") {
     WHEN("the actor sets no behavior") {
@@ -120,5 +118,3 @@ SCENARIO("an actor system shuts down after the last actor terminates") {
     }
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/base64.test.cpp
+++ b/libcaf_core/caf/detail/base64.test.cpp
@@ -14,8 +14,6 @@ using namespace std::literals::string_literals;
 
 using caf::detail::base64;
 
-namespace {
-
 TEST("encoding") {
   check_eq(base64::encode("A"sv), "QQ=="sv);
   check_eq(base64::encode("AB"sv), "QUI="sv);
@@ -31,5 +29,3 @@ TEST("decoding") {
   check_eq(base64::decode("aHR0cHM6Ly9hY3Rvci1mcmFtZXdvcmsub3Jn"sv),
            "https://actor-framework.org"s);
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/beacon.test.cpp
+++ b/libcaf_core/caf/detail/beacon.test.cpp
@@ -14,8 +14,6 @@
 using namespace caf;
 using namespace std::literals;
 
-namespace {
-
 SCENARIO("beacons can be disposed") {
   auto disposable_beacon = detail::beacon{};
   GIVEN("a beacon") {
@@ -34,5 +32,3 @@ SCENARIO("beacons can be disposed") {
     }
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/bounds_checker.test.cpp
+++ b/libcaf_core/caf/detail/bounds_checker.test.cpp
@@ -15,6 +15,8 @@ bool bounds_check(U x) {
   return caf::detail::bounds_checker<T>::check(x);
 }
 
+} // namespace
+
 TEST("small integers") {
   check_eq(bounds_check<int8_t>(128), false);
   check_eq(bounds_check<int8_t>(127), true);
@@ -41,5 +43,3 @@ TEST("large unsigned integers") {
   check_eq(bounds_check<uint64_t>(std::numeric_limits<int64_t>::max()), true);
   check_eq(bounds_check<uint64_t>(std::numeric_limits<uint64_t>::max()), true);
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/config_consumer.test.cpp
+++ b/libcaf_core/caf/detail/config_consumer.test.cpp
@@ -56,6 +56,8 @@ struct fixture {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("config_consumer") {
@@ -92,5 +94,3 @@ TEST("simplified syntax") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/detail/default_mailbox.test.cpp
+++ b/libcaf_core/caf/detail/default_mailbox.test.cpp
@@ -17,6 +17,8 @@ auto make_int_msg(int value) {
   return make_mailbox_element(nullptr, make_message_id(P), make_message(value));
 }
 
+} // namespace
+
 TEST("a default-constructed mailbox is empty") {
   detail::default_mailbox uut;
   check(!uut.closed());
@@ -75,5 +77,3 @@ TEST("calling push_front inserts messages at the beginning") {
     check_eq(results[3].get_as<int>(0), 2);
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/format.test.cpp
+++ b/libcaf_core/caf/detail/format.test.cpp
@@ -15,8 +15,6 @@
 using namespace caf;
 using namespace std::literals;
 
-namespace {
-
 #ifdef CAF_USE_STD_FORMAT
 
 using caf::detail::fmt_fwd;
@@ -125,5 +123,3 @@ TEST("ill-formatted formatting strings throw") {
 }
 
 #endif
-
-} // namespace

--- a/libcaf_core/caf/detail/ieee_754.test.cpp
+++ b/libcaf_core/caf/detail/ieee_754.test.cpp
@@ -23,6 +23,8 @@ using flimits = std::numeric_limits<float>;
 
 using dlimits = std::numeric_limits<double>;
 
+} // namespace
+
 #define CHECK_RT(value) check_eq(roundtrip(value), caf::test::approx{value})
 
 #define CHECK_PRED_RT(pred, value) check(pred(roundtrip(value)))
@@ -97,5 +99,3 @@ TEST("packing and then unpacking doubles returns the original value") {
     CHECK_SIGN_RT(-dlimits::infinity());
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/latch.test.cpp
+++ b/libcaf_core/caf/detail/latch.test.cpp
@@ -10,8 +10,6 @@
 
 using namespace caf;
 
-namespace {
-
 SCENARIO("latches synchronize threads") {
   GIVEN("a latch and three threads") {
     detail::latch sync{2};
@@ -29,5 +27,3 @@ SCENARIO("latches synchronize threads") {
       t.join();
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/log_level_map.test.cpp
+++ b/libcaf_core/caf/detail/log_level_map.test.cpp
@@ -15,8 +15,6 @@ using namespace std::literals;
 
 using caf::log::level;
 
-namespace {
-
 TEST("log level maps render the default log levels") {
   detail::log_level_map uut;
   check_eq(uut[level::quiet], "OFF");
@@ -109,5 +107,3 @@ TEST("log level maps allow case-insensitive lookup by name") {
   check_eq(uut.by_name("TRACE"), level::trace);
   check_eq(uut.by_name("trace"), level::trace);
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/mbr_list.test.cpp
+++ b/libcaf_core/caf/detail/mbr_list.test.cpp
@@ -19,6 +19,8 @@ void fill(list_type& xs, Ts... args) {
   (xs.emplace_back(args), ...);
 }
 
+} // namespace
+
 TEST("a default default-constructed list is empty") {
   list_type uut;
   check_eq(uut.empty(), true);
@@ -87,5 +89,3 @@ TEST("lists allow iterator-based access") {
                            [](int acc, const int& x) { return acc + x; }),
            12);
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/meta_object.test.cpp
+++ b/libcaf_core/caf/detail/meta_object.test.cpp
@@ -16,8 +16,12 @@
 #include <tuple>
 #include <type_traits>
 
+namespace {
+
 struct i32_wrapper;
 struct i64_wrapper;
+
+} // namespace
 
 // +5 to avoid clash with caf.message_builder test
 CAF_BEGIN_TYPE_ID_BLOCK(meta_object_test, caf::first_custom_type_id + 5)
@@ -29,6 +33,8 @@ using namespace std::string_literals;
 
 using namespace caf;
 using namespace caf::detail;
+
+namespace {
 
 struct i32_wrapper {
   // Initialized in meta_object.cpp.
@@ -78,7 +84,7 @@ size_t i32_wrapper::instances = 0;
 
 size_t i64_wrapper::instances = 0;
 
-namespace {
+} // namespace
 
 TEST("meta objects allow construction and destruction of objects") {
   auto meta_i32_wrapper = make_meta_object<i32_wrapper>("i32_wrapper");
@@ -126,5 +132,3 @@ TEST("init_global_meta_objects takes care of creating a meta object table") {
 TEST_INIT() {
   init_global_meta_objects<id_block::meta_object_test>();
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/monotonic_buffer_resource.test.cpp
+++ b/libcaf_core/caf/detail/monotonic_buffer_resource.test.cpp
@@ -14,8 +14,6 @@
 
 using namespace caf;
 
-namespace {
-
 SCENARIO("monotonic buffers group allocations") {
   GIVEN("a monotonic buffer resource") {
     detail::monotonic_buffer_resource mbr;
@@ -117,5 +115,3 @@ SCENARIO("monotonic buffers provide storage for STL containers") {
     }
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/parse.test.cpp
+++ b/libcaf_core/caf/detail/parse.test.cpp
@@ -53,6 +53,8 @@ expected<T> read(std::string_view str) {
   return ps.error();
 }
 
+} // namespace
+
 #define CHECK_NUMBER(type, value) check_eq(read<type>(#value), type(value))
 
 #define CHECK_NUMBER_3(type, value, cpp_value)                                 \
@@ -204,5 +206,3 @@ TEST("IPv6 endpoint") {
   check_eq(read<ipv6_endpoint>("127.0.0.1:65536"), pec::integer_overflow);
   check_eq(read<ipv6_endpoint>("[1::2]:8080"), ipv6_endpoint({{1}, {2}}, 8080));
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/parser/read_bool.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_bool.test.cpp
@@ -41,6 +41,8 @@ struct fixture {
   bool_parser p;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("valid booleans") {
@@ -64,5 +66,3 @@ TEST("invalid booleans") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/detail/parser/read_config.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_config.test.cpp
@@ -225,6 +225,8 @@ std::string with_windows_newlines(std::string_view str) {
   return result;
 }
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("read_config feeds into a consumer") {
@@ -235,5 +237,3 @@ TEST("read_config feeds into a consumer") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/detail/parser/read_floating_point.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_floating_point.test.cpp
@@ -35,6 +35,8 @@ std::optional<double> read(std::string_view str) {
   return consumer.x;
 }
 
+} // namespace
+
 TEST("predecimal only") {
   check_eq(read("0"), 0.);
   check_eq(read("+0"), 0.);
@@ -84,5 +86,3 @@ TEST("scientific noation") {
   check_eq(read("+12e-3"), 12e-3);
   check_eq(read("-12e-3"), -12e-3);
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/parser/read_number.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_number.test.cpp
@@ -123,6 +123,8 @@ struct fixture {
   range_parser r;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("add ascii - unsigned") {
@@ -347,5 +349,3 @@ TEST("the parser rejects invalid step values") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/detail/parser/read_number_or_timespan.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_number_or_timespan.test.cpp
@@ -78,6 +78,8 @@ res_t res(std::chrono::duration<Rep, Period> x) {
   return res_t{std::chrono::duration_cast<timespan>(x)};
 }
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("valid numbers and timespans") {
@@ -108,5 +110,3 @@ TEST("invalid timespans") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/detail/parser/read_signed_integer.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_signed_integer.test.cpp
@@ -61,6 +61,8 @@ T max_val() {
   return std::numeric_limits<T>::max();
 }
 
+} // namespace
+
 #define ZERO_VALUE(type, literal) check_eq(read<type>(#literal), type(0));
 
 #define MAX_VALUE(type, literal)                                               \
@@ -171,5 +173,3 @@ TEST("maximal value") {
   OVERFLOW(int64_t, 9223372036854775808);
   OVERFLOW(int64_t, 0x8000000000000000);
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/parser/read_string.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_string.test.cpp
@@ -40,6 +40,8 @@ struct fixture {
   string_parser p;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("empty string") {
@@ -96,5 +98,3 @@ TEST("invalid strings") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/detail/parser/read_timespan.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_timespan.test.cpp
@@ -56,6 +56,8 @@ std::optional<timespan> read(std::string_view str) {
   return consumer.x;
 }
 
+} // namespace
+
 TEST("todo") {
   check_eq(read("12ns"), 12_ns);
   check_eq(read("34us"), 34_us);
@@ -64,5 +66,3 @@ TEST("todo") {
   check_eq(read("60min"), 1_h);
   check_eq(read("90h"), 90_h);
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/parser/read_unsigned_integer.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_unsigned_integer.test.cpp
@@ -48,6 +48,8 @@ T max_val() {
   return std::numeric_limits<T>::max();
 }
 
+} // namespace
+
 #define ZERO_VALUE(type, literal) check_eq(read<type>(#literal), type(0));
 
 #define MAX_VALUE(type, literal)                                               \
@@ -110,5 +112,3 @@ TEST("maximal value") {
   OVERFLOW(uint64_t, 18446744073709551616);
   OVERFLOW(uint64_t, 0x10000000000000000);
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/private_thread_pool.test.cpp
+++ b/libcaf_core/caf/detail/private_thread_pool.test.cpp
@@ -14,8 +14,6 @@
 using namespace caf;
 using namespace std::literals;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::deterministic) {
 
 SCENARIO("private threads count towards detached actors") {
@@ -87,5 +85,3 @@ SCENARIO("private threads rerun their resumable when it returns resume_later") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/detail/rfc3629.test.cpp
+++ b/libcaf_core/caf/detail/rfc3629.test.cpp
@@ -123,6 +123,8 @@ constexpr std::string_view ascii_2 = R"__(
  *                      \____/_/   \_|_|                                      *
 )__";
 
+} // namespace
+
 TEST("rfc3629::valid checks whether an input is valid UTF-8") {
   SECTION("valid ASCII input") {
     check(valid_utf8(ascii_1));
@@ -220,5 +222,3 @@ TEST("rfc3629::validate stops at the first invalid byte") {
     check_eq(rfc3629::validate(data), res_t{10, false});
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/ring_buffer.test.cpp
+++ b/libcaf_core/caf/detail/ring_buffer.test.cpp
@@ -20,6 +20,8 @@ int pop(ring_buffer<int>& buf) {
   return result;
 }
 
+} // namespace
+
 TEST("push_back adds element") {
   ring_buffer<int> buf{3};
   log::test::debug("full capacity of ring buffer");
@@ -182,5 +184,3 @@ TEST("ring-buffers are copiable") {
   check_eq(pop(buf), 3);
   check_eq(buf.empty(), true);
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/sync_ring_buffer.test.cpp
+++ b/libcaf_core/caf/detail/sync_ring_buffer.test.cpp
@@ -32,6 +32,8 @@ void producer(string_queue* queue, int first, int last) {
     queue->push(std::to_string(i));
 }
 
+} // namespace
+
 TEST("a default-constructed ring buffer is empty") {
   string_queue queue;
   auto now = std::chrono::steady_clock::now();
@@ -65,5 +67,3 @@ TEST("sync_ring_buffer can be used with multiple producers") {
   for (auto& t : producers)
     t.join();
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/type_id_list_builder.test.cpp
+++ b/libcaf_core/caf/detail/type_id_list_builder.test.cpp
@@ -11,8 +11,6 @@
 
 using namespace caf;
 
-namespace {
-
 using builder_t = detail::type_id_list_builder;
 
 SCENARIO("a default-constructed type_id_list_builder is empty") {
@@ -139,5 +137,3 @@ OUTLINE("passing an size hint to the builder pre-allocates memory") {
     |   24 |       32 |
   )";
 }
-
-} // namespace

--- a/libcaf_core/caf/detail/unique_function.test.cpp
+++ b/libcaf_core/caf/detail/unique_function.test.cpp
@@ -33,6 +33,8 @@ private:
   size_t* instance_counter_;
 };
 
+} // namespace
+
 #define CHECK_VALID(f)                                                         \
   check(!f.is_nullptr());                                                      \
   check(static_cast<bool>(f));                                                 \
@@ -162,5 +164,3 @@ TEST("move assign") {
 }
 
 // NOLINTEND(bugprone-use-after-move)
-
-} // namespace

--- a/libcaf_core/caf/dictionary.test.cpp
+++ b/libcaf_core/caf/dictionary.test.cpp
@@ -8,8 +8,6 @@
 
 using namespace caf;
 
-namespace {
-
 using int_dict = dictionary<int>;
 
 TEST("construction and comparison") {
@@ -123,5 +121,3 @@ TEST("element access") {
   check_eq(xs["b"], 2);
   check_eq(xs["e"], 0);
 }
-
-} // namespace

--- a/libcaf_core/caf/dynamic_spawn.test.cpp
+++ b/libcaf_core/caf/dynamic_spawn.test.cpp
@@ -280,6 +280,8 @@ struct fixture {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("mirror") {
@@ -530,5 +532,3 @@ TEST("move-only function object") {
 TEST_INIT() {
   caf::init_global_meta_objects<caf::id_block::dynamic_spawn_test>();
 }
-
-} // namespace

--- a/libcaf_core/caf/error.test.cpp
+++ b/libcaf_core/caf/error.test.cpp
@@ -10,8 +10,6 @@
 using namespace caf;
 using namespace std::literals;
 
-namespace {
-
 TEST("default-constructed errors evaluate to false") {
   error err;
   check(!err);
@@ -68,5 +66,3 @@ SCENARIO("errors provide human-readable to_string output") {
     }
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/event_based_actor.test.cpp
+++ b/libcaf_core/caf/event_based_actor.test.cpp
@@ -14,8 +14,6 @@
 using namespace caf;
 using namespace std::literals;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("GH-1920 regression") {
@@ -237,5 +235,3 @@ SCENARIO("setting an infinite idle timeout is an error") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/event_based_mail.test.cpp
+++ b/libcaf_core/caf/event_based_mail.test.cpp
@@ -20,8 +20,6 @@
 using namespace caf;
 using namespace std::literals;
 
-namespace {
-
 using dummy_actor = typed_actor<result<int>(int)>;
 
 using dummy_behavior = dummy_actor::behavior_type;
@@ -687,5 +685,3 @@ TEST("delegate message") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/exit_reason.test.cpp
+++ b/libcaf_core/caf/exit_reason.test.cpp
@@ -35,6 +35,8 @@ struct fixture {
   }
 };
 
+} // namespace
+
 #define CHECK_SERIALIZATION(error_code)                                        \
   check_eq(error_code, roundtrip(error_code))
 
@@ -51,5 +53,3 @@ TEST("exit_reason values are serializable") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/expected.test.cpp
+++ b/libcaf_core/caf/expected.test.cpp
@@ -40,6 +40,8 @@ using e_str = expected<std::string>;
 using e_void = expected<void>;
 using e_iptr = expected<counted_int_ptr>;
 
+} // namespace
+
 // NOLINTBEGIN(bugprone-use-after-move)
 
 TEST("expected reports its status via has_value() or operator bool()") {
@@ -935,5 +937,3 @@ TEST("transform_or does nothing when called with a value") {
 }
 
 // NOLINTEND(bugprone-use-after-move)
-
-} // namespace

--- a/libcaf_core/caf/flow/byte.test.cpp
+++ b/libcaf_core/caf/flow/byte.test.cpp
@@ -25,6 +25,8 @@ auto to_bytes(const T& data) {
   return byte_arr;
 }
 
+} // namespace
+
 WITH_FIXTURE(test::fixture::flow) {
 
 SCENARIO("to_chunks splits a sequence of bytes into chunks") {
@@ -351,5 +353,3 @@ SCENARIO("split_as_utf8_at rejects invalid UTF-8 inputs") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/concat_map.test.cpp
+++ b/libcaf_core/caf/flow/concat_map.test.cpp
@@ -34,6 +34,8 @@ struct concat_map_adder_state {
 
 struct fixture : test::fixture::flow, test::fixture::deterministic {};
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("concat_map merges multiple observables") {
@@ -82,5 +84,3 @@ SCENARIO("concat_map merges multiple observables") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/flow/flat_map.test.cpp
+++ b/libcaf_core/caf/flow/flat_map.test.cpp
@@ -34,6 +34,8 @@ public:
 
 struct fixture : test::fixture::flow, test::fixture::deterministic {};
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("flat_map merges multiple observables") {
@@ -86,5 +88,3 @@ SCENARIO("flat_map merges multiple observables") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/flow/for_each.test.cpp
+++ b/libcaf_core/caf/flow/for_each.test.cpp
@@ -10,8 +10,6 @@
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::flow) {
 
 SCENARIO("for_each iterates all values in a stream") {
@@ -109,5 +107,3 @@ SCENARIO("for_each iterates all values in a stream") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/generation.test.cpp
+++ b/libcaf_core/caf/flow/generation.test.cpp
@@ -30,6 +30,8 @@ auto iota_vec(size_t n, int init = 1) {
   return result;
 }
 
+} // namespace
+
 WITH_FIXTURE(test::fixture::flow) {
 
 SCENARIO("repeater sources repeat one value indefinitely") {
@@ -406,5 +408,3 @@ SCENARIO("users can provide custom generators") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/mixed.test.cpp
+++ b/libcaf_core/caf/flow/mixed.test.cpp
@@ -21,8 +21,6 @@ using std::vector;
 using namespace caf;
 using namespace caf::flow;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::flow) {
 
 TEST("sum up all the multiples of 3 or 5 below 1000") {
@@ -90,5 +88,3 @@ TEST("GH-1399 regression") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/flow/multicaster.test.cpp
+++ b/libcaf_core/caf/flow/multicaster.test.cpp
@@ -16,8 +16,6 @@ using std::vector;
 using namespace caf;
 using namespace caf::flow;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::flow) {
 
 SCENARIO("a multicaster pushes items to all subscribers") {
@@ -118,5 +116,3 @@ SCENARIO("a multicaster discards items that arrive before a subscriber") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/observable.test.cpp
+++ b/libcaf_core/caf/flow/observable.test.cpp
@@ -13,8 +13,6 @@ using std::vector;
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::flow) {
 
 // Note: we always double the checks for the operator-under-test by calling it
@@ -600,5 +598,3 @@ TEST("start_with(value) builds observable that emits value first") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/observe_on.test.cpp
+++ b/libcaf_core/caf/flow/observe_on.test.cpp
@@ -14,8 +14,6 @@
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::deterministic) {
 
 SCENARIO("observe_on moves data between actors") {
@@ -41,5 +39,3 @@ SCENARIO("observe_on moves data between actors") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/buffer.test.cpp
+++ b/libcaf_core/caf/flow/op/buffer.test.cpp
@@ -64,6 +64,8 @@ struct fixture : test::fixture::deterministic, test::fixture::flow {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("the buffer operator groups items together") {
@@ -486,5 +488,3 @@ SCENARIO("on_request actions can turn into no-ops") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/cell.test.cpp
+++ b/libcaf_core/caf/flow/op/cell.test.cpp
@@ -26,6 +26,8 @@ struct fixture : test::fixture::deterministic, test::fixture::flow {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("a null cell emits zero items") {
@@ -164,5 +166,3 @@ SCENARIO("a failed cell emits zero item") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/concat.test.cpp
+++ b/libcaf_core/caf/flow/op/concat.test.cpp
@@ -25,7 +25,10 @@ auto seq(const std::vector<T>& xs, Args&&... args) {
   return res;
 }
 
+} // namespace
+
 WITH_FIXTURE(test::fixture::flow) {
+
 TEST("concat operators with empty inputs emit no values") {
   auto nil = [this] { return make_observable().empty<int>().as_observable(); };
   SECTION("blueprint") {
@@ -71,5 +74,3 @@ TEST("concat operators with non-empty inputs emit all values") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/defer.test.cpp
+++ b/libcaf_core/caf/flow/op/defer.test.cpp
@@ -10,8 +10,6 @@
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::flow) {
 
 SCENARIO("the defer operator produces a fresh observable for each observer") {
@@ -49,5 +47,3 @@ SCENARIO("the defer operator produces a fresh observable for each observer") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/empty.test.cpp
+++ b/libcaf_core/caf/flow/op/empty.test.cpp
@@ -10,8 +10,6 @@
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::flow) {
 
 SCENARIO("an empty observable terminates normally") {
@@ -33,5 +31,3 @@ SCENARIO("an empty observable terminates normally") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/fail.test.cpp
+++ b/libcaf_core/caf/flow/op/fail.test.cpp
@@ -8,8 +8,6 @@
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::flow) {
 
 SCENARIO("the fail operator immediately calls on_error on any subscriber") {
@@ -31,5 +29,3 @@ SCENARIO("the fail operator immediately calls on_error on any subscriber") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/interval.test.cpp
+++ b/libcaf_core/caf/flow/op/interval.test.cpp
@@ -22,6 +22,8 @@ using i64_list = std::vector<int64_t>;
 
 struct fixture : test::fixture::deterministic, test::fixture::flow {};
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("scoped coordinators wait on observable intervals") {
@@ -93,5 +95,3 @@ SCENARIO("a timer is an observable interval with a single value") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/mcast.test.cpp
+++ b/libcaf_core/caf/flow/op/mcast.test.cpp
@@ -30,6 +30,8 @@ struct fixture : test::fixture::flow {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("closed mcast operators appear empty") {
@@ -121,5 +123,3 @@ SCENARIO("mcast operators buffer items that they cannot ship immediately") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/merge.test.cpp
+++ b/libcaf_core/caf/flow/op/merge.test.cpp
@@ -60,6 +60,8 @@ struct fixture : test::fixture::deterministic, test::fixture::flow {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("the merge operator combines inputs") {
@@ -537,5 +539,3 @@ TEST("the merge operator ignores request() calls with no subscriber") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/never.test.cpp
+++ b/libcaf_core/caf/flow/op/never.test.cpp
@@ -10,8 +10,6 @@
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::flow) {
 
 SCENARIO("the never operator never invokes callbacks except when disposed") {
@@ -41,5 +39,3 @@ SCENARIO("the never operator never invokes callbacks except when disposed") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/on_backpressure_buffer.test.cpp
+++ b/libcaf_core/caf/flow/op/on_backpressure_buffer.test.cpp
@@ -12,8 +12,6 @@
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::flow) {
 
 SCENARIO("the backpressure operator is transparent with sufficient demand") {
@@ -171,5 +169,3 @@ TEST("external dispose") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/prefix_and_tail.test.cpp
+++ b/libcaf_core/caf/flow/op/prefix_and_tail.test.cpp
@@ -44,6 +44,8 @@ auto ls_range(T first, T last) {
   return result;
 }
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("prefix_and_tail splits off initial elements") {
@@ -365,5 +367,3 @@ SCENARIO("disposing the tail of head_and_tail disposes the operator") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/publish.test.cpp
+++ b/libcaf_core/caf/flow/op/publish.test.cpp
@@ -37,6 +37,8 @@ auto make_hot_generator() {
   return std::make_pair(n, fn);
 }
 
+} // namespace
+
 WITH_FIXTURE(test::fixture::flow) {
 
 SCENARIO("publish creates a connectable observable") {
@@ -238,5 +240,3 @@ SCENARIO("publishers dispose unexpected subscriptions") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/sample.test.cpp
+++ b/libcaf_core/caf/flow/op/sample.test.cpp
@@ -43,6 +43,8 @@ struct fixture : test::fixture::deterministic, test::fixture::flow {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("the sample operator emits items at regular intervals") {
@@ -360,5 +362,3 @@ SCENARIO("disposing a sample operator completes the flow") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/ucast.test.cpp
+++ b/libcaf_core/caf/flow/op/ucast.test.cpp
@@ -23,6 +23,8 @@ struct fixture : test::fixture::flow {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("closed ucast operators appear empty") {
@@ -147,5 +149,3 @@ SCENARIO("requesting from disposed ucast operators is a no-op") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/flow/op/zip_with.test.cpp
+++ b/libcaf_core/caf/flow/op/zip_with.test.cpp
@@ -36,6 +36,8 @@ struct fixture : test::fixture::flow {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("zip_with combines inputs") {
@@ -232,5 +234,3 @@ SCENARIO("the zip_with operators disposes unexpected subscriptions") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/flow/single.test.cpp
+++ b/libcaf_core/caf/flow/single.test.cpp
@@ -18,8 +18,6 @@ using std::vector;
 using namespace caf;
 using namespace caf::flow;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::flow) {
 
 SCENARIO("singles emit at most one value") {
@@ -50,5 +48,3 @@ SCENARIO("singles emit at most one value") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/step/ignore_elements.test.cpp
+++ b/libcaf_core/caf/flow/step/ignore_elements.test.cpp
@@ -14,8 +14,6 @@
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::flow) {
 
 TEST("calling ignore_elements on range(1, 10) produces []") {
@@ -40,5 +38,3 @@ TEST("ignore_elements operator forwards errors") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/step/skip_last.test.cpp
+++ b/libcaf_core/caf/flow/step/skip_last.test.cpp
@@ -14,8 +14,6 @@
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::flow) {
 
 TEST("calling skip_last(5) on range(1, 10) produces [1, 2, 3, 4, 5]") {
@@ -70,5 +68,3 @@ TEST("skip_last operator forwards errors") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/step/take_last.test.cpp
+++ b/libcaf_core/caf/flow/step/take_last.test.cpp
@@ -14,8 +14,6 @@
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::flow) {
 
 TEST("calling take_last(5) on range(1, 100) produces[96, 97, 98, 99, 100]") {
@@ -72,5 +70,3 @@ TEST("take_last operator forwards errors") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/flow/string.test.cpp
+++ b/libcaf_core/caf/flow/string.test.cpp
@@ -21,6 +21,8 @@ auto tostr(const std::vector<char>& chars) {
   return std::string{chars.begin(), chars.end()};
 }
 
+} // namespace
+
 WITH_FIXTURE(test::fixture::flow) {
 
 SCENARIO("normalize_newlines converts all newline styles to UNIX style") {
@@ -124,5 +126,3 @@ SCENARIO("to_lines splits a character sequence into lines") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_core/caf/function_view.test.cpp
+++ b/libcaf_core/caf/function_view.test.cpp
@@ -74,6 +74,8 @@ struct fixture {
   actor_system system;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("empty_function_view") {
@@ -122,5 +124,3 @@ TEST("calling function_view on an actor that quit") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/handles.test.cpp
+++ b/libcaf_core/caf/handles.test.cpp
@@ -24,12 +24,16 @@ using testee_actor = typed_actor<result<int32_t>(int32_t)>;
 
 // Dynamically typed testee.
 behavior dt_testee() {
-  return {[](int32_t x) { return x * x; }};
+  return {
+    [](int32_t x) { return x * x; },
+  };
 }
 
 // Statically typed testee.
 testee_actor::behavior_type st_testee() {
-  return {[](int32_t x) { return x * x; }};
+  return {
+    [](int32_t x) { return x * x; },
+  };
 }
 
 // A simple wrapper for storing a handle in all representations.
@@ -58,6 +62,8 @@ struct fixture : test::fixture::deterministic {
   handle_set a1{sys.spawn(dt_testee)};
   handle_set a2{sys.spawn(st_testee)};
 };
+
+} // namespace
 
 WITH_FIXTURE(fixture) {
 
@@ -258,5 +264,3 @@ TEST("mpi_string_representation") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/hash/fnv.test.cpp
+++ b/libcaf_core/caf/hash/fnv.test.cpp
@@ -10,8 +10,6 @@
 
 using namespace std::literals;
 
-namespace {
-
 TEST("hash::fnv can build hash values incrementally") {
   caf::hash::fnv<uint32_t> f;
   check_eq(f.result, 0x811C9DC5u);
@@ -40,6 +38,8 @@ TEST("fnv::compute generates a hash value in one step") {
   }
 }
 
+namespace {
+
 struct foo {
   std::string bar;
 };
@@ -49,10 +49,10 @@ bool inspect(Inspector& f, foo& x) {
   return f.object(x).fields(f.field("bar", x.bar));
 }
 
+} // namespace
+
 TEST("fnv::compute can create hash values for types with inspect overloads") {
   using hash_type = caf::hash::fnv<uint32_t>;
   check_eq(hash_type::compute(foo{"abcd"}), 0xCE3479BDu);
   check_eq(hash_type::compute(foo{"C++ Actor Framework"}), 0x2FF91FE5u);
 }
-
-} // namespace

--- a/libcaf_core/caf/hash/sha1.test.cpp
+++ b/libcaf_core/caf/hash/sha1.test.cpp
@@ -18,6 +18,8 @@ auto make_bytes(Ts... xs) {
   return sha1::result_type{{static_cast<std::byte>(xs)...}};
 }
 
+} // namespace
+
 TEST("strings are hashed by their content only") {
   auto str = "dGhlIHNhbXBsZSBub25jZQ==258EAFA5-E914-47DA-95CA-C5AB0DC85B11"sv;
   check_eq(sha1::compute(str),
@@ -27,5 +29,3 @@ TEST("strings are hashed by their content only") {
                       0xcf, 0x38, 0x59, 0x45,   //       13 - 16
                       0xb2, 0xbe, 0xc4, 0xea)); //       17 - 20
 }
-
-} // namespace

--- a/libcaf_core/caf/inspector_access_type.test.cpp
+++ b/libcaf_core/caf/inspector_access_type.test.cpp
@@ -15,8 +15,6 @@
 using namespace caf;
 using namespace std::literals;
 
-namespace {
-
 TEST("inspect_access_type") {
   check(
     std::is_same_v<decltype(inspect_access_type<caf::binary_serializer, int>()),
@@ -57,5 +55,3 @@ TEST("inspect_access_type") {
         decltype(inspect_access_type<caf::binary_serializer, action>()),
         inspector_access_type::unsafe>);
 }
-
-} // namespace

--- a/libcaf_core/caf/intrusive/lifo_inbox.test.cpp
+++ b/libcaf_core/caf/intrusive/lifo_inbox.test.cpp
@@ -38,6 +38,8 @@ std::string drain(inbox_type& xs) {
   return caf::deep_to_string(tmp);
 }
 
+} // namespace
+
 TEST("a default default-constructed inbox is empty") {
   inbox_type uut;
   check(!uut.closed());
@@ -69,5 +71,3 @@ TEST("push_front unblocks a blocked reader") {
   check_eq(uut.emplace_front(2), inbox_result::success);
   check_eq(drain(uut), "[2, 1]");
 }
-
-} // namespace

--- a/libcaf_core/caf/intrusive/linked_list.test.cpp
+++ b/libcaf_core/caf/intrusive/linked_list.test.cpp
@@ -35,6 +35,8 @@ void fill(list_type& xs, Ts... args) {
   (xs.emplace_back(args), ...);
 }
 
+} // namespace
+
 TEST("a default default-constructed list is empty") {
   list_type uut;
   check_eq(uut.empty(), true);
@@ -228,5 +230,3 @@ SCENARIO("splice transfers all elements from one list to another") {
     }
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/intrusive/stack.test.cpp
+++ b/libcaf_core/caf/intrusive/stack.test.cpp
@@ -33,6 +33,8 @@ auto pop(int_stack& xs) {
   return ptr->value;
 }
 
+} // namespace
+
 TEST("a default-constructed stack is empty") {
   int_stack uut;
   check(uut.empty());
@@ -62,5 +64,3 @@ TEST("popping values from a stack returns the last pushed value") {
   check_eq(pop(uut), 1);
   check(uut.empty());
 }
-
-} // namespace

--- a/libcaf_core/caf/intrusive_ptr.test.cpp
+++ b/libcaf_core/caf/intrusive_ptr.test.cpp
@@ -83,6 +83,8 @@ void check_class_instances() {
   this_test.check_eq(class1_instances, 0);
 }
 
+} // namespace
+
 TEST("make_counted") {
   {
     auto p = make_counted<class0>();
@@ -146,5 +148,3 @@ TEST("full_test") {
   }
   check_class_instances();
 }
-
-} // namespace

--- a/libcaf_core/caf/ipv4_address.test.cpp
+++ b/libcaf_core/caf/ipv4_address.test.cpp
@@ -16,6 +16,8 @@ namespace {
 
 const auto addr = make_ipv4_address;
 
+} // namespace
+
 TEST("constructing") {
   auto localhost = addr(127, 0, 0, 1);
   check_eq(localhost.bits(), to_network_order(0x7F000001u));
@@ -120,5 +122,3 @@ TEST("operators") {
   check_eq(addr(16, 0, 0, 8) | addr(255, 2, 4, 6), addr(255, 2, 4, 14));
   check_eq(addr(16, 0, 0, 8) ^ addr(255, 2, 4, 6), addr(239, 2, 4, 14));
 }
-
-} // namespace

--- a/libcaf_core/caf/ipv4_endpoint.test.cpp
+++ b/libcaf_core/caf/ipv4_endpoint.test.cpp
@@ -50,6 +50,8 @@ struct fixture {
   }
 };
 
+} // namespace
+
 #define CHECK_TO_STRING(addr) check_eq(addr, to_string(addr##_ep))
 
 #define CHECK_COMPARISON(addr1, addr2)                                         \
@@ -115,5 +117,3 @@ TEST("serialization") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/ipv4_subnet.test.cpp
+++ b/libcaf_core/caf/ipv4_subnet.test.cpp
@@ -22,6 +22,8 @@ ipv4_subnet operator/(ipv4_address addr, uint8_t prefix) {
   return {addr, prefix};
 }
 
+} // namespace
+
 TEST("constructing") {
   ipv4_subnet zero{addr(0, 0, 0, 0), 32};
   check_eq(zero.network_address(), addr(0, 0, 0, 0));
@@ -70,5 +72,3 @@ TEST("serialization") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/ipv6_address.test.cpp
+++ b/libcaf_core/caf/ipv6_address.test.cpp
@@ -21,6 +21,8 @@ ipv6_address addr(std::initializer_list<uint16_t> prefix,
   return ipv6_address{prefix, suffix};
 }
 
+} // namespace
+
 TEST("constructing") {
   ipv6_address::array_type localhost_bytes{
     {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}};
@@ -73,5 +75,3 @@ TEST("to string") {
   check_eq(to_string(addr({0x01})), "1::");
   check_eq(to_string(addr({}, {0xFFFF, 0x01, 0x01})), "0.1.0.1");
 }
-
-} // namespace

--- a/libcaf_core/caf/ipv6_endpoint.test.cpp
+++ b/libcaf_core/caf/ipv6_endpoint.test.cpp
@@ -49,6 +49,8 @@ struct fixture {
   }
 };
 
+} // namespace
+
 #define CHECK_TO_STRING(addr) check_eq(addr, to_string(addr##_ep))
 
 #define CHECK_COMPARISON(addr1, addr2)                                         \
@@ -136,5 +138,3 @@ TEST("serialization") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/ipv6_subnet.test.cpp
+++ b/libcaf_core/caf/ipv6_subnet.test.cpp
@@ -20,6 +20,8 @@ ipv6_subnet operator/(ipv6_address addr, uint8_t prefix) {
   return {addr, prefix};
 }
 
+} // namespace
+
 TEST("constructing") {
   auto zero = ipv6_address() / 128;
   check_eq(zero.network_address(), ipv6_address());
@@ -85,5 +87,3 @@ TEST("serialization") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/json_array.test.cpp
+++ b/libcaf_core/caf/json_array.test.cpp
@@ -46,6 +46,8 @@ std::string printed(const json_array& arr) {
   return result;
 }
 
+} // namespace
+
 TEST("default-constructed") {
   auto arr = json_array{};
   check(arr.empty());
@@ -87,5 +89,3 @@ TEST("from non-empty array") {
   check_eq(printed(arr), "[\n  1,\n  \"two\",\n  3\n]");
   check_eq(deep_copy(arr), arr);
 }
-
-} // namespace

--- a/libcaf_core/caf/json_builder.test.cpp
+++ b/libcaf_core/caf/json_builder.test.cpp
@@ -106,8 +106,6 @@ struct fixture {
 
 } // namespace
 
-namespace {
-
 WITH_FIXTURE(fixture) {
 
 TEST("empty JSON value") {
@@ -522,5 +520,3 @@ TEST("nested sequence in struct") {
 TEST_INIT() {
   caf::init_global_meta_objects<caf::id_block::json_builder_test>();
 }
-
-} // namespace

--- a/libcaf_core/caf/json_reader.test.cpp
+++ b/libcaf_core/caf/json_reader.test.cpp
@@ -390,6 +390,8 @@ fixture::fixture() {
   add_test_case("\r\n{\r\n\"a\":\r\n1, \"b\"\r\n:\r\n2}\r\n", my_request(1, 2));
 }
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("json baselines") {
@@ -461,5 +463,3 @@ SCENARIO("mappers enable custom type names in JSON input") {
 TEST_INIT() {
   caf::init_global_meta_objects<caf::id_block::json_reader_test>();
 }
-
-} // namespace

--- a/libcaf_core/caf/json_value.test.cpp
+++ b/libcaf_core/caf/json_value.test.cpp
@@ -367,4 +367,3 @@ TEST("non-empty object with nested values") {
   check_eq(obj.value("min-uint64").to_unsigned(), 0u);
   check_eq(obj.value("max-uint64").to_unsigned(), UINT64_MAX);
 }
-

--- a/libcaf_core/caf/json_value.test.cpp
+++ b/libcaf_core/caf/json_value.test.cpp
@@ -54,6 +54,8 @@ std::string printed(const json_value& val) {
   return result;
 }
 
+} // namespace
+
 TEST("default-constructed") {
   auto val = json_value{};
   check(val.is_null());
@@ -366,4 +368,3 @@ TEST("non-empty object with nested values") {
   check_eq(obj.value("max-uint64").to_unsigned(), UINT64_MAX);
 }
 
-} // namespace

--- a/libcaf_core/caf/json_writer.test.cpp
+++ b/libcaf_core/caf/json_writer.test.cpp
@@ -206,6 +206,8 @@ struct fixture {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("the JSON writer converts builtin types to strings") {
@@ -516,5 +518,3 @@ SCENARIO("the JSON compresses empty lists and objects") {
 TEST_INIT() {
   caf::init_global_meta_objects<caf::id_block::json_write_test>();
 }
-
-} // namespace

--- a/libcaf_core/caf/log/event.test.cpp
+++ b/libcaf_core/caf/log/event.test.cpp
@@ -67,6 +67,8 @@ de_chunk(const std::pair<std::string_view, chunked_string>& x) {
   return {x.first, to_string(x.second)};
 }
 
+} // namespace
+
 TEST("fields builder") {
   auto init_sub_fields = [](auto& builder) {
     auto init_sub_sub_fields = [](auto& builder) {
@@ -191,5 +193,3 @@ TEST("with_message") {
   auto event_3 = event_2->with_message("message 2");
   check_ne(event_2->timestamp(), event_3->timestamp());
 }
-
-} // namespace

--- a/libcaf_core/caf/mail_cache.test.cpp
+++ b/libcaf_core/caf/mail_cache.test.cpp
@@ -55,6 +55,8 @@ struct fixture {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("a mail cache can buffer messages until the actor is ready") {
@@ -83,5 +85,3 @@ TEST("a mail cache throws when exceeding its capacity") {
 #endif // CAF_ENABLE_EXCEPTIONS
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/mailbox_element.test.cpp
+++ b/libcaf_core/caf/mailbox_element.test.cpp
@@ -33,6 +33,8 @@ std::optional<tuple<Ts...>> fetch(const mailbox_element& x) {
   return fetch<Ts...>(x.content());
 }
 
+} // namespace
+
 TEST("empty_message") {
   auto m1 = make_mailbox_element(nullptr, make_message_id(), make_message());
   check(m1->mid.is_async());
@@ -64,5 +66,3 @@ TEST("high_priority") {
                                  make_message_id(message_priority::high), 42);
   check(m1->mid.category() == message_id::urgent_message_category);
 }
-
-} // namespace

--- a/libcaf_core/caf/message.test.cpp
+++ b/libcaf_core/caf/message.test.cpp
@@ -82,6 +82,8 @@ std::string msg_as_string(Ts&&... xs) {
   return to_string(make_message(std::forward<Ts>(xs)...));
 }
 
+} // namespace
+
 TEST("messages allow index-based access") {
   auto msg = make_message("abc"s, uint32_t{10}, 20.0);
   check_eq(msg.size(), 3u);
@@ -194,5 +196,3 @@ TEST("messages implicitly convert string-like things to strings") {
 TEST_INIT() {
   init_global_meta_objects<id_block::message_test>();
 }
-
-} // namespace

--- a/libcaf_core/caf/message_builder.test.cpp
+++ b/libcaf_core/caf/message_builder.test.cpp
@@ -63,8 +63,6 @@ CAF_BEGIN_TYPE_ID_BLOCK(message_builder_test, caf::first_custom_type_id)
 
 CAF_END_TYPE_ID_BLOCK(message_builder_test)
 
-namespace {
-
 TEST("message_builder can build messages incrementally") {
   message_builder builder;
   SECTION("a default-constructed builder is empty") {
@@ -209,5 +207,3 @@ TEST("message_builder can build messages from iterator pairs") {
 TEST_INIT() {
   init_global_meta_objects<id_block::message_builder_test>();
 }
-
-} // namespace

--- a/libcaf_core/caf/message_handler.test.cpp
+++ b/libcaf_core/caf/message_handler.test.cpp
@@ -28,6 +28,8 @@ message_handler handle_b() {
   };
 }
 
+} // namespace
+
 WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("message handler may be assigned") {
@@ -48,5 +50,3 @@ TEST("message handler may be assigned") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/message_id.test.cpp
+++ b/libcaf_core/caf/message_id.test.cpp
@@ -8,8 +8,6 @@
 
 using namespace caf;
 
-namespace {
-
 TEST("default construction") {
   message_id x;
   check_eq(x.is_async(), true);
@@ -79,5 +77,3 @@ TEST("with_category") {
     check_eq(x.is_answered(), false);
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/message_lifetime.test.cpp
+++ b/libcaf_core/caf/message_lifetime.test.cpp
@@ -78,6 +78,8 @@ struct fixture : test::fixture::deterministic {
   scoped_actor self{sys};
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("nocopy_in_scoped_actor") {
@@ -121,5 +123,3 @@ TEST_INIT() {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/mixin/sender.test.cpp
+++ b/libcaf_core/caf/mixin/sender.test.cpp
@@ -42,6 +42,8 @@ struct fixture : test::fixture::deterministic {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("delayed actor messages receive responses") {
@@ -104,5 +106,3 @@ TEST("exceptions while processing a message will send error to the sender") {
 #endif // CAF_ENABLE_EXCEPTIONS
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/monitor.test.cpp
+++ b/libcaf_core/caf/monitor.test.cpp
@@ -10,8 +10,6 @@
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("monitoring another actor") {
@@ -128,5 +126,3 @@ TEST("monitoring another actor") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/node_id.test.cpp
+++ b/libcaf_core/caf/node_id.test.cpp
@@ -59,6 +59,8 @@ T unbox(std::optional<T> x) {
   return std::move(*x);
 }
 
+} // namespace
+
 TEST("node IDs are convertible from string") {
   node_id::default_data::host_id_type hash{{
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
@@ -95,5 +97,3 @@ TEST("node IDs are serializable") {
     check_eq(uri_based_id, roundtrip(uri_based_id));
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/none.test.cpp
+++ b/libcaf_core/caf/none.test.cpp
@@ -13,8 +13,6 @@
 
 using namespace caf;
 
-namespace {
-
 TEST("none is serializable") {
   check_eq(to_string(none), "none");
 }
@@ -23,5 +21,3 @@ TEST("none is comparable") {
   check(!none);
   check_eq(none.compare(none), 0);
 }
-
-} // namespace

--- a/libcaf_core/caf/pec.test.cpp
+++ b/libcaf_core/caf/pec.test.cpp
@@ -35,6 +35,8 @@ struct fixture {
   }
 };
 
+} // namespace
+
 #define CHECK_SERIALIZATION(error_code)                                        \
   check_eq(error_code, roundtrip(error_code))
 
@@ -67,5 +69,3 @@ TEST("pec values are serializable") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/policy/select_all.test.cpp
+++ b/libcaf_core/caf/policy/select_all.test.cpp
@@ -52,6 +52,8 @@ struct fixture : test::fixture::deterministic {
   }
 };
 
+} // namespace
+
 #define SUBTEST(message)                                                       \
   dispatch_messages();                                                         \
   log::test::debug("subtest: {}", message);                                    \
@@ -193,5 +195,3 @@ TEST("select_all calls the error handler at most once") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/policy/select_any.test.cpp
+++ b/libcaf_core/caf/policy/select_any.test.cpp
@@ -50,6 +50,8 @@ struct fixture : test::fixture::deterministic {
   }
 };
 
+} // namespace
+
 #define SUBTEST(message)                                                       \
   dispatch_messages();                                                         \
   log::test::debug("subtest: {}", message);                                    \
@@ -168,5 +170,3 @@ TEST("select_any calls the error handler at most once") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/request_timeout.test.cpp
+++ b/libcaf_core/caf/request_timeout.test.cpp
@@ -219,6 +219,8 @@ behavior ping_multiplexed3(ping_actor* self, std::shared_ptr<bool> had_timeout,
   return {};
 }
 
+} // namespace
+
 WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("single timeout") {
@@ -302,5 +304,3 @@ TEST("multiplexed timeout") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/response_handle.test.cpp
+++ b/libcaf_core/caf/response_handle.test.cpp
@@ -48,6 +48,8 @@ struct fixture : test::fixture::deterministic {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("response handles are convertible to observables and singles") {
@@ -230,5 +232,3 @@ SCENARIO("response handles are convertible to observables and singles") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/response_promise.test.cpp
+++ b/libcaf_core/caf/response_promise.test.cpp
@@ -96,6 +96,8 @@ behavior requester_v2(event_based_actor* self, actor worker) {
   };
 }
 
+} // namespace
+
 WITH_FIXTURE(test::fixture::deterministic) {
 
 SCENARIO("response promises allow delaying of response messages") {
@@ -212,5 +214,3 @@ TEST("GH - 1306 regression") {
   // access the self pointer this triggers a heap-use-after-free since the AUT
   // has been destroyed at this point.
 }
-
-} // namespace

--- a/libcaf_core/caf/result.test.cpp
+++ b/libcaf_core/caf/result.test.cpp
@@ -11,14 +11,6 @@
 
 using namespace caf;
 
-namespace {
-
-template <class T>
-void test_unit_void() {
-  auto x = result<T>{};
-  test::runnable::current().check(holds_alternative<message>(x));
-}
-
 TEST("value") {
   auto x = result<int>{42};
   require(holds_alternative<message>(x));
@@ -38,11 +30,11 @@ TEST("expected") {
 }
 
 TEST("void_specialization") {
-  test_unit_void<void>();
+  auto x = result<void>{};
+  check(holds_alternative<message>(x));
 }
 
 TEST("unit_specialization") {
-  test_unit_void<unit_t>();
+  auto x = result<unit_t>{};
+  check(holds_alternative<message>(x));
 }
-
-} // namespace

--- a/libcaf_core/caf/run_delayed.test.cpp
+++ b/libcaf_core/caf/run_delayed.test.cpp
@@ -52,6 +52,8 @@ struct fixture : test::fixture::deterministic {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("run_delayed triggers an action after a relative timeout") {
@@ -200,5 +202,3 @@ SCENARIO("run_delayed_weak triggers an action after a relative timeout") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/run_scheduled.test.cpp
+++ b/libcaf_core/caf/run_scheduled.test.cpp
@@ -19,6 +19,8 @@ behavior dummy_behavior() {
   };
 }
 
+} // namespace
+
 WITH_FIXTURE(test::fixture::deterministic) {
 
 SCENARIO("run_scheduled triggers an action after a relative timeout") {
@@ -106,5 +108,3 @@ SCENARIO("run_scheduled_weak triggers an action after a relative timeout") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/scheduler.test.cpp
+++ b/libcaf_core/caf/scheduler.test.cpp
@@ -49,6 +49,8 @@ struct testee : resumable, ref_counted {
   std::shared_ptr<latch> rendezvous;
 };
 
+} // namespace
+
 OUTLINE("scheduling resumables") {
   GIVEN("an actor system using the work <sched> scheduler") {
     auto sched = block_parameters<std::string>();
@@ -177,5 +179,3 @@ OUTLINE("scheduling units that are awaiting") {
     | stealing    |
   )";
 }
-
-} // namespace

--- a/libcaf_core/caf/sec.test.cpp
+++ b/libcaf_core/caf/sec.test.cpp
@@ -16,8 +16,6 @@
 using namespace caf;
 using namespace std::literals;
 
-namespace {
-
 TEST("system error codes are convertible to strings") {
   check_eq(to_string(sec::none), "none");
   check_eq(to_string(sec::invalid_argument), "invalid_argument");
@@ -59,5 +57,3 @@ TEST("system error codes are inspectable") {
     check_eq(copy, val);
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/serial_reply.test.cpp
+++ b/libcaf_core/caf/serial_reply.test.cpp
@@ -24,8 +24,6 @@ CAF_BEGIN_TYPE_ID_BLOCK(serial_reply_test, caf::first_custom_type_id + 30)
 
 CAF_END_TYPE_ID_BLOCK(serial_reply_test)
 
-namespace {
-
 TEST("test_serial_reply") {
   actor_system_config cfg;
   actor_system system{cfg};
@@ -90,5 +88,3 @@ TEST("test_serial_reply") {
 TEST_INIT() {
   init_global_meta_objects<id_block::serial_reply_test>();
 }
-
-} // namespace

--- a/libcaf_core/caf/serialization.test.cpp
+++ b/libcaf_core/caf/serialization.test.cpp
@@ -683,6 +683,8 @@ struct fixture : caf::test::fixture::deterministic {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 OUTLINE("serializing and then deserializing primitive values") {
@@ -820,8 +822,6 @@ OUTLINE("serializing and then deserializing the 'nasty' type") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace
 
 TEST_INIT() {
   init_global_meta_objects<id_block::serialization_test>();

--- a/libcaf_core/caf/serializer.test.cpp
+++ b/libcaf_core/caf/serializer.test.cpp
@@ -147,6 +147,8 @@ private:
   bool state_ = false;
 };
 
+} // namespace
+
 TEST("base serializer") {
   auto cfg = actor_system_config{};
   auto sys = actor_system{cfg};
@@ -168,5 +170,3 @@ TEST("base serializer") {
     check(serializer.list(std::vector<bool>{true, false}));
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/settings.test.cpp
+++ b/libcaf_core/caf/settings.test.cpp
@@ -96,8 +96,6 @@ CAF_BEGIN_TYPE_ID_BLOCK(settings_test, caf::first_custom_type_id + 40)
 
 CAF_END_TYPE_ID_BLOCK(settings_test)
 
-namespace {
-
 WITH_FIXTURE(fixture) {
 
 TEST("put") {
@@ -228,5 +226,3 @@ TEST("put and put_missing decomposes user-defined types") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/span.test.cpp
+++ b/libcaf_core/caf/span.test.cpp
@@ -31,6 +31,8 @@ struct fixture {
   i16_list rshorts{64, 32, 16, 8, 4, 2, 1};
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("default construction") {
@@ -103,5 +105,3 @@ TEST("spans are convertible from compatible containers") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/stateful_actor.test.cpp
+++ b/libcaf_core/caf/stateful_actor.test.cpp
@@ -113,6 +113,8 @@ struct fixture : test::fixture::deterministic {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("stateful actors can be dynamically typed") {
@@ -274,5 +276,3 @@ TEST("returned behaviors take precedence over make_behavior in the state") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/stream.test.cpp
+++ b/libcaf_core/caf/stream.test.cpp
@@ -37,6 +37,8 @@ behavior int_sink(event_based_actor* self, std::shared_ptr<ivec> results) {
   };
 }
 
+} // namespace
+
 WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("default-constructed streams are invalid") {
@@ -147,5 +149,3 @@ TEST("streams allow actors to transmit flow items to other actors") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/string_algorithms.test.cpp
+++ b/libcaf_core/caf/string_algorithms.test.cpp
@@ -31,6 +31,8 @@ std::string join(str_list vec) {
   return caf::join(vec, ",");
 }
 
+} // namespace
+
 TEST("splitting") {
   check_eq(split(""), str_list{""});
   check_eq(split(","), str_list{"", ""});
@@ -78,5 +80,3 @@ TEST("ends with") {
   check(!ends_with("foobar", "car"));
   check(!ends_with("foobar", "afoobar"));
 }
-
-} // namespace

--- a/libcaf_core/caf/telemetry/collector/prometheus.test.cpp
+++ b/libcaf_core/caf/telemetry/collector/prometheus.test.cpp
@@ -22,6 +22,8 @@ struct fixture {
   metric_registry registry;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("the Prometheus collector generates text output") {
@@ -73,5 +75,3 @@ some_request_duration_seconds_count{x="get"} 3 42000
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/telemetry/counter.test.cpp
+++ b/libcaf_core/caf/telemetry/counter.test.cpp
@@ -9,8 +9,6 @@
 
 using namespace caf;
 
-namespace {
-
 TEST("counters can only increment") {
   SECTION("double counters") {
     telemetry::dbl_counter c;
@@ -44,5 +42,3 @@ TEST("counters can only increment") {
     }
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/telemetry/gauge.test.cpp
+++ b/libcaf_core/caf/telemetry/gauge.test.cpp
@@ -9,8 +9,6 @@
 
 using namespace caf;
 
-namespace {
-
 TEST("gauges can increment and decrement") {
   SECTION("double gauges") {
     telemetry::dbl_gauge g;
@@ -64,5 +62,3 @@ TEST("gauges can increment and decrement") {
     }
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/telemetry/histogram.test.cpp
+++ b/libcaf_core/caf/telemetry/histogram.test.cpp
@@ -15,8 +15,6 @@
 using namespace caf;
 using namespace caf::telemetry;
 
-namespace {
-
 TEST("double histograms use infinity for the last bucket") {
   dbl_histogram h1{.1, .2, .4, .8};
   check_eq(h1.buckets().size(), 5u);
@@ -46,5 +44,3 @@ TEST("histograms aggregate to buckets and keep a sum") {
   check_eq(buckets[3].count.value(), 2); // 9, 10
   check_eq(h1.sum(), 55);
 }
-
-} // namespace

--- a/libcaf_core/caf/telemetry/label.test.cpp
+++ b/libcaf_core/caf/telemetry/label.test.cpp
@@ -19,6 +19,8 @@ size_t hash_of(const T& x) {
   return f(x);
 }
 
+} // namespace
+
 TEST("labels wrap name and value") {
   check_eq(to_string(label{"foo", "bar"}), "foo=bar");
   label foobar{"foo", "bar"};
@@ -41,5 +43,3 @@ TEST("labels are convertible from views") {
   check_eq(hash_of(foobar), hash_of(foobar_view));
   check_eq(hash_of(foobar), hash_of(label{foobar_view}));
 }
-
-} // namespace

--- a/libcaf_core/caf/telemetry/metric_registry.test.cpp
+++ b/libcaf_core/caf/telemetry/metric_registry.test.cpp
@@ -91,6 +91,8 @@ struct fixture {
   test_collector collector;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("registries lazily create metrics") {
@@ -293,6 +295,8 @@ SCENARIO("metric registries can merge families from other registries") {
 
 } // WITH_FIXTURE(fixture)
 
+namespace {
+
 struct foo_state {
   static constexpr const char* name = "foo";
 
@@ -300,6 +304,8 @@ struct foo_state {
     return {};
   }
 };
+
+} // namespace
 
 TEST("enabling actor metrics per config creates metric instances") {
   actor_system_config cfg;
@@ -314,5 +320,3 @@ TEST("enabling actor metrics per config creates metric instances") {
   check_ne(collector.result.find(R"(caf.actor.mailbox-size{name="foo"})"),
            std::string::npos);
 }
-
-} // namespace

--- a/libcaf_core/caf/telemetry/timer.test.cpp
+++ b/libcaf_core/caf/telemetry/timer.test.cpp
@@ -9,8 +9,6 @@
 using namespace caf;
 using namespace caf::telemetry;
 
-namespace {
-
 TEST("timers observe how much time passes in a scope") {
   SECTION("timers call observe() with the measured time") {
     dbl_histogram h1{1, 2, 4, 8};
@@ -27,5 +25,3 @@ TEST("timers observe how much time passes in a scope") {
     check_eq(t.histogram_ptr(), nullptr);
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/thread_hook.test.cpp
+++ b/libcaf_core/caf/thread_hook.test.cpp
@@ -99,15 +99,19 @@ TEST("counting_no_system") {
   }
 }
 
-WITH_FIXTURE(fixture<dummy_thread_hook>) {
+using dummy_thread_hook_fixture = fixture<dummy_thread_hook>;
+
+WITH_FIXTURE(dummy_thread_hook_fixture) {
 
 TEST("counting_no_args") {
   // nop
 }
 
-} // WITH_FIXTURE(fixture<dummy_thread_hook>)
+} // WITH_FIXTURE(dummy_thread_hook_fixture)
 
-WITH_FIXTURE(fixture<counting_thread_hook>) {
+using counting_thread_hook_fixture = fixture<counting_thread_hook>;
+
+WITH_FIXTURE(counting_thread_hook_fixture) {
 
 TEST("counting_system_without_actor") {
   {
@@ -130,4 +134,4 @@ TEST("counting_system_with_actor") {
   }
 }
 
-} // WITH_FIXTURE(fixture<counting_thread_hook>)
+} // WITH_FIXTURE(counting_thread_hook_fixture)

--- a/libcaf_core/caf/thread_hook.test.cpp
+++ b/libcaf_core/caf/thread_hook.test.cpp
@@ -89,6 +89,8 @@ struct fixture {
   }
 };
 
+} // namespace
+
 TEST("counting_no_system") {
   {
     assumed_init_calls = 0;
@@ -97,19 +99,15 @@ TEST("counting_no_system") {
   }
 }
 
-using dummy_thread_hook_fixture = fixture<dummy_thread_hook>;
-
-WITH_FIXTURE(dummy_thread_hook_fixture) {
+WITH_FIXTURE(fixture<dummy_thread_hook>) {
 
 TEST("counting_no_args") {
   // nop
 }
 
-} // WITH_FIXTURE(dummy_thread_hook_fixture)
+} // WITH_FIXTURE(fixture<dummy_thread_hook>)
 
-using counting_thread_hook_fixture = fixture<counting_thread_hook>;
-
-WITH_FIXTURE(counting_thread_hook_fixture) {
+WITH_FIXTURE(fixture<counting_thread_hook>) {
 
 TEST("counting_system_without_actor") {
   {
@@ -132,6 +130,4 @@ TEST("counting_system_with_actor") {
   }
 }
 
-} // WITH_FIXTURE(counting_thread_hook_fixture)
-
-} // namespace
+} // WITH_FIXTURE(fixture<counting_thread_hook>)

--- a/libcaf_core/caf/type_id_list.test.cpp
+++ b/libcaf_core/caf/type_id_list.test.cpp
@@ -48,8 +48,6 @@ CAF_END_TYPE_ID_BLOCK(type_id_test)
 
 using namespace caf;
 
-namespace {
-
 TEST("lists store the size at index 0") {
   type_id_t data[] = {3, 1, 2, 4};
   type_id_list xs{data};
@@ -116,5 +114,3 @@ TEST("type ID lists are concatenable") {
            type_id_list::concat(make_type_id_list<int8_t, int16_t>(),
                                 make_type_id_list<int32_t, int64_t>()));
 }
-
-} // namespace

--- a/libcaf_core/caf/typed_actor_view.test.cpp
+++ b/libcaf_core/caf/typed_actor_view.test.cpp
@@ -71,6 +71,8 @@ struct fixture : test::fixture::deterministic {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("typed actors may use the flow API") {
@@ -145,5 +147,3 @@ SCENARIO("typed actors may use the flow API") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/typed_behavior.test.cpp
+++ b/libcaf_core/caf/typed_behavior.test.cpp
@@ -13,8 +13,6 @@
 
 using namespace caf;
 
-namespace {
-
 TEST("make_typed_behavior automatically deduces its types") {
   using handle = typed_actor<result<void>(std::string),
                              result<int32_t>(int32_t), result<double>(double)>;
@@ -23,5 +21,3 @@ TEST("make_typed_behavior automatically deduces its types") {
                                   [](double x) { return x; });
   static_assert(std::is_same_v<handle::behavior_type, decltype(bhvr)>);
 }
-
-} // namespace

--- a/libcaf_core/caf/typed_message_view.test.cpp
+++ b/libcaf_core/caf/typed_message_view.test.cpp
@@ -10,8 +10,6 @@
 
 using namespace caf;
 
-namespace {
-
 TEST("message views detach their content") {
   auto msg1 = make_message(1, 2, 3, "four");
   auto msg2 = msg1;
@@ -40,5 +38,3 @@ TEST("message views allow mutating elements") {
   check_eq(msg1.get_as<int>(0), 10);
   check_eq(msg2.get_as<int>(0), 1);
 }
-
-} // namespace

--- a/libcaf_core/caf/typed_response_promise.test.cpp
+++ b/libcaf_core/caf/typed_response_promise.test.cpp
@@ -101,6 +101,8 @@ testee_actor::behavior_type requester_v2(testee_actor::pointer self,
   };
 }
 
+} // namespace
+
 WITH_FIXTURE(test::fixture::deterministic) {
 
 SCENARIO("response promises allow delaying of response messages") {
@@ -195,5 +197,3 @@ SCENARIO("response promises allow delegation") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_core/caf/typed_spawn.test.cpp
+++ b/libcaf_core/caf/typed_spawn.test.cpp
@@ -301,6 +301,8 @@ struct fixture : test::fixture::deterministic {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 // -- putting it all together --------------------------------------------------
@@ -449,5 +451,3 @@ SCENARIO("state classes may use typed pointers") {
 TEST_INIT() {
   caf::init_global_meta_objects<caf::id_block::typed_spawn_test>();
 }
-
-} // namespace

--- a/libcaf_core/caf/typed_stream.test.cpp
+++ b/libcaf_core/caf/typed_stream.test.cpp
@@ -56,6 +56,8 @@ behavior int_sink(event_based_actor* self, std::shared_ptr<ivec> results) {
   };
 }
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("default-constructed") {
@@ -115,5 +117,3 @@ TEST("streams allow actors to transmit flow items to others") {
 TEST_INIT() {
   init_global_meta_objects<id_block::typed_stream_test>();
 }
-
-} // namespace

--- a/libcaf_core/caf/unit.test.cpp
+++ b/libcaf_core/caf/unit.test.cpp
@@ -14,23 +14,20 @@
 
 using namespace caf;
 
-namespace {
-
-behavior testee(event_based_actor* self) {
-  return {
-    [](add_atom) -> result<unit_t> { return unit; },
-    [](get_atom) -> result<void> { return {}; },
-    [](put_atom) -> unit_t { return unit; },
-    [](resolve_atom) -> void {},
-    [=](update_atom) -> result<unit_t> {
-      auto rp = self->make_response_promise<unit_t>();
-      rp.deliver(unit);
-      return rp;
-    },
-  };
-}
-
 TEST("unit_results") {
+  auto testee = [](event_based_actor* self) -> behavior {
+    return {
+      [](add_atom) -> result<unit_t> { return unit; },
+      [](get_atom) -> result<void> { return {}; },
+      [](put_atom) -> unit_t { return unit; },
+      [](resolve_atom) -> void {},
+      [=](update_atom) -> result<unit_t> {
+        auto rp = self->make_response_promise<unit_t>();
+        rp.deliver(unit);
+        return rp;
+      },
+    };
+  };
   actor_system_config cfg;
   actor_system sys{cfg};
   scoped_actor self{sys};
@@ -60,5 +57,3 @@ TEST("actor_address") {
   scoped_actor self{sys};
   check_ne(self.address().id(), 0u);
 }
-
-} // namespace

--- a/libcaf_core/caf/unordered_flat_map.test.cpp
+++ b/libcaf_core/caf/unordered_flat_map.test.cpp
@@ -13,8 +13,6 @@
 
 using namespace caf;
 
-namespace {
-
 using int_map = unordered_flat_map<int, int>;
 
 using string_map = unordered_flat_map<std::string, std::string>;
@@ -186,5 +184,3 @@ TEST("calling at() with an invalid key throws std::out_of_range") {
   check_throws<std::out_of_range>([&] { xs.at(10); });
 }
 #endif // CAF_ENABLE_EXCEPTIONS
-
-} // namespace

--- a/libcaf_core/caf/uri.test.cpp
+++ b/libcaf_core/caf/uri.test.cpp
@@ -212,6 +212,8 @@ bool operator"" _i(const char* cstr, size_t cstr_len) {
   return err != none;
 }
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("default URIs are empty") {
@@ -526,5 +528,3 @@ TEST("serialization") {
 #undef SERIALIZATION_ROUNDTRIP
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_core/caf/uuid.test.cpp
+++ b/libcaf_core/caf/uuid.test.cpp
@@ -36,6 +36,8 @@ uuid operator"" _uuid(const char* cstr, size_t cstr_len) {
   return result;
 }
 
+} // namespace
+
 TEST("default generated UUIDs have all 128 bits set to zero") {
   uuid nil;
   check(!nil);
@@ -177,5 +179,3 @@ SCENARIO("UUIDs are hashable") {
     }
   }
 }
-
-} // namespace

--- a/libcaf_core/caf/version.test.cpp
+++ b/libcaf_core/caf/version.test.cpp
@@ -10,8 +10,6 @@
 
 using namespace caf;
 
-namespace {
-
 TEST("version functions must return the values from the build configuration") {
   check_eq(version::get_major(), CAF_VERSION_MAJOR);
   check_eq(version::get_minor(), CAF_VERSION_MINOR);
@@ -22,5 +20,3 @@ TEST("version functions must return the values from the build configuration") {
   check_eq(version::c_str(), vstr);
   check_eq(static_cast<int>(make_abi_token()), CAF_VERSION_MAJOR);
 }
-
-} // namespace

--- a/libcaf_io/caf/io/basp/connection_state.test.cpp
+++ b/libcaf_io/caf/io/basp/connection_state.test.cpp
@@ -8,8 +8,6 @@
 
 using namespace caf::io::basp;
 
-namespace {
-
 OUTLINE("critical connection states require a connection shutdown") {
   GIVEN("connection state <state>") {
     auto state = block_parameters<connection_state>();
@@ -57,5 +55,3 @@ OUTLINE("connection states are convertible to system error codes") {
     | no_route_to_receiving_node      | no_route_to_receiving_node        |
   )_";
 }
-
-} // namespace

--- a/libcaf_io/caf/io/basp/header.test.cpp
+++ b/libcaf_io/caf/io/basp/header.test.cpp
@@ -10,8 +10,6 @@
 
 using namespace caf::io::basp;
 
-namespace {
-
 TEST("headers require a valid operation type") {
   header bad{static_cast<message_type>(0xFF), 0, 0, 0, 0, 0};
   check(!valid(bad));
@@ -89,5 +87,3 @@ TEST("heartbeat messages must be all-zero except for the message type") {
   header bad4{message_type::heartbeat, 0, 0, 0, 0, 1};
   check(!valid(bad4));
 }
-
-} // namespace

--- a/libcaf_io/caf/io/basp/message_queue.test.cpp
+++ b/libcaf_io/caf/io/basp/message_queue.test.cpp
@@ -46,6 +46,8 @@ struct fixture : test::fixture::deterministic {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("default construction") {
@@ -140,5 +142,3 @@ TEST("dropping") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_io/caf/io/middleman.test.cpp
+++ b/libcaf_io/caf/io/middleman.test.cpp
@@ -10,8 +10,6 @@
 using namespace caf;
 using namespace caf::io;
 
-namespace {
-
 TEST("GH-1900 regression") {
   // Note: we don't need to actually run `spawn_client`, we only check for a
   // compiler error. We shouldn't actually run this code, since it will assume
@@ -25,5 +23,3 @@ TEST("GH-1900 regression") {
   };
   check(std::is_same_v<decltype(fn), decltype(fn)>);
 }
-
-} // namespace

--- a/libcaf_io/caf/io/network/ip_endpoint.test.cpp
+++ b/libcaf_io/caf/io/network/ip_endpoint.test.cpp
@@ -19,8 +19,6 @@ using namespace std::literals;
 
 using io::network::interfaces;
 
-namespace {
-
 TEST("IP endpoints are empty by default, copyable and movable") {
   auto addr_int = [](const void* ptr) {
     return reinterpret_cast<intptr_t>(ptr);
@@ -114,5 +112,3 @@ TEST("IP endpoints are convertible from string plus port") {
   }
 }
 #endif
-
-} // namespace

--- a/libcaf_io/caf/io/network/protocol.test.cpp
+++ b/libcaf_io/caf/io/network/protocol.test.cpp
@@ -18,8 +18,6 @@ using namespace std::literals;
 
 using caf::io::network::protocol;
 
-namespace {
-
 TEST("inspection") {
   auto roundtrip = [this](auto x) {
     using value_type = decltype(x);
@@ -56,5 +54,3 @@ TEST("string conversion") {
   check_eq(to_string(ipv6_tcp), "TCP/IPv6");
   check_eq(to_string(ipv6_udp), "UDP/IPv6");
 }
-
-} // namespace

--- a/libcaf_io/caf/io/network/receive_buffer.test.cpp
+++ b/libcaf_io/caf/io/network/receive_buffer.test.cpp
@@ -13,8 +13,6 @@ using namespace std::literals;
 
 using caf::io::network::receive_buffer;
 
-namespace {
-
 TEST("construction") {
   SECTION("default-constructed buffers are empty") {
     receive_buffer uut;
@@ -175,5 +173,3 @@ TEST("swap exchanges the content of two buffers") {
   check(buf1.data() == buf2_data);
   check(buf2.data() == buf1_data);
 }
-
-} // namespace

--- a/libcaf_io/caf/io/system_messages.test.cpp
+++ b/libcaf_io/caf/io/system_messages.test.cpp
@@ -12,8 +12,6 @@
 using namespace caf;
 using namespace caf::io;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("new_connection_msg is serializable") {
@@ -165,5 +163,3 @@ TEST("dataram_servant_closed_msg is serializable") {
 }
 
 } // WITH_FIXTURE(test::fixture::deterministic)
-
-} // namespace

--- a/libcaf_net/caf/detail/rfc6455.test.cpp
+++ b/libcaf_net/caf/detail/rfc6455.test.cpp
@@ -32,6 +32,8 @@ auto take(const T& xs, size_t num_bytes) {
   return std::vector<typename T::value_type>{xs.begin(), xs.begin() + n};
 }
 
+} // namespace
+
 TEST("masking the full payload") {
   auto key = uint32_t{0xDEADC0DE};
   auto data = bytes({0x12, 0x34, 0x45, 0x67, 0x89, 0x9A});
@@ -312,5 +314,3 @@ TEST("decode a header with valid mask key plus large data") {
   check_eq(hdr.opcode, impl::binary_frame);
   check_eq(hdr.payload_len, data.size());
 }
-
-} // namespace

--- a/libcaf_net/caf/net/accept_socket.test.cpp
+++ b/libcaf_net/caf/net/accept_socket.test.cpp
@@ -33,6 +33,8 @@ struct fixture {
   uri::authority_type auth;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("tcp connect") {
@@ -49,5 +51,3 @@ TEST("tcp connect") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_net/caf/net/actor_shell.test.cpp
+++ b/libcaf_net/caf/net/actor_shell.test.cpp
@@ -134,6 +134,8 @@ struct fixture {
   net::stream_socket fd2;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("actor shells can receive messages") {
@@ -236,5 +238,3 @@ TEST("actor shells can use flows") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_net/caf/net/datagram_socket.test.cpp
+++ b/libcaf_net/caf/net/datagram_socket.test.cpp
@@ -9,11 +9,7 @@
 using namespace caf;
 using namespace caf::net;
 
-namespace {
-
 TEST("invalid_socket") {
   datagram_socket x;
   check_ne(allow_connreset(x, true), none);
 }
-
-} // namespace

--- a/libcaf_net/caf/net/http/async_client.test.cpp
+++ b/libcaf_net/caf/net/http/async_client.test.cpp
@@ -126,6 +126,8 @@ struct fixture {
   std::thread mpx_thread;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("the client sends HTTP requests") {
@@ -311,5 +313,3 @@ SCENARIO("unexpected aborts in the HTTP layer are reported as errors") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_net/caf/net/http/client.test.cpp
+++ b/libcaf_net/caf/net/http/client.test.cpp
@@ -150,6 +150,8 @@ struct fixture {
   std::thread mpx_thread;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("the client sends HTTP requests") {
@@ -473,5 +475,3 @@ SCENARIO("apps can return errors to abort the HTTP layer") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_net/caf/net/http/header.test.cpp
+++ b/libcaf_net/caf/net/http/header.test.cpp
@@ -9,8 +9,6 @@
 using namespace caf;
 using namespace std::literals;
 
-namespace {
-
 TEST("parsing a http request") {
   net::http::header hdr;
   hdr.parse_fields("Host: localhost:8090\r\n"
@@ -73,5 +71,3 @@ TEST("parsing a http request") {
     check_eq(remainder, "Remainder");
   }
 }
-
-} // namespace

--- a/libcaf_net/caf/net/http/request_header.test.cpp
+++ b/libcaf_net/caf/net/http/request_header.test.cpp
@@ -10,8 +10,6 @@
 using namespace caf;
 using namespace std::literals;
 
-namespace {
-
 TEST("parsing a http request") {
   net::http::request_header hdr;
   hdr.parse("GET /foo/bar?user=foo&pw=bar#baz HTTP/1.1\r\n"
@@ -185,5 +183,3 @@ TEST("invalid request headers are copyable and movable") {
     check_invalid(other);
   }
 }
-
-} // namespace

--- a/libcaf_net/caf/net/http/response_header.test.cpp
+++ b/libcaf_net/caf/net/http/response_header.test.cpp
@@ -9,8 +9,6 @@
 using namespace caf;
 using namespace std::literals;
 
-namespace {
-
 TEST("parsing a valid http response") {
   net::http::response_header hdr;
   SECTION("parsing a one line header") {
@@ -152,5 +150,3 @@ TEST("copying and moving invalid response header results in invalid requests") {
     check(!uut.valid());
   }
 }
-
-} // namespace

--- a/libcaf_net/caf/net/http/router.test.cpp
+++ b/libcaf_net/caf/net/http/router.test.cpp
@@ -35,6 +35,8 @@ struct fixture {
   }
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("routes must have one 'arg' entry per argument") {
@@ -157,5 +159,3 @@ SCENARIO("routes must have one 'arg' entry per argument") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_net/caf/net/http/server.test.cpp
+++ b/libcaf_net/caf/net/http/server.test.cpp
@@ -146,6 +146,8 @@ struct fixture {
   std::thread mpx_thread;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("the server parses HTTP GET requests into header fields") {
@@ -233,5 +235,3 @@ SCENARIO("the client receives a chunked HTTP response") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_net/caf/net/ip.test.cpp
+++ b/libcaf_net/caf/net/ip.test.cpp
@@ -32,6 +32,8 @@ struct fixture {
   std::vector<ip_address> addrs;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("resolve localhost") {
@@ -61,5 +63,3 @@ TEST("local addresses any") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_net/caf/net/lp/frame.test.cpp
+++ b/libcaf_net/caf/net/lp/frame.test.cpp
@@ -20,6 +20,8 @@ std::vector<std::byte> to_vec(span<const T> values) {
   return std::vector<std::byte>{values.begin(), values.end()};
 }
 
+} // namespace
+
 TEST("default construction") {
   net::lp::frame uut;
   check(!uut);
@@ -70,5 +72,3 @@ TEST("copying, moving and swapping") {
   check_eq(uut6.bytes().data(), uut3.bytes().data());
   check_eq(uut5.bytes().data(), uut4.bytes().data());
 }
-
-} // namespace

--- a/libcaf_net/caf/net/multiplexer.test.cpp
+++ b/libcaf_net/caf/net/multiplexer.test.cpp
@@ -182,6 +182,8 @@ T unbox(caf::expected<T> x) {
   return std::move(*x);
 }
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("the multiplexer has no socket managers after default construction") {
@@ -293,5 +295,3 @@ SCENARIO("a multiplexer terminates its thread after shutting down") {
 // }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_net/caf/net/network_socket.test.cpp
+++ b/libcaf_net/caf/net/network_socket.test.cpp
@@ -9,8 +9,6 @@
 using namespace caf;
 using namespace caf::net;
 
-namespace {
-
 TEST("invalid socket") {
   network_socket x;
   check_eq(allow_udp_connreset(x, true), sec::network_syscall_failed);
@@ -20,5 +18,3 @@ TEST("invalid socket") {
   check_eq(remote_port(x), sec::network_syscall_failed);
   check_eq(remote_addr(x), sec::network_syscall_failed);
 }
-
-} // namespace

--- a/libcaf_net/caf/net/octet_stream/transport.test.cpp
+++ b/libcaf_net/caf/net/octet_stream/transport.test.cpp
@@ -115,6 +115,8 @@ private:
   consume_impl_t consume_impl_;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("receive") {
@@ -219,5 +221,3 @@ TEST("switching the protocol resets the delta") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_net/caf/net/octet_stream/with.test.cpp
+++ b/libcaf_net/caf/net/octet_stream/with.test.cpp
@@ -61,6 +61,8 @@ struct fixture {
   std::thread mpx_thread;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("a flow bridge connects flows to a socket") {
@@ -106,5 +108,3 @@ TEST("a flow bridge connects flows to a socket") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_net/caf/net/pipe_socket.test.cpp
+++ b/libcaf_net/caf/net/pipe_socket.test.cpp
@@ -11,8 +11,6 @@
 using namespace caf;
 using namespace caf::net;
 
-namespace {
-
 TEST("send and receive") {
   byte_buffer send_buf{std::byte(1), std::byte(2), std::byte(3), std::byte(4),
                        std::byte(5), std::byte(6), std::byte(7), std::byte(8)};
@@ -27,5 +25,3 @@ TEST("send and receive") {
   check_eq(static_cast<size_t>(read(rd_sock, receive_buf)), send_buf.size());
   check(std::equal(send_buf.begin(), send_buf.end(), receive_buf.begin()));
 }
-
-} // namespace

--- a/libcaf_net/caf/net/socket.test.cpp
+++ b/libcaf_net/caf/net/socket.test.cpp
@@ -9,13 +9,9 @@
 using namespace caf;
 using namespace caf::net;
 
-namespace {
-
 TEST("invalid socket") {
   auto x = invalid_socket;
   check_eq(x.id, invalid_socket_id);
   check_eq(child_process_inherit(x, true), sec::network_syscall_failed);
   check_eq(nonblocking(x, true), sec::network_syscall_failed);
 }
-
-} // namespace

--- a/libcaf_net/caf/net/socket_guard.test.cpp
+++ b/libcaf_net/caf/net/socket_guard.test.cpp
@@ -46,6 +46,8 @@ struct fixture {
   dummy_socket sock;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("cleanup") {
@@ -79,5 +81,3 @@ TEST("release") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_net/caf/net/stream_socket.test.cpp
+++ b/libcaf_net/caf/net/stream_socket.test.cpp
@@ -19,10 +19,6 @@ std::byte operator"" _b(unsigned long long x) {
   return static_cast<std::byte>(x);
 }
 
-} // namespace
-
-namespace {
-
 struct fixture {
   fixture() : rd_buf(124) {
     auto maybe_sockets = make_stream_socket_pair();
@@ -50,6 +46,8 @@ struct fixture {
   stream_socket second;
   byte_buffer rd_buf;
 };
+
+} // namespace
 
 WITH_FIXTURE(fixture) {
 
@@ -103,5 +101,3 @@ TEST("transfer data using multiple buffers") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_net/caf/net/tcp_accept_socket.test.cpp
+++ b/libcaf_net/caf/net/tcp_accept_socket.test.cpp
@@ -16,8 +16,6 @@ using namespace caf;
 using namespace caf::net;
 using namespace std::literals;
 
-namespace {
-
 TEST("opening and accepting tcp on a socket") {
   uri::authority_type auth;
   auth.port = 0;
@@ -86,5 +84,3 @@ TEST("calling accepting") {
              sec::socket_operation_failed);
   }
 }
-
-} // namespace

--- a/libcaf_net/caf/net/tcp_stream_socket.test.cpp
+++ b/libcaf_net/caf/net/tcp_stream_socket.test.cpp
@@ -16,8 +16,6 @@ using namespace caf;
 using namespace caf::net;
 using namespace std::literals;
 
-namespace {
-
 TEST("opening and connecting via tcp socket") {
   auto unbox = [this](auto expected) {
     if (expected)
@@ -141,5 +139,3 @@ TEST("tcp connect to invalid destination") {
     check(!conn.has_value());
   }
 }
-
-} // namespace

--- a/libcaf_net/caf/net/typed_actor_shell.test.cpp
+++ b/libcaf_net/caf/net/typed_actor_shell.test.cpp
@@ -150,6 +150,8 @@ struct fixture {
   net::stream_socket fd2;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("actor shells can receive messages") {
@@ -256,5 +258,3 @@ TEST("actor shells can use flows") {
 TEST_INIT() {
   init_global_meta_objects<caf::id_block::typed_actor_shell_test>();
 }
-
-} // namespace

--- a/libcaf_net/caf/net/udp_datagram_socket.test.cpp
+++ b/libcaf_net/caf/net/udp_datagram_socket.test.cpp
@@ -68,6 +68,8 @@ error read_from_socket(udp_datagram_socket sock, byte_buffer& buf) {
   return make_error(sec::runtime_error, "too many read attempts");
 }
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 TEST("socket creation") {
@@ -93,5 +95,3 @@ TEST("read and write") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_net/caf/net/web_socket/handshake.test.cpp
+++ b/libcaf_net/caf/net/web_socket/handshake.test.cpp
@@ -55,6 +55,8 @@ struct fixture {
   byte_buffer bytes;
 };
 
+} // namespace
+
 WITH_FIXTURE(fixture) {
 
 SCENARIO("handshake generates HTTP GET requests according to RFC 6455") {
@@ -89,5 +91,3 @@ SCENARIO("handshake objects validate HTTP response headers") {
 }
 
 } // WITH_FIXTURE(fixture)
-
-} // namespace

--- a/libcaf_test/caf/test/block_type.test.cpp
+++ b/libcaf_test/caf/test/block_type.test.cpp
@@ -8,8 +8,6 @@
 
 using caf::test::block_type;
 
-namespace {
-
 TEST("is_extension checks whether a block type needs a predecessor") {
   using caf::test::is_extension;
   SECTION("is_extension is true for all AND_* types and BUT") {
@@ -28,5 +26,3 @@ TEST("is_extension checks whether a block type needs a predecessor") {
     check(!is_extension(block_type::then));
   }
 }
-
-} // namespace

--- a/libcaf_test/caf/test/fixture/deterministic.test.cpp
+++ b/libcaf_test/caf/test/fixture/deterministic.test.cpp
@@ -21,7 +21,7 @@ using caf::anon_mail;
 
 using namespace std::literals;
 
-namespace fixture = caf::test::fixture;
+namespace {
 
 struct my_int {
   int value;
@@ -40,13 +40,7 @@ bool operator==(my_int lhs, int rhs) noexcept {
   return lhs.value == rhs;
 }
 
-bool operator==(int lhs, my_int rhs) noexcept {
-  return lhs == rhs.value;
-}
-
-bool operator!=(my_int lhs, my_int rhs) noexcept {
-  return lhs.value != rhs.value;
-}
+} // namespace
 
 CAF_BEGIN_TYPE_ID_BLOCK(deterministic_fixture_test, caf::first_custom_type_id)
 
@@ -54,9 +48,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(deterministic_fixture_test, caf::first_custom_type_id)
 
 CAF_END_TYPE_ID_BLOCK(deterministic_fixture_test)
 
-namespace {
-
-WITH_FIXTURE(fixture::deterministic) {
+WITH_FIXTURE(caf::test::fixture::deterministic) {
 
 TEST("the deterministic fixture provides a deterministic scheduler") {
   auto initialized = std::make_shared<bool>(false);
@@ -505,10 +497,8 @@ TEST("calling next_timeout or last_timeout with no pending timeout throws") {
 }
 #endif // CAF_ENABLE_EXCEPTIONS
 
-} // WITH_FIXTURE(fixture::deterministic)
+} // WITH_FIXTURE(caf::test::fixture::deterministic)
 
 TEST_INIT() {
   caf::init_global_meta_objects<caf::id_block::deterministic_fixture_test>();
 }
-
-} // namespace

--- a/libcaf_test/caf/test/fixture/flow.test.cpp
+++ b/libcaf_test/caf/test/fixture/flow.test.cpp
@@ -10,8 +10,6 @@
 
 using namespace caf;
 
-namespace {
-
 WITH_FIXTURE(test::fixture::flow) {
 
 TEST("range() creates a blueprint for a range of numbers") {
@@ -31,5 +29,3 @@ TEST("collect() eagerly evaluates an observable and returns a vector") {
 }
 
 } // WITH_FIXTURE(test::fixture::flow)
-
-} // namespace

--- a/libcaf_test/caf/test/outline.hpp
+++ b/libcaf_test/caf/test/outline.hpp
@@ -36,6 +36,7 @@ public:
 } // namespace caf::test
 
 #define OUTLINE(description)                                                   \
+  namespace {                                                                  \
   struct CAF_PP_UNIFYN(outline_)                                               \
     : caf::test::runnable_with_examples, caf_test_case_auto_fixture {          \
     using super = caf::test::runnable_with_examples;                           \
@@ -46,6 +47,7 @@ public:
   ptrdiff_t CAF_PP_UNIFYN(outline_)::register_id                               \
     = caf::test::registry::add<CAF_PP_UNIFYN(outline_)>(                       \
       caf_test_suite_name, description, caf::test::block_type::outline);       \
+  }                                                                            \
   void CAF_PP_UNIFYN(outline_)::do_run()
 
 #define EXAMPLES this->make_examples_setter()

--- a/libcaf_test/caf/test/outline.test.cpp
+++ b/libcaf_test/caf/test/outline.test.cpp
@@ -10,8 +10,6 @@
 
 #include <numeric>
 
-namespace {
-
 OUTLINE("eating cucumbers") {
   GIVEN("there are <start> cucumbers") {
     auto start = block_parameters<int>();
@@ -72,5 +70,3 @@ OUTLINE("counting numbers") {
     | [1, 2, 3] |   6 |   okay |
   )";
 }
-
-} // namespace

--- a/libcaf_test/caf/test/scenario.hpp
+++ b/libcaf_test/caf/test/scenario.hpp
@@ -83,6 +83,7 @@ public:
        and_then_scope; and_then_scope.leave())
 
 #define SCENARIO(description)                                                  \
+  namespace {                                                                  \
   struct CAF_PP_UNIFYN(scenario_)                                              \
     : caf::test::runnable, caf_test_case_auto_fixture {                        \
     using super = caf::test::runnable;                                         \
@@ -93,4 +94,5 @@ public:
   ptrdiff_t CAF_PP_UNIFYN(scenario_)::register_id                              \
     = caf::test::registry::add<CAF_PP_UNIFYN(scenario_)>(                      \
       caf_test_suite_name, description, caf::test::block_type::scenario);      \
+  }                                                                            \
   void CAF_PP_UNIFYN(scenario_)::do_run()

--- a/libcaf_test/caf/test/scenario.test.cpp
+++ b/libcaf_test/caf/test/scenario.test.cpp
@@ -9,8 +9,6 @@
 
 #include "caf/config.hpp"
 
-namespace {
-
 #ifdef CAF_ENABLE_EXCEPTIONS
 SCENARIO("a scenario may not contain a section") {
   auto entered_section = false;
@@ -63,9 +61,13 @@ SCENARIO("each run starts with fresh local variables") {
   }
 }
 
+namespace {
+
 struct int_fixture {
   int my_int = 0;
 };
+
+} // namespace
 
 WITH_FIXTURE(int_fixture) {
 
@@ -156,5 +158,3 @@ SCENARIO("scenario-1") {
     }
   }
 }
-
-} // namespace

--- a/libcaf_test/caf/test/suite.hpp
+++ b/libcaf_test/caf/test/suite.hpp
@@ -19,13 +19,12 @@
 struct caf_test_case_auto_fixture {};
 
 #define SUITE(name)                                                            \
+  namespace CAF_PP_UNIFYN(caf_suite_) {                                        \
   namespace {                                                                  \
-  static_assert(                                                               \
-    std::is_same_v<std::decay_t<decltype(caf_test_suite_name)>, caf::unit_t>,  \
-    "only one SUITE per translation unit is supported");                       \
   constexpr std::string_view caf_test_suite_name = name;                       \
   }                                                                            \
-  namespace
+  }                                                                            \
+  namespace CAF_PP_UNIFYN(caf_suite_)
 
 #define WITH_FIXTURE(name)                                                     \
   namespace CAF_PP_UNIFYN(caf_fixture_) {                                      \

--- a/libcaf_test/caf/test/test.hpp
+++ b/libcaf_test/caf/test/test.hpp
@@ -40,6 +40,7 @@ public:
        CAF_PP_UNIFYN(scope_); CAF_PP_UNIFYN(scope_).leave())
 
 #define TEST(description)                                                      \
+  namespace {                                                                  \
   struct CAF_PP_UNIFYN(test_)                                                  \
     : caf::test::runnable, caf_test_case_auto_fixture {                        \
     using super = caf::test::runnable;                                         \
@@ -50,4 +51,5 @@ public:
   ptrdiff_t CAF_PP_UNIFYN(test_)::register_id                                  \
     = caf::test::registry::add<CAF_PP_UNIFYN(test_)>(                          \
       caf_test_suite_name, description, caf::test::block_type::test);          \
+  }                                                                            \
   void CAF_PP_UNIFYN(test_)::do_run()

--- a/libcaf_test/caf/test/test.hpp
+++ b/libcaf_test/caf/test/test.hpp
@@ -41,15 +41,15 @@ public:
 
 #define TEST(description)                                                      \
   namespace {                                                                  \
-  struct CAF_PP_UNIFYN(test_)                                                  \
+  struct CAF_PP_UNIFYN(caf_test_)                                              \
     : caf::test::runnable, caf_test_case_auto_fixture {                        \
     using super = caf::test::runnable;                                         \
     using super::super;                                                        \
     void do_run() override;                                                    \
     static ptrdiff_t register_id;                                              \
   };                                                                           \
-  ptrdiff_t CAF_PP_UNIFYN(test_)::register_id                                  \
-    = caf::test::registry::add<CAF_PP_UNIFYN(test_)>(                          \
+  ptrdiff_t CAF_PP_UNIFYN(caf_test_)::register_id                              \
+    = caf::test::registry::add<CAF_PP_UNIFYN(caf_test_)>(                      \
       caf_test_suite_name, description, caf::test::block_type::test);          \
   }                                                                            \
-  void CAF_PP_UNIFYN(test_)::do_run()
+  void CAF_PP_UNIFYN(caf_test_)::do_run()

--- a/libcaf_test/caf/test/test.test.cpp
+++ b/libcaf_test/caf/test/test.test.cpp
@@ -9,8 +9,6 @@
 
 using caf::test::block_type;
 
-namespace {
-
 TEST("tests can contain different types of checks") {
   auto& rep = caf::test::reporter::instance();
   SECTION("check_ne checks for inequality") {
@@ -111,9 +109,13 @@ TEST("each run starts with fresh local variables") {
   }
 }
 
+namespace {
+
 struct int_fixture {
   int my_int = 0;
 };
+
+} // namespace
 
 WITH_FIXTURE(int_fixture) {
 
@@ -129,5 +131,3 @@ TEST("each run starts with a fresh fixture") {
 }
 
 } // WITH_FIXTURE(int_fixture)
-
-} // namespace


### PR DESCRIPTION
I've made a few tweaks to our test macros to make our put-test-into-the-anonymous-namespace workaround obsolete.