### PR TITLE
Remove remnants of caf profiler

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,6 @@ config = [
     ],
     // Default CMake flags for the builds.
     buildFlags: [
-        'CAF_ENABLE_ACTOR_PROFILER:BOOL=ON',
         'CAF_ENABLE_EXAMPLES:BOOL=ON',
         'CAF_ENABLE_ROBOT_TESTS:BOOL=ON',
         'CAF_ENABLE_RUNTIME_CHECKS:BOOL=ON',

--- a/cmake/build_config.hpp.in
+++ b/cmake/build_config.hpp.in
@@ -27,8 +27,6 @@
 
 #cmakedefine CAF_ENABLE_EXCEPTIONS
 
-#cmakedefine CAF_ENABLE_ACTOR_PROFILER
-
 #cmakedefine CAF_USE_STD_FORMAT
 
 // Backwards compatibility macros.


### PR DESCRIPTION
Noticed we had some stuff left form the CAF profiler which doesn't really exist since 0.18. 