### PR TITLE
Launch background tasks after multiplexer was run

### DIFF
--- a/libcaf_net/caf/net/middleman.cpp
+++ b/libcaf_net/caf/net/middleman.cpp
@@ -78,6 +78,7 @@ void launch_prom_server(actor_system& sys, const prom_config& cfg) {
 }
 
 void launch_background_tasks(actor_system& sys) {
+  auto lg = log::net::trace("");
   auto& cfg = sys.config();
   if (auto pcfg = get_as<prom_config>(cfg, "caf.net.prometheus-http")) {
     launch_prom_server(sys, *pcfg);
@@ -111,10 +112,10 @@ middleman::~middleman() {
 void middleman::start() {
   auto fn = [this] {
     mpx_->set_thread_id();
-    launch_background_tasks(sys_);
     mpx_->run();
   };
   mpx_thread_ = sys_.launch_thread("caf.net.mpx", thread_owner::system, fn);
+  launch_background_tasks(sys_);
 }
 
 void middleman::stop() {


### PR DESCRIPTION
Closes #2060.

The `net::middleman` background tasks, in this case the Prometheus scraper, where run before the multiplexer was run. This means the multiplexer never saw a write event on the 0 socket.

If any kind of server was launched after the initial start, it would send an event to the multiplexer, and it would read the prometheus server data, and start handing it as well. But if no other server was started, then the multiplexer thread will be idle.

Simplest solution, without touching the multiplexer logic, was to reorder the start. Hope this is fine. Alternatively, I could go into the multiplexer details.  