### PR TITLE
Make `from_container` work with `std::generator`

### DIFF
--- a/libcaf_core/caf/flow/op/from_generator.hpp
+++ b/libcaf_core/caf/flow/op/from_generator.hpp
@@ -27,8 +27,11 @@ public:
   // -- constructors, destructors, and assignment operators --------------------
 
   from_generator_sub(coordinator* parent, observer<output_type> out,
-                     const Generator& gen, const std::tuple<Steps...>& steps)
-    : parent_(parent), out_(std::move(out)), gen_(gen), steps_(steps) {
+                     Generator gen, const std::tuple<Steps...>& steps)
+    : parent_(parent),
+      out_(std::move(out)),
+      gen_(std::make_shared<Generator>(std::move(gen))),
+      steps_(steps) {
     // nop
   }
 
@@ -116,7 +119,7 @@ private:
   }
 
   void pull(size_t n) {
-    auto fn = [this, n](auto&... steps) { gen_.pull(n, steps..., *this); };
+    auto fn = [this, n](auto&... steps) { gen_->pull(n, steps..., *this); };
     std::apply(fn, steps_);
   }
 
@@ -127,7 +130,7 @@ private:
   error err_;
   size_t demand_ = 0;
   observer<output_type> out_;
-  Generator gen_;
+  std::shared_ptr<Generator> gen_;
   std::tuple<Steps...> steps_;
 };
 


### PR DESCRIPTION
This fixes `from_container` to work with `std::generator`. Additionally, it makes `from_generator` and `from_callable` work with non-copyable callbacks.

I'm opening this pull request primarily for discussion, as this currently breaks the `retry` flow operator when used in combination with `from_container`, as that no longer restarts the iteration from the start of the container. I am uncertain what to do about that. I do personally think that the benefit of this change far outweighs its downsides, but this should definitely be discussed.

Note that this is a breaking change for public-facing APIs, so _iff_ this change makes it should probably land in the `release/2` branch.

See also:
- Fixes #1968