### PR TITLE
Mark mail types as `[[nodiscard]]`

### DIFF
--- a/libcaf_core/caf/anon_mail.hpp
+++ b/libcaf_core/caf/anon_mail.hpp
@@ -22,7 +22,7 @@ namespace caf {
 /// Provides a fluent interface for sending anonymous messages to actors at a
 /// specific point in time.
 template <message_priority Priority, class... Args>
-class anon_scheduled_mail_t {
+class [[nodiscard]] anon_scheduled_mail_t {
 public:
   anon_scheduled_mail_t(message&& content, actor_clock::time_point timeout)
     : content_(std::move(content)), timeout_(timeout) {
@@ -61,7 +61,7 @@ private:
 
 /// Provides a fluent interface for sending anonymous messages to actors.
 template <message_priority Priority, class... Args>
-class anon_mail_t {
+class [[nodiscard]] anon_mail_t {
 public:
   explicit anon_mail_t(message&& content) : content_(std::move(content)) {
     // nop

--- a/libcaf_core/caf/blocking_mail.hpp
+++ b/libcaf_core/caf/blocking_mail.hpp
@@ -14,7 +14,7 @@ namespace caf {
 /// Provides a fluent interface for sending asynchronous messages to actors at a
 /// specific point in time.
 template <message_priority Priority, class Trait, class... Args>
-class blocking_scheduled_mail_t
+class [[nodiscard]] blocking_scheduled_mail_t
   : public async_scheduled_mail_t<Priority, Trait, Args...> {
 public:
   using super = async_scheduled_mail_t<Priority, Trait, Args...>;
@@ -76,7 +76,8 @@ private:
 
 /// Provides a fluent interface for sending asynchronous messages to actors.
 template <message_priority Priority, class Trait, class... Args>
-class blocking_mail_t : public async_mail_base_t<Priority, Trait, Args...> {
+class [[nodiscard]] blocking_mail_t
+  : public async_mail_base_t<Priority, Trait, Args...> {
 public:
   using super = async_mail_base_t<Priority, Trait, Args...>;
 

--- a/libcaf_core/caf/event_based_mail.hpp
+++ b/libcaf_core/caf/event_based_mail.hpp
@@ -14,7 +14,7 @@ namespace caf {
 /// Provides a fluent interface for sending asynchronous messages to actors at a
 /// specific point in time.
 template <message_priority Priority, class Trait, class... Args>
-class event_based_scheduled_mail_t
+class [[nodiscard]] event_based_scheduled_mail_t
   : public async_scheduled_mail_t<Priority, Trait, Args...> {
 public:
   using super = async_scheduled_mail_t<Priority, Trait, Args...>;
@@ -84,7 +84,8 @@ private:
 
 /// Provides a fluent interface for sending asynchronous messages to actors.
 template <message_priority Priority, class Trait, class... Args>
-class event_based_mail_t : public async_mail_base_t<Priority, Trait, Args...> {
+class [[nodiscard]] event_based_mail_t
+  : public async_mail_base_t<Priority, Trait, Args...> {
 public:
   using super = async_mail_base_t<Priority, Trait, Args...>;
 


### PR DESCRIPTION
This makes it harder to incorrectly use `self->mail(…)` and `anon_mail(…)`; it's easy to accidentally forget to send mail or delegate it or send a request with it.