### PR TITLE
Fix OOM issue with typed behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   URI with a percent-encoded character at the end of the string (#2080).
 - Fix parsing of HTTP request headers that do not use the absolute path syntax
   in the first line (#2074).
+- Optimize templates for compile-time checks used by typed behaviors. This
+  drastically reduces memory usage during compilation and avoids OOM errors when
+  spawning typed actors with a large number of message handlers (#1970).
 
 ## [1.0.2] - 2024-10-30
 

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -215,6 +215,7 @@ caf_add_component(
     caf/detail/thread_safe_actor_clock.cpp
     caf/detail/type_id_list_builder.cpp
     caf/detail/type_id_list_builder.test.cpp
+    caf/detail/type_list.test.cpp
     caf/detail/unique_function.test.cpp
     caf/dictionary.test.cpp
     caf/disposable.cpp

--- a/libcaf_core/caf/detail/type_list.test.cpp
+++ b/libcaf_core/caf/detail/type_list.test.cpp
@@ -1,0 +1,65 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#include "caf/detail/type_list.hpp"
+
+using std::is_same_v;
+
+namespace caf::detail {
+
+namespace {
+
+struct sx {};
+struct s1 {};
+struct s2 {};
+struct s3 {};
+struct s4 {};
+
+template <class R, class... Ts>
+using rm_t = tl_remove_t<type_list<Ts...>, R>;
+
+} // namespace
+
+// Remove from empty list.
+static_assert(is_same_v<rm_t<s1>, type_list<>>);
+
+// Remove from single element list.
+static_assert(is_same_v<rm_t<sx, sx>, type_list<>>);
+static_assert(is_same_v<rm_t<sx, s1>, type_list<s1>>);
+
+// Remove from two element list.
+static_assert(is_same_v<rm_t<sx, s1, s2>, type_list<s1, s2>>);
+static_assert(is_same_v<rm_t<sx, s1, sx>, type_list<s1>>);
+static_assert(is_same_v<rm_t<sx, sx, s2>, type_list<s2>>);
+static_assert(is_same_v<rm_t<sx, sx, sx>, type_list<>>);
+
+// Remove from three element list.
+static_assert(is_same_v<rm_t<sx, s1, s2, s3>, type_list<s1, s2, s3>>);
+static_assert(is_same_v<rm_t<sx, s1, s2, sx>, type_list<s1, s2>>);
+static_assert(is_same_v<rm_t<sx, s1, sx, s3>, type_list<s1, s3>>);
+static_assert(is_same_v<rm_t<sx, s1, sx, sx>, type_list<s1>>);
+static_assert(is_same_v<rm_t<sx, sx, s2, s3>, type_list<s2, s3>>);
+static_assert(is_same_v<rm_t<sx, sx, s2, sx>, type_list<s2>>);
+static_assert(is_same_v<rm_t<sx, sx, sx, s3>, type_list<s3>>);
+static_assert(is_same_v<rm_t<sx, sx, sx, sx>, type_list<>>);
+
+// Remove from four element list.
+static_assert(is_same_v<rm_t<sx, s1, s2, s3, s4>, type_list<s1, s2, s3, s4>>);
+static_assert(is_same_v<rm_t<sx, s1, s2, s3, sx>, type_list<s1, s2, s3>>);
+static_assert(is_same_v<rm_t<sx, s1, s2, sx, s4>, type_list<s1, s2, s4>>);
+static_assert(is_same_v<rm_t<sx, s1, s2, sx, sx>, type_list<s1, s2>>);
+static_assert(is_same_v<rm_t<sx, s1, sx, s3, s4>, type_list<s1, s3, s4>>);
+static_assert(is_same_v<rm_t<sx, s1, sx, s3, sx>, type_list<s1, s3>>);
+static_assert(is_same_v<rm_t<sx, s1, sx, sx, s4>, type_list<s1, s4>>);
+static_assert(is_same_v<rm_t<sx, s1, sx, sx, sx>, type_list<s1>>);
+static_assert(is_same_v<rm_t<sx, sx, s2, s3, s4>, type_list<s2, s3, s4>>);
+static_assert(is_same_v<rm_t<sx, sx, s2, s3, sx>, type_list<s2, s3>>);
+static_assert(is_same_v<rm_t<sx, sx, s2, sx, s4>, type_list<s2, s4>>);
+static_assert(is_same_v<rm_t<sx, sx, s2, sx, sx>, type_list<s2>>);
+static_assert(is_same_v<rm_t<sx, sx, sx, s3, s4>, type_list<s3, s4>>);
+static_assert(is_same_v<rm_t<sx, sx, sx, s3, sx>, type_list<s3>>);
+static_assert(is_same_v<rm_t<sx, sx, sx, sx, s4>, type_list<s4>>);
+static_assert(is_same_v<rm_t<sx, sx, sx, sx, sx>, type_list<>>);
+
+} // namespace caf::detail

--- a/libcaf_core/caf/typed_actor.test.cpp
+++ b/libcaf_core/caf/typed_actor.test.cpp
@@ -4,8 +4,11 @@
 
 #include "caf/typed_actor.hpp"
 
+#include "caf/test/test.hpp"
+
+#include "caf/init_global_meta_objects.hpp"
+#include "caf/type_id.hpp"
 #include "caf/typed_actor_pointer.hpp"
-#include "caf/typed_actor_view.hpp"
 #include "caf/typed_behavior.hpp"
 #include "caf/typed_event_based_actor.hpp"
 
@@ -165,4 +168,79 @@ static_assert(
   std::is_same_v<type_list<bool>::append_from<type_list<int>, type_list<float>>,
                  type_list<bool, int, float>>);
 
+struct s01 {};
+struct s02 {};
+struct s03 {};
+struct s04 {};
+struct s05 {};
+struct s06 {};
+struct s07 {};
+struct s08 {};
+struct s09 {};
+struct s10 {};
+struct s11 {};
+struct s12 {};
+struct s13 {};
+struct s14 {};
+struct s15 {};
+struct s16 {};
+struct s17 {};
+struct s18 {};
+struct s19 {};
+struct s20 {};
+
+struct t1970 {
+  using signatures = type_list<
+    result<void>(s01), result<void>(s15), result<void>(s07), result<void>(s12),
+    result<void>(s19), result<void>(s03), result<void>(s10), result<void>(s20),
+    result<void>(s05), result<void>(s14), result<void>(s08), result<void>(s17),
+    result<void>(s02), result<void>(s18), result<void>(s11), result<void>(s04),
+    result<void>(s13), result<void>(s09), result<void>(s16), result<void>(s06)>;
+};
+
+using a1970 = typed_actor<t1970>;
+
 } // namespace
+
+CAF_BEGIN_TYPE_ID_BLOCK(typed_actor_test, caf::first_custom_type_id + 130)
+
+  CAF_ADD_TYPE_ID(typed_actor_test, (s01))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s02))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s03))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s04))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s05))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s06))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s07))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s08))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s09))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s10))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s11))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s12))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s13))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s14))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s15))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s16))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s17))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s18))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s19))
+  CAF_ADD_TYPE_ID(typed_actor_test, (s20))
+
+CAF_END_TYPE_ID_BLOCK(typed_actor_test)
+
+TEST("GH-1970 regression") {
+  // The reported issue was that typed actors would blow up to several dozens of
+  // GB of memory usage during compile time when instantiating a typed actor
+  // with a large number of message handlers, e.g., 20. So the regression test
+  // simply checks that the following code actually compiles, as opposed to
+  // OOMing the compiler.
+  auto bhvr = typed_behavior<t1970>{
+    [](s01) {}, [](s02) {}, [](s03) {}, [](s04) {}, [](s05) {},
+    [](s06) {}, [](s07) {}, [](s08) {}, [](s09) {}, [](s10) {},
+    [](s11) {}, [](s12) {}, [](s13) {}, [](s14) {}, [](s15) {},
+    [](s16) {}, [](s17) {}, [](s18) {}, [](s19) {}, [](s20) {},
+  };
+}
+
+TEST_INIT() {
+  caf::init_global_meta_objects<caf::id_block::typed_actor_test>();
+}


### PR DESCRIPTION
Closes #1970.

After a bit of digging (thanks @shariarriday for doing the compile-time profiling!), we found the culprit: `detail::tl_remove_t`. This is used heavily by the constructor of `typed_behavior` via `interface_mismatch_t`. The patch boils down do basically consuming up to three elements at once from the input list to minimize the number of template instantiations the compiler has to deal with.