### PR TITLE
Fix 

### DIFF
--- a/libcaf_net/caf/net/web_socket/client.cpp
+++ b/libcaf_net/caf/net/web_socket/client.cpp
@@ -121,6 +121,10 @@ std::unique_ptr<client> client::make(handshake_ptr hs, upper_layer_ptr up_ptr) {
   return std::make_unique<client_impl>(std::move(hs), std::move(up_ptr));
 }
 
+std::unique_ptr<client> client::make(handshake&& hs, upper_layer_ptr up) {
+  return make(std::make_unique<handshake>(std::move(hs)), std::move(up));
+}
+
 // -- constructors, destructors, and assignment operators --------------------
 
 client::~client() {

--- a/libcaf_net/caf/net/web_socket/client.hpp
+++ b/libcaf_net/caf/net/web_socket/client.hpp
@@ -30,9 +30,7 @@ public:
 
   static std::unique_ptr<client> make(handshake_ptr hs, upper_layer_ptr up);
 
-  static std::unique_ptr<client> make(handshake&& hs, upper_layer_ptr up) {
-    return make(std::make_unique<handshake>(std::move(hs)), std::move(up));
-  }
+  static std::unique_ptr<client> make(handshake&& hs, upper_layer_ptr up);
 };
 
 } // namespace caf::net::web_socket


### PR DESCRIPTION
Relates #1919 
The compile error is only visible in c++23 mode on clang (tested v17, v18 and v19). Basically missing the definition of `upper_layer_ptr` in the header file, which is required to run the destructor. 