### PR TITLE
Add startup check for socket manager in HTTP client factory

### DIFF
--- a/libcaf_net/caf/net/actor_shell.test.cpp
+++ b/libcaf_net/caf/net/actor_shell.test.cpp
@@ -144,7 +144,7 @@ TEST("actor shells can receive messages") {
   auto app = app_t::make(actor{self});
   auto transport = net::octet_stream::transport::make(fd1, std::move(app));
   auto mgr = net::socket_manager::make(&mpx, std::move(transport));
-  mpx.start(mgr);
+  require(mpx.start(mgr));
   fd1.id = net::invalid_socket_id;
   actor hdl;
   self->receive([&hdl](actor& x) { hdl = x; },
@@ -164,7 +164,7 @@ TEST("actor shells can send asynchronous messages") {
   auto app = app_t::make(actor{self});
   auto transport = net::octet_stream::transport::make(fd1, std::move(app));
   auto mgr = net::socket_manager::make(&mpx, std::move(transport));
-  mpx.start(mgr);
+  require(mpx.start(mgr));
   fd1.id = net::invalid_socket_id;
   auto msg = "hello actor shell\n"s;
   auto n = net::write(fd2, as_bytes(make_span(msg)));
@@ -193,7 +193,7 @@ TEST("actor shells can send request messages") {
   auto app = app_t::make(actor{self}, cb);
   auto transport = net::octet_stream::transport::make(fd1, std::move(app));
   auto mgr = net::socket_manager::make(&mpx, std::move(transport));
-  mpx.start(mgr);
+  require(mpx.start(mgr));
   fd1.id = net::invalid_socket_id;
   auto msg = "request"s;
   self->receive([msg](get_atom) { return msg; },
@@ -225,7 +225,7 @@ TEST("actor shells can use flows") {
   auto app = app_t::make(actor{self}, cb);
   auto transport = net::octet_stream::transport::make(fd1, std::move(app));
   auto mgr = net::socket_manager::make(&mpx, std::move(transport));
-  mpx.start(mgr);
+  require(mpx.start(mgr));
   fd1.id = net::invalid_socket_id;
   auto msg = "request"s;
   self->receive([msg](get_atom) { return msg; },

--- a/libcaf_net/caf/net/http/async_client.test.cpp
+++ b/libcaf_net/caf/net/http/async_client.test.cpp
@@ -19,8 +19,6 @@
 
 #include "caf/raise_error.hpp"
 
-#include <iostream>
-
 #ifdef CAF_WINDOWS
 #  include <winsock2.h>
 #else
@@ -115,7 +113,9 @@ struct fixture {
     auto client = net::http::client::make(std::move(app));
     auto transport = net::octet_stream::transport::make(fd2, std::move(client));
     auto mgr = net::socket_manager::make(mpx.get(), std::move(transport));
-    mpx->start(mgr);
+    if (!mpx->start(mgr)) {
+      CAF_RAISE_ERROR(std::logic_error, "failed to start socket manager");
+    }
     fd2.id = net::invalid_socket_id;
     return {res, disposable{mgr}};
   }

--- a/libcaf_net/caf/net/http/client.test.cpp
+++ b/libcaf_net/caf/net/http/client.test.cpp
@@ -129,7 +129,9 @@ struct fixture {
     auto client = net::http::client::make(std::move(app));
     auto transport = net::octet_stream::transport::make(fd2, std::move(client));
     auto mgr = net::socket_manager::make(mpx.get(), std::move(transport));
-    mpx->start(mgr);
+    if (!mpx->start(mgr)) {
+      CAF_RAISE_ERROR(std::logic_error, "failed to start socket manager");
+    }
     fd2.id = net::invalid_socket_id;
   }
 
@@ -140,7 +142,9 @@ struct fixture {
     auto client = net::http::client::make(std::move(app));
     auto transport = net::octet_stream::transport::make(fd2, std::move(client));
     auto mgr = net::socket_manager::make(mpx.get(), std::move(transport));
-    mpx->start(mgr);
+    if (!mpx->start(mgr)) {
+      CAF_RAISE_ERROR(std::logic_error, "failed to start socket manager");
+    }
     fd2.id = net::invalid_socket_id;
   }
 

--- a/libcaf_net/caf/net/http/client_factory.cpp
+++ b/libcaf_net/caf/net/http/client_factory.cpp
@@ -123,8 +123,10 @@ client_factory::do_start_impl(Conn conn, http::method method,
   auto transport = transport_t::make(std::move(conn), std::move(http_client));
   transport->active_policy().connect();
   auto ptr = net::socket_manager::make(config_->mpx, std::move(transport));
-  config_->mpx->start(ptr);
-  return std::pair{std::move(ret), disposable{std::move(ptr)}};
+  if (config_->mpx->start(ptr))
+    return std::pair{std::move(ret), disposable{std::move(ptr)}};
+  return make_error(sec::disposed,
+                    "failed to register socket manager to net::multiplexer");
 }
 
 expected<std::pair<async::future<response>, disposable>>

--- a/libcaf_net/caf/net/http/client_factory.cpp
+++ b/libcaf_net/caf/net/http/client_factory.cpp
@@ -125,7 +125,7 @@ client_factory::do_start_impl(Conn conn, http::method method,
   auto ptr = net::socket_manager::make(config_->mpx, std::move(transport));
   if (config_->mpx->start(ptr))
     return std::pair{std::move(ret), disposable{std::move(ptr)}};
-  return make_error(sec::disposed,
+  return make_error(sec::logic_error,
                     "failed to register socket manager to net::multiplexer");
 }
 

--- a/libcaf_net/caf/net/http/server.test.cpp
+++ b/libcaf_net/caf/net/http/server.test.cpp
@@ -125,7 +125,9 @@ struct fixture {
     auto server = net::http::server::make(std::move(app));
     auto transport = net::octet_stream::transport::make(fd2, std::move(server));
     auto mgr = net::socket_manager::make(mpx.get(), std::move(transport));
-    mpx->start(mgr);
+    if (!mpx->start(mgr)) {
+      CAF_RAISE_ERROR(std::logic_error, "failed to start socket manager");
+    }
     fd2.id = net::invalid_socket_id;
   }
 
@@ -136,7 +138,9 @@ struct fixture {
     auto server = net::http::server::make(std::move(app));
     auto transport = net::octet_stream::transport::make(fd2, std::move(server));
     auto mgr = net::socket_manager::make(mpx.get(), std::move(transport));
-    mpx->start(mgr);
+    if (!mpx->start(mgr)) {
+      CAF_RAISE_ERROR(std::logic_error, "failed to start socket manager");
+    }
     fd2.id = net::invalid_socket_id;
   }
 

--- a/libcaf_net/caf/net/http/server_factory.cpp
+++ b/libcaf_net/caf/net/http/server_factory.cpp
@@ -175,8 +175,10 @@ expected<disposable> do_start_impl(Config& cfg, Acceptor acc,
                                             cfg.max_connections,
                                             cfg.monitored_actors);
   auto ptr = net::socket_manager::make(cfg.mpx, std::move(impl));
-  cfg.mpx->start(ptr);
-  return expected<disposable>{disposable{std::move(ptr)}};
+  if (cfg.mpx->start(ptr))
+    return expected<disposable>{disposable{std::move(ptr)}};
+  return make_error(sec::logic_error,
+                    "failed to register socket manager to net::multiplexer");
 }
 
 } // namespace

--- a/libcaf_net/caf/net/lp/client_factory.cpp
+++ b/libcaf_net/caf/net/lp/client_factory.cpp
@@ -22,8 +22,10 @@ expected<disposable> do_start_impl(Config& cfg, Conn conn,
   auto transport = internal::make_transport(std::move(conn), std::move(impl));
   transport->active_policy().connect();
   auto ptr = socket_manager::make(cfg.mpx, std::move(transport));
-  cfg.mpx->start(ptr);
-  return expected<disposable>{disposable{std::move(ptr)}};
+  if (cfg.mpx->start(ptr))
+    return expected<disposable>{disposable{std::move(ptr)}};
+  return make_error(sec::logic_error,
+                    "failed to register socket manager to net::multiplexer");
 }
 
 } // namespace

--- a/libcaf_net/caf/net/lp/framing.cpp
+++ b/libcaf_net/caf/net/lp/framing.cpp
@@ -206,8 +206,9 @@ disposable run_impl(multiplexer& mpx, Conn& conn,
   auto transport = internal::make_transport(std::move(conn),
                                             framing::make(std::move(bridge)));
   auto manager = net::socket_manager::make(&mpx, std::move(transport));
-  mpx.start(manager);
-  return manager->as_disposable();
+  if (mpx.start(manager))
+    return manager->as_disposable();
+  return disposable{};
 }
 
 } // namespace

--- a/libcaf_net/caf/net/lp/framing.test.cpp
+++ b/libcaf_net/caf/net/lp/framing.test.cpp
@@ -156,7 +156,9 @@ struct fixture {
     auto client = net::lp::framing::make(std::move(app));
     auto transport = net::octet_stream::transport::make(fd2, std::move(client));
     auto mgr = net::socket_manager::make(mpx.get(), std::move(transport));
-    mpx->start(mgr);
+    if (!mpx->start(mgr)) {
+      CAF_RAISE_ERROR(std::logic_error, "failed to start socket manager");
+    }
     fd2.id = net::invalid_socket_id;
   }
 

--- a/libcaf_net/caf/net/lp/server_factory.cpp
+++ b/libcaf_net/caf/net/lp/server_factory.cpp
@@ -93,8 +93,10 @@ do_start_impl(Config& cfg, Acceptor acc,
   auto handler = internal::make_accept_handler(std::move(conn_acc),
                                                cfg.max_connections);
   auto ptr = net::socket_manager::make(cfg.mpx, std::move(handler));
-  cfg.mpx->start(ptr);
-  return expected<disposable>{disposable{std::move(ptr)}};
+  if (cfg.mpx->start(ptr))
+    return expected<disposable>{disposable{std::move(ptr)}};
+  return make_error(sec::logic_error,
+                    "failed to register socket manager to net::multiplexer");
 }
 
 } // namespace

--- a/libcaf_net/caf/net/multiplexer.hpp
+++ b/libcaf_net/caf/net/multiplexer.hpp
@@ -82,7 +82,7 @@ public:
 
   /// Registers `mgr` for initialization in the multiplexer's thread.
   /// @threadsafe
-  virtual bool start(socket_manager_ptr mgr) = 0;
+  [[nodiscard]] virtual bool start(socket_manager_ptr mgr) = 0;
 
   /// Signals the multiplexer to initiate shutdown.
   /// @threadsafe

--- a/libcaf_net/caf/net/multiplexer.hpp
+++ b/libcaf_net/caf/net/multiplexer.hpp
@@ -82,7 +82,7 @@ public:
 
   /// Registers `mgr` for initialization in the multiplexer's thread.
   /// @threadsafe
-  virtual void start(socket_manager_ptr mgr) = 0;
+  virtual bool start(socket_manager_ptr mgr) = 0;
 
   /// Signals the multiplexer to initiate shutdown.
   /// @threadsafe

--- a/libcaf_net/caf/net/octet_stream/client_factory.cpp
+++ b/libcaf_net/caf/net/octet_stream/client_factory.cpp
@@ -28,8 +28,10 @@ expected<disposable> do_start_impl(Config& cfg, Conn conn,
   auto transport = internal::make_transport(std::move(conn), std::move(bridge));
   transport->active_policy().connect();
   auto ptr = net::socket_manager::make(cfg.mpx, std::move(transport));
-  cfg.mpx->start(ptr);
-  return disposable{std::move(ptr)};
+  if (cfg.mpx->start(ptr))
+    return expected<disposable>{disposable{std::move(ptr)}};
+  return make_error(sec::logic_error,
+                    "failed to register socket manager to net::multiplexer");
 }
 
 } // namespace

--- a/libcaf_net/caf/net/octet_stream/server_factory.cpp
+++ b/libcaf_net/caf/net/octet_stream/server_factory.cpp
@@ -107,8 +107,10 @@ do_start_impl(Config& cfg, Acceptor acc,
                                                cfg.max_connections,
                                                cfg.monitored_actors);
   auto ptr = net::socket_manager::make(cfg.mpx, std::move(handler));
-  cfg.mpx->start(ptr);
-  return expected<disposable>{disposable{std::move(ptr)}};
+  if (cfg.mpx->start(ptr))
+    return expected<disposable>{disposable{std::move(ptr)}};
+  return make_error(sec::logic_error,
+                    "failed to register socket manager to net::multiplexer");
 }
 
 } // namespace

