### PR TITLE
Add missing option for HTTP max response size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - New `with_userinfo` member function for URIs that allows setting the user-info
   sub-component without going through an URI builder.
 - CAF now supports chunked encoding for HTTP clients (#2038).
+- Added a missing configuration option to the HTTP client API that allows
+  users to set the maximum size of the response.
 
 ### Fixed
 

--- a/libcaf_core/caf/defaults.hpp
+++ b/libcaf_core/caf/defaults.hpp
@@ -163,7 +163,10 @@ namespace caf::defaults::net {
 constexpr auto max_connections = make_parameter("max-connections", size_t{64});
 
 /// Default maximum size for incoming HTTP requests: 64KiB.
-constexpr auto http_max_request_size = uint32_t{65'536};
+constexpr auto http_max_request_size = uint32_t{64 * 1024};
+
+/// Default maximum size for incoming HTTP response: 512KiB.
+constexpr auto http_max_response_size = uint32_t{512 * 1024};
 
 /// The default port for HTTP servers.
 constexpr auto http_default_port = uint16_t{80};

--- a/libcaf_net/caf/net/http/client.cpp
+++ b/libcaf_net/caf/net/http/client.cpp
@@ -39,11 +39,6 @@ public:
     read_chunks,
   };
 
-  // -- constants --------------------------------------------------------------
-
-  /// Default maximum size for incoming HTTP responses: 512KiB.
-  static constexpr uint32_t default_max_response_size = 512 * 1024;
-
   // -- constructors, destructors, and assignment operators --------------------
 
   explicit client_impl(upper_layer_ptr up) : up_(std::move(up)) {
@@ -304,7 +299,7 @@ private:
   size_t payload_len_ = 0;
 
   /// Maximum size for incoming HTTP requests.
-  size_t max_response_size_ = default_max_response_size;
+  size_t max_response_size_ = defaults::net::http_max_response_size;
 };
 
 } // namespace

--- a/libcaf_net/caf/net/http/client_factory.hpp
+++ b/libcaf_net/caf/net/http/client_factory.hpp
@@ -51,6 +51,9 @@ public:
   /// Add an additional HTTP header field to the request.
   client_factory& add_header_field(std::string key, std::string value);
 
+  /// Sets the maximum response size to @p value. Defaults to 512KiB.
+  client_factory& max_response_size(size_t value);
+
   /// Add an additional HTTP header fields to the request.
   template <class KeyValueMap>
   client_factory& add_header_fields(KeyValueMap&& kv_map) {


### PR DESCRIPTION
Backport of #2086 so it can go into CAF 1.1.0.