### PR TITLE
Implement a mechanism for merging type lists

### DIFF
--- a/libcaf_core/caf/type_list.hpp
+++ b/libcaf_core/caf/type_list.hpp
@@ -6,6 +6,26 @@
 
 namespace caf {
 
+template <class... Ts>
+struct type_list;
+
+template <class... Ts>
+struct tl_concat_helper;
+
+template <class... Ts>
+struct tl_concat_helper<type_list<Ts...>> {
+  using type = type_list<Ts...>;
+};
+
+template <class... Ts, class... Us, class... Lists>
+struct tl_concat_helper<type_list<Ts...>, type_list<Us...>, Lists...>
+  : tl_concat_helper<type_list<Ts..., Us...>, Lists...> {
+  // nop
+};
+
+template <class... Ts>
+using tl_concat_t = typename tl_concat_helper<Ts...>::type;
+
 /// A list of types.
 template <class... Ts>
 struct type_list {
@@ -15,6 +35,9 @@ struct type_list {
 
   template <class... Us>
   using append = type_list<Ts..., Us...>;
+
+  template <class... Lists>
+  using append_from = tl_concat_t<type_list<Ts...>, Lists...>;
 };
 
 template <class... Ts>

--- a/libcaf_core/caf/typed_actor.test.cpp
+++ b/libcaf_core/caf/typed_actor.test.cpp
@@ -161,4 +161,9 @@ static_assert(std::is_convertible_v<dummy5, dummy3>,
 static_assert(std::is_convertible_v<dummy5, dummy4>,
               "handle not assignable to narrower definition");
 
+static_assert(
+    std::is_same_v<type_list<bool>::append_from<type_list<int>, type_list<float>>,
+    type_list<bool, int, float>>
+    );
+
 } // namespace


### PR DESCRIPTION
The use case for this is merging signatures in typed actor traits:

```cpp
struct foo_actor_traits {
  using signatures = type_list<result<int>()>;
};
using foo_actor = typed_actor<foo_actor_traits>;

struct bar_actor_traits {
  using signatures = type_list<result<float>()>
    // Also support everything a `foo_actor` does.
    ::append_from<foo_actor_traits::signatures>;
};
using bar_actor = typed_actor<bar_actor_traits>;
```

This was previously discussed in Gitter: https://matrix.to/#/!qNeqsDdXWDBZExYTpF:gitter.im/$IM3ue5X-g4K60D7qqTmVjD_x74qBE1HYiprbgq9YIEs?via=gitter.im&via=matrix.org&via=the-gdn.net