### PR TITLE
Fix warning in observe-on

### DIFF
--- a/examples/flow/observe-on.cpp
+++ b/examples/flow/observe-on.cpp
@@ -26,8 +26,8 @@ struct config : caf::actor_system_config {
 void caf_main(caf::actor_system& sys, const config& cfg) {
   // Create two actors without actually running them yet.
   auto n = get_or(cfg, "num-values", default_num_values);
-  auto [src, launch_src] = sys.spawn_inactive();
   auto [snk, launch_snk] = sys.spawn_inactive();
+  auto [src, launch_src] = sys.spawn_inactive();
   // Define our data flow: generate data on `src` and print it on `snk`.
   src
     // Get an observable factory.


### PR DESCRIPTION
Relates https://github.com/actor-framework/actor-framework/issues/1280

This warning looks to be an bug with the compiler. Just reversing the order of declaration fixes the warning. I have tried to look into the codebase and could not find any place where `ptr_` can be undefined. This fixes the warning on gdb 11.4.0 compiler.