### PR TITLE
Fix parsing of flags on the command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   `actor_cast`. This resolves an issue with `send` that could lead to undefined
   behavior (#1972).
 - Add missing export declaration for the `caf::net::prometheus` symbol (#2042).
+- Boolean flags now accept arguments on the command line (#2048). For example,
+  `--foo=true` is now equivalent to `--foo` and `--foo=false` will set the flag
+  to `false`. Short options like `-f` only accept the argument when passing it
+  without a space, e.g., `-ffalse`.
 
 ## [1.0.2] - 2024-10-30
 

--- a/libcaf_core/caf/config_option_set.test.cpp
+++ b/libcaf_core/caf/config_option_set.test.cpp
@@ -242,6 +242,16 @@ TEST("string parameters") {
   check_eq(read<std::string>({"-vfoobar"}), "foobar");
 }
 
+TEST("boolean parameters") {
+  opts.add<bool>("value,v", "some value");
+  check_eq(read<bool>({"-v"}), true);
+  check_eq(read<bool>({"-vtrue"}), true);
+  check_eq(read<bool>({"-vfalse"}), false);
+  check_eq(read<bool>({"--value"}), true);
+  check_eq(read<bool>({"--value=true"}), true);
+  check_eq(read<bool>({"--value=false"}), false);
+}
+
 TEST("flat CLI options") {
   key = "foo.bar";
   opts.add<std::string>("?foo", "bar,b", "some value");


### PR DESCRIPTION
Boolean flags now accept arguments on the command line (#2048). For example, `--foo=true` is now equivalent to `--foo` and `--foo=false` will set the flag to `false`. Short options like `-f` only accept the argument when passing it without a space, e.g., `-ffalse`.