### PR TITLE
Fix `ssl_ctx_chain_if`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Use `localtime_s` on all Windows platforms to fix a build error with
   MSYS/UCRT64 (#2059).
 - Fix rendering of nested JSON lists (#2068).
+- Add missing `pragma once` guards to multiple headers under `caf/net/ssl/`.
+- Fix the behavior of `use_certificate_file_if` and `use_private_key_file_if`.
+  Both functions did not leave the `caf::net::ssl::context` unchanged if one of
+  the arguments was invalid but instead applied the invalid arguments to the
+  context regardless, resulting in an OpenSSL error.
 
 ## [1.0.2] - 2024-10-30
 

--- a/libcaf_net/CMakeLists.txt
+++ b/libcaf_net/CMakeLists.txt
@@ -103,6 +103,7 @@ caf_add_component(
     caf/net/socket_manager.cpp
     caf/net/ssl/connection.cpp
     caf/net/ssl/context.cpp
+    caf/net/ssl/context.test.cpp
     caf/net/ssl/dtls.cpp
     caf/net/ssl/errc.cpp
     caf/net/ssl/format.cpp

--- a/libcaf_net/caf/net/ssl/context.hpp
+++ b/libcaf_net/caf/net/ssl/context.hpp
@@ -287,7 +287,7 @@ expected<net::ssl::context>
 ssl_ctx_chain_if(net::ssl::context& ctx, std::string_view fn_error,
                  bool (net::ssl::context::*fn)(Ts...), Args&... args) {
   using net::ssl::context;
-  if ((!args && ...) || (ctx.*fn)(args.get()...))
+  if (!(args && ...) || (ctx.*fn)(args.get()...))
     return expected<context>{std::move(ctx)};
   else
     return expected<context>{context::last_error_or_unexpected(fn_error)};

--- a/libcaf_net/caf/net/ssl/context.test.cpp
+++ b/libcaf_net/caf/net/ssl/context.test.cpp
@@ -1,0 +1,63 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#include "caf/net/ssl/context.hpp"
+
+#include "caf/test/test.hpp"
+
+#include "caf/net/ssl/format.hpp"
+#include "caf/net/ssl/tls.hpp"
+
+namespace ssl = caf::net::ssl;
+
+TEST("invalid arguments to ..._if DSL functions leave the context unchanged") {
+  SECTION("add_verify_path_if") {
+    auto res = ssl::context::make_server(ssl::tls::v1_0)
+                 .and_then(ssl::add_verify_path_if(nullptr));
+    check_has_value(res);
+  }
+  SECTION("load_verify_file_if") {
+    auto res = ssl::context::make_server(ssl::tls::v1_0)
+                 .and_then(ssl::load_verify_file_if(nullptr));
+    check_has_value(res);
+  }
+  SECTION("use_password_if") {
+    auto res = ssl::context::make_server(ssl::tls::v1_0)
+                 .and_then(ssl::use_password_if(nullptr));
+    check_has_value(res);
+  }
+  SECTION("use_certificate_file_if") {
+    SECTION("invalid path") {
+      auto res
+        = ssl::context::make_server(ssl::tls::v1_0)
+            .and_then(ssl::use_certificate_file_if(nullptr, ssl::format::pem));
+      check_has_value(res);
+    }
+    SECTION("invalid format") {
+      auto res = ssl::context::make_server(ssl::tls::v1_0)
+                   .and_then(ssl::use_certificate_file_if(
+                     "/foo/bar", std::optional<ssl::format>{}));
+      check_has_value(res);
+    }
+  }
+  SECTION("use_certificate_chain_file_if") {
+    auto res = ssl::context::make_server(ssl::tls::v1_0)
+                 .and_then(ssl::use_certificate_chain_file_if(nullptr));
+    check_has_value(res);
+  }
+  SECTION("use_private_key_file_if") {
+    SECTION("invalid path") {
+      auto res
+        = ssl::context::make_server(ssl::tls::v1_0)
+            .and_then(ssl::use_private_key_file_if(nullptr, ssl::format::pem));
+      check_has_value(res);
+    }
+    SECTION("invalid format") {
+      auto res = ssl::context::make_server(ssl::tls::v1_0)
+                   .and_then(ssl::use_private_key_file_if(
+                     "/foo/bar", std::optional<ssl::format>{}));
+      check_has_value(res);
+    }
+  }
+}

--- a/libcaf_net/caf/net/ssl/dtls.hpp
+++ b/libcaf_net/caf/net/ssl/dtls.hpp
@@ -2,6 +2,8 @@
 // the main distribution directory for license terms and copyright or visit
 // https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
 
+#pragma once
+
 #include "caf/default_enum_inspect.hpp"
 #include "caf/detail/net_export.hpp"
 #include "caf/fwd.hpp"

--- a/libcaf_net/caf/net/ssl/errc.hpp
+++ b/libcaf_net/caf/net/ssl/errc.hpp
@@ -2,6 +2,8 @@
 // the main distribution directory for license terms and copyright or visit
 // https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
 
+#pragma once
+
 #include "caf/default_enum_inspect.hpp"
 #include "caf/detail/net_export.hpp"
 #include "caf/fwd.hpp"

--- a/libcaf_net/caf/net/ssl/format.hpp
+++ b/libcaf_net/caf/net/ssl/format.hpp
@@ -2,6 +2,8 @@
 // the main distribution directory for license terms and copyright or visit
 // https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
 
+#pragma once
+
 #include "caf/default_enum_inspect.hpp"
 #include "caf/detail/net_export.hpp"
 #include "caf/fwd.hpp"

--- a/libcaf_net/caf/net/ssl/password.hpp
+++ b/libcaf_net/caf/net/ssl/password.hpp
@@ -2,6 +2,8 @@
 // the main distribution directory for license terms and copyright or visit
 // https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
 
+#pragma once
+
 #include "caf/default_enum_inspect.hpp"
 #include "caf/detail/net_export.hpp"
 #include "caf/fwd.hpp"

--- a/libcaf_net/caf/net/ssl/startup.hpp
+++ b/libcaf_net/caf/net/ssl/startup.hpp
@@ -2,6 +2,8 @@
 // the main distribution directory for license terms and copyright or visit
 // https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
 
+#pragma once
+
 #include "caf/detail/net_export.hpp"
 #include "caf/fwd.hpp"
 

--- a/libcaf_net/caf/net/ssl/tls.hpp
+++ b/libcaf_net/caf/net/ssl/tls.hpp
@@ -2,6 +2,8 @@
 // the main distribution directory for license terms and copyright or visit
 // https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
 
+#pragma once
+
 #include "caf/default_enum_inspect.hpp"
 #include "caf/detail/net_export.hpp"
 #include "caf/fwd.hpp"

--- a/libcaf_net/caf/net/ssl/verify.hpp
+++ b/libcaf_net/caf/net/ssl/verify.hpp
@@ -2,6 +2,8 @@
 // the main distribution directory for license terms and copyright or visit
 // https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
 
+#pragma once
+
 #include "caf/default_enum_inspect.hpp"
 #include "caf/detail/net_export.hpp"
 #include "caf/fwd.hpp"

--- a/libcaf_test/caf/test/runnable.hpp
+++ b/libcaf_test/caf/test/runnable.hpp
@@ -156,6 +156,21 @@ public:
   bool check(bool value, const detail::source_location& location
                          = detail::source_location::current());
 
+  /// Checks whether `what` holds a value.
+  template <class T>
+  bool check_has_value(const expected<T>& what,
+                       const detail::source_location& location
+                       = detail::source_location::current()) {
+    if (what.has_value()) {
+      reporter::instance().pass(location);
+      return true;
+    }
+    auto msg = detail::format("expected<T> contains an error: {}",
+                              what.error());
+    reporter::instance().fail(msg, location);
+    return false;
+  }
+
   /// Evaluates whether `lhs` and `rhs` are equal and fails otherwise.
   template <class T0, class T1>
   void require_eq(const T0& lhs, const T1& rhs,


### PR DESCRIPTION
This private function had a bug for functions with multiple arguments such as `use_certificate_file_if` and `use_private_key_file_if` that caused the function to apply invalid arguments to the context instead of leaving the context unchanged. Furthermore, several headers under `caf/net/ssl` missed `pragma once` guards.

Reported by @raxyte, thanks!