### PR TITLE
Fix test flag in CMake

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -409,7 +409,7 @@ caf_add_log_component(system)
 
 # Bandaid: currently produces an internal compiler error on MSVC. Disable until
 # further investigation.
-if(NOT MSVC)
+if(NOT MSVC AND CAF_ENABLE_TESTING)
   target_sources(caf-core-test PRIVATE caf/behavior.test.cpp)
 endif()
 


### PR DESCRIPTION
When including CAF with FetchContent we get an error about accessing caf-core-test with doesn't exist. Probably also breaks all CAF builds with tests disabled. 