### PR TITLE
Fix compilation error in Clang 20 for json::value::member operator==

### DIFF
--- a/libcaf_core/caf/detail/json.cpp
+++ b/libcaf_core/caf/detail/json.cpp
@@ -605,6 +605,13 @@ T* make_impl(monotonic_buffer_resource* storage) {
 
 } // namespace
 
+bool value::equals(const value::member& lhs, const value::member& rhs) {
+  if (lhs.key == rhs.key && lhs.val != nullptr && rhs.val != nullptr) {
+    return *lhs.val == *rhs.val;
+  }
+  return false;
+}
+
 std::string_view realloc(std::string_view str, monotonic_buffer_resource* res) {
   using alloc_t = detail::monotonic_buffer_resource::allocator<char>;
   auto buf = alloc_t{res}.allocate(str.size());

--- a/libcaf_core/caf/detail/json.hpp
+++ b/libcaf_core/caf/detail/json.hpp
@@ -183,24 +183,23 @@ public:
   void assign_array(const storage_ptr& ptr) {
     assign_array(&ptr->buf);
   }
+
+  static bool equals(const value::member& lhs, const value::member& rhs);
 };
+
+inline bool operator==(const value::member& lhs, const value::member& rhs) {
+  return value::equals(lhs, rhs);
+}
+
+inline bool operator!=(const value::member& lhs, const value::member& rhs) {
+  return !(lhs == rhs);
+}
 
 inline bool operator==(const value& lhs, const value& rhs) {
   return lhs.data == rhs.data;
 }
 
 inline bool operator!=(const value& lhs, const value& rhs) {
-  return !(lhs == rhs);
-}
-
-inline bool operator==(const value::member& lhs, const value::member& rhs) {
-  if (lhs.key == rhs.key && lhs.val != nullptr && rhs.val != nullptr) {
-    return *lhs.val == *rhs.val;
-  }
-  return false;
-}
-
-inline bool operator!=(const value::member& lhs, const value::member& rhs) {
   return !(lhs == rhs);
 }
 


### PR DESCRIPTION
Closes #2092.
The operator== for `json::value` and `json::value::member` call each other. Reordering them and moving one to the implementation file solved the issue for Clang v20.1.0.