--- a/libcaf_net/caf/net/typed_actor_shell.test.cpp
+++ b/libcaf_net/caf/net/typed_actor_shell.test.cpp
@@ -160,7 +160,7 @@ TEST("actor shells can receive messages") {
   auto app = app_t::make(actor{self});
   auto transport = net::octet_stream::transport::make(fd1, std::move(app));
   auto mgr = net::socket_manager::make(&mpx, std::move(transport));
-  mpx.start(mgr);
+  require(mpx.start(mgr));
   fd1.id = net::invalid_socket_id;
   testee_actor hdl;
   self->receive([&hdl](testee_actor& x) { hdl = x; },
@@ -180,7 +180,7 @@ TEST("actor shells can send asynchronous messages") {
   auto app = app_t::make(actor{self});
   auto transport = net::octet_stream::transport::make(fd1, std::move(app));
   auto mgr = net::socket_manager::make(&mpx, std::move(transport));
-  mpx.start(mgr);
+  require(mpx.start(mgr));
   fd1.id = net::invalid_socket_id;
   auto msg = "hello actor shell\n"s;
   auto n = net::write(fd2, as_bytes(make_span(msg)));
@@ -209,7 +209,7 @@ TEST("actor shells can send request messages") {
   auto app = app_t::make(actor{self}, cb);
   auto transport = net::octet_stream::transport::make(fd1, std::move(app));
   auto mgr = net::socket_manager::make(&mpx, std::move(transport));
-  mpx.start(mgr);
+  require(mpx.start(mgr));
   fd1.id = net::invalid_socket_id;
   auto msg = "request"s;
   self->receive([msg](get_atom) { return msg; },
@@ -241,7 +241,7 @@ TEST("actor shells can use flows") {
   auto app = app_t::make(actor{self}, cb);
   auto transport = net::octet_stream::transport::make(fd1, std::move(app));
   auto mgr = net::socket_manager::make(&mpx, std::move(transport));
-  mpx.start(mgr);
+  require(mpx.start(mgr));
   fd1.id = net::invalid_socket_id;
   auto msg = "request"s;
   self->receive([msg](get_atom) { return msg; },

--- a/libcaf_net/tests/drivers/autobahn.cpp
+++ b/libcaf_net/tests/drivers/autobahn.cpp
@@ -307,7 +307,8 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
   mgr->add_cleanup_listener(caf::make_single_shot_action([] { //
     shutdown_flag = true;
   }));
-  mpx->start(mgr);
+  if (!mpx->start(mgr))
+    return EXIT_FAILURE;
   // Wait until the server shuts down.
   while (!shutdown_flag.load()) {
     std::this_thread::sleep_for(1s);


### PR DESCRIPTION
Closes #1954.

Hard to test this since all our multiplexer tests run the `mpx` thread locally. However, I confirmed the code from the ticket running. 
This code does break ABI. I don't know a way of checking if `mpx` is shutting down locally. Comparing the number of running socket managers doesn't work since running the current manager it's delayed. 
I've had many issues with trying to manually run `mng->dispose()` since it's also delayed and run in the `mpx` thread which is no longer running. Then I've tried running `abort` or `handle_error` but those ended in an segmentation fault. 

In the end, checking the boolean from start and manually returning an error is the simplest solution I've found. 