### PR TITLE
Avoid clang-tidy false positives for intrusive_ptr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 ### Fixed
 
 - Fix build error in `caf-net` when building with C++23 (#1919).
+- Restructure some implementation details of `intrsuive_ptr` (no functional
+  changes) to make it easier for `clang-tidy` to analyze the code. This fixes a
+  false positive reported by `clang-tidy` in some use cases where `clang-tidy`
+  would falsely report a use-after-free bug.
 
 ## [1.0.2] - 2024-10-30
 

--- a/libcaf_core/caf/intrusive_ptr.hpp
+++ b/libcaf_core/caf/intrusive_ptr.hpp
@@ -102,10 +102,12 @@ public:
   /// Returns the raw pointer without modifying reference
   /// count and sets this to `nullptr`.
   pointer detach() noexcept {
-    auto result = ptr_;
-    if (result)
+    if (ptr_ != nullptr) {
+      auto result = ptr_;
       ptr_ = nullptr;
-    return result;
+      return result;
+    }
+    return nullptr;
   }
 
   /// Returns the raw pointer without modifying reference
@@ -115,10 +117,8 @@ public:
   }
 
   void reset(pointer new_value = nullptr, bool add_ref = true) noexcept {
-    auto old = ptr_;
-    set_ptr(new_value, add_ref);
-    if (old)
-      intrusive_ptr_access<T>::release(old);
+    intrusive_ptr tmp{new_value, add_ref};
+    swap(tmp);
   }
 
   template <class... Ts>


### PR DESCRIPTION
This is an interesting one that came out of a customer code base. `clang-tidy` would complain about a use-after-free in `intrusive_ptr` in some nested code constructs, claiming that `reset` would free a pointer only for the destructor to accessing the pointer again (passing it to `intrusive_ptr_access<T>::release`). That's of course not possible, because we re-assign `ptr_` in `release` after releasing the previous pointer. However, somehow `clang-tidy` did not make that connection. That was with `clang-tidy` from LLVM version 19.1.3. It also seemed to be a bit confused about `detach` in one instance.

Using the swap-with-temporary idiom in `reset` seems to be easier to swallow for `clang-tidy`. No functional change either way, just refactoring.