### PR TITLE
Fix std::format unit test

### DIFF
--- a/libcaf_core/caf/detail/format.test.cpp
+++ b/libcaf_core/caf/detail/format.test.cpp
@@ -27,8 +27,7 @@ static_assert(
   std::is_same_v<decltype(fmt_fwd(std::declval<const int&>())), const int&>);
 // Types without a formatter overload are forwarded as std::string.
 static_assert(
-  std::is_same_v<decltype(fmt_fwd(std::declval<std::vector<int>>())),
-                 std::string>);
+  std::is_same_v<decltype(fmt_fwd(std::declval<caf::uri>())), std::string>);
 
 #endif
 


### PR DESCRIPTION
Closes #1963 
When building in c++23 mode with `std::format` support a static cast in the unit tests will fail. The main reason is that c++23 adds support for ranges to std::format, so a `vector` can be formatted now. Changed the test to use another type that isn't in the std library. 