### PR TITLE
List available modules in the manual

### DIFF
--- a/manual/core/ConfiguringActorApplications.rst
+++ b/manual/core/ConfiguringActorApplications.rst
@@ -47,18 +47,22 @@ function would resemble the following (pseudo) code:
 .. code-block:: C++
 
   int main(int argc, char** argv) {
-    // Initialize the global type information before anything else.
-    init_global_meta_objects<...>();
+    // Initialize user defined types and messages if needed.
+    init_global_meta_objects<custom_types_1>();
+    // Initialize the global type information before creating the config.
     core::init_global_meta_objects();
     // Create the config.
     actor_system_config cfg;
     // Read CLI options.
-    cfg.parse(argc, argv);
+    auto err = cfg.parse(argc, argv);
+    if (err)
+      return EXIT_FAILURE;
     // Return immediately if a help text was printed.
-    if (cfg.cli_helptext_printed)
+    if (cfg.helptext_printed())
       return 0;
-    // Load modules.
-    cfg.load<...>();
+    // Load modules (the provided example will load `net::middleman`).
+    net::middleman::init_global_meta_objects();
+    cfg.load<net::middleman>();
     // Create the actor system.
     actor_system sys{cfg};
     // Run user-defined code.

--- a/manual/core/ConfiguringActorApplications.rst
+++ b/manual/core/ConfiguringActorApplications.rst
@@ -93,6 +93,43 @@ module loaded looks as follows:
 
 .. _system-config-module:
 
+Available Modules
+-----------------
+
+The core functionalities of CAF can be extended by loading different modules at
+runtime. This modular design enables users to fine-tune which features of CAF
+to include in their applications, ensuring they don't introduce overhead for
+unused functionality. Here is a comprehensive list of available modules:
+
+.. list-table:: CAF Modules
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Module
+     - Description
+   * - ``openssl::manager``
+     - Adds SSL/TLS encryption support to network communications. Enables
+       secure communication between actors over untrusted networks. Requires
+       OpenSSL libraries.
+   * - ``io::middleman``
+     - Provides I/O and socket support, and enables communication between actor
+       applications by managing proxy actor instances representing remote
+       actors.
+   * - ``net::middleman``
+     - Provides modern network interfaces with improved type safety and
+       configuration options. Designed as the successor to the traditional I/O
+       middleman.
+
+The exact modules available may vary depending on the way CAF was configured
+and compiled. Every module can be disabled at build time.
+
+.. note::
+
+  Note that the ``io::middleman`` module is in maintenance mode and will be
+  deprecated in favor of the ``net::middleman`` module in a future instance
+  of CAF.
+
+
 Loading Modules
 ---------------
 
@@ -119,7 +156,7 @@ Alternatively, users can load modules in user-defined config classes.
      }
    };
 
-The third option is to simply call ``x.load<mod1>()`` on a config
+The third option is to simply call ``cfg.load<mod1>()`` on a config
 object *before* initializing an actor system with it.
 
 .. _system-config-options:


### PR DESCRIPTION
Closes #1522.

Listed the active CAF modules. 

Also, used the opportunity to update to `cfg.helptext_printed()` member function call, and clarify how to load modules in the manual system start since this came up a few times in chat. 