### PR TITLE
Fix is_constructible assertions for typed actors

### DIFF
--- a/libcaf_core/caf/typed_actor.hpp
+++ b/libcaf_core/caf/typed_actor.hpp
@@ -120,36 +120,36 @@ public:
   typed_actor& operator=(typed_actor&&) = default;
   typed_actor& operator=(const typed_actor&) = default;
 
-  template <class... Ts>
+  template <class... Ts,
+            class = std::enable_if_t<detail::tl_subset_of_v<
+              signatures, typename typed_actor<Ts...>::signatures>>>
   typed_actor(const typed_actor<Ts...>& other) : ptr_(other.ptr_) {
-    static_assert(detail::tl_subset_of<
-                    signatures, typename typed_actor<Ts...>::signatures>::value,
-                  "Cannot assign incompatible handle");
+    // nop
   }
 
   // allow `handle_type{this}` for typed actors
   template <class T,
-            class = std::enable_if_t<actor_traits<T>::is_statically_typed>>
+            class = std::enable_if_t<actor_traits<T>::is_statically_typed>,
+            class = std::enable_if_t<
+              detail::tl_subset_of_v<signatures, typename T::signatures>>>
   typed_actor(T* ptr) : ptr_(ptr->ctrl()) {
-    static_assert(
-      detail::tl_subset_of<signatures, typename T::signatures>::value,
-      "Cannot assign T* to incompatible handle type");
     CAF_ASSERT(ptr != nullptr);
   }
 
   // Enable `handle_type{self}` for typed actor views.
-  template <class T, class = std::enable_if_t<
-                       std::is_base_of_v<typed_actor_view_base, T>>>
+  template <
+    class T,
+    class = std::enable_if_t<std::is_base_of_v<typed_actor_view_base, T>>,
+    class = std::enable_if_t<
+      detail::tl_subset_of_v<signatures, typename T::signatures>>>
   explicit typed_actor(T ptr) : ptr_(ptr.ctrl()) {
-    static_assert(
-      detail::tl_subset_of<signatures, typename T::signatures>::value,
-      "Cannot assign T to incompatible handle type");
+    // nop
   }
 
-  template <class... Ts>
+  template <class... Ts,
+            class = std::enable_if_t<detail::tl_subset_of_v<
+              signatures, typename typed_actor<Ts...>::signatures>>>
   typed_actor& operator=(const typed_actor<Ts...>& other) {
-    static_assert(detail::tl_subset_of<signatures, type_list<Ts...>>::value,
-                  "Cannot assign incompatible handle");
     ptr_ = other.ptr_;
     return *this;
   }

--- a/libcaf_core/caf/typed_actor.test.cpp
+++ b/libcaf_core/caf/typed_actor.test.cpp
@@ -94,32 +94,59 @@ static_assert(std::is_assignable_v<dual_hdl1, dual_hdl2>);
 static_assert(std::is_assignable_v<triple_hdl2, triple_hdl1>);
 static_assert(std::is_assignable_v<triple_hdl1, triple_hdl2>);
 
-// Check type conversions from handles with a narrower definition.
-static_assert(std::is_constructible_v<dual_hdl1, single_hdl1>);
-static_assert(std::is_constructible_v<dual_hdl1, single_hdl2>);
-static_assert(std::is_constructible_v<dual_hdl2, single_hdl1>);
-static_assert(std::is_constructible_v<dual_hdl2, single_hdl2>);
-static_assert(std::is_constructible_v<triple_hdl1, single_hdl1>);
-static_assert(std::is_constructible_v<triple_hdl1, single_hdl2>);
-static_assert(std::is_constructible_v<triple_hdl1, dual_hdl1>);
-static_assert(std::is_constructible_v<triple_hdl1, dual_hdl2>);
-static_assert(std::is_constructible_v<triple_hdl2, single_hdl1>);
-static_assert(std::is_constructible_v<triple_hdl2, single_hdl2>);
-static_assert(std::is_constructible_v<triple_hdl2, dual_hdl1>);
-static_assert(std::is_constructible_v<triple_hdl2, dual_hdl2>);
+// Check type conversions to handles with a narrower definition.
 
