### PR TITLE
Fix doxygen syntax in files

### DIFF
--- a/cmake/Doxyfile.in
+++ b/cmake/Doxyfile.in
@@ -251,6 +251,7 @@ TAB_SIZE               = 2
 # @} or use a double escape (\\{ and \\})
 
 ALIASES                = "experimental=@attention This feature is **experimental**."
+ALIASES                += "threadsafe=@attention This function is thread-safe."
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For

--- a/libcaf_core/caf/async/execution_context.hpp
+++ b/libcaf_core/caf/async/execution_context.hpp
@@ -33,7 +33,7 @@ public:
 
   /// Schedules @p what to run on the event loop of the execution context. This
   /// member function may get called from external sources or threads.
-  /// @thread-safe
+  /// @threadsafe
   virtual void schedule(action what) = 0;
 
   ///@copydoc schedule

--- a/libcaf_core/caf/chunked_string.cpp
+++ b/libcaf_core/caf/chunked_string.cpp
@@ -44,7 +44,7 @@ chunked_string_builder::chunked_string_builder(
   new (&chunks_) list_type(resource);
 }
 
-void chunked_string_builder::chunked_string_builder::append(char ch) {
+void chunked_string_builder::append(char ch) {
   if (current_block_ == nullptr) { // Lazy initialization.
     current_block_ = allocator_t<char>{resource()}.allocate(chunk_size);
     write_pos_ = 0;

--- a/libcaf_core/caf/deserializer.hpp
+++ b/libcaf_core/caf/deserializer.hpp
@@ -19,7 +19,6 @@
 
 namespace caf {
 
-/// @ingroup TypeSystem
 /// Technology-independent deserialization interface.
 class CAF_CORE_EXPORT deserializer : public load_inspector_base<deserializer> {
 public:
@@ -135,28 +134,28 @@ public:
   virtual bool value(bool& x) = 0;
 
   /// @copydoc value
-  virtual bool value(int8_t&) = 0;
+  virtual bool value(int8_t& x) = 0;
 
   /// @copydoc value
-  virtual bool value(uint8_t&) = 0;
+  virtual bool value(uint8_t& x) = 0;
 
   /// @copydoc value
-  virtual bool value(int16_t&) = 0;
+  virtual bool value(int16_t& x) = 0;
 
   /// @copydoc value
-  virtual bool value(uint16_t&) = 0;
+  virtual bool value(uint16_t& x) = 0;
 
   /// @copydoc value
-  virtual bool value(int32_t&) = 0;
+  virtual bool value(int32_t& x) = 0;
 
   /// @copydoc value
-  virtual bool value(uint32_t&) = 0;
+  virtual bool value(uint32_t& x) = 0;
 
   /// @copydoc value
-  virtual bool value(int64_t&) = 0;
+  virtual bool value(int64_t& x) = 0;
 
   /// @copydoc value
-  virtual bool value(uint64_t&) = 0;
+  virtual bool value(uint64_t& x) = 0;
 
   /// @copydoc value
   template <class T>
@@ -170,22 +169,22 @@ public:
     }
   }
   /// @copydoc value
-  virtual bool value(float&) = 0;
+  virtual bool value(float& x) = 0;
 
   /// @copydoc value
-  virtual bool value(double&) = 0;
+  virtual bool value(double& x) = 0;
 
   /// @copydoc value
-  virtual bool value(long double&) = 0;
+  virtual bool value(long double& x) = 0;
 
   /// @copydoc value
-  virtual bool value(std::string&) = 0;
+  virtual bool value(std::string& x) = 0;
 
   /// @copydoc value
-  virtual bool value(std::u16string&) = 0;
+  virtual bool value(std::u16string& x) = 0;
 
   /// @copydoc value
-  virtual bool value(std::u32string&) = 0;
+  virtual bool value(std::u32string& x) = 0;
 
   /// Reads a byte sequence from the input.
   /// @param x The byte sequence.

--- a/libcaf_core/caf/detail/json.hpp
+++ b/libcaf_core/caf/detail/json.hpp
@@ -470,9 +470,6 @@ value* parse(string_parser_state& ps, monotonic_buffer_resource* storage);
 // Parses the input string and makes a deep copy of all strings.
 value* parse(file_parser_state& ps, monotonic_buffer_resource* storage);
 
-// Parses the input file and makes a deep copy of all strings.
-value* parse(string_parser_state& ps, monotonic_buffer_resource* storage);
-
 // Parses the input and makes a shallow copy of strings whenever possible.
 // Strings that do not have escaped characters are not copied, other strings
 // will be copied.

--- a/libcaf_core/caf/detail/test_coordinator.cpp
+++ b/libcaf_core/caf/detail/test_coordinator.cpp
@@ -182,7 +182,7 @@ void test_coordinator::inline_all_enqueues() {
   after_next_enqueue([this] { inline_all_enqueues_helper(); });
 }
 
-test_actor_clock& test_coordinator::test_coordinator::clock() {
+test_actor_clock& test_coordinator::clock() {
   return dynamic_cast<test_actor_clock&>(system().clock());
 }
 

--- a/libcaf_core/caf/json_builder.hpp
+++ b/libcaf_core/caf/json_builder.hpp
@@ -50,12 +50,12 @@ public:
     skip_empty_fields_ = value;
   }
 
-  /// Returns whether the writer omits '@type' annotations for JSON objects.
+  /// Returns whether the writer omits `@type` annotations for JSON objects.
   [[nodiscard]] bool skip_object_type_annotation() const noexcept {
     return skip_object_type_annotation_;
   }
 
-  /// Configures whether the writer omits '@type' annotations for JSON objects.
+  /// Configures whether the writer omits `@type` annotations for JSON objects.
   void skip_object_type_annotation(bool value) noexcept {
     skip_object_type_annotation_ = value;
   }
@@ -237,7 +237,7 @@ private:
   // fields as `$field: null` (false).
   bool skip_empty_fields_ = json_writer::skip_empty_fields_default;
 
-  // Configures whether we omit the top-level '@type' annotation.
+  // Configures whether we omit the top-level `@type` annotation.
   bool skip_object_type_annotation_ = false;
 
   std::string_view field_type_suffix_ = json_writer::field_type_suffix_default;

--- a/libcaf_core/caf/json_writer.hpp
+++ b/libcaf_core/caf/json_writer.hpp
@@ -95,12 +95,12 @@ public:
     skip_empty_fields_ = value;
   }
 
-  /// Returns whether the writer omits '@type' annotations for JSON objects.
+  /// Returns whether the writer omits `@type` annotations for JSON objects.
   [[nodiscard]] bool skip_object_type_annotation() const noexcept {
     return skip_object_type_annotation_;
   }
 
-  /// Configures whether the writer omits '@type' annotations for JSON objects.
+  /// Configures whether the writer omits `@type` annotations for JSON objects.
   void skip_object_type_annotation(bool value) noexcept {
     skip_object_type_annotation_ = value;
   }
@@ -289,7 +289,7 @@ private:
   // fields as `$field: null` (false).
   bool skip_empty_fields_ = skip_empty_fields_default;
 
-  // Configures whether we omit the top-level '@type' annotation.
+  // Configures whether we omit the top-level `@type` annotation.
   bool skip_object_type_annotation_ = false;
 
   // Configures how we generate type annotations for fields.

--- a/libcaf_core/caf/logger.cpp
+++ b/libcaf_core/caf/logger.cpp
@@ -152,7 +152,7 @@ public:
   // -- logging ----------------------------------------------------------------
 
   /// Writes an entry to the event-queue of the logger.
-  /// @thread-safe
+  /// @threadsafe
   void do_log(log::event_ptr&& event) override {
     if (cfg_.inline_output)
       handle_event(*event);

--- a/libcaf_core/caf/scheduler.hpp
+++ b/libcaf_core/caf/scheduler.hpp
@@ -28,7 +28,7 @@ public:
   virtual ~scheduler();
 
   /// Schedules @p what to run at some point in the future.
-  /// @thread-safe
+  /// @threadsafe
   virtual void schedule(resumable* what) = 0;
 
   /// Delay the next execution of @p what. Unlike `schedule`, this function is

--- a/libcaf_core/caf/serializer.hpp
+++ b/libcaf_core/caf/serializer.hpp
@@ -21,7 +21,6 @@
 
 namespace caf {
 
-/// @ingroup TypeSystem
 /// Technology-independent serialization interface.
 class CAF_CORE_EXPORT serializer : public save_inspector_base<serializer> {
 public:

--- a/libcaf_core/caf/telemetry/metric_registry.cpp
+++ b/libcaf_core/caf/telemetry/metric_registry.cpp
@@ -78,7 +78,7 @@ metric_registry::get_label_names(span_t<label_view> xs) {
 }
 
 std::vector<std::string>
-metric_registry::to_sorted_vec(span<const std::string_view> xs) {
+metric_registry::to_sorted_vec(span_t<const std::string_view> xs) {
   std::vector<std::string> result;
   if (!xs.empty()) {
     result.reserve(xs.size());
@@ -90,7 +90,7 @@ metric_registry::to_sorted_vec(span<const std::string_view> xs) {
 }
 
 std::vector<std::string>
-metric_registry::to_sorted_vec(span<const label_view> xs) {
+metric_registry::to_sorted_vec(span_t<const label_view> xs) {
   std::vector<std::string> result;
   if (!xs.empty()) {
     result.reserve(xs.size());
@@ -103,7 +103,7 @@ metric_registry::to_sorted_vec(span<const label_view> xs) {
 
 void metric_registry::assert_properties(
   const metric_family* ptr, metric_type type,
-  span<const std::string_view> label_names, std::string_view unit,
+  span_t<const std::string_view> label_names, std::string_view unit,
   bool is_sum) {
   auto labels_match = [&] {
     const auto& xs = ptr->label_names();
@@ -146,7 +146,7 @@ struct label_name_eq {
 
 void metric_registry::assert_properties(const metric_family* ptr,
                                         metric_type type,
-                                        span<const label_view> labels,
+                                        span_t<const label_view> labels,
                                         std::string_view unit, bool is_sum) {
   auto labels_match = [&] {
     const auto& xs = ptr->label_names();

--- a/libcaf_core/caf/telemetry/metric_registry.hpp
+++ b/libcaf_core/caf/telemetry/metric_registry.hpp
@@ -361,7 +361,26 @@ public:
     return result;
   }
 
-  /// @copydoc gauge_family
+  /// Returns a histogram metric family. Creates the family lazily if
+  /// necessary, but fails if the full name already belongs to a different
+  /// family.
+  /// @param prefix The prefix (namespace) this family belongs to. Usually the
+  ///               application or protocol name, e.g., `http`. The prefix `caf`
+  ///               as well as prefixes starting with an underscore are
+  ///               reserved.
+  /// @param name The human-readable name of the metric, e.g., `requests`.
+  /// @param label_names Names for all label dimensions of the metric.
+  /// @param upper_bounds Upper bounds for the metric buckets.
+  /// @param helptext Short explanation of the metric.
+  /// @param unit Unit of measurement. Please use base units such as `bytes` or
+  ///             `seconds` (prefer lowercase). The pseudo-unit `1` identifies
+  ///             dimensionless counts.
+  /// @param is_sum Setting this to `true` indicates that this metric adds
+  ///               something up to a total, where only the total value is of
+  ///               interest. For example, the total number of HTTP requests.
+  /// @note The first call wins when calling this function multiple times with
+  ///       different bucket settings. Later calls skip checking the bucket
+  ///       settings, mainly because this check would be rather expensive.
   template <class ValueType = int64_t>
   metric_family_impl<histogram<ValueType>>*
   histogram_family(std::string_view prefix, std::string_view name,
@@ -408,7 +427,7 @@ public:
     return fptr->get_or_add(labels);
   }
 
-  /// @copdoc histogram_instance
+  /// @copydoc histogram_instance
   template <class ValueType = int64_t>
   histogram<ValueType>*
   histogram_instance(std::string_view prefix, std::string_view name,
@@ -428,6 +447,7 @@ public:
   ///               as well as prefixes starting with an underscore are
   ///               reserved.
   /// @param name The human-readable name of the metric, e.g., `requests`.
+  /// @param upper_bounds Upper bounds for the metric buckets.
   /// @param helptext Short explanation of the metric.
   /// @param unit Unit of measurement. Please use base units such as `bytes` or
   ///             `seconds` (prefer lowercase). The pseudo-unit `1` identifies

--- a/libcaf_io/caf/io/basp/all.hpp
+++ b/libcaf_io/caf/io/basp/all.hpp
@@ -67,6 +67,7 @@
 ///     from the payload.
 ///
 /// # Node IDs
+/// @anchor node_ids
 ///
 /// The ID of a node consists of a 120 bit hash and the process ID. Note that
 /// we use "node" as a synonym for "CAF instance". The hash is generated from
@@ -95,11 +96,11 @@
 ///
 /// - **Source Node ID**: 18 bytes.
 ///
-///   The address of the source node. See [Node IDs](# Node IDs).
+///   The address of the source node. See [Node IDs](#node_ids).
 ///
 /// - **Destination Node ID**: 18 bytes.
 ///
-///   The address of the destination node. See [Node IDs](# Node IDs).
+///   The address of the destination node. See [Node IDs](#node_ids).
 ///   Upon receiving this datagram, a BASP Broker compares this node ID
 ///   to its own ID. On a mismatch, it selects the next hop and forwards
 ///   this datagram unchanged.

--- a/libcaf_io/caf/io/network/manager.hpp
+++ b/libcaf_io/caf/io/network/manager.hpp
@@ -36,7 +36,7 @@ public:
     return !parent_;
   }
 
-  /// Detach this manager from its parent and invoke `detach_message()``
+  /// Detach this manager from its parent and invoke `detach_message()`
   /// if `invoke_detach_message == true`.
   void detach(scheduler* ctx, bool invoke_disconnect_message);
 

--- a/libcaf_net/caf/net/multiplexer.hpp
+++ b/libcaf_net/caf/net/multiplexer.hpp
@@ -64,7 +64,7 @@ public:
   /// Schedules @p what to run after reaching @p when on the event loop of the
   /// execution context. This member function may get called from external
   /// sources or threads.
-  /// @thread-safe
+  /// @threadsafe
   virtual void schedule(steady_time_point when, action what) = 0;
 
   // -- properties -------------------------------------------------------------
@@ -81,11 +81,11 @@ public:
   // -- thread-safe signaling --------------------------------------------------
 
   /// Registers `mgr` for initialization in the multiplexer's thread.
-  /// @thread-safe
+  /// @threadsafe
   virtual void start(socket_manager_ptr mgr) = 0;
 
   /// Signals the multiplexer to initiate shutdown.
-  /// @thread-safe
+  /// @threadsafe
   virtual void shutdown() = 0;
 
   // -- callbacks for socket managers ------------------------------------------

--- a/libcaf_net/caf/net/ssl/connection.hpp
+++ b/libcaf_net/caf/net/ssl/connection.hpp
@@ -48,12 +48,11 @@ public:
   // -- error handling ---------------------------------------------------------
 
   /// Returns the error code for a preceding call to `connect`, `accept`,
-  /// `read`, `write` or `close.
-  /// @param ret The (negative) result from the preceding call.
+  /// `read`, `write` or `close`.
   errc last_error(ptrdiff_t ret) const;
 
   /// Returns a human-readable representation of the error for a preceding call
-  /// to `connect`, `accept`, `read`, `write` or `close.
+  /// to `connect`, `accept`, `read`, `write` or `close`.
   /// @param ret The (negative) result from the preceding call.
   std::string last_error_string(ptrdiff_t ret) const;
 

--- a/libcaf_test/caf/test/reporter.cpp
+++ b/libcaf_test/caf/test/reporter.cpp
@@ -582,7 +582,7 @@ public:
   // -- logging ----------------------------------------------------------------
 
   /// Writes an entry to the event-queue of the logger.
-  /// @thread-safe
+  /// @threadsafe
   void do_log(log::event_ptr&& event) override {
     // We omit fields such as component and actor ID. When not filtering
     // non-test log messages, we add these fields to the message in order to be


### PR DESCRIPTION
Relates https://github.com/actor-framework/actor-framework/issues/1946

This fixes all of the missing documentation and syntax issues in the codebase.