### PR TITLE
Add a system metric to track running actors by name

### DIFF
--- a/libcaf_core/caf/abstract_actor.cpp
+++ b/libcaf_core/caf/abstract_actor.cpp
@@ -190,7 +190,7 @@ void abstract_actor::register_at_system() {
   if (getf(is_registered_flag))
     return;
   setf(is_registered_flag);
-  [[maybe_unused]] auto count = home_system().registry().inc_running();
+  [[maybe_unused]] auto count = home_system().registry().inc_running(name());
   log::system::debug("actor {} increased running count to {}", id(), count);
 }
 
@@ -198,7 +198,7 @@ void abstract_actor::unregister_from_system() {
   if (!getf(is_registered_flag))
     return;
   unsetf(is_registered_flag);
-  [[maybe_unused]] auto count = home_system().registry().dec_running();
+  [[maybe_unused]] auto count = home_system().registry().dec_running(name());
   log::system::debug("actor {} decreased running count to {}", id(), count);
 }
 

--- a/libcaf_core/caf/actor_registry.cpp
+++ b/libcaf_core/caf/actor_registry.cpp
@@ -13,6 +13,7 @@
 #include "caf/scoped_actor.hpp"
 #include "caf/sec.hpp"
 #include "caf/stateful_actor.hpp"
+#include "caf/telemetry/metric_family_impl.hpp"
 
 #include <limits>
 #include <mutex>
@@ -77,7 +78,8 @@ void actor_registry::erase(actor_id key) {
   }
 }
 
-size_t actor_registry::inc_running() {
+size_t actor_registry::inc_running(std::string_view name) {
+  ++*system_.base_metrics().running_actors_by_name->get_or_add({{"name", name}});
   return ++*system_.base_metrics().running_actors;
 }
 
@@ -85,7 +87,8 @@ size_t actor_registry::running() const {
   return static_cast<size_t>(system_.base_metrics().running_actors->value());
 }
 
-size_t actor_registry::dec_running() {
+size_t actor_registry::dec_running(std::string_view name) {
+  --*system_.base_metrics().running_actors_by_name->get_or_add({{"name", name}});
   size_t new_val = --*system_.base_metrics().running_actors;
   if (new_val <= 1) {
     std::unique_lock<std::mutex> guard(running_mtx_);

--- a/libcaf_core/caf/actor_registry.hpp
+++ b/libcaf_core/caf/actor_registry.hpp
@@ -10,7 +10,6 @@
 #include "caf/actor_control_block.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/fwd.hpp"
-#include "caf/telemetry/int_gauge.hpp"
 
 #include <atomic>
 #include <condition_variable>
@@ -20,6 +19,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace caf {
 
@@ -53,11 +53,11 @@ public:
 
   /// Increases running-actors-count by one.
   /// @returns the increased count.
-  size_t inc_running();
+  size_t inc_running(std::string_view name);
 
   /// Decreases running-actors-count by one.
   /// @returns the decreased count.
-  size_t dec_running();
+  size_t dec_running(std::string_view name);
 
   /// Returns the number of currently running actors.
   size_t running() const;

--- a/libcaf_core/caf/actor_registry.hpp
+++ b/libcaf_core/caf/actor_registry.hpp
@@ -64,7 +64,8 @@ public:
 
   /// Blocks the caller until running-actors-count becomes `expected`
   /// (must be either 0 or 1).
-  void await_running_count_equal(size_t expected) const;
+  bool await_running_count_equal(size_t expected,
+                                 timespan timeout = infinite) const;
 
   /// Returns the actor associated with `key` or `invalid_actor`.
   template <class T = strong_actor_ptr>

--- a/libcaf_core/caf/actor_system.cpp
+++ b/libcaf_core/caf/actor_system.cpp
@@ -257,7 +257,9 @@ auto make_base_metrics(telemetry::metric_registry& reg) {
     reg.counter_singleton("caf.system", "processed-messages",
                           "Number of processed messages.", "1", true),
     reg.gauge_singleton("caf.system", "running-actors",
-                        "Number of currently running actors."),
+                     "Number of currently running actors."),
+    reg.gauge_family("caf.system", "running-actors-by-name", {{"name"}},
+                     "Number of currently running actors by name."),
     reg.gauge_singleton("caf.system", "queued-messages",
                         "Number of messages in all mailboxes.", "1", true),
   };

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -166,6 +166,10 @@ public:
     /// Tracks the current number of running actors in the system.
     telemetry::int_gauge* running_actors;
 
+    /// Tracks the current number of running actors in the system keyed by the
+    /// actor name.
+    telemetry::int_gauge_family* running_actors_by_name;
+
     /// Counts the total number of messages that wait in a mailbox.
     telemetry::int_gauge* queued_messages;
   };

--- a/libcaf_core/caf/blocking_actor.cpp
+++ b/libcaf_core/caf/blocking_actor.cpp
@@ -137,7 +137,7 @@ public:
     intrusive_ptr_release(self_->ctrl());
     sys.release_private_thread(thread_);
     if (!hidden_) {
-      [[maybe_unused]] auto count = sys.registry().dec_running();
+      [[maybe_unused]] auto count = sys.registry().dec_running(self_->name());
       log::system::debug("actor {} decreased running count to {}", id, count);
     }
     return resumable::done;
@@ -170,7 +170,7 @@ void blocking_actor::launch(scheduler*, bool, bool hide) {
   // Note: must *not* call register_at_system() to stop actor cleanup from
   // decrementing the count before releasing the thread.
   if (!hide) {
-    [[maybe_unused]] auto count = sys.registry().inc_running();
+    [[maybe_unused]] auto count = sys.registry().inc_running(name());
     log::system::debug("actor {} increased running count to {}", id(), count);
   }
   thread->resume(new blocking_actor_runner(this, thread, hide));

--- a/manual/core/Metrics.rst
+++ b/manual/core/Metrics.rst
@@ -480,6 +480,11 @@ caf.system.running-actors
   - **Type**: ``int_gauge``
   - **Label dimensions**: none.
 
+caf.system.running-actors-by-name
+  - Tracks the current number of running actors itemized by their actor name.
+  - **Type**: ``int_gauge``
+  - **Label dimensions**: ``name``.
+
 caf.system.processed-messages
   - Counts the total number of processed messages.
   - **Type**: ``int_counter``


### PR DESCRIPTION
This change adds an additional actor system metric to track the number of running actors by name.

This is useful both as a general metric as well as when dealing with an actor system that is unable to shut down cleanly. In the second case, this metric can be collected to reveal which actors are remaining and blocking termination.

The function `await_running_count_equal()` now takes an optional timeout value to support the second use-case.

Implementation note:
I opted to add an additional metric instead of extending the existing `running-actors` metric because the number of currently running actor is returned by `inc_running()` and `dec_running()`, and calculating the total based on a gauge family is more costly than accessing a single atomic counter in a contested and potentially hot part of the code.

Preceding discussion: https://github.com/actor-framework/actor-framework/issues/1997#issuecomment-2634935723