### PR TITLE
Add reuse-address flags to helptext and robot 

### DIFF
--- a/libcaf_io/caf/io/middleman.cpp
+++ b/libcaf_io/caf/io/middleman.cpp
@@ -115,7 +115,7 @@ public:
     if (const std::string* cfg_addr = get_if<std::string>(&cfg, "address"))
       if (*cfg_addr != "" && *cfg_addr != "0.0.0.0")
         addr = cfg_addr->c_str();
-    return start(port, addr, get_or(cfg, "reuse", false));
+    return start(port, addr, get_or(cfg, "reuse-address", false));
   }
 
   expected<uint16_t> start(uint16_t port, const char* in, bool reuse) {
@@ -196,7 +196,8 @@ void middleman::add_module_options(actor_system_config& cfg) {
     .add<size_t>("workers", "number of deserialization workers");
   config_option_adder{cfg.custom_options(), "caf.middleman.prometheus-http"}
     .add<uint16_t>("port", "listening port for incoming scrapes")
-    .add<std::string>("address", "bind address for the HTTP server socket");
+    .add<std::string>("address", "bind address for the HTTP server socket")
+    .add<bool>("reuse-address", "configure socket with SO_REUSEADDR");
   // Add the defaults to the config so they show up in --dump-config.
   auto& grp = put_dictionary(cfg.content, "caf.middleman");
   auto default_id = std::string{defaults::middleman::app_identifier};

--- a/libcaf_net/caf/net/middleman.cpp
+++ b/libcaf_net/caf/net/middleman.cpp
@@ -143,7 +143,8 @@ void* middleman::subtype_ptr() {
 void middleman::add_module_options(actor_system_config& cfg) {
   config_option_adder{cfg.custom_options(), "caf.net.prometheus-http"}
     .add<uint16_t>("port", "listening port for incoming scrapes")
-    .add<std::string>("address", "bind address for the HTTP server socket");
+    .add<std::string>("address", "bind address for the HTTP server socket")
+    .add<bool>("reuse-address", "configure socket with SO_REUSEADDR");
   config_option_adder{cfg.custom_options(), "caf.net.prometheus-http.tls"}
     .add<std::string>("key-file", "path to the Promehteus private key file")
     .add<std::string>("cert-file", "path to the Promehteus private cert file");

--- a/robot/middleman/driver.cpp
+++ b/robot/middleman/driver.cpp
@@ -118,7 +118,7 @@ int server(actor_system& sys, std::string_view mode, uint16_t port) {
   auto& mm = sys.middleman();
   if (mode == "remote_actor") {
     auto cell = sys.spawn(cell_impl, 42);
-    auto actual_port = io::publish(cell, port);
+    auto actual_port = io::publish(cell, port, nullptr, true);
     if (!actual_port) {
       std::cout << "failed to open port " << port << ": "
                 << to_string(actual_port.error()) << '\n';
@@ -127,7 +127,7 @@ int server(actor_system& sys, std::string_view mode, uint16_t port) {
     return EXIT_SUCCESS;
   }
   if (mode == "remote_spawn") {
-    auto actual_port = mm.open(port);
+    auto actual_port = mm.open(port, nullptr, true);
     if (!actual_port) {
       std::cout << "failed to open port " << port << ": "
                 << to_string(actual_port.error()) << '\n';
@@ -138,7 +138,7 @@ int server(actor_system& sys, std::string_view mode, uint16_t port) {
   if (mode == "remote_lookup") {
     auto cell = sys.spawn(cell_impl, 23);
     sys.registry().put("cell", cell);
-    auto actual_port = mm.open(port);
+    auto actual_port = mm.open(port, nullptr, true);
     if (!actual_port) {
       std::cout << "failed to open port " << port << ": "
                 << to_string(actual_port.error()) << '\n';
@@ -151,7 +151,7 @@ int server(actor_system& sys, std::string_view mode, uint16_t port) {
   if (mode == "unpublish" || mode == "monitor_node"
       || mode == "deserialization_error") {
     auto ctrl = sys.spawn(controller_impl);
-    auto actual_port = io::publish(ctrl, port);
+    auto actual_port = io::publish(ctrl, port, nullptr, true);
     if (!actual_port) {
       std::cout << "failed to open port " << port << ": "
                 << to_string(actual_port.error()) << '\n';
@@ -166,7 +166,7 @@ int server(actor_system& sys, std::string_view mode, uint16_t port) {
   }
   if (mode == "rendezvous") {
     auto cell = sys.spawn(actor_hdl_cell_impl);
-    auto actual_port = io::publish(cell, port);
+    auto actual_port = io::publish(cell, port, nullptr, true);
     if (!actual_port) {
       std::cout << "failed to open port " << port << ": "
                 << to_string(actual_port.error()) << '\n';

--- a/robot/middleman/middleman.robot
+++ b/robot/middleman/middleman.robot
@@ -109,7 +109,7 @@ Deserialization Error
 Prometheus
     [Tags]    Middleman
     [Teardown]    Terminate All Processes
-    Start Process    ${BINARY_PATH}  -s  -m  prometheus  --caf.middleman.prometheus-http.port  ${PR_SERVER_PORT}
+    Start Process    ${BINARY_PATH}  -s  -m  prometheus  --caf.middleman.prometheus-http.port  ${PR_SERVER_PORT}  --caf.middleman.prometheus-http.reuse-address
     Wait Until Keyword Succeeds    5s    25ms    Check If Reachable  ${PR_HTTP_URL}
     ${resp}=     GET    ${PR_HTTP_URL}
     ${content}=  Decode Bytes To String  ${resp.content}  utf-8


### PR DESCRIPTION
This PR consists of two commits:
- First part introduces the `reuse-address` CLI switch for `prometheus-http` (for both net::middleman and io::middleman). This was enabled in the codebase, but somehow not in the config part. Also renames the `reuse` to `reuse-address` in `io` to be consistent with `net`. Since it wasn't possible to configure this beforehand this it not be a breaking change.
- Second part forces all sockets to reuse addresses in the `robot-middleman-driver`, since this robot test would fail on consecutive runs. 

Relates #1994 