### PR TITLE
Add a `filter_map` step to flows

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -260,6 +260,7 @@ caf_add_component(
     caf/flow/op/zip_with.test.cpp
     caf/flow/scoped_coordinator.cpp
     caf/flow/single.test.cpp
+    caf/flow/step/filter_map.test.cpp
     caf/flow/step/ignore_elements.test.cpp
     caf/flow/step/skip_last.test.cpp
     caf/flow/step/take_last.test.cpp

--- a/libcaf_core/caf/flow/observable.hpp
+++ b/libcaf_core/caf/flow/observable.hpp
@@ -280,6 +280,11 @@ public:
   }
 
   template <class Predicate>
+  auto filter_map(Predicate predicate) && {
+    return add_step(step::filter_map<Predicate>{std::move(predicate)});
+  }
+
+  template <class Predicate>
   auto take_while(Predicate predicate) && {
     return add_step(step::take_while<Predicate>{std::move(predicate)});
   }
@@ -695,6 +700,13 @@ template <class T>
 template <class F>
 transformation<step::map<F>> observable<T>::map(F f) {
   return transform(step::map(std::move(f)));
+}
+
+template <class T>
+template <class Predicate>
+transformation<step::filter_map<Predicate>>
+observable<T>::filter_map(Predicate predicate) {
+  return transform(step::map{std::move(predicate)});
 }
 
 template <class T>

--- a/libcaf_core/caf/flow/observable_decl.hpp
+++ b/libcaf_core/caf/flow/observable_decl.hpp
@@ -123,6 +123,11 @@ public:
   template <class F>
   transformation<step::map<F>> map(F f);
 
+  /// Returns a transformation that applies `f` to each input and emits the
+  /// result of the function application for each item that is not `nullopt`.
+  template <class F>
+  transformation<step::filter_map<F>> filter_map(F f);
+
   /// When producing items faster than the consumer can consume them, the
   /// observable will buffer up to `buffer_size` items before raising an error.
   observable<T> on_backpressure_buffer(size_t buffer_size,

--- a/libcaf_core/caf/flow/step/all.hpp
+++ b/libcaf_core/caf/flow/step/all.hpp
@@ -5,6 +5,7 @@
 #include "caf/flow/step/do_on_next.hpp"
 #include "caf/flow/step/element_at.hpp"
 #include "caf/flow/step/filter.hpp"
+#include "caf/flow/step/filter_map.hpp"
 #include "caf/flow/step/ignore_elements.hpp"
 #include "caf/flow/step/map.hpp"
 #include "caf/flow/step/on_error_complete.hpp"

--- a/libcaf_core/caf/flow/step/filter_map.hpp
+++ b/libcaf_core/caf/flow/step/filter_map.hpp
@@ -1,0 +1,58 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+#include "caf/detail/type_traits.hpp"
+#include "caf/fwd.hpp"
+
+#include <utility>
+
+namespace caf::flow::step {
+
+template <class F>
+class filter_map {
+public:
+  using trait = detail::get_callable_trait_t<F>;
+
+  static_assert(!std::is_same_v<typename trait::result_type, void>,
+                "filter_map functions may not return void");
+
+  static_assert(trait::num_args == 1,
+                "filter_map functions must take exactly one argument");
+
+  using input_type = std::decay_t<detail::tl_head_t<typename trait::arg_types>>;
+
+  using output_type = std::decay_t<typename trait::result_type::value_type>;
+
+  explicit filter_map(F fn) : fn_(std::move(fn)) {
+    // nop
+  }
+
+  filter_map(filter_map&&) = default;
+  filter_map(const filter_map&) = default;
+  filter_map& operator=(filter_map&&) = default;
+  filter_map& operator=(const filter_map&) = default;
+
+  template <class Next, class... Steps>
+  bool on_next(const input_type& item, Next& next, Steps&... steps) {
+    auto mapped = fn_(item);
+    return mapped ? next.on_next(std::move(*mapped), steps...) : true;
+  }
+
+  template <class Next, class... Steps>
+  void on_complete(Next& next, Steps&... steps) {
+    next.on_complete(steps...);
+  }
+
+  template <class Next, class... Steps>
+  void on_error(const error& what, Next& next, Steps&... steps) {
+    next.on_error(what, steps...);
+  }
+
+private:
+  F fn_;
+};
+
+} // namespace caf::flow::step

--- a/libcaf_core/caf/flow/step/filter_map.test.cpp
+++ b/libcaf_core/caf/flow/step/filter_map.test.cpp
@@ -1,0 +1,31 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#include "caf/test/fixture/flow.hpp"
+#include "caf/test/scenario.hpp"
+
+using namespace caf;
+
+namespace {} // namespace
+
+WITH_FIXTURE(test::fixture::flow) {
+
+SCENARIO("filter_map filters and maps values") {
+  GIVEN("a list of integers") {
+    WHEN("filtering out odd ones with filter_map") {
+      THEN("the observer receives only even values") {
+        const auto outputs
+          = collect(make_observable().iota(0).take(10).filter_map(
+            [](int x) -> std::optional<int> {
+              return x % 2 == 0 ? std::make_optional(x) : std::nullopt;
+            }));
+        require(outputs.has_value());
+        const auto expected_outputs = std::vector<int>{0, 2, 4, 6, 8};
+        check_eq(*outputs, expected_outputs);
+      }
+    }
+  }
+}
+
+} // WITH_FIXTURE(test::fixture::flow)

--- a/libcaf_core/caf/flow/step/fwd.hpp
+++ b/libcaf_core/caf/flow/step/fwd.hpp
@@ -22,6 +22,9 @@ template <class>
 class filter;
 
 template <class>
+class filter_map;
+
+template <class>
 class ignore_elements;
 
 template <class>


### PR DESCRIPTION
Working with flows, I found myself very frequently writing code like this:

```cpp
my_observable
  .map([](foo_t foo) { return cond(foo) ? to_optional(move(foo)) : nullopt; })
  .filter([](const optional<foo_t>& foo) { return foo.has_value(); })
  .map([](optional<foo_t> foo) { return move(*foo); })
```

There's a less noisy way to write this with `flat_map`, but that's arguably not intuitive:

```cpp
my_observable
  .flat_map([self](auto x) {
    return cond(x)
      ? self->make_observable().just(move(x))
      : self->make_observable().empty();
  })
```

The change from this PR introduces `filter_map`, which shortens the entire thing to just this:

```cpp
my_observable
  .filter_map([](foo_t foo) { return cond(foo) ? to_optional(move(foo)) : nullopt; })
```