### PR TITLE
Follow RFC 3986 recommendation on query strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   code. This change makes it easier to handle errors in a consistent way and to
   distinguish between requests that have been dropped and those that resulted in
   an error while processing the request (#2070).
+- The URI parser in CAF now accepts URIs that use reserved characters such as
+  `*`, `/` or `?` in the query string. This change follows the recommendation in
+  the RFC 3986, which states that "query components are often used to carry
+  identifying information in the form of key=value pairs and one frequently used
+  value is a reference to another URI".
 
 ### Added
 

--- a/libcaf_core/caf/detail/parser/read_config.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_config.test.cpp
@@ -8,6 +8,7 @@
 #include "caf/test/test.hpp"
 
 #include "caf/config_value.hpp"
+#include "caf/detail/source_location.hpp"
 #include "caf/log/test.hpp"
 #include "caf/parser_state.hpp"
 #include "caf/pec.hpp"
@@ -67,13 +68,15 @@ struct test_consumer {
 };
 
 struct fixture : test::fixture::deterministic {
-  expected<log_type> parse(std::string_view str, bool expect_success = true) {
+  expected<log_type> parse(std::string_view str, bool expect_success = true,
+                           caf::detail::source_location loc
+                           = caf::detail::source_location::current()) {
     test_consumer f;
     string_parser_state res{str.begin(), str.end()};
     detail::parser::read_config(res, f);
     if ((res.code == pec::success) != expect_success) {
-      log::test::error("unexpected parser result state: {}", res.code);
-      log::test::error("input remainder: {}", std::string{res.i, res.e});
+      log::test::error({"unexpected parser result state: {}", loc}, res.code);
+      log::test::error({"input remainder: {}", loc}, std::string{res.i, res.e});
     }
     return std::move(f.log);
   }


### PR DESCRIPTION
For users, this change notably relaxes what `make_uri` accepts.