-static_assert(std::is_assignable_v<dual_hdl1, single_hdl1>);
-static_assert(std::is_assignable_v<dual_hdl1, single_hdl2>);
-static_assert(std::is_assignable_v<dual_hdl2, single_hdl1>);
-static_assert(std::is_assignable_v<dual_hdl2, single_hdl2>);
-static_assert(std::is_assignable_v<triple_hdl1, single_hdl1>);
-static_assert(std::is_assignable_v<triple_hdl1, single_hdl2>);
-static_assert(std::is_assignable_v<triple_hdl1, dual_hdl1>);
-static_assert(std::is_assignable_v<triple_hdl1, dual_hdl2>);
-static_assert(std::is_assignable_v<triple_hdl2, single_hdl1>);
-static_assert(std::is_assignable_v<triple_hdl2, single_hdl2>);
-static_assert(std::is_assignable_v<triple_hdl2, dual_hdl1>);
-static_assert(std::is_assignable_v<triple_hdl2, dual_hdl2>);
+static_assert(std::is_constructible_v<single_hdl1, dual_hdl1>);
+static_assert(std::is_constructible_v<single_hdl2, dual_hdl1>);
+static_assert(std::is_constructible_v<single_hdl1, dual_hdl2>);
+static_assert(std::is_constructible_v<single_hdl2, dual_hdl2>);
+static_assert(std::is_constructible_v<single_hdl1, triple_hdl1>);
+static_assert(std::is_constructible_v<single_hdl2, triple_hdl1>);
+static_assert(std::is_constructible_v<single_hdl1, triple_hdl2>);
+static_assert(std::is_constructible_v<single_hdl2, triple_hdl2>);
+static_assert(std::is_constructible_v<dual_hdl1, triple_hdl1>);
+static_assert(std::is_constructible_v<dual_hdl2, triple_hdl1>);
+static_assert(std::is_constructible_v<dual_hdl1, triple_hdl2>);
+static_assert(std::is_constructible_v<dual_hdl2, triple_hdl2>);
+
+static_assert(!std::is_constructible_v<dual_hdl1, single_hdl1>);
+static_assert(!std::is_constructible_v<dual_hdl1, single_hdl2>);
+static_assert(!std::is_constructible_v<dual_hdl2, single_hdl1>);
+static_assert(!std::is_constructible_v<dual_hdl2, single_hdl2>);
+static_assert(!std::is_constructible_v<triple_hdl1, single_hdl1>);
+static_assert(!std::is_constructible_v<triple_hdl1, single_hdl2>);
+static_assert(!std::is_constructible_v<triple_hdl1, dual_hdl1>);
+static_assert(!std::is_constructible_v<triple_hdl1, dual_hdl2>);
+static_assert(!std::is_constructible_v<triple_hdl2, single_hdl1>);
+static_assert(!std::is_constructible_v<triple_hdl2, single_hdl2>);
+static_assert(!std::is_constructible_v<triple_hdl2, dual_hdl1>);
+static_assert(!std::is_constructible_v<triple_hdl2, dual_hdl2>);
+
+static_assert(std::is_assignable_v<single_hdl1, dual_hdl1>);
+static_assert(std::is_assignable_v<single_hdl2, dual_hdl1>);
+static_assert(std::is_assignable_v<single_hdl1, dual_hdl2>);
+static_assert(std::is_assignable_v<single_hdl2, dual_hdl2>);
+static_assert(std::is_assignable_v<single_hdl1, triple_hdl1>);
+static_assert(std::is_assignable_v<single_hdl2, triple_hdl1>);
+static_assert(std::is_assignable_v<single_hdl1, triple_hdl2>);
+static_assert(std::is_assignable_v<single_hdl2, triple_hdl2>);
+static_assert(std::is_assignable_v<dual_hdl1, triple_hdl1>);
+static_assert(std::is_assignable_v<dual_hdl2, triple_hdl1>);
+static_assert(std::is_assignable_v<dual_hdl1, triple_hdl2>);
+static_assert(std::is_assignable_v<dual_hdl2, triple_hdl2>);
+
+static_assert(!std::is_assignable_v<dual_hdl1, single_hdl1>);
+static_assert(!std::is_assignable_v<dual_hdl1, single_hdl2>);
+static_assert(!std::is_assignable_v<dual_hdl2, single_hdl1>);
+static_assert(!std::is_assignable_v<dual_hdl2, single_hdl2>);
+static_assert(!std::is_assignable_v<triple_hdl1, single_hdl1>);
+static_assert(!std::is_assignable_v<triple_hdl1, single_hdl2>);
+static_assert(!std::is_assignable_v<triple_hdl1, dual_hdl1>);
+static_assert(!std::is_assignable_v<triple_hdl1, dual_hdl2>);
+static_assert(!std::is_assignable_v<triple_hdl2, single_hdl1>);
+static_assert(!std::is_assignable_v<triple_hdl2, single_hdl2>);
+static_assert(!std::is_assignable_v<triple_hdl2, dual_hdl1>);
+static_assert(!std::is_assignable_v<triple_hdl2, dual_hdl2>);
 
 // --- check extension API of type system --------------------------------------
 

--- a/libcaf_core/caf/typed_actor_pointer.hpp
+++ b/libcaf_core/caf/typed_actor_pointer.hpp
@@ -49,23 +49,19 @@ public:
 
   typed_actor_pointer& operator=(const typed_actor_pointer&) = default;
 
-  template <class Supertype>
+  template <
+    class Supertype,
+    class = std::enable_if_t< //
+      detail::tl_subset_of_v<signatures, typename Supertype::signatures>>>
   typed_actor_pointer& operator=(Supertype* ptr) {
-    using namespace detail;
-    static_assert(
-      tl_subset_of<signatures, typename Supertype::signatures>::value,
-      "cannot assign pointer of unrelated actor type");
     view_.reset(ptr);
     return *this;
   }
 
   template <class... OtherSigs,
             class = std::enable_if_t< //
-              detail::tl_subset_of<signatures, type_list<OtherSigs...>>::value>>
+              detail::tl_subset_of_v<signatures, type_list<OtherSigs...>>>>
   typed_actor_pointer& operator=(typed_actor_pointer<OtherSigs...> other) {
-    using namespace detail;
-    static_assert(tl_subset_of<signatures, type_list<OtherSigs...>>::value,
-                  "cannot assign pointer of unrelated actor type");
     view_.reset(other.internal_ptr());
     return *this;
   }


### PR DESCRIPTION
During the review of #2067 it came up that the `is_constructible` and `is_assignable` assertions for typed actors gave false positives. Namely, they don't evaluate the `static_assert` in the constructor/operator body. This PR refactors these assertions using SFINAE. 