### PR TITLE
Add HTTP multipart writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - When starting a server or client using length-prefix framing, users can now
   specify the maximum message size via `max_message_size` and the number of
   bytes for the length prefix via `size_field`.
+- The namespace `caf::net::http` now contains two new classes for dealing with
+  HTTP multipart requests and responses: `multipart_reader` and
+  `multipart_writer`.
 
 ### Fixed
 

--- a/libcaf_core/caf/callback.hpp
+++ b/libcaf_core/caf/callback.hpp
@@ -62,6 +62,30 @@ private:
   F f_;
 };
 
+/// Utility class for wrapping a function object of type `F` by reference.
+template <class F, class Signature>
+class callback_ref_impl;
+
+template <class F, class Result, class... Ts>
+class callback_ref_impl<F, Result(Ts...)> final
+  : public callback<Result(Ts...)> {
+public:
+  explicit callback_ref_impl(F& f) : f_(&f) {
+    // nop
+  }
+
+  callback_ref_impl(callback_ref_impl&&) = default;
+
+  callback_ref_impl& operator=(callback_ref_impl&&) = default;
+
+  Result operator()(Ts... xs) override {
+    return (*f_)(std::forward<Ts>(xs)...);
+  }
+
+private:
+  F* f_;
+};
+
 /// Wraps `fun` into a @ref callback function object.
 /// @relates callback
 template <class F>

--- a/libcaf_net/CMakeLists.txt
+++ b/libcaf_net/CMakeLists.txt
@@ -56,6 +56,8 @@ caf_add_component(
     caf/net/http/method.cpp
     caf/net/http/multipart_reader.cpp
     caf/net/http/multipart_reader.test.cpp
+    caf/net/http/multipart_writer.cpp
+    caf/net/http/multipart_writer.test.cpp
     caf/net/http/request.cpp
     caf/net/http/request_header.cpp
     caf/net/http/request_header.test.cpp

--- a/libcaf_net/caf/net/http/multipart_reader.cpp
+++ b/libcaf_net/caf/net/http/multipart_reader.cpp
@@ -32,7 +32,7 @@ multipart_reader::multipart_reader(const responder& res)
   // nop
 }
 
