### PR TITLE
Revert "Add `mail_cache::stash` overload with no arguments"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - New flow operators: `retry`, `combine_latest` and `on_error_resume_next`.
 - New `with_userinfo` member function for URIs that allows setting the user-info
   sub-component without going through an URI builder.
-- The utility class `mail_cache` received a `stash` overload that takes no
-  arguments for stashing the current message.
 
 ### Fixed
 

--- a/libcaf_core/caf/mail_cache.hpp
+++ b/libcaf_core/caf/mail_cache.hpp
@@ -4,10 +4,11 @@
 
 #pragma once
 
-#include "caf/delegated.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/intrusive/stack.hpp"
+#include "caf/intrusive_ptr.hpp"
 #include "caf/mailbox_element.hpp"
+#include "caf/ref_counted.hpp"
 
 #include <cstddef>
 
@@ -50,29 +51,10 @@ public:
   /// Adds `msg` to the cache.
   void stash(message msg);
 
-  /// Adds the current message to the cache. Returns a `delegated<Ts...>` if
-  /// `Ts...` is not empty, otherwise returns a `delegated<message>`.
-  /// This is a convenience function for `stash(self->current_message())` that
-  /// also returns a `delegated` for returning from the current message handler
-  /// (can be safely ignored if not needed).
-  template <class... Ts>
-  auto stash() {
-    do_stash_current();
-    if constexpr (sizeof...(Ts) == 0) {
-      return delegated<message>{};
-    } else {
-      return delegated<Ts...>{};
-    }
-  }
-
   /// Removes all elements from the cache and returns them to the mailbox.
   void unstash();
 
 private:
-  void do_stash(mailbox_element* src, message&& msg);
-
-  void do_stash_current();
-
   local_actor* self_;
   size_t max_size_ = 0;
   size_t size_ = 0;


### PR DESCRIPTION
Reverts actor-framework/actor-framework#2062

I remembered why we didn't add this overload when designing the class. It makes it super easy to write really nasty bugs. If you would call the no-args version in a default handler (primary use case), you'd store an empty message in the cache because CAF will move the message into the handler argument. CAF will also move individual values out of a message whenever it can, so again, calling the no-args version will do the wrong thing.