### PR TITLE
Implement fan out request in the new mail API

### DIFF
--- a/libcaf_core/caf/abstract_scheduled_actor.hpp
+++ b/libcaf_core/caf/abstract_scheduled_actor.hpp
@@ -33,8 +33,13 @@ public:
   template <class...>
   friend class event_based_response_handle;
 
+  template <class, class...>
+  friend class event_based_fan_out_response_handle;
+
   template <class...>
   friend struct detail::response_to_flow_cell_helper;
+
+
 
   // -- member types -----------------------------------------------------------
 

--- a/libcaf_core/caf/abstract_scheduled_actor.hpp
+++ b/libcaf_core/caf/abstract_scheduled_actor.hpp
@@ -39,8 +39,6 @@ public:
   template <class...>
   friend struct detail::response_to_flow_cell_helper;
 
-
-
   // -- member types -----------------------------------------------------------
 
   using super = local_actor;

--- a/libcaf_core/caf/detail/response_type_check.hpp
+++ b/libcaf_core/caf/detail/response_type_check.hpp
@@ -4,13 +4,29 @@
 
 #pragma once
 
-#include "caf/detail/concepts.hpp"
+#include "caf/detail/callable_trait.hpp"
 #include "caf/fwd.hpp"
+#include "caf/policy/select_all_tag.hpp"
+#include "caf/policy/select_any_tag.hpp"
 #include "caf/type_list.hpp"
 
 #include <type_traits>
 
 namespace caf::detail {
+
+template <class OnError>
+constexpr void on_error_type_check() {
+  // Type-check OnError.
+  using on_error_trait_helper = detail::get_callable_trait_helper<OnError>;
+  static_assert(on_error_trait_helper::valid,
+                "OnError must provide a single, non-template operator()");
+  using on_error_trait = typename on_error_trait_helper::type;
+  static_assert(std::is_same_v<typename on_error_trait::result_type, void>,
+                "OnError must return void");
+  using on_error_args = typename on_error_trait::decayed_arg_types;
+  static_assert(std::is_same_v<on_error_args, type_list<error>>,
+                "OnError must accept a single argument of type caf::error");
+}
 
 template <class OnValue, class OnError, class... Results>
 constexpr void response_type_check() {
@@ -27,16 +43,46 @@ constexpr void response_type_check() {
     static_assert(std::is_same_v<on_value_args, res_t>,
                   "OnValue does not match the expected response types");
   }
-  // Type-check OnError.
-  using on_error_trait_helper = detail::get_callable_trait_helper<OnError>;
-  static_assert(on_error_trait_helper::valid,
-                "OnError must provide a single, non-template operator()");
-  using on_error_trait = typename on_error_trait_helper::type;
-  static_assert(std::is_same_v<typename on_error_trait::result_type, void>,
-                "OnError must return void");
-  using on_error_args = typename on_error_trait::decayed_arg_types;
-  static_assert(std::is_same_v<on_error_args, type_list<error>>,
-                "OnError must accept a single argument of type caf::error");
+  on_error_type_check<OnError>();
+}
+
+/// Policy-aware type checking for fan-out response handles.
+template <class Policy, class OnValue, class OnError, class... Results>
+constexpr void fan_out_response_type_check() {
+  // Type check for OnValue - select all policy.
+  if constexpr (std::is_same_v<Policy, policy::select_all_tag_t>) {
+    using res_t = type_list<Results...>;
+    using on_value_trait_helper = detail::get_callable_trait_helper<OnValue>;
+    static_assert(on_value_trait_helper::valid,
+                  "OnValue must provide a single, non-template operator()");
+    using on_value_trait = typename on_value_trait_helper::type;
+    static_assert(std::is_same_v<typename on_value_trait::result_type, void>,
+                  "OnValue must return void");
+    if constexpr (!std::is_same_v<res_t, type_list<message>>) {
+      using on_value_args = typename on_value_trait::decayed_arg_types;
+      if constexpr (sizeof...(Results) == 0) {
+        static_assert(
+          std::is_same_v<on_value_args, type_list<>>,
+          "OnValue for select_all with void results must take no arguments");
+      } else if constexpr (sizeof...(Results) == 1) {
+        using expected_type
+          = type_list<std::vector<typename detail::tl_head<res_t>::type>>;
+        static_assert(std::is_same_v<on_value_args, expected_type>,
+                      "OnValue for select_all with single result type must "
+                      "accept std::vector<Result>");
+      } else {
+        using expected_type = type_list<std::vector<std::tuple<Results...>>>;
+        static_assert(std::is_same_v<on_value_args, expected_type>,
+                      "OnValue for select_all with multiple result types must "
+                      "accept std::vector<std::tuple<Results...>>");
+      }
+    }
+    on_error_type_check<OnError>();
+  } else {
+    static_assert(std::is_same_v<Policy, policy::select_any_tag_t>);
+    // Select any fan out request has the same signatures as a regular request.
+    response_type_check<OnValue, OnError, Results...>();
+  }
 }
 
 } // namespace caf::detail

--- a/libcaf_core/caf/event_based_fan_out_response_handle.hpp
+++ b/libcaf_core/caf/event_based_fan_out_response_handle.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "caf/abstract_scheduled_actor.hpp"
+#include "caf/detail/concepts.hpp"
 #include "caf/detail/response_type_check.hpp"
 #include "caf/disposable.hpp"
 #include "caf/flow/fwd.hpp"
@@ -17,135 +18,14 @@
 #include <type_traits>
 
 namespace caf::policy {
+
 struct select_all_tag_t {};
-constexpr auto select_all_v = select_all_tag_t{};
+constexpr auto select_all_tag = select_all_tag_t{};
 
 struct select_any_tag_t {};
-constexpr auto select_any_v = select_any_tag_t{};
+constexpr auto select_any_tag = select_any_tag_t{};
+
 } // namespace caf::policy
-
-namespace caf::detail1 {
-
-template <class... Ts>
-struct select_all_helper_value_oracle {
-  using type = std::tuple<Ts...>;
-};
-
-template <class T>
-struct select_all_helper_value_oracle<T> {
-  using type = T;
-};
-
-template <class... Ts>
-using select_all_helper_value_t =
-  typename select_all_helper_value_oracle<Ts...>::type;
-
-template <class F, class... Ts>
-struct select_all_helper;
-
-template <class F, class T, class... Ts>
-struct select_all_helper<F, T, Ts...> {
-  using value_type = select_all_helper_value_t<T, Ts...>;
-  // using value_type
-  //   = std::conditional_t<sizeof...(Ts) == 0, T, std::tuple<T, Ts...>>;
-  std::vector<value_type> results;
-  std::shared_ptr<size_t> pending;
-  disposable timeouts;
-  F f;
-
-  template <class Fun>
-  select_all_helper(size_t pending, disposable timeouts, Fun&& f)
-    : pending(std::make_shared<size_t>(pending)),
-      timeouts(std::move(timeouts)),
-      f(std::forward<Fun>(f)) {
-    results.reserve(pending);
-  }
-
-  void operator()(T& x, Ts&... xs) {
-    auto lg = log::core::trace("pending = {}", *pending);
-    if (*pending > 0) {
-      results.emplace_back(std::move(x), std::move(xs)...);
-      if (--*pending == 0) {
-        timeouts.dispose();
-        f(std::move(results));
-      }
-    }
-  }
-
-  auto wrap() {
-    return [this](T& x, Ts&... xs) { (*this)(x, xs...); };
-  }
-};
-
-template <class F>
-struct select_all_helper<F> {
-  std::shared_ptr<size_t> pending;
-  disposable timeouts;
-  F f;
-
-  template <class Fun>
-  select_all_helper(size_t pending, disposable timeouts, Fun&& f)
-    : pending(std::make_shared<size_t>(pending)),
-      timeouts(std::move(timeouts)),
-      f(std::forward<Fun>(f)) {
-    // nop
-  }
-
-  void operator()() {
-    auto lg = log::core::trace("pending = {}", *pending);
-    if (*pending > 0 && --*pending == 0) {
-      timeouts.dispose();
-      f();
-    }
-  }
-
-  auto wrap() {
-    return [this] { (*this)(); };
-  }
-};
-
-template <class F, class = typename detail::get_callable_trait<F>::arg_types>
-struct select_select_all_helper;
-
-template <class F, class... Ts>
-struct select_select_all_helper<F, type_list<std::vector<std::tuple<Ts...>>>> {
-  using type = select_all_helper<F, Ts...>;
-};
-
-template <class F, class T>
-struct select_select_all_helper<F, type_list<std::vector<T>>> {
-  using type = select_all_helper<F, T>;
-};
-
-template <class F>
-struct select_select_all_helper<F, type_list<>> {
-  using type = select_all_helper<F>;
-};
-
-template <class F>
-using select_all_helper_t = typename select_select_all_helper<F>::type;
-
-template <class F, class = typename detail::get_callable_trait<F>::arg_types>
-struct select_any_factory;
-
-template <class F, class... Ts>
-struct select_any_factory<F, type_list<Ts...>> {
-  template <class Fun>
-  static auto
-  make(std::shared_ptr<size_t> pending, disposable timeouts, Fun f) {
-    return [pending{std::move(pending)}, timeouts{std::move(timeouts)},
-            f{std::move(f)}](Ts... xs) mutable {
-      auto lg = log::core::trace("pending = {}", *pending);
-      if (*pending > 0) {
-        timeouts.dispose();
-        f(xs...);
-        *pending = 0;
-      }
-    };
-  }
-};
-
-} // namespace caf::detail1
 
 namespace caf::detail {
 
@@ -171,28 +51,6 @@ struct event_based_fan_out_response_handle_oracle<Policy,
 template <class Policy, class Result>
 using event_based_fan_out_response_handle_t =
   typename event_based_fan_out_response_handle_oracle<Policy, Result>::type;
-
-// template <class Result>
-// struct event_based_delayed_response_handle_oracle;
-//
-// template <>
-// struct event_based_delayed_response_handle_oracle<message> {
-//   using type = event_based_delayed_response_handle<message>;
-// };
-//
-// template <>
-// struct event_based_delayed_response_handle_oracle<type_list<void>> {
-//   using type = event_based_delayed_response_handle<>;
-// };
-//
-// template <class... Results>
-// struct event_based_delayed_response_handle_oracle<type_list<Results...>> {
-//   using type = event_based_delayed_response_handle<Results...>;
-// };
-//
-// template <class Result>
-// using event_based_delayed_response_handle_t =
-//   typename event_based_delayed_response_handle_oracle<Result>::type;
 
 } // namespace caf::detail
 
