### PR TITLE
Validate periods for buffer and interval operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   `actor_cast`. This resolves an issue with `send` that could lead to undefined
   behavior (#1972).
 - Add missing export declaration for the `caf::net::prometheus` symbol (#2042).
+- The `buffer` and `interval` operators now properly check the time period
+  parameter and produce an error if the period is zero or negative (#2030).
+  Passing an invalid delay parameter to `to_stream` or `to_typed_stream`
+  likewise produces a stream that immediately calls `on_error` on any client
+  that tries to subscribe to it.
 
 ## [1.0.2] - 2024-10-30
 

--- a/libcaf_core/caf/flow/observable_builder.hpp
+++ b/libcaf_core/caf/flow/observable_builder.hpp
@@ -157,6 +157,13 @@ public:
   template <class Rep, class Period>
   observable<int64_t> interval(std::chrono::duration<Rep, Period> initial_delay,
                                std::chrono::duration<Rep, Period> period) {
+    using duration_t = std::chrono::duration<Rep, Period>;
+    if (period <= duration_t::zero()) {
+      auto what = make_error(sec::invalid_argument,
+                             "interval operators require a positive period");
+      return parent_->add_child_hdl(std::in_place_type<op::fail<int64_t>>,
+                                    std::move(what));
+    }
     return parent_->add_child_hdl(std::in_place_type<op::interval>,
                                   initial_delay, period);
   }

--- a/libcaf_core/caf/flow/op/buffer.test.cpp
+++ b/libcaf_core/caf/flow/op/buffer.test.cpp
@@ -487,4 +487,24 @@ SCENARIO("on_request actions can turn into no-ops") {
   }
 }
 
+SCENARIO("a buffer must have a positive period") {
+  GIVEN("a buffer operator") {
+    WHEN("calling .buffer(3, 0s)") {
+      THEN("the operator raises an error") {
+        auto err = std::make_shared<error>();
+        auto num_items = std::make_shared<int>(0);
+        make_observable()
+          .iota(1)
+          .take(100)
+          .buffer(3, 0s)
+          .do_on_error([err](const error& what) { *err = what; })
+          .for_each([num_items](const cow_vector<int>&) { *num_items += 1; });
+        dispatch_messages();
+        check_eq(*num_items, 0);
+        check_eq(*err, caf::sec::invalid_argument);
+      }
+    }
+  }
+}
+
 } // WITH_FIXTURE(fixture)

--- a/libcaf_core/caf/flow/op/cold.hpp
+++ b/libcaf_core/caf/flow/op/cold.hpp
@@ -5,9 +5,7 @@
 #pragma once
 
 #include "caf/detail/atomic_ref_counted.hpp"
-#include "caf/flow/observer.hpp"
 #include "caf/flow/op/base.hpp"
-#include "caf/flow/subscription.hpp"
 
 namespace caf::flow::op {
 

--- a/libcaf_core/caf/flow/op/fail.hpp
+++ b/libcaf_core/caf/flow/op/fail.hpp
@@ -4,11 +4,10 @@
 
 #pragma once
 
+#include "caf/disposable.hpp"
 #include "caf/error.hpp"
-#include "caf/flow/observable.hpp"
 #include "caf/flow/observer.hpp"
 #include "caf/flow/op/cold.hpp"
-#include "caf/flow/subscription.hpp"
 
 namespace caf::flow::op {
 

--- a/libcaf_core/caf/flow/op/interval.cpp
+++ b/libcaf_core/caf/flow/op/interval.cpp
@@ -114,7 +114,7 @@ interval::interval(coordinator* parent, timespan initial_delay, timespan period)
 interval::interval(coordinator* parent, timespan initial_delay, timespan period,
                    int64_t max_val)
   : super(parent),
-    initial_delay_(initial_delay),
+    initial_delay_(std::max(initial_delay, timespan::zero())),
     period_(period),
     max_(max_val) {
   // nop

--- a/libcaf_core/caf/flow/op/interval.test.cpp
+++ b/libcaf_core/caf/flow/op/interval.test.cpp
@@ -94,4 +94,25 @@ SCENARIO("a timer is an observable interval with a single value") {
   }
 }
 
+SCENARIO("an interval must have a positive period") {
+  GIVEN("an observable interval") {
+    WHEN("an observer subscribes to it with a negative period") {
+      THEN("the coordinator fails the observable") {
+        auto outputs = i64_list{};
+        auto err = std::make_shared<error>();
+        auto obs
+          = coordinator()
+              ->make_observable()
+              .interval(50ms, -25ms)
+              .take(3)
+              .do_on_error([err](const error& what) { *err = std::move(what); })
+              .for_each([&outputs](int64_t x) { outputs.emplace_back(x); });
+        run_flows();
+        check(outputs.empty());
+        check_eq(*err, sec::invalid_argument);
+      }
+    }
+  }
+}
+
 } // WITH_FIXTURE(fixture)


### PR DESCRIPTION
Fix a deadlock when passing a zero or negative duration parameter to `buffer` and `interval` operators. When passing an invalid argument, CAF now produces an observable that fails immediately upon subscription. Trying to create a stream with an invalid maximum delay likewise produces a stream that aborts immediately.

Closes #2030.