### PR TITLE
Configure SSL hostname validation

### DIFF
--- a/libcaf_net/caf/net/http/with.cpp
+++ b/libcaf_net/caf/net/http/with.cpp
@@ -398,6 +398,7 @@ with_t::client::request(http::method method, const_byte_span payload) {
   config_->path = endpoint.path_query_fragment();
   config_->method = method;
   config_->payload = payload;
+  do_add_header_field("Host", endpoint.authority().host_str());
   auto lift = [this](disposable&& disp) {
     return std::pair(std::move(config_->resp), std::move(disp));
   };

--- a/libcaf_net/caf/net/ssl/connection.cpp
+++ b/libcaf_net/caf/net/ssl/connection.cpp
@@ -71,7 +71,7 @@ errc connection::last_error(ptrdiff_t ret) const {
   return detail::ssl_errc_from_native(code);
 }
 
-// -- SNI support --------------------------------------------------------------
+// -- SSL hostname validation and SNI support ----------------------------------
 
 bool connection::sni_hostname(const char* hostname) noexcept {
   if (!pimpl_ || !hostname)
@@ -84,6 +84,10 @@ const char* connection::sni_hostname() noexcept {
   if (!pimpl_)
     return nullptr;
   return SSL_get_servername(native(pimpl_), TLSEXT_NAMETYPE_host_name);
+}
+
+bool connection::hostname(const char* hostname) noexcept {
+  return SSL_set1_host(native(pimpl_), hostname);
 }
 
 // -- connecting and teardown --------------------------------------------------

--- a/libcaf_net/caf/net/ssl/connection.hpp
+++ b/libcaf_net/caf/net/ssl/connection.hpp
@@ -56,7 +56,7 @@ public:
   /// @param ret The (negative) result from the preceding call.
   std::string last_error_string(ptrdiff_t ret) const;
 
-  // -- SNI support -----------------------------------------------------------
+  // -- SSL hostname validation and SNI support -------------------------------
 
   /// Sets the SNI hostname for this connection before handshake.
   /// Must be called before connect().
@@ -64,6 +64,10 @@ public:
 
   /// Reads the SNI hostname from the connection.
   [[nodiscard]] const char* sni_hostname() noexcept;
+
+  /// Sets the SSL hostname used for certificate validation of this connection.
+  /// Must be called before connect().
+  [[nodiscard]] bool hostname(const char* hostname) noexcept;
 
   // -- connecting and teardown ------------------------------------------------
 

--- a/libcaf_net/caf/net/ssl/context.cpp
+++ b/libcaf_net/caf/net/ssl/context.cpp
@@ -29,6 +29,7 @@ auto native(context::impl* ptr) {
 struct context::user_data {
   password::callback_ptr pw_callback;
   std::string sni_hostname;
+  bool hostname_validation = true;
 };
 
 // -- constructors, destructors, and assignment operators ----------------------
@@ -357,6 +358,18 @@ const char* context::sni_hostname() const noexcept {
   if (!data_ || data_->sni_hostname.empty())
     return nullptr;
   return data_->sni_hostname.c_str();
+}
+
+void context::hostname_validation(bool enabled) noexcept {
+  if (data_ == nullptr)
+    data_ = new user_data;
+  data_->hostname_validation = enabled;
+}
+
+bool context::hostname_validation() const noexcept {
+  if (!data_)
+    return true;
+  return data_->hostname_validation;
 }
 
 } // namespace caf::net::ssl

--- a/libcaf_net/caf/net/ssl/context.hpp
+++ b/libcaf_net/caf/net/ssl/context.hpp
@@ -243,6 +243,12 @@ public:
   /// Returns the optional SNI hostname or `nullptr` if is not configured.
   const char* sni_hostname() const noexcept;
 
+  /// Configures the hostname validation for SSL. Enabled by default.
+  void hostname_validation(bool) noexcept;
+
+  /// Checks if SSL hostname validation is turned on. Enabled by default.
+  bool hostname_validation() const noexcept;
+
 private:
   constexpr explicit context(impl* ptr) : pimpl_(ptr) {
     // nop
@@ -539,6 +545,18 @@ inline auto use_sni_hostname(caf::uri uri) noexcept {
     }
     return make_error(sec::runtime_error,
                       "Failed to set SNI hostname from URI {}", arg1);
+  };
+}
+
+/// Sets whether the hostname validation is turned on for all client
+/// connections.
+/// Note: The client connection will query this parameter and
+/// inject the hostname automatically from the destination.
+/// @returns a function object for chaining `expected<T>::and_then()`.
+inline auto use_hostname_validation(bool enabled) noexcept {
+  return [arg1 = std::move(enabled)](context ctx) mutable -> expected<context> {
+    ctx.hostname_validation(arg1);
+    return expected{std::move(ctx)};
   };
 }
 

--- a/libcaf_net/caf/net/ssl/context.test.cpp
+++ b/libcaf_net/caf/net/ssl/context.test.cpp
@@ -16,6 +16,9 @@ TEST("constructing and setting values in the context object") {
   auto maybe_ctx = ssl::context::make_client(ssl::tls::v1_0);
   require(maybe_ctx.has_value());
   auto ctx = std::move(*maybe_ctx);
+  SECTION("default constructed context enables hostname validation") {
+    check(ctx.hostname_validation());
+  }
   SECTION("default constructed context discards SNI") {
     check_eq(ctx.sni_hostname(), nullptr);
   }
@@ -111,5 +114,15 @@ TEST("invalid arguments to ..._if DSL functions leave the context unchanged") {
                    .and_then(ssl::use_sni_hostname(*uri));
       check(!res.has_value());
     }
+  }
+  SECTION("use_hostname_validation") {
+    auto res = ssl::context::make_client(ssl::tls::v1_0)
+                 .and_then(ssl::use_hostname_validation(true));
+    if (check_has_value(res))
+      check(res->hostname_validation());
+    res = ssl::context::make_client(ssl::tls::v1_0)
+            .and_then(ssl::use_hostname_validation(false));
+    if (check_has_value(res))
+      check(!res->hostname_validation());
   }
 }


### PR DESCRIPTION
Fix for security issue regarding hostname validation in SSL.
Note that it's not possible to fetch the hostname from the SSL connection object, so only the setter is provided, no getter. The docs mention that it is possible to fetch the SNI hostname (which we already covered) and to use it in combination. 