-bool multipart_reader::do_parse(consume_fn fn, void* obj) {
+bool multipart_reader::do_parse(consume_fn& fn) {
   // Ensure the MIME type indicates multipart content.
   if (mime_type_.find("multipart/") != 0) {
     return false;
@@ -108,7 +108,7 @@ bool multipart_reader::do_parse(consume_fn fn, void* obj) {
       content_view = content_view.substr(0, content_view.size() - 2);
     }
     auto content = as_bytes(make_span(content_view));
-    fn(obj, std::move(hdr), content);
+    fn(std::move(hdr), content);
     payload.remove_prefix(next_boundary + boundary_size);
   }
   return true;

--- a/libcaf_net/caf/net/http/multipart_writer.cpp
+++ b/libcaf_net/caf/net/http/multipart_writer.cpp
@@ -1,0 +1,92 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#include "caf/net/http/multipart_writer.hpp"
+
+#include "caf/span.hpp"
+
+namespace caf::net::http {
+
+namespace {
+
+/// The default boundary string used by the multipart writer. No particular
+/// reason for this string, just using the example string from rfc2046.
+constexpr std::string_view default_boundary = "gc0p4Jq0M2Yt08j34c0p";
+
+// Helper function to write a string to a byte buffer
+void write_string(byte_buffer& buf, std::string_view str) {
+  auto bytes = as_bytes(make_span(str));
+  buf.insert(buf.end(), bytes.begin(), bytes.end());
+}
+
+} // namespace
+
+multipart_writer::header_builder&
+multipart_writer::header_builder::add(std::string_view key,
+                                      std::string_view value) {
+  auto& buf = writer_->buf_;
+  write_string(buf, key);
+  write_string(buf, ": ");
+  write_string(buf, value);
+  write_string(buf, "\r\n");
+  return *this;
+}
+
+multipart_writer::multipart_writer() : boundary_(default_boundary) {
+  // nop
+}
+
+multipart_writer::multipart_writer(std::string boundary)
+  : boundary_(std::move(boundary)) {
+  // nop
+}
+
+void multipart_writer::reset() {
+  buf_.clear();
+}
+
+void multipart_writer::reset(std::string boundary) {
+  boundary_ = std::move(boundary);
+  buf_.clear();
+}
+
+void multipart_writer::append(const_byte_span payload) {
+  do_append(payload, [](void*, header_builder&) {}, nullptr);
+}
+
+void multipart_writer::append(const_byte_span payload, std::string_view key,
+                              std::string_view value) {
+  using kvp_t = std::pair<std::string_view, std::string_view>;
+  auto fn = [](void* kvp_ptr, header_builder& builder) {
+    auto& kvp = *static_cast<kvp_t*>(kvp_ptr);
+    builder.add(kvp.first, kvp.second);
+  };
+  auto kvp = kvp_t{key, value};
+  do_append(payload, fn, &kvp);
+}
+
+const_byte_span multipart_writer::finalize() {
+  write_string(buf_, "--");
+  write_string(buf_, boundary_);
+  write_string(buf_, "--\r\n");
+  return make_span(buf_);
+}
+
+std::string_view multipart_writer::boundary() const noexcept {
+  return boundary_;
+}
+
+void multipart_writer::do_append(const_byte_span payload, add_headers_fn fn,
+                                 void* obj) {
+  header_builder builder{this};
+  write_string(buf_, "--");
+  write_string(buf_, boundary_);
+  write_string(buf_, "\r\n");
+  fn(obj, builder);
+  write_string(buf_, "\r\n");
+  buf_.insert(buf_.end(), payload.begin(), payload.end());
+  write_string(buf_, "\r\n");
+}
+
+} // namespace caf::net::http

--- a/libcaf_net/caf/net/http/multipart_writer.hpp
+++ b/libcaf_net/caf/net/http/multipart_writer.hpp
@@ -1,0 +1,106 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+#include "caf/byte_buffer.hpp"
+#include "caf/byte_span.hpp"
+#include "caf/detail/net_export.hpp"
+
+#include <string_view>
+
+namespace caf::net::http {
+
+/// A utility class for creating multipart content for HTTP requests.
+class CAF_NET_EXPORT multipart_writer {
+public:
+  class CAF_NET_EXPORT header_builder {
+  public:
+    explicit header_builder(multipart_writer* writer) : writer_(writer) {
+      // nop
+    }
+
+    header_builder& add(std::string_view key, std::string_view value);
+
+  private:
+    multipart_writer* writer_;
+  };
+
+  friend class header_builder;
+
+  /// Constructs a multipart_writer with a default boundary.
+  multipart_writer();
+
+  /// Constructs a multipart_writer with a custom boundary.
+  explicit multipart_writer(std::string boundary);
+
+  /// Clears the buffer but keeps the boundary string.
+  void reset();
+
+  /// Clears the buffer and sets a new boundary string.
+  void reset(std::string boundary);
+
+  /// Appends a payload with no headers.
+  void append(const_byte_span payload);
+
+  /// Appends a payload with no headers from a string_view.
+  void append(std::string_view payload) {
+    append(as_bytes(make_span(payload)));
+  }
+
+  /// Appends a payload with a single header field.
+  void append(const_byte_span payload, std::string_view key,
+              std::string_view value);
+
+  /// Appends a payload with a single header field from a string_view.
+  void append(std::string_view payload, std::string_view key,
+              std::string_view value) {
+    append(as_bytes(make_span(payload)), key, value);
+  }
+
+  /// Appends a payload with custom header configuration.
+  /// @param payload The payload to append.
+  /// @param add_headers A function object for writing the headers to this part.
+  ///                    The function object must be invocable with a
+  ///                    `header_builder&` argument.
+  template <class AddHeadersFn>
+  void append(const_byte_span payload, AddHeadersFn&& add_headers) {
+    using add_headers_t = std::decay_t<AddHeadersFn>;
+    auto fn = [](void* ctx, header_builder& builder) {
+      (*static_cast<add_headers_t*>(ctx))(builder);
+    };
+    do_append(payload, fn, &add_headers);
+  }
+
+  /// Appends a payload with custom header configuration from a string_view.
+  template <class AddHeadersFn>
+  void append(std::string_view payload, AddHeadersFn&& add_headers) {
+    append(as_bytes(make_span(payload)),
+           std::forward<AddHeadersFn>(add_headers));
+  }
+
+  /// Finalizes the multipart content by adding the final boundary and returns
+  /// the rendered multipart body as a const_byte_span.
+  const_byte_span finalize();
+
+  /// Returns the boundary used by this writer.
+  std::string_view boundary() const noexcept;
+
+private:
+  using add_headers_fn = void (*)(void*, header_builder&);
+
+  /// Appends a payload with custom header configuration.
+  /// @param payload The payload to append.
+  /// @param fn A function object for writing the headers to this part.
+  /// @param obj Additional context for the function object.
+  void do_append(const_byte_span payload, add_headers_fn fn, void* obj);
+
+  /// The buffer containing the multipart content.
+  byte_buffer buf_;
+
+  /// The boundary string used to separate parts.
+  std::string boundary_;
+};
+
+} // namespace caf::net::http

--- a/libcaf_net/caf/net/http/multipart_writer.test.cpp
+++ b/libcaf_net/caf/net/http/multipart_writer.test.cpp
@@ -1,0 +1,174 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#include "caf/net/http/multipart_writer.hpp"
+
+#include "caf/test/scenario.hpp"
+
+#include "caf/span.hpp"
+
+using namespace caf;
+using namespace caf::net::http;
+using namespace std::literals;
+
+SCENARIO("a multipart writer accepts payloads with no headers") {
+  GIVEN("a multipart_writer and a payload") {
+    multipart_writer writer;
+    auto payload1 = "Hello, World!"sv;
+    WHEN("the payload is appended with no headers") {
+      writer.append(payload1);
+      auto result = to_string_view(writer.finalize());
+      THEN("the result only contains the payload and the boundary") {
+        std::string_view expected = "--gc0p4Jq0M2Yt08j34c0p\r\n"
+                                    "\r\n"
+                                    "Hello, World!\r\n"
+                                    "--gc0p4Jq0M2Yt08j34c0p--\r\n";
+        check_eq(result, expected);
+      }
+    }
+  }
+  GIVEN("a multipart_writer and multiple payload") {
+    multipart_writer writer;
+    auto payload1 = "Hello, World!"sv;
+    auto payload2 = "Hello, World, again!"sv;
+    auto payload3 = "Hello, World, again and again!"sv;
+    WHEN("the payload is appended with no headers") {
+      writer.append(payload1);
+      writer.append(payload2);
+      writer.append(payload3);
+      auto result = to_string_view(writer.finalize());
+      THEN("the result contains the payloads and the boundary") {
+        std::string_view expected = "--gc0p4Jq0M2Yt08j34c0p\r\n"
+                                    "\r\n"
+                                    "Hello, World!\r\n"
+                                    "--gc0p4Jq0M2Yt08j34c0p\r\n"
+                                    "\r\n"
+                                    "Hello, World, again!\r\n"
+                                    "--gc0p4Jq0M2Yt08j34c0p\r\n"
+                                    "\r\n"
+                                    "Hello, World, again and again!\r\n"
+                                    "--gc0p4Jq0M2Yt08j34c0p--\r\n";
+        check_eq(result, expected);
+      }
+    }
+  }
+}
+
+SCENARIO("a multipart writer accepts payloads with a single header field") {
+  GIVEN("a multipart_writer and a payload") {
+    multipart_writer writer;
+    auto payload1 = "Hello, World!"sv;
+    WHEN("the payload is appended with a single header field") {
+      writer.append(payload1, "Content-Type", "text/plain");
+      auto result = to_string_view(writer.finalize());
+      THEN("the result contains the header and the payload") {
+        std::string_view expected = "--gc0p4Jq0M2Yt08j34c0p\r\n"
+                                    "Content-Type: text/plain\r\n"
+                                    "\r\n"
+                                    "Hello, World!\r\n"
+                                    "--gc0p4Jq0M2Yt08j34c0p--\r\n";
+        check_eq(result, expected);
+      }
+    }
+  }
+}
+
+SCENARIO("a multipart writer accepts payloads with a header builder function") {
+  GIVEN("a multipart_writer and a payload") {
+    multipart_writer writer;
+    auto payload1 = "Hello, World!"sv;
+    WHEN("passing a function that adds no headers") {
+      writer.append(payload1, [](auto&) {});
+      auto result = to_string_view(writer.finalize());
+      THEN("the result only contains the payload and the boundary") {
+        std::string_view expected = "--gc0p4Jq0M2Yt08j34c0p\r\n"
+                                    "\r\n"
+                                    "Hello, World!\r\n"
+                                    "--gc0p4Jq0M2Yt08j34c0p--\r\n";
+        check_eq(result, expected);
+      }
+    }
+    WHEN("passing a function that adds a single header field") {
+      writer.append(payload1,
+                    [](auto& w) { w.add("Content-Type", "text/plain"); });
+      auto result = to_string_view(writer.finalize());
+      THEN("the result contains the header and the payload") {
+        std::string_view expected = "--gc0p4Jq0M2Yt08j34c0p\r\n"
+                                    "Content-Type: text/plain\r\n"
+                                    "\r\n"
+                                    "Hello, World!\r\n"
+                                    "--gc0p4Jq0M2Yt08j34c0p--\r\n";
+        check_eq(result, expected);
+      }
+    }
+    WHEN("passing a function that adds multiple header fields") {
+      writer.append(payload1, [](auto& w) {
+        w.add("Content-Type", "text/plain");
+        w.add("Custom-Field", "FooBar");
+      });
+      auto result = to_string_view(writer.finalize());
+      THEN("the result contains the headers and the payload") {
+        std::string_view expected = "--gc0p4Jq0M2Yt08j34c0p\r\n"
+                                    "Content-Type: text/plain\r\n"
+                                    "Custom-Field: FooBar\r\n"
+                                    "\r\n"
+                                    "Hello, World!\r\n"
+                                    "--gc0p4Jq0M2Yt08j34c0p--\r\n";
+        check_eq(result, expected);
+      }
+    }
+  }
+}
+
+SCENARIO("a multipart writer allows setting custom boundaries") {
+  GIVEN("a multipart_writer and a payload") {
+    multipart_writer writer{"custom-boundary"};
+    check_eq(writer.boundary(), "custom-boundary");
+    auto payload1 = "Hello, World!"sv;
+    WHEN("the payload is appended with no headers") {
+      writer.append(payload1);
+      auto result = to_string_view(writer.finalize());
+      THEN("the result only contains the payload and the boundary") {
+        std::string_view expected = "--custom-boundary\r\n"
+                                    "\r\n"
+                                    "Hello, World!\r\n"
+                                    "--custom-boundary--\r\n";
+        check_eq(result, expected);
+      }
+    }
+  }
+}
+
+SCENARIO("a multipart writer can be re-used after resetting") {
+  GIVEN("a multipart_writer and two payloads") {
+    multipart_writer writer;
+    auto payload1 = "Hello, World!"sv;
+    auto payload2 = "Hello, World, again!"sv;
+    WHEN("resetting the writer after appending a payload") {
+      writer.append(payload1);
+      writer.reset();
+      writer.append(payload2);
+      auto result = to_string_view(writer.finalize());
+      THEN("the result contains only what was appended after resetting") {
+        std::string_view expected = "--gc0p4Jq0M2Yt08j34c0p\r\n"
+                                    "\r\n"
+                                    "Hello, World, again!\r\n"
+                                    "--gc0p4Jq0M2Yt08j34c0p--\r\n";
+        check_eq(result, expected);
+      }
+    }
+    WHEN("resetting the writer with a new boundary") {
+      writer.reset("custom-boundary");
+      writer.append(payload2);
+      auto result = to_string_view(writer.finalize());
+      THEN("the result contains only what was appended after resetting") {
+        std::string_view expected = "--custom-boundary\r\n"
+                                    "\r\n"
+                                    "Hello, World, again!\r\n"
+                                    "--custom-boundary--\r\n";
+        check_eq(result, expected);
+      }
+    }
+  }
+}

--- a/libcaf_net/caf/net/http/multipart_writer.test.cpp
+++ b/libcaf_net/caf/net/http/multipart_writer.test.cpp
@@ -28,7 +28,7 @@ SCENARIO("a multipart writer accepts payloads with no headers") {
       }
     }
   }
-  GIVEN("a multipart_writer and multiple payload") {
+  GIVEN("a multipart_writer and multiple payloads") {
     multipart_writer writer;
     auto payload1 = "Hello, World!"sv;
     auto payload2 = "Hello, World, again!"sv;


### PR DESCRIPTION
Closes #2073.

Adds a convenience API for writing an HTTP multipart body.