### PR TITLE
Fix `add_header_fields` in the HTTP DSL

### DIFF
--- a/libcaf_net/caf/net/http/with.cpp
+++ b/libcaf_net/caf/net/http/with.cpp
@@ -377,10 +377,8 @@ with_t::client&& with_t::client::max_retry_count(size_t value) && {
   return std::move(*this);
 }
 
-with_t::client&& with_t::client::add_header_field(std::string name,
-                                                  std::string value) && {
+void with_t::client::do_add_header_field(std::string name, std::string value) {
   config_->fields.insert(std::pair{std::move(name), std::move(value)});
-  return std::move(*this);
 }
 
 expected<std::pair<async::future<response>, disposable>>


### PR DESCRIPTION
Apply the `forward_like` patch that we did a while back in `main` (before merging `release/2` back).