### PR TITLE
Fix move semantics of key-value HTTP header pairs

### DIFF
--- a/libcaf_core/caf/detail/forward_like.hpp
+++ b/libcaf_core/caf/detail/forward_like.hpp
@@ -1,0 +1,30 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+namespace caf::detail {
+
+// Backport of C++23's forward_like. Remove when upgrading to C+23.
+// Source: https://en.cppreference.com/w/cpp/utility/forward_like
+template <class T, class U>
+constexpr auto&& forward_like(U&& x) noexcept {
+  constexpr bool is_adding_const = std::is_const_v<std::remove_reference_t<T>>;
+  if constexpr (std::is_lvalue_reference_v<T&&>) {
+    if constexpr (is_adding_const)
+      return std::as_const(x);
+    else
+      return static_cast<U&>(x);
+  } else {
+    if constexpr (is_adding_const)
+      return std::move(std::as_const(x));
+    else
+      return std::move(x);
+  }
+}
+
+} // namespace caf::detail

--- a/libcaf_net/caf/net/http/client_factory.hpp
+++ b/libcaf_net/caf/net/http/client_factory.hpp
@@ -18,6 +18,7 @@
 #include "caf/async/future.hpp"
 #include "caf/async/promise.hpp"
 #include "caf/async/spsc_buffer.hpp"
+#include "caf/detail/forward_like.hpp"
 #include "caf/detail/latch.hpp"
 #include "caf/disposable.hpp"
 #include "caf/timespan.hpp"
@@ -54,7 +55,8 @@ public:
   template <class KeyValueMap>
   client_factory& add_header_fields(KeyValueMap&& kv_map) {
     for (auto& [key, value] : kv_map) {
-      add_header_field(std::move(key), std::move(value));
+      add_header_field(detail::forward_like<KeyValueMap>(key),
+                       detail::forward_like<KeyValueMap>(value));
     }
     return *this;
   }


### PR DESCRIPTION
We always moved values from kv-pair. Reported in chat. 