### PR TITLE
Allow custom actor serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com).
 
+## 2.0.0
+
+### Changed
+
+- Serializer interfaces have received an overhaul to allow custom serialization
+  of actor handles. There are also two new base types for serialization:
+  `byte_reader` and `byte_writer`. These new types allow users to write generic
+  code for serializers that operate on byte sequences.
+
 ## Unreleased
 
 ### Added

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -119,7 +119,9 @@ caf_add_component(
     caf/blocking_actor.cpp
     caf/blocking_actor.test.cpp
     caf/blocking_mail.test.cpp
+    caf/byte_reader.cpp
     caf/byte_span.cpp
+    caf/byte_writer.cpp
     caf/chrono.cpp
     caf/chrono.test.cpp
     caf/chunk.cpp

--- a/libcaf_core/caf/actor.hpp
+++ b/libcaf_core/caf/actor.hpp
@@ -137,7 +137,7 @@ public:
 
   template <class Inspector>
   friend bool inspect(Inspector& f, actor& x) {
-    return inspect(f, x.ptr_);
+    return f.value(x.ptr_);
   }
 
   /// Releases the reference held by handle `x`. Using the

--- a/libcaf_core/caf/actor_addr.hpp
+++ b/libcaf_core/caf/actor_addr.hpp
@@ -97,7 +97,7 @@ public:
 
   template <class Inspector>
   friend bool inspect(Inspector& f, actor_addr& x) {
-    return inspect(f, x.ptr_);
+    return f.value(x.ptr_);
   }
 
   /// Releases the reference held by handle `x`. Using the

--- a/libcaf_core/caf/actor_control_block.cpp
+++ b/libcaf_core/caf/actor_control_block.cpp
@@ -92,7 +92,7 @@ error_code<sec> load_actor(strong_actor_ptr& storage, actor_system* sys,
   return sec::no_proxy_registry;
 }
 
-error_code<sec> save_actor(strong_actor_ptr& storage, actor_id aid,
+error_code<sec> save_actor(const strong_actor_ptr& storage, actor_id aid,
                            const node_id& nid) {
   // Register locally running actors to be able to deserialize them later.
   if (storage) {

--- a/libcaf_core/caf/binary_deserializer.cpp
+++ b/libcaf_core/caf/binary_deserializer.cpp
@@ -352,4 +352,31 @@ bool binary_deserializer::value(std::vector<bool>& x) {
   return end_sequence();
 }
 
+bool binary_deserializer::value(strong_actor_ptr& ptr) {
+  auto aid = actor_id{0};
+  auto nid = node_id{};
+  if (!value(aid)) {
+    return false;
+  }
+  if (!inspect(*this, nid)) {
+    return false;
+  }
+  if (aid == 0) {
+    ptr = nullptr;
+  } else if (auto err = load_actor(ptr, context_, aid, nid)) {
+    set_error(err);
+    return false;
+  }
+  return true;
+}
+
+bool binary_deserializer::value(weak_actor_ptr& ptr) {
+  strong_actor_ptr tmp;
+  if (!value(tmp)) {
+    return false;
+  }
+  ptr.reset(tmp.get());
+  return true;
+}
+
 } // namespace caf

--- a/libcaf_core/caf/binary_deserializer.hpp
+++ b/libcaf_core/caf/binary_deserializer.hpp
@@ -206,6 +206,10 @@ public:
 
   bool value(std::vector<bool>& x);
 
+  virtual bool value(strong_actor_ptr& ptr);
+
+  virtual bool value(weak_actor_ptr& ptr);
+
 private:
   explicit binary_deserializer(actor_system& sys) noexcept;
 

--- a/libcaf_core/caf/binary_serializer.cpp
+++ b/libcaf_core/caf/binary_serializer.cpp
@@ -278,4 +278,31 @@ bool binary_serializer::value(const std::vector<bool>& x) {
   return end_sequence();
 }
 
+bool binary_serializer::value(const strong_actor_ptr& ptr) {
+  actor_id aid = 0;
+  node_id nid;
+  if (ptr != nullptr) {
+    aid = ptr->id();
+    nid = ptr->node();
+  }
+  if (!value(aid)) {
+    return false;
+  }
+  if (!inspect(*this, nid)) {
+    return false;
+  }
+  if (ptr != nullptr) {
+    if (auto err = save_actor(ptr, aid, nid)) {
+      set_error(err);
+      return false;
+    }
+  }
+  return true;
+}
+
+bool binary_serializer::value(const weak_actor_ptr& ptr) {
+  auto tmp = ptr.lock();
+  return value(tmp);
+}
+
 } // namespace caf

--- a/libcaf_core/caf/binary_serializer.hpp
+++ b/libcaf_core/caf/binary_serializer.hpp
@@ -187,6 +187,10 @@ public:
 
   bool value(const std::vector<bool>& x);
 
+  virtual bool value(const strong_actor_ptr& ptr);
+
+  virtual bool value(const weak_actor_ptr& ptr);
+
 private:
   /// Stores the serialized output.
   byte_buffer& buf_;

--- a/libcaf_core/caf/byte_reader.cpp
+++ b/libcaf_core/caf/byte_reader.cpp
@@ -1,0 +1,13 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#include "caf/byte_reader.hpp"
+
+namespace caf {
+
+byte_reader::~byte_reader() {
+  // nop
+}
+
+} // namespace caf

--- a/libcaf_core/caf/byte_reader.hpp
+++ b/libcaf_core/caf/byte_reader.hpp
@@ -1,0 +1,26 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+#include "caf/deserializer.hpp"
+#include "caf/detail/core_export.hpp"
+#include "caf/span.hpp"
+
+#include <cstdio>
+
+namespace caf {
+
+/// Deserializes inspectable objects from a sequence of bytes.
+class CAF_CORE_EXPORT byte_reader : public deserializer {
+public:
+  using deserializer::deserializer;
+
+  ~byte_reader() override;
+
+  /// Resets the reader and loads a sequence of bytes to deserialize from.
+  virtual bool load_bytes(span<const std::byte> bytes) = 0;
+};
+
+} // namespace caf

--- a/libcaf_core/caf/byte_writer.cpp
+++ b/libcaf_core/caf/byte_writer.cpp
@@ -1,0 +1,13 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#include "caf/byte_writer.hpp"
+
+namespace caf {
+
+byte_writer::~byte_writer() {
+  // nop
+}
+
+} // namespace caf

--- a/libcaf_core/caf/byte_writer.hpp
+++ b/libcaf_core/caf/byte_writer.hpp
@@ -1,0 +1,29 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+#include "caf/detail/core_export.hpp"
+#include "caf/serializer.hpp"
+#include "caf/span.hpp"
+
+#include <cstdio>
+
+namespace caf {
+
+/// Serializes inspectable objects to a sequence of bytes.
+class CAF_CORE_EXPORT byte_writer : public serializer {
+public:
+  using serializer::serializer;
+
+  ~byte_writer() override;
+
+  /// Retrieves the serialized bytes.
+  virtual span<const std::byte> bytes() const = 0;
+
+  /// Clears any buffered data and resets the writer to its initial state.
+  virtual void reset() = 0;
+};
+
+} // namespace caf

--- a/libcaf_core/caf/config_value_writer.cpp
+++ b/libcaf_core/caf/config_value_writer.cpp
@@ -43,6 +43,10 @@ config_value_writer::~config_value_writer() {
 
 // -- interface functions ------------------------------------------------------
 
+bool config_value_writer::has_human_readable_format() const noexcept {
+  return true;
+}
+
 bool config_value_writer::begin_object(type_id_t, std::string_view) {
   CHECK_NOT_EMPTY();
   auto f = detail::make_overload(

--- a/libcaf_core/caf/config_value_writer.hpp
+++ b/libcaf_core/caf/config_value_writer.hpp
@@ -37,17 +37,17 @@ public:
 
   config_value_writer(config_value* dst, actor_system& sys) : super(sys) {
     st_.push(dst);
-    has_human_readable_format_ = true;
   }
 
   explicit config_value_writer(config_value* dst) {
     st_.push(dst);
-    has_human_readable_format_ = true;
   }
 
   ~config_value_writer() override;
 
   // -- interface functions ----------------------------------------------------
+
+  bool has_human_readable_format() const noexcept override;
 
   bool begin_object(type_id_t type, std::string_view name) override;
 

--- a/libcaf_core/caf/deserializer.cpp
+++ b/libcaf_core/caf/deserializer.cpp
@@ -63,6 +63,32 @@ bool deserializer::end_associative_array() {
   return end_sequence();
 }
 
+bool deserializer::value(strong_actor_ptr& ptr) {
+  auto aid = actor_id{0};
+  auto nid = node_id{};
+  auto ok = object(ptr).pretty_name("actor").fields(field("id", aid),
+                                                    field("node", nid));
+  if (!ok) {
+    return false;
+  }
+  if (aid == 0 || !nid) {
+    ptr = nullptr;
+  } else if (auto err = load_actor(ptr, context_, aid, nid)) {
+    set_error(err);
+    return false;
+  }
+  return true;
+}
+
+bool deserializer::value(weak_actor_ptr& ptr) {
+  strong_actor_ptr tmp;
+  if (!value(tmp)) {
+    return false;
+  }
+  ptr.reset(tmp.get());
+  return true;
+}
+
 bool deserializer::list(std::vector<bool>& x) {
   x.clear();
   size_t size = 0;

--- a/libcaf_core/caf/deserializer.hpp
+++ b/libcaf_core/caf/deserializer.hpp
@@ -191,6 +191,12 @@ public:
   /// @returns A non-zero error code on failure, `sec::success` otherwise.
   virtual bool value(span<std::byte> x) = 0;
 
+  /// @copydoc value
+  virtual bool value(strong_actor_ptr& ptr);
+
+  /// @copydoc value
+  virtual bool value(weak_actor_ptr& ptr);
+
   using super::list;
 
   /// Adds each boolean in `xs` to the output. Derived classes can override this

--- a/libcaf_core/caf/detail/stringification_inspector.cpp
+++ b/libcaf_core/caf/detail/stringification_inspector.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/detail/stringification_inspector.hpp"
 
+#include "caf/actor_control_block.hpp"
 #include "caf/detail/print.hpp"
 
 #include <algorithm>
@@ -169,6 +170,23 @@ bool stringification_inspector::value(span<const std::byte> x) {
   sep();
   detail::append_hex(result_, x.data(), x.size());
   return true;
+}
+
+bool stringification_inspector::value(const strong_actor_ptr& ptr) {
+  if (!ptr) {
+    sep();
+    result_ += "null";
+  } else {
+    sep();
+    detail::print(result_, ptr->id());
+    result_ += '@';
+    result_ += to_string(ptr->node());
+  }
+  return true;
+}
+
+bool stringification_inspector::value(const weak_actor_ptr& ptr) {
+  return value(ptr.lock());
 }
 
 bool stringification_inspector::list(const std::vector<bool>& xs) {

--- a/libcaf_core/caf/detail/stringification_inspector.hpp
+++ b/libcaf_core/caf/detail/stringification_inspector.hpp
@@ -115,6 +115,10 @@ public:
 
   bool value(span<const std::byte> x);
 
+  bool value(const strong_actor_ptr& ptr);
+
+  bool value(const weak_actor_ptr& ptr);
+
   using super::list;
 
   bool list(const std::vector<bool>& xs);

--- a/libcaf_core/caf/detail/type_traits.hpp
+++ b/libcaf_core/caf/detail/type_traits.hpp
@@ -748,6 +748,16 @@ struct is_builtin_inspector_type<std::u32string, IsLoading> {
   static constexpr bool value = true;
 };
 
+template <bool IsLoading>
+struct is_builtin_inspector_type<strong_actor_ptr, IsLoading> {
+  static constexpr bool value = true;
+};
+
+template <bool IsLoading>
+struct is_builtin_inspector_type<weak_actor_ptr, IsLoading> {
+  static constexpr bool value = true;
+};
+
 template <>
 struct is_builtin_inspector_type<std::string_view, false> {
   static constexpr bool value = true;

--- a/libcaf_core/caf/json_builder.cpp
+++ b/libcaf_core/caf/json_builder.cpp
@@ -83,6 +83,10 @@ json_value json_builder::seal() {
 
 // -- overrides ----------------------------------------------------------------
 
+bool json_builder::has_human_readable_format() const noexcept {
+  return true;
+}
+
 bool json_builder::begin_object(type_id_t id, std::string_view name) {
   auto add_type_annotation = [this, id, name] {
     CAF_ASSERT(top() == type::key);
@@ -400,7 +404,6 @@ bool json_builder::value(span<const std::byte> x) {
 // -- state management ---------------------------------------------------------
 
 void json_builder::init() {
-  has_human_readable_format_ = true;
   storage_ = make_counted<detail::json::storage>();
   val_ = detail::json::make_value(storage_);
   stack_.reserve(32);

--- a/libcaf_core/caf/json_builder.hpp
+++ b/libcaf_core/caf/json_builder.hpp
@@ -27,10 +27,6 @@ public:
     init();
   }
 
-  explicit json_builder(actor_system& sys) : super(sys) {
-    init();
-  }
-
   json_builder(const json_builder&) = delete;
 
   json_builder& operator=(const json_builder&) = delete;
@@ -84,6 +80,8 @@ public:
   json_value seal();
 
   // -- overrides --------------------------------------------------------------
+
+  bool has_human_readable_format() const noexcept override;
 
   bool begin_object(type_id_t type, std::string_view name) override;
 

--- a/libcaf_core/caf/json_reader.cpp
+++ b/libcaf_core/caf/json_reader.cpp
@@ -146,6 +146,12 @@ bool json_reader::load(std::string_view json_text) {
   return true;
 }
 
+bool json_reader::load_bytes(span<const std::byte> bytes) {
+  auto utf8 = std::string_view{reinterpret_cast<const char*>(bytes.data()),
+                               bytes.size()};
+  return load(utf8);
+}
+
 bool json_reader::load_from(std::istream& input) {
   reset();
   using iterator_t = std::istreambuf_iterator<char>;

--- a/libcaf_core/caf/json_reader.hpp
+++ b/libcaf_core/caf/json_reader.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "caf/deserializer.hpp"
+#include "caf/byte_reader.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/detail/json.hpp"
 
@@ -15,11 +15,11 @@
 namespace caf {
 
 /// Deserializes an inspectable object from a JSON-formatted string.
-class CAF_CORE_EXPORT json_reader : public deserializer {
+class CAF_CORE_EXPORT json_reader : public byte_reader {
 public:
   // -- member types -----------------------------------------------------------
 
-  using super = deserializer;
+  using super = byte_reader;
 
   struct sequence {
     detail::json::array::const_iterator pos;
@@ -131,6 +131,8 @@ public:
   ///          until either destroying this reader or calling `reset`.
   /// @note Implicitly calls `reset`.
   bool load(std::string_view json_text);
+
+  bool load_bytes(span<const std::byte> bytes) override;
 
   /// Reads the input stream @p input and parses the content into an internal
   /// representation. After loading the JSON input, the reader is ready for

--- a/libcaf_core/caf/json_writer.cpp
+++ b/libcaf_core/caf/json_writer.cpp
@@ -58,6 +58,12 @@ json_writer::~json_writer() {
   // nop
 }
 
+// -- properties ---------------------------------------------------------------
+
+span<const std::byte> json_writer::bytes() const {
+  return {reinterpret_cast<const std::byte*>(buf_.data()), buf_.size()};
+}
+
 // -- modifiers ----------------------------------------------------------------
 
 void json_writer::reset() {

--- a/libcaf_core/caf/json_writer.cpp
+++ b/libcaf_core/caf/json_writer.cpp
@@ -68,6 +68,10 @@ void json_writer::reset() {
 
 // -- overrides ----------------------------------------------------------------
 
+bool json_writer::has_human_readable_format() const noexcept {
+  return true;
+}
+
 bool json_writer::begin_object(type_id_t id, std::string_view name) {
   auto add_type_annotation = [this, id, name] {
     CAF_ASSERT(top() == type::key);
@@ -434,7 +438,6 @@ bool json_writer::value(span<const std::byte> x) {
 // -- state management ---------------------------------------------------------
 
 void json_writer::init() {
-  has_human_readable_format_ = true;
   // Reserve some reasonable storage for the character buffer. JSON grows
   // quickly, so we can start at 1kb to avoid a couple of small allocations in
   // the beginning.

--- a/libcaf_core/caf/json_writer.hpp
+++ b/libcaf_core/caf/json_writer.hpp
@@ -136,6 +136,8 @@ public:
 
   // -- overrides --------------------------------------------------------------
 
+  bool has_human_readable_format() const noexcept override;
+
   bool begin_object(type_id_t type, std::string_view name) override;
 
   bool end_object() override;

--- a/libcaf_core/caf/json_writer.hpp
+++ b/libcaf_core/caf/json_writer.hpp
@@ -4,19 +4,19 @@
 
 #pragma once
 
+#include "caf/byte_writer.hpp"
 #include "caf/detail/core_export.hpp"
-#include "caf/serializer.hpp"
 
 #include <vector>
 
 namespace caf {
 
 /// Serializes an inspectable object to a JSON-formatted string.
-class CAF_CORE_EXPORT json_writer : public serializer {
+class CAF_CORE_EXPORT json_writer : public byte_writer {
 public:
   // -- member types -----------------------------------------------------------
 
-  using super = serializer;
+  using super = byte_writer;
 
   /// Reflects the structure of JSON objects according to ECMA-404. This enum
   /// skips types such as `members` or `value` since they are not needed to
@@ -57,6 +57,8 @@ public:
   ~json_writer() override;
 
   // -- properties -------------------------------------------------------------
+
+  span<const std::byte> bytes() const override;
 
   /// Returns a string view into the internal buffer.
   /// @warning This view becomes invalid when calling any non-const member
@@ -132,7 +134,7 @@ public:
   /// Removes all characters from the buffer and restores the writer to its
   /// initial state.
   /// @warning Invalidates all string views into the buffer.
-  void reset();
+  void reset() override;
 
   // -- overrides --------------------------------------------------------------
 

--- a/libcaf_core/caf/serializer.cpp
+++ b/libcaf_core/caf/serializer.cpp
@@ -28,6 +28,32 @@ bool serializer::end_associative_array() {
   return end_sequence();
 }
 
+bool serializer::value(const strong_actor_ptr& ptr) {
+  auto aid = actor_id{0};
+  auto nid = node_id{};
+  if (ptr != nullptr) {
+    aid = ptr->id();
+    nid = ptr->node();
+  }
+  auto ok = object(ptr).pretty_name("actor").fields(field("id", aid),
+                                                    field("node", nid));
+  if (!ok) {
+    return false;
+  }
+  if (ptr != nullptr) {
+    if (auto err = save_actor(ptr, aid, nid)) {
+      set_error(err);
+      return false;
+    }
+  }
+  return true;
+}
+
+bool serializer::value(const weak_actor_ptr& ptr) {
+  auto tmp = ptr.lock();
+  return value(tmp);
+}
+
 bool serializer::list(const std::vector<bool>& xs) {
   if (!begin_sequence(xs.size()))
     return false;

--- a/libcaf_core/caf/serializer.hpp
+++ b/libcaf_core/caf/serializer.hpp
@@ -44,9 +44,7 @@ public:
     return context_;
   }
 
-  bool has_human_readable_format() const noexcept {
-    return has_human_readable_format_;
-  }
+  virtual bool has_human_readable_format() const noexcept = 0;
 
   // -- interface functions ----------------------------------------------------
 
@@ -162,6 +160,10 @@ public:
   /// @returns A non-zero error code on failure, `sec::success` otherwise.
   virtual bool value(span<const std::byte> x) = 0;
 
+  virtual bool value(const strong_actor_ptr& ptr);
+
+  virtual bool value(const weak_actor_ptr& ptr);
+
   using super::list;
 
   /// Adds each boolean in `xs` to the output. Derived classes can override this
@@ -170,11 +172,8 @@ public:
   virtual bool list(const std::vector<bool>& xs);
 
 protected:
-  /// Provides access to the ::proxy_registry and to the ::actor_system.
+  /// Provides access to the ::actor_system.
   actor_system* context_ = nullptr;
-
-  /// Configures whether client code should assume human-readable output.
-  bool has_human_readable_format_ = false;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/serializer.test.cpp
+++ b/libcaf_core/caf/serializer.test.cpp
@@ -30,6 +30,10 @@ public:
 
   // -- interface functions ----------------------------------------------------
 
+  bool has_human_readable_format() const noexcept override {
+    return false;
+  }
+
   bool begin_object(type_id_t, std::string_view) override {
     return state_;
   };

--- a/libcaf_core/caf/typed_actor.hpp
+++ b/libcaf_core/caf/typed_actor.hpp
@@ -232,7 +232,7 @@ public:
 
   template <class Inspector>
   friend bool inspect(Inspector& f, typed_actor& x) {
-    return inspect(f, x.ptr_);
+    return f.value(x.ptr_);
   }
 
   /// Releases the reference held by handle `x`. Using the


### PR DESCRIPTION
- Turn actor handles into a first-class type for serializers.
- Add new base type for serializers that operate on byte sequences.

(note: merges to the `release/2` branch, not `main`)