### PR TITLE
Make it harder to misuse concurrency limits in `merge`

### DIFF
--- a/libcaf_core/caf/flow/observable.hpp
+++ b/libcaf_core/caf/flow/observable.hpp
@@ -861,7 +861,7 @@ struct has_max_concurrent_arg : std::false_type {};
 
 template <class T, class... Ts>
 struct has_max_concurrent_arg<T, Ts...> {
-  static constexpr bool value = std::is_unsigned_v<std::decay_t<T>>;
+  static constexpr bool value = std::is_same_v<std::decay_t<T>, size_t>;
 };
 
 template <class... Ts>

--- a/libcaf_core/caf/flow/observable_builder.hpp
+++ b/libcaf_core/caf/flow/observable_builder.hpp
@@ -199,7 +199,7 @@ public:
   /// @param xs The remaining observables to merge.
   template <class Input, class... Inputs>
   auto merge(Input x, Inputs... xs) {
-    if constexpr (std::is_unsigned_v<Input>) {
+    if constexpr (std::is_same_v<Input, size_t>) {
       return merge_with_concurrency(x, std::move(xs)...);
     } else {
       return merge_with_concurrency(sizeof...(Inputs) + 1, std::move(x),

--- a/libcaf_core/caf/flow/op/merge.test.cpp
+++ b/libcaf_core/caf/flow/op/merge.test.cpp
@@ -545,7 +545,7 @@ TEST("the merge operator allows setting a maximum concurrency") {
   auto snk = coordinator()->add_child(std::in_place_type<snk_t>);
   SECTION("observable_builder") {
     SECTION("merging multiple observables") {
-      auto uut = make_observable().merge(17u, in1, in2);
+      auto uut = make_observable().merge(size_t{17}, in1, in2);
       auto sub = uut.subscribe(snk->as_observer());
       auto* ptr = dynamic_cast<caf::flow::op::merge_sub<int>*>(sub.ptr());
       check_eq(ptr->max_concurrent(), 17u);
@@ -554,7 +554,7 @@ TEST("the merge operator allows setting a maximum concurrency") {
   }
   SECTION("operator") {
     SECTION("merging multiple observables") {
-      auto uut = in1.merge(17u, in2);
+      auto uut = in1.merge(size_t{17}, in2);
       auto sub = uut.subscribe(snk->as_observer());
       auto* ptr = dynamic_cast<caf::flow::op::merge_sub<int>*>(sub.ptr());
       check_eq(ptr->max_concurrent(), 17u);
@@ -562,7 +562,7 @@ TEST("the merge operator allows setting a maximum concurrency") {
     }
     SECTION("calling merge on an observable<observable<T>>") {
       auto in = make_observable().from_container(std::vector{in1, in2});
-      auto uut = std::move(in).merge(17u);
+      auto uut = std::move(in).merge(size_t{17});
       auto sub = uut.subscribe(snk->as_observer());
       auto* ptr = dynamic_cast<caf::flow::op::merge_sub<int>*>(sub.ptr());
       check_eq(ptr->max_concurrent(), 17u);


### PR DESCRIPTION
Without this change it's easy to accidentally set the new concurrency limit option for the `merge` operator to something like `std::numeric_limits<T>::max()`, which would silently overflow on platforms where `sizeof(size_t) < sizeof(T)`.