### PR TITLE
Ensure that HTTP incoming data is parsed only once

### DIFF
--- a/libcaf_net/caf/net/http/server.cpp
+++ b/libcaf_net/caf/net/http/server.cpp
@@ -201,6 +201,7 @@ public:
             if (!invoke_upper_layer(input.subspan(0, payload_len_)))
               return -1;
             consumed += static_cast<ptrdiff_t>(payload_len_);
+            input = input.subspan(payload_len_);
             mode_ = mode::read_header;
           } else {
             // Wait for more data.


### PR DESCRIPTION
Relates #2073.

When processing data it was possible to parse the request body again as the first line of a new request. In most cases this would fail immediately so it stayed unnoticed. 
The regression test I come up with isn't very sophisticated and only tests the case where the data is well formed, but it's the easiest approach.