@@ -236,7 +94,7 @@ public:
     // TODO type checks
     // detail::response_type_check<OnValue, OnError, Results...>();
     behavior bhvr;
-    if constexpr (std::is_same_v<Policy, policy::select_all_tag_t>) {
+    if constexpr (std::same_as<Policy, policy::select_all_tag_t>) {
       bhvr = make_select_all_behavior(std::move(on_value), std::move(on_error));
     } else {
       bhvr = make_select_any_behavior(std::move(on_value), std::move(on_error));
@@ -260,7 +118,7 @@ public:
     // detail::response_type_check<OnValue, OnError, Results...>();
     // - no pending timeout in select_all, but there is in regular then.
     behavior bhvr;
-    if constexpr (std::is_same_v<Policy, policy::select_all_tag_t>) {
+    if constexpr (std::same_as<Policy, policy::select_all_tag_t>) {
       bhvr = make_select_all_behavior(std::move(on_value), std::move(on_error));
     } else {
       bhvr = make_select_any_behavior(std::move(on_value), std::move(on_error));
@@ -278,14 +136,15 @@ public:
                                  });
   }
 
-  template <class T>
+  template <class... Ts>
   auto as_single() && {
     auto lg = log::core::trace("ids_ = {}", state_.mids);
-    if constexpr (std::is_same_v<Policy, policy::select_all_tag_t>) {
-      auto cell = make_counted<flow::op::cell<std::vector<T>>>(
+    using value_type = detail::select_all_helper_value_t<Ts...>;
+    if constexpr (std::same_as<Policy, policy::select_all_tag_t>) {
+      auto cell = make_counted<flow::op::cell<std::vector<value_type>>>(
         state_.self->flow_context());
       auto bhvr = make_select_all_behavior(
-        [cell, self = state_.self](std::vector<T> value) {
+        [cell, self = state_.self](std::vector<value_type> value) {
           cell->set_value(std::move(value));
           self->run_actions();
         },
@@ -299,9 +158,10 @@ public:
       using val_t = typename decltype(cell)::value_type::output_type;
       return flow::single<val_t>{std::move(cell)}.as_observable();
     } else {
-      auto cell = make_counted<flow::op::cell<T>>(state_.self->flow_context());
+      auto cell
+        = make_counted<flow::op::cell<value_type>>(state_.self->flow_context());
       auto bhvr = make_select_any_behavior(
-        [cell, self = state_.self](T value) {
+        [cell, self = state_.self](value_type value) {
           cell->set_value(std::move(value));
           self->run_actions();
         },
@@ -369,251 +229,4 @@ private:
   }
 };
 
-/*
-/// This helper class identifies an expected response message and enables
-/// `request(...).then(...)`.
-template <>
-class event_based_response_handle<message> {
-public:
-  // -- friends ----------------------------------------------------------------
-
-  friend class scheduled_actor;
-
-  // -- constructors, destructors, and assignment operators --------------------
-
-  event_based_response_handle(abstract_scheduled_actor* self, message_id mid,
-                              disposable pending_timeout)
-    : state_{self, mid, std::move(pending_timeout)} {
-    // nop
-  }
-
-  // -- then and await ---------------------------------------------------------
-
-  template <class OnValue, class OnError>
-  void await(OnValue on_value, OnError on_error) && {
-    detail::response_type_check<OnValue, OnError, message>();
-    auto bhvr = behavior{std::move(on_value), std::move(on_error)};
-    state_.self->add_awaited_response_handler(
-      state_.mid, std::move(bhvr), std::move(state_.pending_timeout));
-  }
-
-  template <class OnValue>
-  void await(OnValue on_value) && {
-    return std::move(*this).await(std::move(on_value),
-                                  [self = state_.self](error& err) {
-                                    self->call_error_handler(err);
-                                  });
-  }
-
-  template <class OnValue, class OnError>
-  void then(OnValue on_value, OnError on_error) && {
-    detail::response_type_check<OnValue, OnError, message>();
-    auto bhvr = behavior{std::move(on_value), std::move(on_error)};
-    state_.self->add_multiplexed_response_handler(
-      state_.mid, std::move(bhvr), std::move(state_.pending_timeout));
-  }
-
-  template <class OnValue>
-  void then(OnValue on_value) && {
-    return std::move(*this).then(std::move(on_value),
-                                 [self = state_.self](error& err) {
-                                   self->call_error_handler(err);
-                                 });
-  }
-
-  template <class... Ts>
-  auto as_observable() && {
-    auto cell = state_.self->template response_to_flow_cell<Ts...>(
-      state_.mid, std::move(state_.pending_timeout));
-    using cell_t = typename decltype(cell)::value_type;
-    using val_t = typename cell_t::output_type;
-    return flow::single<val_t>{std::move(cell)}.as_observable();
-  }
-
-private:
-  /// Holds the state for the handle.
-  event_based_response_handle_state state_;
-};
-
-/// Similar to `event_based_response_handle`, but also holds the `disposable`
-/// for the delayed request message.
-template <class... Results>
-class event_based_delayed_response_handle {
-public:
-  using decorated_type = event_based_response_handle<Results...>;
-
-  // -- constructors, destructors, and assignment operators --------------------
-
-  event_based_delayed_response_handle(abstract_scheduled_actor* self,
-                                      message_id mid,
-                                      disposable pending_timeout,
-                                      disposable pending_request)
-    : decorated(self, mid, std::move(pending_timeout)),
-      pending_request(std::move(pending_request)) {
-    // nop
-  }
-
-  // -- then and await ---------------------------------------------------------
-
-  /// @copydoc event_based_response_handle::await
-  template <class OnValue, class OnError>
-  disposable await(OnValue on_value, OnError on_error) && {
-    std::move(decorated).await(std::move(on_value), std::move(on_error));
-    return std::move(pending_request);
-  }
-
-  /// @copydoc event_based_response_handle::await
-  template <class OnValue>
-  disposable await(OnValue on_value) && {
-    std::move(decorated).await(std::move(on_value));
-    return std::move(pending_request);
-  }
-
-  /// @copydoc event_based_response_handle::then
-  template <class OnValue, class OnError>
-  disposable then(OnValue on_value, OnError on_error) && {
-    std::move(decorated).then(std::move(on_value), std::move(on_error));
-    return std::move(pending_request);
-  }
-
-  /// @copydoc event_based_response_handle::then
-  template <class OnValue>
-  disposable then(OnValue on_value) && {
-    std::move(decorated).then(std::move(on_value));
-    return std::move(pending_request);
-  }
-
-  auto as_observable() && {
-    return std::move(decorated).as_observable();
-  }
-
-  // -- properties -------------------------------------------------------------
-
-  /// The wrapped handle type.
-  decorated_type decorated;
-
-  /// Stores a handle to the in-flight request if the request messages was
-  /// delayed/scheduled.
-  disposable pending_request;
-};
-
-// Specialization for dynamically typed messages.
-template <>
-class event_based_delayed_response_handle<message> {
-public:
-  using decorated_type = event_based_response_handle<message>;
-
-  // -- constructors, destructors, and assignment operators --------------------
-
-  event_based_delayed_response_handle(abstract_scheduled_actor* self,
-                                      message_id mid,
-                                      disposable pending_timeout,
-                                      disposable pending_request)
-    : decorated(self, mid, std::move(pending_timeout)),
-      pending_request(std::move(pending_request)) {
-    // nop
-  }
-
-  // -- then and await ---------------------------------------------------------
-
-  /// @copydoc event_based_response_handle::await
-  template <class OnValue, class OnError>
-  disposable await(OnValue on_value, OnError on_error) && {
-    std::move(decorated).await(std::move(on_value), std::move(on_error));
-    return std::move(pending_request);
-  }
-
-  /// @copydoc event_based_response_handle::await
-  template <class OnValue>
-  disposable await(OnValue on_value) && {
-    std::move(decorated).await(std::move(on_value));
-    return std::move(pending_request);
-  }
-
-  /// @copydoc event_based_response_handle::then
-  template <class OnValue, class OnError>
-  disposable then(OnValue on_value, OnError on_error) && {
-    std::move(decorated).then(std::move(on_value), std::move(on_error));
-    return std::move(pending_request);
-  }
-
-  /// @copydoc event_based_response_handle::then
-  template <class OnValue>
-  disposable then(OnValue on_value) && {
-    std::move(decorated).then(std::move(on_value));
-    return std::move(pending_request);
-  }
-
-  template <class... Ts>
-  auto as_observable() && {
-    return std::move(decorated).template as_observable<Ts...>();
-  }
-
-  // -- properties -------------------------------------------------------------
-
-  /// The wrapped handle type.
-  decorated_type decorated;
-
-  /// Stores a handle to the in-flight request if the request messages was
-  /// delayed/scheduled.
-  disposable pending_request;
-};
-
-// tuple-like access for event_based_delayed_response_handle
-
-template <size_t I, class... Results>
-decltype(auto) get(caf::event_based_delayed_response_handle<Results...>& x) {
-  if constexpr (I == 0) {
-    return x.decorated;
-  } else {
-    static_assert(I == 1);
-    return x.pending_request;
-  }
-}
-
-template <size_t I, class... Results>
-decltype(auto)
-get(const caf::event_based_delayed_response_handle<Results...>& x) {
-  if constexpr (I == 0) {
-    return x.decorated;
-  } else {
-    static_assert(I == 1);
-    return x.pending_request;
-  }
-}
-
-template <size_t I, class... Results>
-decltype(auto) get(caf::event_based_delayed_response_handle<Results...>&& x) {
-  if constexpr (I == 0) {
-    return std::move(x.decorated);
-  } else {
-    static_assert(I == 1);
-    return std::move(x.pending_request);
-  }
-}
-*/
-
 } // namespace caf
-
-// enable structured bindings for event_based_delayed_response_handle
-
-/*
-namespace std {
-
-template <class... Results>
-struct tuple_size<caf::event_based_delayed_response_handle<Results...>> {
-  static constexpr size_t value = 2;
-};
-
-template <class... Results>
-struct tuple_element<0, caf::event_based_delayed_response_handle<Results...>> {
-  using type = caf::event_based_response_handle<Results...>;
-};
-
-template <class... Results>
-struct tuple_element<1, caf::event_based_delayed_response_handle<Results...>> {
-  using type = caf::disposable;
-};
-
-} // namespace std
-*/

--- a/libcaf_core/caf/event_based_fan_out_response_handle.hpp
+++ b/libcaf_core/caf/event_based_fan_out_response_handle.hpp
@@ -5,25 +5,18 @@
 #pragma once
 
 #include "caf/abstract_scheduled_actor.hpp"
+#include "caf/detail/response_type_check.hpp"
 #include "caf/disposable.hpp"
 #include "caf/flow/fwd.hpp"
 #include "caf/fwd.hpp"
 #include "caf/message_id.hpp"
 #include "caf/policy/select_all.hpp"
+#include "caf/policy/select_all_tag.hpp"
 #include "caf/policy/select_any.hpp"
+#include "caf/policy/select_any_tag.hpp"
 #include "caf/type_list.hpp"
 
 #include <type_traits>
-
-namespace caf::policy {
-
-struct select_all_tag_t {};
-constexpr auto select_all_tag = select_all_tag_t{};
-
-struct select_any_tag_t {};
-constexpr auto select_any_tag = select_any_tag_t{};
-
-} // namespace caf::policy
 
 namespace caf::detail {
 
@@ -153,8 +146,7 @@ public:
   template <class OnValue, class OnError>
   void await(OnValue on_value, OnError on_error) && {
     auto lg = log::core::trace("ids_ = {}", state_.mids);
-    // TODO type checks
-    // detail::response_type_check<OnValue, OnError, Results...>();
+    detail::fan_out_response_type_check<Policy, OnValue, OnError, Results...>();
     behavior bhvr;
     if constexpr (std::same_as<Policy, policy::select_all_tag_t>) {
       bhvr = make_select_all_behavior(std::move(on_value), std::move(on_error));
@@ -177,8 +169,7 @@ public:
   template <class OnValue, class OnError>
   void then(OnValue on_value, OnError on_error) && {
     auto lg = log::core::trace("ids_ = {}", state_.mids);
-    // detail::response_type_check<OnValue, OnError, Results...>();
-    // - no pending timeout in select_all, but there is in regular then.
+    detail::fan_out_response_type_check<Policy, OnValue, OnError, Results...>();
     behavior bhvr;
     if constexpr (std::same_as<Policy, policy::select_all_tag_t>) {
       bhvr = make_select_all_behavior(std::move(on_value), std::move(on_error));

--- a/libcaf_core/caf/event_based_fan_out_response_handle.hpp
+++ b/libcaf_core/caf/event_based_fan_out_response_handle.hpp
@@ -51,16 +51,15 @@ struct fan_out_response_to_flow_cell_helper<Policy> {
   static auto make_behavior(abstract_scheduled_actor* self,
                             flow::coordinator* coord) {
     auto cell = make_counted<flow::op::cell<unit_t>>(coord);
-    return std::tuple(
-      std::move(cell),
-      [self, cell] {
-        cell->set_value(unit);
-        self->run_actions();
-      },
-      [self, cell](error err) {
-        cell->set_error(std::move(err));
-        self->run_actions();
-      });
+    return std::tuple{std::move(cell),
+                      [self, cell] {
+                        cell->set_value(unit);
+                        self->run_actions();
+                      },
+                      [self, cell](error err) {
+                        cell->set_error(std::move(err));
+                        self->run_actions();
+                      }};
   }
 };
 
@@ -190,7 +189,7 @@ public:
   }
 
   auto as_single() &&
-    requires (not std::same_as<type_list<Results...>, type_list<message>>)
+    requires (!std::same_as<type_list<Results...>, type_list<message>>)
   {
     return std::move(*this).template as_single_helper<Results...>();
   }
@@ -204,7 +203,7 @@ public:
   }
 
   auto as_observable() &&
-    requires (not std::same_as<type_list<Results...>, type_list<message>>)
+    requires (!std::same_as<type_list<Results...>, type_list<message>>)
   {
     return std::move(*this).template as_single_helper<Results...>().as_observable();
   }

--- a/libcaf_core/caf/event_based_fan_out_response_handle.hpp
+++ b/libcaf_core/caf/event_based_fan_out_response_handle.hpp
@@ -10,67 +10,201 @@
 #include "caf/flow/fwd.hpp"
 #include "caf/fwd.hpp"
 #include "caf/message_id.hpp"
+#include "caf/policy/select_all.hpp"
+#include "caf/policy/select_any.hpp"
 #include "caf/type_list.hpp"
 
 #include <type_traits>
 
+namespace caf::policy {
+struct select_all_tag_t {};
+constexpr auto select_all_v = select_all_tag_t{};
+
+struct select_any_tag_t {};
+constexpr auto select_any_v = select_any_tag_t{};
+} // namespace caf::policy
+
+namespace caf::detail1 {
+
+template <class... Ts>
+struct select_all_helper_value_oracle {
+  using type = std::tuple<Ts...>;
+};
+
+template <class T>
+struct select_all_helper_value_oracle<T> {
+  using type = T;
+};
+
+template <class... Ts>
+using select_all_helper_value_t =
+  typename select_all_helper_value_oracle<Ts...>::type;
+
+template <class F, class... Ts>
+struct select_all_helper;
+
+template <class F, class T, class... Ts>
+struct select_all_helper<F, T, Ts...> {
+  using value_type = select_all_helper_value_t<T, Ts...>;
+  // using value_type
+  //   = std::conditional_t<sizeof...(Ts) == 0, T, std::tuple<T, Ts...>>;
+  std::vector<value_type> results;
+  std::shared_ptr<size_t> pending;
+  disposable timeouts;
+  F f;
+
+  template <class Fun>
+  select_all_helper(size_t pending, disposable timeouts, Fun&& f)
+    : pending(std::make_shared<size_t>(pending)),
+      timeouts(std::move(timeouts)),
+      f(std::forward<Fun>(f)) {
+    results.reserve(pending);
+  }
+
+  void operator()(T& x, Ts&... xs) {
+    auto lg = log::core::trace("pending = {}", *pending);
+    if (*pending > 0) {
+      results.emplace_back(std::move(x), std::move(xs)...);
+      if (--*pending == 0) {
+        timeouts.dispose();
+        f(std::move(results));
+      }
+    }
+  }
+
+  auto wrap() {
+    return [this](T& x, Ts&... xs) { (*this)(x, xs...); };
+  }
+};
+
+template <class F>
+struct select_all_helper<F> {
+  std::shared_ptr<size_t> pending;
+  disposable timeouts;
+  F f;
+
+  template <class Fun>
+  select_all_helper(size_t pending, disposable timeouts, Fun&& f)
+    : pending(std::make_shared<size_t>(pending)),
+      timeouts(std::move(timeouts)),
+      f(std::forward<Fun>(f)) {
+    // nop
+  }
+
+  void operator()() {
+    auto lg = log::core::trace("pending = {}", *pending);
+    if (*pending > 0 && --*pending == 0) {
+      timeouts.dispose();
+      f();
+    }
+  }
+
+  auto wrap() {
+    return [this] { (*this)(); };
+  }
+};
+
+template <class F, class = typename detail::get_callable_trait<F>::arg_types>
+struct select_select_all_helper;
+
+template <class F, class... Ts>
+struct select_select_all_helper<F, type_list<std::vector<std::tuple<Ts...>>>> {
+  using type = select_all_helper<F, Ts...>;
+};
+
+template <class F, class T>
+struct select_select_all_helper<F, type_list<std::vector<T>>> {
+  using type = select_all_helper<F, T>;
+};
+
+template <class F>
+struct select_select_all_helper<F, type_list<>> {
+  using type = select_all_helper<F>;
+};
+
+template <class F>
+using select_all_helper_t = typename select_select_all_helper<F>::type;
+
+template <class F, class = typename detail::get_callable_trait<F>::arg_types>
+struct select_any_factory;
+
+template <class F, class... Ts>
+struct select_any_factory<F, type_list<Ts...>> {
+  template <class Fun>
+  static auto
+  make(std::shared_ptr<size_t> pending, disposable timeouts, Fun f) {
+    return [pending{std::move(pending)}, timeouts{std::move(timeouts)},
+            f{std::move(f)}](Ts... xs) mutable {
+      auto lg = log::core::trace("pending = {}", *pending);
+      if (*pending > 0) {
+        timeouts.dispose();
+        f(xs...);
+        *pending = 0;
+      }
+    };
+  }
+};
+
+} // namespace caf::detail1
+
 namespace caf::detail {
 
-template <class Result>
-struct event_based_response_handle_oracle;
+template <class Policy, class Result>
+struct event_based_fan_out_response_handle_oracle;
 
-template <>
-struct event_based_response_handle_oracle<message> {
-  using type = event_based_response_handle<message>;
+template <class Policy>
+struct event_based_fan_out_response_handle_oracle<Policy, message> {
+  using type = event_based_fan_out_response_handle<Policy, message>;
 };
 
-template <>
-struct event_based_response_handle_oracle<type_list<void>> {
-  using type = event_based_response_handle<>;
+template <class Policy>
+struct event_based_fan_out_response_handle_oracle<Policy, type_list<void>> {
+  using type = event_based_fan_out_response_handle<Policy>;
 };
 
-template <class... Results>
-struct event_based_response_handle_oracle<type_list<Results...>> {
-  using type = event_based_response_handle<Results...>;
+template <class Policy, class... Results>
+struct event_based_fan_out_response_handle_oracle<Policy,
+                                                  type_list<Results...>> {
+  using type = event_based_fan_out_response_handle<Policy, Results...>;
 };
 
-template <class Result>
-using event_based_response_handle_t =
-  typename event_based_response_handle_oracle<Result>::type;
+template <class Policy, class Result>
+using event_based_fan_out_response_handle_t =
+  typename event_based_fan_out_response_handle_oracle<Policy, Result>::type;
 
-template <class Result>
-struct event_based_delayed_response_handle_oracle;
-
-template <>
-struct event_based_delayed_response_handle_oracle<message> {
-  using type = event_based_delayed_response_handle<message>;
-};
-
-template <>
-struct event_based_delayed_response_handle_oracle<type_list<void>> {
-  using type = event_based_delayed_response_handle<>;
-};
-
-template <class... Results>
-struct event_based_delayed_response_handle_oracle<type_list<Results...>> {
-  using type = event_based_delayed_response_handle<Results...>;
-};
-
-template <class Result>
-using event_based_delayed_response_handle_t =
-  typename event_based_delayed_response_handle_oracle<Result>::type;
+// template <class Result>
+// struct event_based_delayed_response_handle_oracle;
+//
+// template <>
+// struct event_based_delayed_response_handle_oracle<message> {
+//   using type = event_based_delayed_response_handle<message>;
+// };
+//
+// template <>
+// struct event_based_delayed_response_handle_oracle<type_list<void>> {
+//   using type = event_based_delayed_response_handle<>;
+// };
+//
+// template <class... Results>
+// struct event_based_delayed_response_handle_oracle<type_list<Results...>> {
+//   using type = event_based_delayed_response_handle<Results...>;
+// };
+//
+// template <class Result>
+// using event_based_delayed_response_handle_t =
+//   typename event_based_delayed_response_handle_oracle<Result>::type;
 
 } // namespace caf::detail
 
 namespace caf {
 
 /// Holds state for a event-based response handles.
-struct event_based_response_handle_state {
+struct event_based_fan_out_response_handle_state {
   /// Points to the parent actor.
   abstract_scheduled_actor* self;
 
-  /// Stores the ID of the message we are waiting for.
-  message_id mid;
+  /// Stores the IDs of the messages we are waiting for.
+  std::vector<message_id> mids;
 
   /// Stores a handle to the in-flight timeout.
   disposable pending_timeout;
@@ -78,8 +212,8 @@ struct event_based_response_handle_state {
 
 /// This helper class identifies an expected response message and enables
 /// `request(...).then(...)`.
-template <class... Results>
-class event_based_response_handle {
+template <class Policy, class... Results>
+class event_based_fan_out_response_handle {
 public:
   // -- friends ----------------------------------------------------------------
 
@@ -87,9 +221,10 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  event_based_response_handle(abstract_scheduled_actor* self, message_id mid,
-                              disposable pending_timeout)
-    : state_{self, mid, std::move(pending_timeout)} {
+  event_based_fan_out_response_handle(abstract_scheduled_actor* self,
+                                      std::vector<message_id> mids,
+                                      disposable pending_timeout)
+    : state_{self, mids, std::move(pending_timeout)} {
     // nop
   }
 
@@ -97,10 +232,18 @@ public:
 
   template <class OnValue, class OnError>
   void await(OnValue on_value, OnError on_error) && {
-    detail::response_type_check<OnValue, OnError, Results...>();
-    auto bhvr = behavior{std::move(on_value), std::move(on_error)};
-    state_.self->add_awaited_response_handler(
-      state_.mid, std::move(bhvr), std::move(state_.pending_timeout));
+    auto lg = log::core::trace("ids_ = {}", state_.mids);
+    // TODO type checks
+    // detail::response_type_check<OnValue, OnError, Results...>();
+    behavior bhvr;
+    if constexpr (std::is_same_v<Policy, policy::select_all_tag_t>) {
+      bhvr = make_select_all_behavior(std::move(on_value), std::move(on_error));
+    } else {
+      bhvr = make_select_any_behavior(std::move(on_value), std::move(on_error));
+    }
+    for (const auto& mid : state_.mids)
+      state_.self->add_awaited_response_handler(mid, bhvr,
+                                                state_.pending_timeout);
   }
 
   template <class OnValue>
@@ -113,10 +256,18 @@ public:
 
   template <class OnValue, class OnError>
   void then(OnValue on_value, OnError on_error) && {
-    detail::response_type_check<OnValue, OnError, Results...>();
-    auto bhvr = behavior{std::move(on_value), std::move(on_error)};
-    state_.self->add_multiplexed_response_handler(
-      state_.mid, std::move(bhvr), std::move(state_.pending_timeout));
+    auto lg = log::core::trace("ids_ = {}", state_.mids);
+    // detail::response_type_check<OnValue, OnError, Results...>();
+    // - no pending timeout in select_all, but there is in regular then.
+    behavior bhvr;
+    if constexpr (std::is_same_v<Policy, policy::select_all_tag_t>) {
+      bhvr = make_select_all_behavior(std::move(on_value), std::move(on_error));
+    } else {
+      bhvr = make_select_any_behavior(std::move(on_value), std::move(on_error));
+    }
+    for (const auto& mid : state_.mids)
+      state_.self->add_multiplexed_response_handler(mid, bhvr,
+                                                    state_.pending_timeout);
   }
 
   template <class OnValue>
@@ -127,19 +278,62 @@ public:
                                  });
   }
 
-  auto as_observable() && {
-    auto cell = state_.self->template response_to_flow_cell<Results...>(
-      state_.mid, std::move(state_.pending_timeout));
-    using cell_t = typename decltype(cell)::value_type;
-    using val_t = typename cell_t::output_type;
-    return flow::single<val_t>{std::move(cell)}.as_observable();
-  }
+  // TODO as observable / as single
+  // auto as_observable() && {
+  //   auto cell = state_.self->template response_to_flow_cell<Results...>(
+  //     state_.mid, std::move(state_.pending_timeout));
+  //   using cell_t = typename decltype(cell)::value_type;
+  //   using val_t = typename cell_t::output_type;
+  //   return flow::single<val_t>{std::move(cell)}.as_observable();
+  // }
 
 private:
   /// Holds the state for the handle.
-  event_based_response_handle_state state_;
+  event_based_fan_out_response_handle_state state_;
+
+  template <class F, class OnError>
+  behavior make_select_all_behavior(F&& f, OnError&& g) {
+    using helper_type = detail::select_all_helper_t<std::decay_t<F>>;
+    helper_type helper{state_.mids.size(), state_.pending_timeout,
+                       std::forward<F>(f)};
+    auto pending = helper.pending;
+    auto error_handler = [pending{std::move(pending)},
+                          timeouts{state_.pending_timeout},
+                          g{std::forward<OnError>(g)}](error& err) mutable {
+      auto lg = log::core::trace("pending = {}", *pending);
+      if (*pending > 0) {
+        timeouts.dispose();
+        *pending = 0;
+        g(err);
+      }
+    };
+    return behavior{std::move(helper), std::move(error_handler)};
+  }
+
+  template <class F, class OnError>
+  behavior make_select_any_behavior(F&& f, OnError&& g) {
+    using factory = caf::detail::select_any_factory<std::decay_t<F>>;
+    auto pending = std::make_shared<size_t>(state_.mids.size());
+    auto result_handler = factory::make(pending, state_.pending_timeout,
+                                        std::forward<F>(f));
+    auto error_handler = [p{std::move(pending)},
+                          timeouts{state_.pending_timeout},
+                          g{std::forward<OnError>(g)}](error&) mutable {
+      if (*p == 0) {
+        // nop
+      } else if (*p == 1) {
+        timeouts.dispose();
+        auto err = make_error(sec::all_requests_failed);
+        g(err);
+      } else {
+        --*p;
+      }
+    };
+    return {std::move(result_handler), std::move(error_handler)};
+  }
 };
 
+/*
 /// This helper class identifies an expected response message and enables
 /// `request(...).then(...)`.
 template <>
@@ -361,11 +555,13 @@ decltype(auto) get(caf::event_based_delayed_response_handle<Results...>&& x) {
     return std::move(x.pending_request);
   }
 }
+*/
 
 } // namespace caf
 
 // enable structured bindings for event_based_delayed_response_handle
 
+/*
 namespace std {
 
 template <class... Results>
@@ -384,3 +580,4 @@ struct tuple_element<1, caf::event_based_delayed_response_handle<Results...>> {
 };
 
 } // namespace std
+*/

--- a/libcaf_core/caf/event_based_mail.hpp
+++ b/libcaf_core/caf/event_based_mail.hpp
@@ -6,6 +6,7 @@
 
 #include "caf/abstract_scheduled_actor.hpp"
 #include "caf/async_mail.hpp"
+#include "caf/event_based_fan_out_response_handle.hpp"
 #include "caf/event_based_response_handle.hpp"
 #include "caf/message.hpp"
 
@@ -142,6 +143,65 @@ public:
     }
     using hdl_t = detail::event_based_response_handle_t<response_type>;
     return hdl_t{self(), mid.response_id(), std::move(in_flight_timeout)};
+  }
+
+  /// // TODO update
+  /// Sends `{xs...}` to each actor in the range `destinations` as a synchronous
+  /// message. Response messages get combined into a single result according to
+  /// the `Policy`.
+  /// @tparam Policy Configures how individual response messages get
+  ///                     combined by the actor. The policy makes sure that the
+  ///                     response handler gets invoked at most once. In case of
+  ///                     one or more errors, the policy calls the error handler
+  ///                     exactly once, with the first error occurred.
+  /// @tparam Container A container type for holding actor handles. Must provide
+  ///                   the type alias `value_type` as well as the member
+  ///                   functions `begin()`, `end()`, and `size()`.
+  /// @param destinations A container holding handles to all destination actors.
+  /// @param timeout Maximum duration before dropping the request. The runtime
+  ///                system will send an error message to the actor in case the
+  ///                receiver does not respond in time.
+  /// @returns A helper object that takes response handlers via `.await()`,
+  ///          `.then()`, or `.receive()`.
+  /// @note The returned handle is actor-specific. Only the actor that called
+  ///       `request` can use it for setting response handlers.
+  template <class Container, class Policy>
+  [[nodiscard]] auto
+  fan_out_request(const Container& destinations, timespan timeout, Policy) {
+    static_assert(detail::is_one_of_v<Policy, policy::select_all_tag_t,
+                                      policy::select_any_tag_t>,
+                  "Allowed policies are select_all and select_any.");
+    using handle_type = typename Container::value_type;
+    detail::send_type_check<none_t, handle_type, Args...>();
+    std::vector<message_id> ids;
+    ids.reserve(destinations.size());
+    std::vector<disposable> pending_msgs;
+    pending_msgs.reserve(destinations.size());
+    for (const auto& dest : destinations) {
+      if (!dest)
+        continue;
+      auto req_id = self()->new_request_id(Priority);
+      dest->enqueue(make_mailbox_element(self()->ctrl(), req_id,
+                                         super::content_),
+                    self()->context());
+      pending_msgs.emplace_back(
+        self()->request_response_timeout(timeout, req_id));
+      ids.emplace_back(req_id.response_id());
+    }
+    if (ids.empty()) {
+      auto req_id = self()->new_request_id(Priority);
+      self()->enqueue(make_mailbox_element(self()->ctrl(), req_id.response_id(),
+                                           make_error(sec::invalid_argument)),
+                      self()->context());
+      ids.emplace_back(req_id.response_id());
+    }
+    using response_type
+      = response_type_t<typename handle_type::signatures,
+                        detail::implicit_conversions_t<std::decay_t<Args>>...>;
+    using result_type
+      = detail::event_based_fan_out_response_handle_t<Policy, response_type>;
+    return result_type{self(), std::move(ids),
+                       disposable::make_composite(std::move(pending_msgs))};
   }
 
 private:

--- a/libcaf_core/caf/event_based_mail.hpp
+++ b/libcaf_core/caf/event_based_mail.hpp
@@ -145,26 +145,25 @@ public:
     return hdl_t{self(), mid.response_id(), std::move(in_flight_timeout)};
   }
 
-  /// // TODO update
   /// Sends `{xs...}` to each actor in the range `destinations` as a synchronous
   /// message. Response messages get combined into a single result according to
   /// the `Policy`.
-  /// @tparam Policy Configures how individual response messages get
-  ///                     combined by the actor. The policy makes sure that the
-  ///                     response handler gets invoked at most once. In case of
-  ///                     one or more errors, the policy calls the error handler
-  ///                     exactly once, with the first error occurred.
   /// @tparam Container A container type for holding actor handles. Must provide
   ///                   the type alias `value_type` as well as the member
   ///                   functions `begin()`, `end()`, and `size()`.
+  /// @tparam Policy Configures how individual response messages get combined by
+  ///                the actor. The policy makes sure that the response handler
+  ///                gets invoked at most once. In case of one or more errors,
+  ///                the policy calls the error handler exactly once, with the
+  ///                first error occurred.
   /// @param destinations A container holding handles to all destination actors.
   /// @param timeout Maximum duration before dropping the request. The runtime
   ///                system will send an error message to the actor in case the
   ///                receiver does not respond in time.
   /// @returns A helper object that takes response handlers via `.await()`,
-  ///          `.then()`, or `.receive()`.
+  ///          `.then()`, `.to_single()`, or `.to_observable()`.
   /// @note The returned handle is actor-specific. Only the actor that called
-  ///       `request` can use it for setting response handlers.
+  ///       `fan_out_request` can use it for setting response handlers.
   template <class Container, class Policy>
   [[nodiscard]] auto
   fan_out_request(const Container& destinations, timespan timeout, Policy) {

--- a/libcaf_core/caf/event_based_mail.hpp
+++ b/libcaf_core/caf/event_based_mail.hpp
@@ -168,8 +168,8 @@ public:
   template <class Container, class Policy>
   [[nodiscard]] auto
   fan_out_request(const Container& destinations, timespan timeout, Policy) {
-    static_assert(detail::is_one_of_v<Policy, policy::select_all_tag_t,
-                                      policy::select_any_tag_t>,
+    static_assert(detail::one_of<Policy, policy::select_all_tag_t,
+                                 policy::select_any_tag_t>,
                   "Allowed policies are select_all and select_any.");
     using handle_type = typename Container::value_type;
     detail::send_type_check<none_t, handle_type, Args...>();

--- a/libcaf_core/caf/event_based_mail.test.cpp
+++ b/libcaf_core/caf/event_based_mail.test.cpp
@@ -847,6 +847,406 @@ TEST("send fan_out_request messages that return two swapped values") {
   }
 }
 
+// Typed actor interfaces for the fan_out_request test.
+using typed_worker_actor = typed_actor<result<int>(int, int)>;
+using typed_worker_behavior = typed_worker_actor::behavior_type;
+using typed_worker_two_values_actor = typed_actor<result<int, int>(int, int)>;
+using typed_worker_two_values_behavior
+  = typed_worker_two_values_actor::behavior_type;
+using typed_worker_void_actor = typed_actor<result<void>(int, int)>;
+using typed_worker_void_behavior = typed_worker_void_actor::behavior_type;
+
+template <typename Fn>
+typed_worker_actor make_typed_server(caf::actor_system& sys, Fn fn) {
+  auto sf = [&]() -> typed_worker_behavior {
+    return {[&](int x, int y) { return fn(x, y); }};
+  };
+  return sys.spawn(sf);
+}
+
+template <typename Fn>
+typed_worker_two_values_actor
+make_typed_server_two_values(caf::actor_system& sys, Fn fn) {
+  auto sf = [&]() -> typed_worker_two_values_behavior {
+    return {[&](int x, int y) -> result<int, int> { return fn(x, y); }};
+  };
+  return sys.spawn(sf);
+}
+
+template <typename Fn>
+typed_worker_void_actor make_typed_server_void(caf::actor_system& sys, Fn fn) {
+  auto sf = [&]() -> typed_worker_void_behavior {
+    return {[&](int x, int y) -> result<void> {
+      fn(x, y);
+      return {};
+    }};
+  };
+  return sys.spawn(sf);
+}
+
+TEST("send fan_out_request messages that return a result using typed actors") {
+  auto [self, launch] = sys.spawn_inactive();
+  auto self_hdl = actor_cast<actor>(self);
+  std::vector<typed_worker_actor> workers{
+    make_typed_server(sys, [](int x, int y) { return x + y; }),
+    make_typed_server(sys, [](int x, int y) { return x + y; }),
+    make_typed_server(sys, [](int x, int y) { return x + y; }),
+  };
+  dispatch_messages();
+  auto sum = std::make_shared<int>(0);
+  auto err = std::make_shared<error>();
+  SECTION("then with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(workers, infinite, policy::select_all_tag)
+      .then([=](std::vector<int> results) {
+        for (auto result : results)
+          test::runnable::current().check_eq(result, 3);
+        *sum = std::accumulate(results.begin(), results.end(), 0);
+      });
+    launch();
+    check_eq(mail_count(), 3u);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[0]);
+    expect<int>().with(3).from(workers[0]).to(self_hdl);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[1]);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[2]);
+    expect<int>().with(3).from(workers[1]).to(self_hdl);
+    expect<int>().with(3).from(workers[2]).to(self_hdl);
+    check_eq(*sum, 9);
+  }
+  SECTION("then with policy select_any") {
+    self->mail(1, 2)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
+      .then([=](int result) { *sum = result; });
+    launch();
+    check_eq(mail_count(), 3u);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[0]);
+    expect<int>().with(3).from(workers[0]).to(self_hdl);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[1]);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[2]);
+    expect<int>().with(3).from(workers[1]).to(self_hdl);
+    expect<int>().with(3).from(workers[2]).to(self_hdl);
+    check_eq(*sum, 3);
+  }
+  SECTION("await with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(workers, infinite, policy::select_all_tag)
+      .await([this, sum](std::vector<int> results) {
+        for (auto result : results)
+          check_eq(result, 3);
+        *sum = std::accumulate(results.begin(), results.end(), 0);
+      });
+    launch();
+    check_eq(mail_count(), 3u);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[2]);
+    expect<int>().with(3).from(workers[2]).to(self_hdl);
+    check_eq(mail_count(), 2u);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[1]);
+    expect<int>().with(3).from(workers[1]).to(self_hdl);
+    check_eq(mail_count(), 1u);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[0]);
+    expect<int>().with(3).from(workers[0]).to(self_hdl);
+    check_eq(mail_count(), 0u);
+    check_eq(*sum, 9);
+  }
+  SECTION("await with policy select_any") {
+    self->mail(1, 2)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
+      .await([sum](int result) { *sum = result; });
+    launch();
+    check_eq(mail_count(), 3u);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[2]);
+    expect<int>().with(3).from(workers[2]).to(self_hdl);
+    check_eq(*sum, 3);
+    check_eq(mail_count(), 2u);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[1]);
+    expect<int>().with(3).from(workers[1]).to(self_hdl);
+    check_eq(mail_count(), 1u);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[0]);
+    expect<int>().with(3).from(workers[0]).to(self_hdl);
+    check_eq(mail_count(), 0u);
+    check_eq(*sum, 3);
+  }
+  SECTION(".to_observable with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(workers, infinite, policy::select_all_tag)
+      .as_observable()
+      .do_on_error([err](const error& x) { *err = x; })
+      .for_each([sum](std::vector<int> results) {
+        *sum = std::accumulate(results.begin(), results.end(), 0);
+      });
+    launch();
+    dispatch_messages();
+    check_eq(*err, error{});
+    check_eq(*sum, 9);
+  }
+  SECTION(".to_observable with policy select_any") {
+    self->mail(3, 5)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
+      .as_observable()
+      .do_on_error([err](const error& x) { *err = x; })
+      .for_each([sum](int x) { *sum = x; });
+    launch();
+    dispatch_messages();
+    check_eq(*err, error{});
+    check_eq(*sum, 8);
+  }
+  SECTION("error response") {
+    std::vector<typed_worker_actor> error_workers{
+      make_typed_server(sys,
+                        [](int, int) -> result<int> {
+                          return caf::error(sec::logic_error);
+                        }),
+      make_typed_server(sys,
+                        [](int, int) -> result<int> {
+                          return caf::error(sec::logic_error);
+                        }),
+      make_typed_server(sys,
+                        [](int, int) -> result<int> {
+                          return caf::error(sec::logic_error);
+                        }),
+    };
+    auto error_sum = std::make_shared<int>(0);
+    auto error_err = std::make_shared<error>();
+    self->mail(1, 2)
+      .fan_out_request(error_workers, infinite, policy::select_any_tag)
+      .then([error_sum](int result) { *error_sum = result; },
+            [error_err](error& err) { *error_err = std::move(err); });
+    launch();
+    dispatch_messages();
+    check_eq(*error_err, error{sec::all_requests_failed});
+    check_eq(*error_sum, 0);
+  }
+}
+
+TEST("send fan_out_request messages that return two swapped values using typed "
+     "actors") {
+  auto [self, launch] = sys.spawn_inactive();
+  auto self_hdl = actor_cast<actor>(self);
+  std::vector<typed_worker_two_values_actor> workers{
+    make_typed_server_two_values(
+      sys, [](int x, int y) { return result<int, int>(y, x); }),
+    make_typed_server_two_values(
+      sys, [](int x, int y) { return result<int, int>(y, x); }),
+    make_typed_server_two_values(
+      sys, [](int x, int y) { return result<int, int>(y, x); }),
+  };
+  dispatch_messages();
+  auto swapped_values = std::make_shared<std::vector<std::pair<int, int>>>();
+  auto single_result = std::make_shared<std::pair<int, int>>();
+  auto err = std::make_shared<error>();
+  SECTION("then with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(workers, infinite, policy::select_all_tag)
+      .then([=](std::vector<std::tuple<int, int>> results) {
+        for (auto result : results) {
+          swapped_values->emplace_back(std::get<0>(result),
+                                       std::get<1>(result));
+        }
+      });
+    launch();
+    check_eq(mail_count(), 3u);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[0]);
+    expect<int, int>().with(2, 1).from(workers[0]).to(self_hdl);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[1]);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[2]);
+    expect<int, int>().with(2, 1).from(workers[1]).to(self_hdl);
+    expect<int, int>().with(2, 1).from(workers[2]).to(self_hdl);
+    check_eq(swapped_values->size(), 3u);
+    for (const auto& pair : *swapped_values) {
+      check_eq(pair.first, 2);
+      check_eq(pair.second, 1);
+    }
+  }
+  SECTION("then with policy select_any") {
+    self->mail(3, 5)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
+      .then([=](int first, int second) {
+        *single_result = std::make_pair(first, second);
+      });
+    launch();
+    check_eq(mail_count(), 3u);
+    expect<int, int>().with(3, 5).from(self_hdl).to(workers[0]);
+    expect<int, int>().with(5, 3).from(workers[0]).to(self_hdl);
+    check_eq(single_result->first, 5);
+    check_eq(single_result->second, 3);
+    expect<int, int>().with(3, 5).from(self_hdl).to(workers[1]);
+    expect<int, int>().with(3, 5).from(self_hdl).to(workers[2]);
+    expect<int, int>().with(5, 3).from(workers[1]).to(self_hdl);
+    expect<int, int>().with(5, 3).from(workers[2]).to(self_hdl);
+  }
+  SECTION("await with policy select_all") {
+    self->mail(7, 11)
+      .fan_out_request(workers, infinite, policy::select_all_tag)
+      .await([this, swapped_values](std::vector<std::tuple<int, int>> results) {
+        for (auto result : results) {
+          check_eq(std::get<0>(result), 11);
+          check_eq(std::get<1>(result), 7);
+          swapped_values->emplace_back(std::get<0>(result),
+                                       std::get<1>(result));
+        }
+      });
+    launch();
+    check_eq(mail_count(), 3u);
+    expect<int, int>().with(7, 11).from(self_hdl).to(workers[2]);
+    expect<int, int>().with(11, 7).from(workers[2]).to(self_hdl);
+    check_eq(mail_count(), 2u);
+    expect<int, int>().with(7, 11).from(self_hdl).to(workers[1]);
+    expect<int, int>().with(11, 7).from(workers[1]).to(self_hdl);
+    check_eq(mail_count(), 1u);
+    expect<int, int>().with(7, 11).from(self_hdl).to(workers[0]);
+    expect<int, int>().with(11, 7).from(workers[0]).to(self_hdl);
+    check_eq(mail_count(), 0u);
+    check_eq(swapped_values->size(), 3u);
+    for (const auto& pair : *swapped_values) {
+      check_eq(pair.first, 11);
+      check_eq(pair.second, 7);
+    }
+  }
+  SECTION("await with policy select_any") {
+    self->mail(13, 17)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
+      .await([single_result](int first, int second) {
+        *single_result = std::make_pair(first, second);
+      });
+    launch();
+    check_eq(mail_count(), 3u);
+    expect<int, int>().with(13, 17).from(self_hdl).to(workers[2]);
+    expect<int, int>().with(17, 13).from(workers[2]).to(self_hdl);
+    check_eq(single_result->first, 17);
+    check_eq(single_result->second, 13);
+    check_eq(mail_count(), 2u);
+    expect<int, int>().with(13, 17).from(self_hdl).to(workers[1]);
+    expect<int, int>().with(17, 13).from(workers[1]).to(self_hdl);
+    check_eq(mail_count(), 1u);
+    expect<int, int>().with(13, 17).from(self_hdl).to(workers[0]);
+    expect<int, int>().with(17, 13).from(workers[0]).to(self_hdl);
+    check_eq(mail_count(), 0u);
+    check_eq(single_result->first, 17);
+    check_eq(single_result->second, 13);
+  }
+  SECTION("as_observable with policy select_all") {
+    self->mail(19, 23)
+      .fan_out_request(workers, infinite, policy::select_all_tag)
+      .as_observable()
+      .do_on_error([err](const error& x) { *err = x; })
+      .for_each(
+        [swapped_values](std::vector<caf::cow_tuple<int, int>> results) {
+          swapped_values->clear();
+          for (auto result : results) {
+            swapped_values->emplace_back(get<0>(result), get<1>(result));
+          }
+        });
+    launch();
+    dispatch_messages();
+    check_eq(*err, error{});
+    check_eq(swapped_values->size(), 3u);
+    for (const auto& pair : *swapped_values) {
+      check_eq(pair.first, 23);
+      check_eq(pair.second, 19);
+    }
+  }
+  SECTION("as_observable with policy select_any") {
+    self->mail(29, 31)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
+      .as_observable()
+      .do_on_error([err](const error& x) { *err = x; })
+      .for_each([single_result](caf::cow_tuple<int, int> result) {
+        *single_result = std::make_pair(get<0>(result), get<1>(result));
+      });
+    launch();
+    dispatch_messages();
+    check_eq(*err, error{});
+    check_eq(single_result->first, 31);
+    check_eq(single_result->second, 29);
+  }
+  SECTION("error response with swapped values") {
+    std::vector<typed_worker_two_values_actor> error_workers{
+      make_typed_server_two_values(sys,
+                                   [](int, int) -> result<int, int> {
+                                     return caf::error(sec::logic_error);
+                                   }),
+      make_typed_server_two_values(sys,
+                                   [](int, int) -> result<int, int> {
+                                     return caf::error(sec::logic_error);
+                                   }),
+      make_typed_server_two_values(sys,
+                                   [](int, int) -> result<int, int> {
+                                     return caf::error(sec::logic_error);
+                                   }),
+    };
+    auto error_result = std::make_shared<std::pair<int, int>>();
+    auto error_err = std::make_shared<error>();
+    self->mail(37, 41)
+      .fan_out_request(error_workers, infinite, policy::select_any_tag)
+      .as_observable()
+      .do_on_error([error_err](const error& x) { *error_err = x; })
+      .for_each([error_result](cow_tuple<int, int> result) {
+        *error_result = std::make_pair(get<0>(result), get<1>(result));
+      });
+    launch();
+    dispatch_messages();
+    check_eq(*error_err, error{sec::all_requests_failed});
+    check_eq(error_result->first, 0);
+    check_eq(error_result->second, 0);
+  }
+}
+
+TEST("send fan_out_request messages with void result using typed actors") {
+  auto [self, launch] = sys.spawn_inactive();
+  auto self_hdl = actor_cast<actor>(self);
+  std::vector<typed_worker_void_actor> workers{
+    make_typed_server_void(sys, [](int, int) {}),
+    make_typed_server_void(sys, [](int, int) {}),
+    make_typed_server_void(sys, [](int, int) {}),
+  };
+  dispatch_messages();
+  auto ran = std::make_shared<bool>(false);
+  SECTION("then with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(workers, infinite, policy::select_all_tag)
+      .then([ran]() { *ran = true; });
+    launch();
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[0]);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[1]);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[2]);
+    dispatch_messages();
+    check(*ran);
+  }
+  SECTION("then with policy select_any") {
+    self->mail(1, 2)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
+      .then([ran]() { *ran = true; });
+    launch();
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[0]);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[1]);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[2]);
+    dispatch_messages();
+    check(*ran);
+  }
+  SECTION("await with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(workers, infinite, policy::select_all_tag)
+      .await([ran]() { *ran = true; });
+    launch();
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[2]);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[1]);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[0]);
+    dispatch_messages();
+    check(*ran);
+  }
+  SECTION("await with policy select_any") {
+    self->mail(1, 2)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
+      .await([ran]() { *ran = true; });
+    launch();
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[2]);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[1]);
+    expect<int, int>().with(1, 2).from(self_hdl).to(workers[0]);
+    dispatch_messages();
+    check(*ran);
+  }
+}
+
 // Test scenarios to implement:
 // + urgent
 // + scheduled/delayed

