### PR TITLE
Fix in-place parsing of percent encoded URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Fix a startup issue when configuring Prometheus export on `caf.net` (#2060).
   This bug caused the Prometheus server to never start up unless starting at
   least one other asynchronous server or client using the `caf.net` API.
+- Fix a bug in the URI parser that could crash the application when parsing an
+  URI with a percent-encoded character at the end of the string (#2080).
 
 ## [1.0.2] - 2024-10-30
 

--- a/libcaf_core/caf/uri.test.cpp
+++ b/libcaf_core/caf/uri.test.cpp
@@ -525,6 +525,10 @@ TEST("serialization") {
   SERIALIZATION_ROUNDTRIP("hi%20there://it%27s@me%21/file%201#%5B42%5D");
 }
 
+TEST("GH-2080 regression") {
+  SERIALIZATION_ROUNDTRIP("https://example.com?q=%2A");
+}
+
 #undef SERIALIZATION_ROUNDTRIP
 
 TEST("with_userinfo creates a copy with new userinfo") {


### PR DESCRIPTION
Closes #2080.

In `uri::decode`, we've called `str.replace` that could shorten the string. If we're close to the end, this could cause the function to access the string out-of-bounds during the next iteration.

I've switched to a different algorithm that does in-place modification with a read and write index.