### PR TITLE
Use localtime_s on all windows platforms

### DIFF
--- a/libcaf_core/caf/detail/print.cpp
+++ b/libcaf_core/caf/detail/print.cpp
@@ -11,7 +11,7 @@ namespace caf::detail {
 
 size_t print_timestamp(char* buf, size_t buf_size, time_t ts, size_t ms) {
   tm time_buf;
-#ifdef CAF_MSVC
+#ifdef CAF_WINDOWS
   localtime_s(&time_buf, &ts);
 #else
   localtime_r(&ts, &time_buf);


### PR DESCRIPTION
Currently Windows builds fail under MSYS/UCRT64, as localtime_r is not in the standard library. Choosing based on platform instead of compiler would fix this, although I'm unsure if this has any adverse implications for Cygwin?