--- a/libcaf_core/caf/event_based_mail.test.cpp
+++ b/libcaf_core/caf/event_based_mail.test.cpp
@@ -1247,13 +1247,6 @@ TEST("send fan_out_request messages with void result using typed actors") {
   }
 }
 
-// Test scenarios to implement:
-// + urgent
-// + scheduled/delayed
-// + no receivers
-// + a few receivers
-// + have an await that returns an expected!
-
 TEST("send fan_out_request messages with invalid setups") {
   auto [self, launch] = sys.spawn_inactive();
   auto self_hdl = actor_cast<actor>(self);

--- a/libcaf_core/caf/event_based_mail.test.cpp
+++ b/libcaf_core/caf/event_based_mail.test.cpp
@@ -526,7 +526,7 @@ TEST("send fan_out_request messages that return a result") {
   auto err = std::make_shared<error>();
   SECTION("then with policy select_all") {
     self->mail(1, 2)
-      .fan_out_request(workers, infinite, policy::select_all_v)
+      .fan_out_request(workers, infinite, policy::select_all_tag)
       .then([=](std::vector<int> results) {
         for (auto result : results)
           test::runnable::current().check_eq(result, 3);
@@ -544,7 +544,7 @@ TEST("send fan_out_request messages that return a result") {
   }
   SECTION("then with policy select_any") {
     self->mail(1, 2)
-      .fan_out_request(workers, infinite, policy::select_any_v)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
       .then([=](int result) { *sum = result; });
     launch();
     check_eq(mail_count(), 3u);
@@ -558,7 +558,7 @@ TEST("send fan_out_request messages that return a result") {
   }
   SECTION("await with policy select_all") {
     self->mail(1, 2)
-      .fan_out_request(workers, infinite, policy::select_all_v)
+      .fan_out_request(workers, infinite, policy::select_all_tag)
       .await([this, sum](std::vector<int> results) {
         for (auto result : results)
           check_eq(result, 3);
@@ -579,7 +579,7 @@ TEST("send fan_out_request messages that return a result") {
   }
   SECTION("await with policy select_any") {
     self->mail(1, 2)
-      .fan_out_request(workers, infinite, policy::select_any_v)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
       .await([sum](int result) { *sum = result; });
     launch();
     check_eq(mail_count(), 3u);
@@ -597,7 +597,7 @@ TEST("send fan_out_request messages that return a result") {
   }
   SECTION(".to_observable with policy select_all") {
     self->mail(1, 2)
-      .fan_out_request(workers, infinite, policy::select_all_v)
+      .fan_out_request(workers, infinite, policy::select_all_tag)
       .as_observable<int>()
       .do_on_error([err](const error& x) { *err = x; })
       .for_each([sum](std::vector<int> results) {
@@ -610,7 +610,7 @@ TEST("send fan_out_request messages that return a result") {
   }
   SECTION(".to_observable with policy select_any") {
     self->mail(3, 5)
-      .fan_out_request(workers, infinite, policy::select_any_v)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
       .as_observable<int>()
       .do_on_error([err](const error& x) { *err = x; })
       .for_each([sum](int x) { *sum = x; });
@@ -621,7 +621,7 @@ TEST("send fan_out_request messages that return a result") {
   }
   SECTION("error response") {
     self->mail("Hello")
-      .fan_out_request(workers, infinite, policy::select_any_v)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
       .as_observable<int>()
       .do_on_error([err](const error& x) { *err = x; })
       .for_each([sum](int x) { *sum = x; });
@@ -644,7 +644,7 @@ TEST("send fan_out_request messages with void result") {
   auto ran = std::make_shared<bool>(false);
   SECTION("then with policy select_all") {
     self->mail(1, 2)
-      .fan_out_request(workers, infinite, policy::select_all_v)
+      .fan_out_request(workers, infinite, policy::select_all_tag)
       .then([ran]() { *ran = true; });
     launch();
     expect<int, int>().with(1, 2).from(self_hdl).to(workers[0]);
@@ -655,7 +655,7 @@ TEST("send fan_out_request messages with void result") {
   }
   SECTION("then with policy select_any") {
     self->mail(1, 2)
-      .fan_out_request(workers, infinite, policy::select_any_v)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
       .then([ran]() { *ran = true; });
     launch();
     expect<int, int>().with(1, 2).from(self_hdl).to(workers[0]);
@@ -666,7 +666,7 @@ TEST("send fan_out_request messages with void result") {
   }
   SECTION("await with policy select_all") {
     self->mail(1, 2)
-      .fan_out_request(workers, infinite, policy::select_all_v)
+      .fan_out_request(workers, infinite, policy::select_all_tag)
       .await([ran]() { *ran = true; });
     launch();
     expect<int, int>().with(1, 2).from(self_hdl).to(workers[2]);
@@ -677,7 +677,7 @@ TEST("send fan_out_request messages with void result") {
   }
   SECTION("await with policy select_any") {
     self->mail(1, 2)
-      .fan_out_request(workers, infinite, policy::select_any_v)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
       .await([ran]() { *ran = true; });
     launch();
     expect<int, int>().with(1, 2).from(self_hdl).to(workers[2]);
@@ -797,7 +797,7 @@ TEST("send fan_out_request messages with invalid setups") {
   auto result = std::make_shared<error>();
   SECTION("then with policy select_all") {
     self->mail(1, 2)
-      .fan_out_request(workers, infinite, policy::select_all_v)
+      .fan_out_request(workers, infinite, policy::select_all_tag)
       .then(
         [=](std::vector<int> results) {
           test::runnable::current().fail("expected an error, got: {}", results);
@@ -815,7 +815,7 @@ TEST("send fan_out_request messages with invalid setups") {
   }
   SECTION("then with policy select_any") {
     self->mail(1, 2)
-      .fan_out_request(workers, infinite, policy::select_any_v)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
       .then(
         [=](int results) {
           test::runnable::current().fail("expected an error, got: {}", results);
@@ -833,7 +833,7 @@ TEST("send fan_out_request messages with invalid setups") {
   }
   SECTION("await with policy select_all") {
     self->mail(1, 2)
-      .fan_out_request(workers, infinite, policy::select_all_v)
+      .fan_out_request(workers, infinite, policy::select_all_tag)
       .await(
         [=](std::vector<int> results) {
           test::runnable::current().fail("expected an error, got: {}", results);
@@ -851,7 +851,7 @@ TEST("send fan_out_request messages with invalid setups") {
   }
   SECTION("await with policy select_any") {
     self->mail(1, 2)
-      .fan_out_request(workers, infinite, policy::select_any_v)
+      .fan_out_request(workers, infinite, policy::select_any_tag)
       .then(
         [=](int results) {
           test::runnable::current().fail("expected an error, got: {}", results);

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -62,6 +62,7 @@ template <class...> class cow_tuple;
 template <class...> class delegated;
 template <class...> class event_based_delayed_response_handle;
 template <class...> class event_based_response_handle;
+template <class, class...> class event_based_fan_out_response_handle;
 template <class...> class result;
 template <class...> class typed_actor;
 template <class...> class typed_actor_pointer;

--- a/libcaf_core/caf/policy/select_all_tag.hpp
+++ b/libcaf_core/caf/policy/select_all_tag.hpp
@@ -1,0 +1,12 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+namespace caf::policy {
+
+struct select_all_tag_t {};
+constexpr auto select_all_tag = select_all_tag_t{};
+
+} // namespace caf::policy

--- a/libcaf_core/caf/policy/select_all_tag.hpp
+++ b/libcaf_core/caf/policy/select_all_tag.hpp
@@ -6,7 +6,12 @@
 
 namespace caf::policy {
 
+/// Tag type to indicate that the fan_out_request should combine all responses
+/// into a container and return them to the actor.
 struct select_all_tag_t {};
+
+/// Tag to indicate that the fan_out_request should combine all responses into a
+/// container and return them to the actor.
 constexpr auto select_all_tag = select_all_tag_t{};
 
 } // namespace caf::policy

--- a/libcaf_core/caf/policy/select_any_tag.hpp
+++ b/libcaf_core/caf/policy/select_any_tag.hpp
@@ -6,8 +6,12 @@
 
 namespace caf::policy {
 
+/// Tag type to indicate that the fan_out_request should pick any valid response
+/// and return it to the actor.
 struct select_any_tag_t {};
 
+/// Tag to indicate that the fan_out_request should pick any valid response and
+/// return it to the actor.
 constexpr auto select_any_tag = select_any_tag_t{};
 
 } // namespace caf::policy

--- a/libcaf_core/caf/policy/select_any_tag.hpp
+++ b/libcaf_core/caf/policy/select_any_tag.hpp
@@ -1,0 +1,13 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+namespace caf::policy {
+
+struct select_any_tag_t {};
+
+constexpr auto select_any_tag = select_any_tag_t{};
+
+} // namespace caf::policy


### PR DESCRIPTION
This PR covers the fan_out_request for event based messages.

Since this is open for a while and grown in size, I propose this for the first round of review, while some things like the delayed and blocking version of the request will be a followup. 

Relates #2009 