### PR TITLE
Fix build issues on Apple clang

### DIFF
--- a/libcaf_core/caf/config.hpp
+++ b/libcaf_core/caf/config.hpp
@@ -69,8 +69,7 @@
     _Pragma("clang diagnostic push")                                           \
     _Pragma("clang diagnostic ignored \"-Winvalid-offsetof\"")
 #  define CAF_PUSH_STRINGOP_OVERREAD_WARNING                                   \
-    _Pragma("clang diagnostic push")                                           \
-    _Pragma("clang diagnostic ignored \"-Wstringop-overread\"")
+    _Pragma("clang diagnostic push")
 #  define CAF_POP_WARNINGS                                                     \
     _Pragma("clang diagnostic pop")
 #  define CAF_COMPILER_VERSION                                                 \

--- a/libcaf_core/caf/detail/split_join.hpp
+++ b/libcaf_core/caf/detail/split_join.hpp
@@ -35,8 +35,9 @@ public:
     auto f = [this](scheduled_actor*, message& msg) -> result<message> {
       auto rp = this->make_response_promise();
       split_(workset_, msg);
-      for (auto& x : workset_)
-        this->send(x.first, std::move(x.second));
+      for (auto& x : workset_) {
+        this->mail(std::move(x.second)).send(x.first);
+      }
       auto g = [this, rp](scheduled_actor*,
                           message& res) mutable -> result<message> {
         join_(value_, res);


### PR DESCRIPTION
- The `stringop-overread` flag does not exist on Clang
- The `split_join_collector` tries to use a member function that no longer exists