### PR TITLE
Add `mail_cache::stash` overload with no arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - New flow operators: `retry`, `combine_latest` and `on_error_resume_next`.
 - New `with_userinfo` member function for URIs that allows setting the user-info
   sub-component without going through an URI builder.
+- The utility class `mail_cache` received a `stash` overload that takes no
+  arguments for stashing the current message.
 
 ### Fixed
 

--- a/libcaf_core/caf/mail_cache.cpp
+++ b/libcaf_core/caf/mail_cache.cpp
@@ -4,11 +4,24 @@
 
 #include "caf/mail_cache.hpp"
 
-#include "caf/config.hpp"
+#include "caf/detail/critical.hpp"
 #include "caf/detail/sync_request_bouncer.hpp"
 #include "caf/local_actor.hpp"
+#include "caf/mailbox_element.hpp"
 
 namespace caf {
+
+mailbox_element* safe_current_mailbox_element(local_actor* self) {
+  auto* ptr = self->current_mailbox_element();
+  if (!ptr) {
+#ifdef CAF_ENABLE_EXCEPTIONS
+    throw std::runtime_error("mail cache: current element is null");
+#else
+    CAF_CRITICAL("mail cache: current element is null");
+#endif
+  }
+  return ptr;
+}
 
 mail_cache::~mail_cache() {
   if (!empty()) {
@@ -21,13 +34,24 @@ mail_cache::~mail_cache() {
 }
 
 void mail_cache::stash(message msg) {
+  return do_stash(safe_current_mailbox_element(self_), std::move(msg));
+}
+
+void mail_cache::do_stash_current() {
+  auto* ptr = safe_current_mailbox_element(self_);
+  return do_stash(ptr, std::move(ptr->payload));
+}
+
+void mail_cache::do_stash(mailbox_element* src, message&& msg) {
+  if (size_ == max_size_) {
 #ifdef CAF_ENABLE_EXCEPTIONS
-  if (size_ == max_size_)
     throw std::runtime_error("mail cache exceeded its maximum size");
+#else
+    CAF_CRITICAL("mail cache exceeded its maximum size");
 #endif
-  auto element = make_mailbox_element(self_->current_sender(),
-                                      self_->take_current_message_id(),
-                                      std::move(msg));
+  }
+  auto element = make_mailbox_element(src->sender, src->mid, std::move(msg));
+  src->mid.mark_as_answered();
   ++size_;
   elements_.push(element.release());
 }

--- a/libcaf_core/caf/mail_cache.hpp
+++ b/libcaf_core/caf/mail_cache.hpp
@@ -4,11 +4,10 @@
 
 #pragma once
 
+#include "caf/delegated.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/intrusive/stack.hpp"
-#include "caf/intrusive_ptr.hpp"
 #include "caf/mailbox_element.hpp"
-#include "caf/ref_counted.hpp"
 
 #include <cstddef>
 
@@ -51,10 +50,29 @@ public:
   /// Adds `msg` to the cache.
   void stash(message msg);
 
+  /// Adds the current message to the cache. Returns a `delegated<Ts...>` if
+  /// `Ts...` is not empty, otherwise returns a `delegated<message>`.
+  /// This is a convenience function for `stash(self->current_message())` that
+  /// also returns a `delegated` for returning from the current message handler
+  /// (can be safely ignored if not needed).
+  template <class... Ts>
+  auto stash() {
+    do_stash_current();
+    if constexpr (sizeof...(Ts) == 0) {
+      return delegated<message>{};
+    } else {
+      return delegated<Ts...>{};
+    }
+  }
+
   /// Removes all elements from the cache and returns them to the mailbox.
   void unstash();
 
 private:
+  void do_stash(mailbox_element* src, message&& msg);
+
+  void do_stash_current();
+
   local_actor* self_;
   size_t max_size_ = 0;
   size_t size_ = 0;

--- a/libcaf_core/caf/mail_cache.test.cpp
+++ b/libcaf_core/caf/mail_cache.test.cpp
@@ -9,6 +9,7 @@
 #include "caf/actor_from_state.hpp"
 #include "caf/actor_system.hpp"
 #include "caf/actor_system_config.hpp"
+#include "caf/detail/build_config.hpp"
 #include "caf/event_based_actor.hpp"
 #include "caf/scoped_actor.hpp"
 
@@ -17,8 +18,9 @@ using namespace std::literals;
 
 namespace {
 
-struct testee_state {
-  explicit testee_state(event_based_actor* self) : self(self), cache(self, 5) {
+// Switches behaviors to have an explicit "ready" transition.
+struct testee_state1 {
+  explicit testee_state1(event_based_actor* self) : self(self), cache(self, 5) {
     // nop
   }
 
@@ -55,24 +57,72 @@ struct fixture {
   }
 };
 
+// Uses an "initialized" flag instead of behavior switching.
+struct testee_state2 {
+  explicit testee_state2(event_based_actor* self) : self(self), cache(self, 5) {
+    // nop
+  }
+
+  behavior make_behavior() {
+    return {
+      [this](ok_atom) {
+        if (!initialized) {
+          initialized = true;
+          cache.unstash();
+        }
+      },
+      [this](get_atom) -> result<int> {
+        if (!initialized) {
+          return cache.stash<int>();
+        }
+        return value;
+      },
+      [this](add_atom, int increment) {
+        if (!initialized) {
+          cache.stash();
+          return;
+        }
+        value += increment;
+      },
+    };
+  }
+
+  bool initialized = false;
+  event_based_actor* self;
+  mail_cache cache;
+  int value = 0;
+};
+
 } // namespace
 
 WITH_FIXTURE(fixture) {
 
 TEST("a mail cache can buffer messages until the actor is ready") {
-  auto aut = sys.spawn(actor_from_state<testee_state>);
-  self->mail(add_atom_v, 1).send(aut);
-  self->mail(add_atom_v, 2).send(aut);
-  self->mail(add_atom_v, 3).send(aut);
-  self->mail(ok_atom_v).send(aut);
-  self->mail(add_atom_v, 4).send(aut);
-  auto res = self->mail(get_atom_v).request(aut, 1s).receive<int>();
-  check_eq(res, 10);
+  SECTION("behavior switching") {
+    auto aut = sys.spawn(actor_from_state<testee_state1>);
+    self->mail(add_atom_v, 1).send(aut);
+    self->mail(add_atom_v, 2).send(aut);
+    self->mail(add_atom_v, 3).send(aut);
+    self->mail(ok_atom_v).send(aut);
+    self->mail(add_atom_v, 4).send(aut);
+    auto res = self->mail(get_atom_v).request(aut, 1s).receive<int>();
+    check_eq(res, 10);
+  }
+  SECTION("initialized flag") {
+    auto aut = sys.spawn(actor_from_state<testee_state2>);
+    self->mail(add_atom_v, 1).send(aut);
+    self->mail(add_atom_v, 2).send(aut);
+    self->mail(add_atom_v, 3).send(aut);
+    self->mail(ok_atom_v).send(aut);
+    self->mail(add_atom_v, 4).send(aut);
+    auto res = self->mail(get_atom_v).request(aut, 1s).receive<int>();
+    check_eq(res, 10);
+  }
 }
 
 #ifdef CAF_ENABLE_EXCEPTIONS
 TEST("a mail cache throws when exceeding its capacity") {
-  auto aut = sys.spawn(actor_from_state<testee_state>);
+  auto aut = sys.spawn(actor_from_state<testee_state1>);
   self->mail(add_atom_v, 1).send(aut);
   self->mail(add_atom_v, 2).send(aut);
   self->mail(add_atom_v, 3).send(aut);


### PR DESCRIPTION
Picks up a user suggestion in chat to make the API a bit more flexible.