### PR TITLE
Add missing option for HTTP max response size

### DIFF
--- a/libcaf_core/caf/defaults.hpp
+++ b/libcaf_core/caf/defaults.hpp
@@ -166,7 +166,10 @@ constexpr auto max_consecutive_reads = make_parameter("max-consecutive-reads",
                                                       size_t{50});
 
 /// Default maximum size for incoming HTTP requests: 64KiB.
-constexpr auto http_max_request_size = uint32_t{65'536};
+constexpr auto http_max_request_size = uint32_t{64 * 1024};
+
+/// Default maximum size for incoming HTTP response: 512KiB.
+constexpr auto http_max_response_size = uint32_t{512 * 1024};
 
 /// The default port for HTTP servers.
 constexpr auto http_default_port = uint16_t{80};

--- a/libcaf_net/caf/net/http/client.cpp
+++ b/libcaf_net/caf/net/http/client.cpp
@@ -39,11 +39,6 @@ public:
     read_chunks,
   };
 
-  // -- constants --------------------------------------------------------------
-
-  /// Default maximum size for incoming HTTP responses: 512KiB.
-  static constexpr uint32_t default_max_response_size = 512 * 1024;
-
   // -- constructors, destructors, and assignment operators --------------------
 
   explicit client_impl(upper_layer_ptr up) : up_(std::move(up)) {
@@ -255,7 +250,7 @@ private:
   size_t payload_len_ = 0;
 
   /// Maximum size for incoming HTTP requests.
-  size_t max_response_size_ = default_max_response_size;
+  size_t max_response_size_ = defaults::net::http_max_response_size;
 };
 
 } // namespace

--- a/libcaf_net/caf/net/http/with.cpp
+++ b/libcaf_net/caf/net/http/with.cpp
@@ -211,6 +211,7 @@ public:
     auto app_t = async_client::make(method, path, fields, payload);
     resp = app_t->get_future();
     auto http_client = http::client::make(std::move(app_t));
+    http_client->max_response_size(max_response_size);
     auto transport = internal::make_transport(std::move(conn),
                                               std::move(http_client));
     transport->active_policy().connect();
@@ -266,8 +267,8 @@ public:
   /// Stores the available routes on the HTTP server.
   std::vector<route_ptr> routes;
 
-  /// Store the maximum request size with 0 meaning "default".
-  size_t max_request_size = 0;
+  /// Store the maximum size for incoming HTTP requests.
+  size_t max_request_size = defaults::net::http_max_request_size;
 
   /// Stores the producer resource for `do_start_server`.
   push_t push;
@@ -288,6 +289,9 @@ public:
 
   /// Stores the response from `do_start_client`.
   async::future<response> resp;
+
+  /// Stores the maximum size for an incoming HTTP response.
+  size_t max_response_size = defaults::net::http_max_response_size;
 };
 
 // -- server API ---------------------------------------------------------------
@@ -360,6 +364,11 @@ with_t::client&& with_t::client::retry_delay(timespan value) && {
 
 with_t::client&& with_t::client::connection_timeout(timespan value) && {
   config_->connection_timeout = value;
+  return std::move(*this);
+}
+
+with_t::client&& with_t::client::max_response_size(size_t value) && {
+  config_->max_response_size = value;
   return std::move(*this);
 }
 

--- a/libcaf_net/caf/net/http/with.hpp
+++ b/libcaf_net/caf/net/http/with.hpp
@@ -43,7 +43,7 @@ public:
 
     ~server();
 
-    /// Sets the maximum request size to @p value.
+    /// Sets the maximum request size to @p value. Defaults to 64KiB.
     [[nodiscard]] server&& max_request_size(size_t value) &&;
 
     /// Sets the maximum number of connections the server permits.
@@ -130,6 +130,9 @@ public:
     /// @param value The new connection timeout.
     /// @returns a reference to this `client`.
     [[nodiscard]] client&& connection_timeout(timespan value) &&;
+
+    /// Sets the maximum response size to @p value. Defaults to 512KiB.
+    [[nodiscard]] client&& max_response_size(size_t value) &&;
 
     /// Sets the maximum number of connection retry attempts.
     /// @param value The new maximum retry count.


### PR DESCRIPTION
Addresses an oversight on the DSL for HTTP clients.