### PR TITLE
Fix test description typos and grammar

### DIFF
--- a/libcaf_core/caf/async/producer_adapter.test.cpp
+++ b/libcaf_core/caf/async/producer_adapter.test.cpp
@@ -155,7 +155,7 @@ void receiver_impl(event_based_actor* self, pull_resource_t inputs,
 
 WITH_FIXTURE(fixture) {
 
-SCENARIO("producers adapters allow integrating producers into event loops") {
+SCENARIO("producer adapters allow integrating producers into event loops") {
   GIVEN("a dynamic set of blocking producers") {
     WHEN("consuming the generated values from an actor via flat_map") {
       THEN("the actor merges all values from all buffers into one") {

--- a/libcaf_core/caf/async/spsc_buffer.test.cpp
+++ b/libcaf_core/caf/async/spsc_buffer.test.cpp
@@ -148,7 +148,7 @@ TEST("resources may be moved") {
 }
 
 SCENARIO("SPSC buffers may go past their capacity") {
-  GIVEN("an SPSC buffer with consumer and produer") {
+  GIVEN("an SPSC buffer with consumer and producer") {
     auto prod = make_counted<dummy_producer>();
     auto cons = make_counted<dummy_consumer>();
     auto buf = make_counted<async::spsc_buffer<int>>(10, 2);
@@ -191,7 +191,7 @@ SCENARIO("SPSC buffers may go past their capacity") {
 }
 
 SCENARIO("the prioritize_errors policy skips processing of pending items") {
-  GIVEN("an SPSC buffer with consumer and produer") {
+  GIVEN("an SPSC buffer with consumer and producer") {
     auto prod = make_counted<dummy_producer>();
     auto cons = make_counted<dummy_consumer>();
     auto buf = make_counted<async::spsc_buffer<int>>(10, 2);

--- a/libcaf_core/caf/detail/log_level_map.test.cpp
+++ b/libcaf_core/caf/detail/log_level_map.test.cpp
@@ -36,7 +36,7 @@ TEST("log level maps render the default log levels") {
   check_eq(uut[level::trace + 1], "TRACE");
 }
 
-TEST("log level maps allows custom log levels") {
+TEST("log level maps allow custom log levels") {
   std::map<std::string, unsigned> custom{{"NOTICE"s, CAF_LOG_LEVEL_WARNING + 1},
                                          {"VERBOSE"s, CAF_LOG_LEVEL_INFO + 1}};
   detail::log_level_map uut;

--- a/libcaf_io/caf/io/system_messages.test.cpp
+++ b/libcaf_io/caf/io/system_messages.test.cpp
@@ -150,7 +150,7 @@ TEST("datagram_servant_passivated_msg is serializable") {
     check_eq(msg1.handle, msg2->handle);
 }
 
-TEST("dataram_servant_closed_msg is serializable") {
+TEST("datagram_servant_closed_msg is serializable") {
   auto dummy_datagram = datagram_handle::from_int(42);
   auto msg1 = datagram_servant_closed_msg{std::vector{dummy_datagram}};
   auto msg2 = serialization_roundtrip(msg1);

--- a/libcaf_net/caf/net/http/client.test.cpp
+++ b/libcaf_net/caf/net/http/client.test.cpp
@@ -260,7 +260,7 @@ SCENARIO("the client sends HTTP requests") {
 }
 
 OUTLINE("sending all available HTTP methods") {
-  GIVEN("a http request with <method> method") {
+  GIVEN("an HTTP request with <method> method") {
     auto method_name = block_parameters<std::string>();
     WHEN("the client sends the <enum value> message") {
       auto method = block_parameters<net::http::method>();

--- a/libcaf_net/caf/net/http/header.test.cpp
+++ b/libcaf_net/caf/net/http/header.test.cpp
@@ -9,7 +9,7 @@
 using namespace caf;
 using namespace std::literals;
 
-TEST("parsing a http request") {
+TEST("parsing an HTTP request") {
   net::http::header hdr;
   hdr.parse_fields("Host: localhost:8090\r\n"
                    "User-Agent: AwesomeLib/1.0\r\n"

--- a/libcaf_net/caf/net/http/request_header.test.cpp
+++ b/libcaf_net/caf/net/http/request_header.test.cpp
@@ -10,7 +10,7 @@
 using namespace caf;
 using namespace std::literals;
 
-TEST("parsing a http request") {
+TEST("parsing an HTTP request") {
   net::http::request_header hdr;
   hdr.parse("GET /foo/bar?user=foo&pw=bar#baz HTTP/1.1\r\n"
             "Host: localhost:8090\r\n"
@@ -33,7 +33,7 @@ TEST("parsing a http request") {
 }
 
 OUTLINE("parsing requests") {
-  GIVEN("a http request with <method> method") {
+  GIVEN("an HTTP request with <method> method") {
     auto method_name = block_parameters<std::string>();
     WHEN("parsing the request with origin form target") {
       auto request = detail::format("{} /foo/bar HTTP/1.1\r\n\r\n",
@@ -119,9 +119,9 @@ TEST("parsing a server-wide HTTP OPTIONS request") {
   check(!hdr.authority().userinfo);
 }
 
-TEST("parsing an invalid http request") {
+TEST("parsing an invalid HTTP request") {
   net::http::request_header hdr;
-  SECTION("header must have a valid http method") {
+  SECTION("header must have a valid HTTP method") {
     hdr.parse("EXTERMINATE /foo/bar HTTP/1.1\r\n\r\n");
     check(!hdr.valid());
   }

--- a/libcaf_net/caf/net/http/response_header.test.cpp
+++ b/libcaf_net/caf/net/http/response_header.test.cpp
@@ -9,7 +9,7 @@
 using namespace caf;
 using namespace std::literals;
 
-TEST("parsing a valid http response") {
+TEST("parsing a valid HTTP response") {
   net::http::response_header hdr;
   SECTION("parsing a one line header") {
     hdr.parse("HTTP/1 200 OK\r\n\r\n");
@@ -39,9 +39,9 @@ TEST("parsing a valid http response") {
   }
 }
 
-TEST("parsing an invalid http response") {
+TEST("parsing an invalid HTTP response") {
   net::http::response_header hdr;
-  SECTION("header must have the http version") {
+  SECTION("header must have the HTTP version") {
     hdr.parse("HTTP/Foo.Bar 200 OK\r\n\r\n");
     check(!hdr.valid());
   }

--- a/libcaf_net/caf/net/tcp_accept_socket.test.cpp
+++ b/libcaf_net/caf/net/tcp_accept_socket.test.cpp
@@ -62,7 +62,7 @@ TEST("opening and accepting tcp on a socket") {
   }
 }
 
-TEST("calling accepting") {
+TEST("calling accept") {
   SECTION("on an invalid socket") {
     tcp_accept_socket x;
     auto err = accept(x);


### PR DESCRIPTION
Fix typos and grammar mistakes in test/scenario descriptions.