### PR TITLE
Remove state from the serialization base types

### DIFF
--- a/libcaf_core/caf/binary_deserializer.cpp
+++ b/libcaf_core/caf/binary_deserializer.cpp
@@ -51,6 +51,14 @@ void unsafe_int_value(binary_deserializer& source, T& x) {
 
 } // namespace
 
+void binary_deserializer::set_error(error stop_reason) {
+  err_ = std::move(stop_reason);
+}
+
+error& binary_deserializer::get_error() noexcept {
+  return err_;
+}
+
 bool binary_deserializer::fetch_next_object_type(type_id_t& type) noexcept {
   type = invalid_type_id;
   emplace_error(sec::unsupported_operation,

--- a/libcaf_core/caf/binary_deserializer.hpp
+++ b/libcaf_core/caf/binary_deserializer.hpp
@@ -26,10 +26,6 @@ namespace caf {
 class CAF_CORE_EXPORT binary_deserializer
   : public load_inspector_base<binary_deserializer> {
 public:
-  // -- member types -----------------------------------------------------------
-
-  using super = load_inspector_base<binary_deserializer>;
-
   // -- constructors, destructors, and assignment operators --------------------
 
   template <class Container>
@@ -102,6 +98,10 @@ public:
   }
 
   // -- overridden member functions --------------------------------------------
+
+  void set_error(error stop_reason) override;
+
+  error& get_error() noexcept override;
 
   bool fetch_next_object_type(type_id_t& type) noexcept;
 
@@ -226,6 +226,9 @@ private:
 
   /// Provides access to the ::proxy_registry and to the ::actor_system.
   actor_system* context_;
+
+  /// The last occurred error.
+  error err_;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/binary_serializer.cpp
+++ b/libcaf_core/caf/binary_serializer.cpp
@@ -32,6 +32,14 @@ void binary_serializer::skip(size_t num_bytes) {
   write_pos_ += num_bytes;
 }
 
+void binary_serializer::set_error(error stop_reason) {
+  err_ = std::move(stop_reason);
+}
+
+error& binary_serializer::get_error() noexcept {
+  return err_;
+}
+
 bool binary_serializer::begin_sequence(size_t list_size) {
   // Use varbyte encoding to compress sequence size on the wire.
   // For 64-bit values, the encoded representation cannot get larger than 10

--- a/libcaf_core/caf/binary_serializer.hpp
+++ b/libcaf_core/caf/binary_serializer.hpp
@@ -93,6 +93,10 @@ public:
 
   // -- interface functions ----------------------------------------------------
 
+  void set_error(error stop_reason) override;
+
+  error& get_error() noexcept override;
+
   constexpr bool begin_object(type_id_t, std::string_view) noexcept {
     return true;
   }
@@ -200,6 +204,8 @@ private:
 
   /// Provides access to the ::proxy_registry and to the ::actor_system.
   actor_system* context_ = nullptr;
+
+  error err_;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/config_value.hpp
+++ b/libcaf_core/caf/config_value.hpp
@@ -224,7 +224,7 @@ public:
     if (detail::load(reader, tmp, token))
       return {std::move(tmp)};
     else
-      return {reader.move_error()};
+      return {std::move(reader.get_error())};
   }
 
   template <class T>
@@ -246,7 +246,7 @@ public:
       config_value_writer writer{this};
       if (writer.apply(x))
         return {};
-      return {writer.move_error()};
+      return {std::move(writer.get_error())};
     }
   }
 

--- a/libcaf_core/caf/config_value_reader.cpp
+++ b/libcaf_core/caf/config_value_reader.cpp
@@ -93,14 +93,12 @@ config_value_reader::associative_array::current() {
 
 config_value_reader::config_value_reader(const config_value* input) {
   st_.push(input);
-  has_human_readable_format_ = true;
 }
 
 config_value_reader::config_value_reader(const config_value* input,
                                          actor_system& sys)
-  : super(sys) {
+  : sys_(&sys) {
   st_.push(input);
-  has_human_readable_format_ = true;
 }
 
 config_value_reader::~config_value_reader() {
@@ -108,6 +106,22 @@ config_value_reader::~config_value_reader() {
 }
 
 // -- interface functions ------------------------------------------------------
+
+void config_value_reader::set_error(error stop_reason) {
+  err_ = std::move(stop_reason);
+}
+
+error& config_value_reader::get_error() noexcept {
+  return err_;
+}
+
+caf::actor_system* config_value_reader::sys() const noexcept {
+  return sys_;
+}
+
+bool config_value_reader::has_human_readable_format() const noexcept {
+  return true;
+}
 
 bool config_value_reader::fetch_next_object_type(type_id_t& type) {
   if (st_.empty()) {

--- a/libcaf_core/caf/config_value_reader.hpp
+++ b/libcaf_core/caf/config_value_reader.hpp
@@ -77,6 +77,14 @@ public:
 
   // -- interface functions ----------------------------------------------------
 
+  void set_error(error stop_reason) override;
+
+  error& get_error() noexcept override;
+
+  caf::actor_system* sys() const noexcept override;
+
+  bool has_human_readable_format() const noexcept override;
+
   bool fetch_next_object_type(type_id_t& type) override;
 
   bool begin_object(type_id_t type, std::string_view name) override;
@@ -150,10 +158,14 @@ private:
   // `settings` as fallback if no such field exists.
   bool fetch_object_type(const settings* obj, type_id_t& type);
 
+  actor_system* sys_ = nullptr;
+
   stack_type st_;
 
   // Stores on-the-fly converted values.
   std::vector<std::unique_ptr<config_value>> scratch_space_;
+
+  error err_;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/config_value_writer.cpp
+++ b/libcaf_core/caf/config_value_writer.cpp
@@ -37,11 +37,32 @@ namespace caf {
 
 // -- constructors, destructors, and assignment operators ----------------------
 
+config_value_writer::config_value_writer(config_value* dst, actor_system& sys)
+  : sys_(&sys) {
+  st_.push(dst);
+}
+
+config_value_writer::config_value_writer(config_value* dst) {
+  st_.push(dst);
+}
+
 config_value_writer::~config_value_writer() {
   // nop
 }
 
 // -- interface functions ------------------------------------------------------
+
+void config_value_writer::set_error(error stop_reason) {
+  err_ = std::move(stop_reason);
+}
+
+error& config_value_writer::get_error() noexcept {
+  return err_;
+}
+
+caf::actor_system* config_value_writer::sys() const noexcept {
+  return sys_;
+}
 
 bool config_value_writer::has_human_readable_format() const noexcept {
   return true;

--- a/libcaf_core/caf/config_value_writer.hpp
+++ b/libcaf_core/caf/config_value_writer.hpp
@@ -18,8 +18,6 @@ class CAF_CORE_EXPORT config_value_writer final : public serializer {
 public:
   // -- member types------------------------------------------------------------
 
-  using super = serializer;
-
   struct present_field {
     settings* parent;
     std::string_view name;
@@ -35,17 +33,19 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  config_value_writer(config_value* dst, actor_system& sys) : super(sys) {
-    st_.push(dst);
-  }
+  config_value_writer(config_value* dst, actor_system& sys);
 
-  explicit config_value_writer(config_value* dst) {
-    st_.push(dst);
-  }
+  explicit config_value_writer(config_value* dst);
 
   ~config_value_writer() override;
 
   // -- interface functions ----------------------------------------------------
+
+  void set_error(error stop_reason) override;
+
+  error& get_error() noexcept override;
+
+  caf::actor_system* sys() const noexcept override;
 
   bool has_human_readable_format() const noexcept override;
 
@@ -118,7 +118,11 @@ public:
 private:
   bool push(config_value&& x);
 
+  caf::actor_system* sys_ = nullptr;
+
   stack_type st_;
+
+  error err_;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/deserializer.cpp
+++ b/libcaf_core/caf/deserializer.cpp
@@ -38,12 +38,12 @@ bool deserializer::assert_next_object_name(std::string_view type_name) {
     if (type_name == found) {
       return true;
     }
-    err_ = format_to_error(sec::type_clash, "{}: expected type {}, got {}",
-                           __func__, type_name, found);
+    set_error(format_to_error(sec::type_clash, "{}: expected type {}, got {}",
+                              __func__, type_name, found));
     return false;
   }
-  err_ = format_to_error(sec::type_clash, "{}: expected type {}, got none",
-                         __func__, type_name);
+  set_error(format_to_error(sec::type_clash, "{}: expected type {}, got none",
+                            __func__, type_name));
   return false;
 }
 
@@ -73,7 +73,7 @@ bool deserializer::value(strong_actor_ptr& ptr) {
   }
   if (aid == 0 || !nid) {
     ptr = nullptr;
-  } else if (auto err = load_actor(ptr, context_, aid, nid)) {
+  } else if (auto err = load_actor(ptr, sys(), aid, nid)) {
     set_error(err);
     return false;
   }

--- a/libcaf_core/caf/deserializer.hpp
+++ b/libcaf_core/caf/deserializer.hpp
@@ -28,23 +28,15 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  deserializer() noexcept = default;
-
-  explicit deserializer(actor_system& sys) noexcept : context_(&sys) {
-    // nop
-  }
-
   virtual ~deserializer();
 
   // -- properties -------------------------------------------------------------
 
-  actor_system* context() const noexcept {
-    return context_;
-  }
+  /// Returns the actor system associated with this deserializer if available.
+  virtual caf::actor_system* sys() const noexcept = 0;
 
-  bool has_human_readable_format() const noexcept {
-    return has_human_readable_format_;
-  }
+  /// Returns whether the serialization format is human-readable.
+  virtual bool has_human_readable_format() const noexcept = 0;
 
   // -- interface functions ----------------------------------------------------
 
@@ -203,13 +195,6 @@ public:
   /// member function to pack the booleans, for example to avoid using one
   /// byte for each value in a binary output format.
   virtual bool list(std::vector<bool>& xs);
-
-protected:
-  /// Provides access to the ::proxy_registry and to the ::actor_system.
-  actor_system* context_ = nullptr;
-
-  /// Configures whether client code should assume human-readable output.
-  bool has_human_readable_format_ = false;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/detail/stringification_inspector.cpp
+++ b/libcaf_core/caf/detail/stringification_inspector.cpp
@@ -12,6 +12,14 @@
 
 namespace caf::detail {
 
+void stringification_inspector::set_error(error stop_reason) {
+  err_ = std::move(stop_reason);
+}
+
+error& stringification_inspector::get_error() noexcept {
+  return err_;
+}
+
 bool stringification_inspector::begin_object(type_id_t, std::string_view name) {
   sep();
   if (name != "std::string") {

--- a/libcaf_core/caf/detail/stringification_inspector.hpp
+++ b/libcaf_core/caf/detail/stringification_inspector.hpp
@@ -43,6 +43,10 @@ public:
 
   // -- serializer interface ---------------------------------------------------
 
+  void set_error(error stop_reason) override;
+
+  error& get_error() noexcept override;
+
   bool begin_object(type_id_t, std::string_view name);
 
   bool end_object();
@@ -264,6 +268,8 @@ private:
   std::string& result_;
 
   bool in_string_object_ = false;
+
+  error err_;
 };
 
 } // namespace caf::detail

--- a/libcaf_core/caf/hash/fnv.hpp
+++ b/libcaf_core/caf/hash/fnv.hpp
@@ -36,7 +36,15 @@ public:
     // nop
   }
 
-  static constexpr bool has_human_readable_format() noexcept {
+  void set_error(error stop_reason) override {
+    err_ = std::move(stop_reason);
+  }
+
+  error& get_error() noexcept override {
+    return err_;
+  }
+
+  constexpr bool has_human_readable_format() noexcept {
     return false;
   }
 
@@ -170,6 +178,8 @@ private:
       while (begin != end)
         result = (*begin++ ^ result) * 1099511628211ull;
   }
+
+  error err_;
 };
 
 } // namespace caf::hash

--- a/libcaf_core/caf/hash/sha1.hpp
+++ b/libcaf_core/caf/hash/sha1.hpp
@@ -31,7 +31,15 @@ public:
 
   sha1() noexcept;
 
-  static constexpr bool has_human_readable_format() noexcept {
+  void set_error(error stop_reason) override {
+    err_ = std::move(stop_reason);
+  }
+
+  error& get_error() noexcept override {
+    return err_;
+  }
+
+  constexpr bool has_human_readable_format() noexcept {
     return false;
   }
 
@@ -167,6 +175,9 @@ private:
 
   /// Stores 512-bit message blocks.
   std::array<uint8_t, 64> message_block_;
+
+  /// Stores the error state.
+  error err_;
 };
 
 } // namespace caf::hash

--- a/libcaf_core/caf/json_builder.cpp
+++ b/libcaf_core/caf/json_builder.cpp
@@ -83,6 +83,18 @@ json_value json_builder::seal() {
 
 // -- overrides ----------------------------------------------------------------
 
+void json_builder::set_error(error stop_reason) {
+  err_ = std::move(stop_reason);
+}
+
+error& json_builder::get_error() noexcept {
+  return err_;
+}
+
+caf::actor_system* json_builder::sys() const noexcept {
+  return sys_;
+}
+
 bool json_builder::has_human_readable_format() const noexcept {
   return true;
 }

--- a/libcaf_core/caf/json_builder.hpp
+++ b/libcaf_core/caf/json_builder.hpp
@@ -81,6 +81,12 @@ public:
 
   // -- overrides --------------------------------------------------------------
 
+  void set_error(error stop_reason) override;
+
+  error& get_error() noexcept override;
+
+  caf::actor_system* sys() const noexcept override;
+
   bool has_human_readable_format() const noexcept override;
 
   bool begin_object(type_id_t type, std::string_view name) override;
@@ -194,6 +200,9 @@ private:
 
   // -- member variables -------------------------------------------------------
 
+  /// The actor system associated with this builder.
+  actor_system* sys_ = nullptr;
+
   // Our output.
   detail::json::value* val_;
 
@@ -239,6 +248,8 @@ private:
   bool skip_object_type_annotation_ = false;
 
   std::string_view field_type_suffix_ = json_writer::field_type_suffix_default;
+
+  error err_;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/json_reader.cpp
+++ b/libcaf_core/caf/json_reader.cpp
@@ -115,12 +115,10 @@ namespace caf {
 
 json_reader::json_reader() {
   field_.reserve(8);
-  has_human_readable_format_ = true;
 }
 
-json_reader::json_reader(actor_system& sys) : super(sys) {
+json_reader::json_reader(actor_system& sys) : sys_(&sys) {
   field_.reserve(8);
-  has_human_readable_format_ = true;
 }
 
 json_reader::~json_reader() {
@@ -128,6 +126,14 @@ json_reader::~json_reader() {
 }
 
 // -- modifiers --------------------------------------------------------------
+
+void json_reader::set_error(error stop_reason) {
+  err_ = std::move(stop_reason);
+}
+
+error& json_reader::get_error() noexcept {
+  return err_;
+}
 
 bool json_reader::load(std::string_view json_text) {
   reset();
@@ -197,6 +203,14 @@ void json_reader::reset() {
 }
 
 // -- interface functions ------------------------------------------------------
+
+caf::actor_system* json_reader::sys() const noexcept {
+  return sys_;
+}
+
+bool json_reader::has_human_readable_format() const noexcept {
+  return true;
+}
 
 bool json_reader::fetch_next_object_type(type_id_t& type) {
   std::string_view type_name;

--- a/libcaf_core/caf/json_reader.hpp
+++ b/libcaf_core/caf/json_reader.hpp
@@ -123,6 +123,10 @@ public:
 
   // -- modifiers --------------------------------------------------------------
 
+  void set_error(error stop_reason) override;
+
+  error& get_error() noexcept override;
+
   /// Parses @p json_text into an internal representation. After loading the
   /// JSON input, the reader is ready for attempting to deserialize inspectable
   /// objects.
@@ -160,6 +164,10 @@ public:
   void reset();
 
   // -- overrides --------------------------------------------------------------
+
+  caf::actor_system* sys() const noexcept override;
+
+  bool has_human_readable_format() const noexcept override;
 
   bool fetch_next_object_type(type_id_t& type) override;
 
@@ -263,6 +271,8 @@ private:
     st_->emplace_back(std::forward<T>(x));
   }
 
+  actor_system* sys_ = nullptr;
+
   detail::monotonic_buffer_resource buf_;
 
   stack_type* st_ = nullptr;
@@ -279,6 +289,8 @@ private:
 
   /// Configures which ID mapper we use to translate between type IDs and names.
   const type_id_mapper* mapper_ = &default_mapper_;
+
+  error err_;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/json_writer.cpp
+++ b/libcaf_core/caf/json_writer.cpp
@@ -74,6 +74,18 @@ void json_writer::reset() {
 
 // -- overrides ----------------------------------------------------------------
 
+void json_writer::set_error(error stop_reason) {
+  err_ = std::move(stop_reason);
+}
+
+error& json_writer::get_error() noexcept {
+  return err_;
+}
+
+caf::actor_system* json_writer::sys() const noexcept {
+  return sys_;
+}
+
 bool json_writer::has_human_readable_format() const noexcept {
   return true;
 }

--- a/libcaf_core/caf/json_writer.hpp
+++ b/libcaf_core/caf/json_writer.hpp
@@ -50,7 +50,7 @@ public:
     init();
   }
 
-  explicit json_writer(actor_system& sys) : super(sys) {
+  explicit json_writer(actor_system& sys) : sys_(&sys) {
     init();
   }
 
@@ -137,6 +137,12 @@ public:
   void reset() override;
 
   // -- overrides --------------------------------------------------------------
+
+  void set_error(error stop_reason) override;
+
+  error& get_error() noexcept override;
+
+  caf::actor_system* sys() const noexcept override;
 
   bool has_human_readable_format() const noexcept override;
 
@@ -269,6 +275,9 @@ private:
 
   // -- member variables -------------------------------------------------------
 
+  // The actor system this writer belongs to.
+  actor_system* sys_ = nullptr;
+
   // The current level of indentation.
   size_t indentation_level_ = 0;
 
@@ -304,6 +313,9 @@ private:
 
   // Configures which ID mapper we use to translate between type IDs and names.
   const type_id_mapper* mapper_ = &default_mapper_;
+
+  /// The last error that occurred.
+  error err_;
 };
 
 /// @relates json_writer::type

--- a/libcaf_core/caf/load_inspector.hpp
+++ b/libcaf_core/caf/load_inspector.hpp
@@ -32,21 +32,13 @@ public:
 
   // -- properties -------------------------------------------------------------
 
-  void set_error(error stop_reason) {
-    err_ = std::move(stop_reason);
-  }
+  virtual void set_error(error stop_reason) = 0;
+
+  virtual error& get_error() noexcept = 0;
 
   template <class... Ts>
   void emplace_error(Ts&&... xs) {
-    err_ = make_error(std::forward<Ts>(xs)...);
-  }
-
-  const error& get_error() const noexcept {
-    return err_;
-  }
-
-  error&& move_error() noexcept {
-    return std::move(err_);
+    set_error(make_error(std::forward<Ts>(xs)...));
   }
 
   template <class... Ts>
@@ -388,9 +380,6 @@ public:
                                                            std::move(set_fun)};
     }
   }
-
-protected:
-  error err_;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/load_inspector_base.hpp
+++ b/libcaf_core/caf/load_inspector_base.hpp
@@ -140,7 +140,7 @@ public:
         if (auto err = set(std::move(tmp)); !err) {
           return true;
         } else {
-          super::set_error(std::move(err));
+          dref().set_error(std::move(err));
           return false;
         }
       } else {

--- a/libcaf_core/caf/save_inspector.hpp
+++ b/libcaf_core/caf/save_inspector.hpp
@@ -32,21 +32,13 @@ public:
 
   // -- properties -------------------------------------------------------------
 
-  void set_error(error stop_reason) {
-    err_ = std::move(stop_reason);
-  }
+  virtual void set_error(error stop_reason) = 0;
+
+  virtual error& get_error() noexcept = 0;
 
   template <class... Ts>
   void emplace_error(Ts&&... xs) {
-    err_ = make_error(std::forward<Ts>(xs)...);
-  }
-
-  const error& get_error() const noexcept {
-    return err_;
-  }
-
-  error&& move_error() noexcept {
-    return std::move(err_);
+    set_error(make_error(std::forward<Ts>(xs)...));
   }
 
   template <class... Ts>
@@ -259,9 +251,6 @@ public:
       get,
     };
   }
-
-protected:
-  error err_;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/serialization.test.cpp
+++ b/libcaf_core/caf/serialization.test.cpp
@@ -418,7 +418,7 @@ struct json_writer_wrapper {
   }
 
   deserializer_ptr make_deserializer() {
-    auto reader = std::make_shared<json_reader>(*sink.context());
+    auto reader = std::make_shared<json_reader>(*sink.sys());
     if (!reader->load(sink.str())) {
       test::runnable::current().fail("failed to load JSON: {}",
                                      reader->get_error());

--- a/libcaf_core/caf/serializer.hpp
+++ b/libcaf_core/caf/serializer.hpp
@@ -30,20 +30,14 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  serializer() noexcept = default;
-
-  explicit serializer(actor_system& sys) noexcept : context_(&sys) {
-    // nop
-  }
-
   virtual ~serializer();
 
   // -- properties -------------------------------------------------------------
 
-  actor_system* context() const noexcept {
-    return context_;
-  }
+  /// Returns the actor system associated with this serializer if available.
+  virtual caf::actor_system* sys() const noexcept = 0;
 
+  /// Returns whether the serialization format is human-readable.
   virtual bool has_human_readable_format() const noexcept = 0;
 
   // -- interface functions ----------------------------------------------------
@@ -170,10 +164,6 @@ public:
   /// member function to pack the booleans, for example to avoid using one
   /// byte for each value in a binary output format.
   virtual bool list(const std::vector<bool>& xs);
-
-protected:
-  /// Provides access to the ::actor_system.
-  actor_system* context_ = nullptr;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/serializer.test.cpp
+++ b/libcaf_core/caf/serializer.test.cpp
@@ -20,7 +20,7 @@ class test_serializer : public serializer {
 public:
   using super = serializer;
 
-  test_serializer(actor_system& sys, bool state) : super(sys), state_(state) {
+  test_serializer(actor_system& sys, bool state) : sys_(&sys), state_(state) {
     // nop
   }
 
@@ -29,6 +29,18 @@ public:
   }
 
   // -- interface functions ----------------------------------------------------
+
+  void set_error(error stop_reason) override {
+    err_ = std::move(stop_reason);
+  }
+
+  error& get_error() noexcept override {
+    return err_;
+  }
+
+  caf::actor_system* sys() const noexcept override {
+    return sys_;
+  }
 
   bool has_human_readable_format() const noexcept override {
     return false;
@@ -148,7 +160,9 @@ public:
   };
 
 private:
+  actor_system* sys_ = nullptr;
   bool state_ = false;
+  error err_;
 };
 
 } // namespace


### PR DESCRIPTION
Push state out of the serialization base types. Prepwork for further refactoring steps.