### PR TITLE
Enable C++20 and use `requires` instead of `enable_if`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 ### Changed
 
+- CAF now requires C++20 to build.
 - When using the HTTP client API, SSL hostname validation is now enabled by
   default. Users can disable it by setting `hostname_validation` to `false` if
   necessary. This change was made to improve security by default.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ cmake_dependent_option(CAF_ENABLE_OPENSSL_MODULE "Build OpenSSL module" ON
 
 # -- CAF options with non-boolean values ---------------------------------------
 
-set(CAF_CXX_VERSION 17 CACHE STRING "Set the C++ version to use for CAF")
+set(CAF_CXX_VERSION 20 CACHE STRING "Set the C++ version to use for CAF")
 set(CAF_LOG_LEVEL "QUIET" CACHE STRING "Set log verbosity of CAF components")
 set(CAF_EXCLUDE_TESTS "" CACHE STRING "List of excluded test suites")
 set(CAF_SANITIZERS "" CACHE STRING

--- a/libcaf_core/caf/actor.hpp
+++ b/libcaf_core/caf/actor.hpp
@@ -53,22 +53,22 @@ public:
 
   actor(const scoped_actor&);
 
-  template <class T,
-            class = std::enable_if_t<actor_traits<T>::is_dynamically_typed>>
+  template <class T>
+    requires actor_traits<T>::is_dynamically_typed
   actor(T* ptr) : ptr_(ptr->ctrl()) {
     CAF_ASSERT(ptr != nullptr);
   }
 
-  template <class T,
-            class = std::enable_if_t<actor_traits<T>::is_dynamically_typed>>
+  template <class T>
+    requires actor_traits<T>::is_dynamically_typed
   actor& operator=(intrusive_ptr<T> ptr) {
     actor tmp{std::move(ptr)};
     swap(tmp);
     return *this;
   }
 
-  template <class T,
-            class = std::enable_if_t<actor_traits<T>::is_dynamically_typed>>
+  template <class T>
+    requires actor_traits<T>::is_dynamically_typed
   actor& operator=(T* ptr) {
     actor tmp{ptr};
     swap(tmp);

--- a/libcaf_core/caf/actor_cast.hpp
+++ b/libcaf_core/caf/actor_cast.hpp
@@ -77,7 +77,8 @@ public:
     return To{};
   }
 
-  template <class T, class = std::enable_if_t<!std::is_pointer_v<T>>>
+  template <class T>
+    requires(!std::is_pointer_v<T>)
   To operator()(const T& x) const {
     return To{x.get()};
   }
@@ -97,7 +98,8 @@ public:
     return static_cast<To*>(x);
   }
 
-  template <class T, class = std::enable_if_t<!std::is_pointer_v<T>>>
+  template <class T>
+    requires(!std::is_pointer_v<T>)
   To* operator()(const T& x) const {
     return (*this)(x.get());
   }
@@ -114,7 +116,8 @@ public:
     return x->ctrl();
   }
 
-  template <class T, class = std::enable_if_t<!std::is_pointer_v<T>>>
+  template <class T>
+    requires(!std::is_pointer_v<T>)
   actor_control_block* operator()(const T& x) const {
     return x.get();
   }

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -212,7 +212,8 @@ public:
   /// A message passing interface (MPI) in run-time checkable representation.
   using mpi = std::set<std::string>;
 
-  template <class T, class E = std::enable_if_t<!is_typed_actor_v<T>>>
+  template <class T>
+    requires(!is_typed_actor_v<T>)
   mpi message_types(type_list<T>) const {
     return mpi{};
   }
@@ -224,7 +225,8 @@ public:
       typename typed_actor<Ts...>::signatures{});
   }
 
-  template <class T, class E = std::enable_if_t<!detail::is_type_list_v<T>>>
+  template <class T>
+    requires(!detail::is_type_list_v<T>)
   mpi message_types(const T&) const {
     type_list<T> token;
     return message_types(token);
@@ -442,7 +444,8 @@ public:
   /// Returns a new actor with run-time type `name`, constructed
   /// with the arguments stored in `args`.
   /// @experimental
-  template <class Handle, class E = std::enable_if_t<is_handle_v<Handle>>>
+  template <class Handle>
+    requires is_handle_v<Handle>
   expected<Handle>
   spawn(const std::string& name, message args, caf::scheduler* ctx = nullptr,
         bool check_interface = true, const mpi* expected_ifs = nullptr) {

--- a/libcaf_core/caf/actor_system_config.cpp
+++ b/libcaf_core/caf/actor_system_config.cpp
@@ -316,7 +316,8 @@ public:
   }
 
   template <class T>
-  std::enable_if_t<std::is_arithmetic_v<T>> operator()(T val) {
+    requires std::is_arithmetic_v<T>
+  void operator()(T val) {
     detail::print(out_, val);
   }
 

--- a/libcaf_core/caf/anon_mail.hpp
+++ b/libcaf_core/caf/anon_mail.hpp
@@ -72,8 +72,8 @@ public:
   anon_mail_t& operator=(const anon_mail_t&) = delete;
 
   /// Tags the message as urgent, i.e., sends it with high priority.
-  template <message_priority P = Priority,
-            class E = std::enable_if_t<P == message_priority::normal>>
+  template <message_priority P = Priority>
+    requires(P == message_priority::normal)
   [[nodiscard]] auto urgent() && {
     using result_t = anon_mail_t<message_priority::high, Args...>;
     return result_t{std::move(content_)};

--- a/libcaf_core/caf/anon_mail.hpp
+++ b/libcaf_core/caf/anon_mail.hpp
@@ -72,9 +72,8 @@ public:
   anon_mail_t& operator=(const anon_mail_t&) = delete;
 
   /// Tags the message as urgent, i.e., sends it with high priority.
-  template <message_priority P = Priority>
-    requires(P == message_priority::normal)
-  [[nodiscard]] auto urgent() && {
+  [[nodiscard]] auto urgent() &&
+    requires(Priority == message_priority::normal) {
     using result_t = anon_mail_t<message_priority::high, Args...>;
     return result_t{std::move(content_)};
   }

--- a/libcaf_core/caf/async/batch.hpp
+++ b/libcaf_core/caf/async/batch.hpp
@@ -205,14 +205,14 @@ private:
 };
 
 template <class Inspector>
-auto inspect(Inspector& f, batch& x)
-  -> std::enable_if_t<!Inspector::is_loading, decltype(x.save(f))> {
+  requires(!Inspector::is_loading)
+auto inspect(Inspector& f, batch& x) -> decltype(x.save(f)) {
   return x.save(f);
 }
 
 template <class Inspector>
-auto inspect(Inspector& f, batch& x)
-  -> std::enable_if_t<Inspector::is_loading, decltype(x.load(f))> {
+  requires Inspector::is_loading
+auto inspect(Inspector& f, batch& x) -> decltype(x.load(f)) {
   return x.load(f);
 }
 

--- a/libcaf_core/caf/async_mail.hpp
+++ b/libcaf_core/caf/async_mail.hpp
@@ -170,8 +170,8 @@ public:
   using super::super;
 
   /// Tags the message as urgent, i.e., sends it with high priority.
-  template <message_priority P = Priority,
-            class E = std::enable_if_t<P == message_priority::normal>>
+  template <message_priority P = Priority>
+    requires(P == message_priority::normal)
   [[nodiscard]] auto urgent() && {
     using result_t = async_mail_t<message_priority::high, Trait, Args...>;
     return result_t{super::self_, std::move(super::content_)};

--- a/libcaf_core/caf/async_mail.hpp
+++ b/libcaf_core/caf/async_mail.hpp
@@ -170,9 +170,8 @@ public:
   using super::super;
 
   /// Tags the message as urgent, i.e., sends it with high priority.
-  template <message_priority P = Priority>
-    requires(P == message_priority::normal)
-  [[nodiscard]] auto urgent() && {
+  [[nodiscard]] auto urgent() &&
+    requires(Priority == message_priority::normal) {
     using result_t = async_mail_t<message_priority::high, Trait, Args...>;
     return result_t{super::self_, std::move(super::content_)};
   }

--- a/libcaf_core/caf/binary_deserializer.hpp
+++ b/libcaf_core/caf/binary_deserializer.hpp
@@ -123,7 +123,8 @@ public:
   bool value(uint64_t& x) noexcept;
 
   template <class T>
-  std::enable_if_t<std::is_integral_v<T>, bool> value(T& x) noexcept {
+    requires std::is_integral_v<T>
+  bool value(T& x) noexcept {
     auto tmp = detail::squashed_int_t<T>{0};
     if (value(tmp)) {
       x = static_cast<T>(tmp);

--- a/libcaf_core/caf/binary_deserializer.hpp
+++ b/libcaf_core/caf/binary_deserializer.hpp
@@ -9,6 +9,7 @@
 #include "caf/load_inspector_base.hpp"
 #include "caf/span.hpp"
 
+#include <concepts>
 #include <cstddef>
 
 namespace caf {
@@ -122,8 +123,7 @@ public:
 
   bool value(uint64_t& x) noexcept;
 
-  template <class T>
-    requires std::is_integral_v<T>
+  template <std::integral T>
   bool value(T& x) noexcept {
     auto tmp = detail::squashed_int_t<T>{0};
     if (value(tmp)) {

--- a/libcaf_core/caf/binary_serializer.hpp
+++ b/libcaf_core/caf/binary_serializer.hpp
@@ -114,7 +114,8 @@ public:
   bool value(uint64_t x);
 
   template <class T>
-  std::enable_if_t<std::is_integral_v<T>, bool> value(T x) {
+    requires std::is_integral_v<T>
+  bool value(T x) {
     return value(static_cast<detail::squashed_int_t<T>>(x));
   }
 

--- a/libcaf_core/caf/binary_serializer.hpp
+++ b/libcaf_core/caf/binary_serializer.hpp
@@ -8,6 +8,7 @@
 #include "caf/fwd.hpp"
 #include "caf/save_inspector_base.hpp"
 
+#include <concepts>
 #include <cstddef>
 
 namespace caf {
@@ -113,8 +114,7 @@ public:
 
   bool value(uint64_t x);
 
-  template <class T>
-    requires std::is_integral_v<T>
+  template <std::integral T>
   bool value(T x) {
     return value(static_cast<detail::squashed_int_t<T>>(x));
   }

--- a/libcaf_core/caf/blocking_mail.hpp
+++ b/libcaf_core/caf/blocking_mail.hpp
@@ -87,9 +87,8 @@ public:
   }
 
   /// Tags the message as urgent, i.e., sends it with high priority.
-  template <message_priority P = Priority,
-            class E = std::enable_if_t<P == message_priority::normal>>
-  [[nodiscard]] auto urgent() && {
+  [[nodiscard]] auto urgent() &&
+    requires(Priority == message_priority::normal) {
     using result_t = blocking_mail_t<message_priority::high, Trait, Args...>;
     return result_t{self(), std::move(super::content_)};
   }

--- a/libcaf_core/caf/catch_all.hpp
+++ b/libcaf_core/caf/catch_all.hpp
@@ -24,8 +24,8 @@ struct catch_all {
 
   catch_all(catch_all&& x) = default;
 
-  template <class T, class = std::enable_if_t<
-                       !std::is_same_v<std::decay_t<T>, catch_all>>>
+  template <class T>
+    requires(!std::is_same_v<std::decay_t<T>, catch_all>)
   explicit catch_all(T&& x) : handler(std::forward<T>(x)) {
     // nop
   }

--- a/libcaf_core/caf/config_value.hpp
+++ b/libcaf_core/caf/config_value.hpp
@@ -98,8 +98,8 @@ public:
 
   config_value(const config_value& other) = default;
 
-  template <class T, class = std::enable_if_t<
-                       !std::is_same_v<std::decay_t<T>, config_value>>>
+  template <class T>
+    requires(!std::is_same_v<std::decay_t<T>, config_value>)
   explicit config_value(T&& x) : data_(lift(std::forward<T>(x))) {
     // nop
   }
@@ -108,8 +108,8 @@ public:
 
   config_value& operator=(const config_value& other) = default;
 
-  template <class T, class = std::enable_if_t<
-                       !std::is_same_v<std::decay_t<T>, config_value>>>
+  template <class T>
+    requires(!std::is_same_v<std::decay_t<T>, config_value>)
   config_value& operator=(T&& x) {
     data_ = lift(std::forward<T>(x));
     return *this;

--- a/libcaf_core/caf/config_value_writer.cpp
+++ b/libcaf_core/caf/config_value_writer.cpp
@@ -342,7 +342,8 @@ public:
   }
 
   template <class T>
-  std::enable_if_t<std::is_integral_v<T>, bool> value(T x) {
+    requires std::is_integral_v<T>
+  bool value(T x) {
     if constexpr (std::is_same_v<T, bool>) {
       return push(config_value{x});
     } else if constexpr (std::is_same_v<T, uint64_t>) {

--- a/libcaf_core/caf/cow_string.hpp
+++ b/libcaf_core/caf/cow_string.hpp
@@ -236,10 +236,9 @@ public:
   }
 
   template <class T>
-  std::enable_if_t<std::is_convertible_v<const T&, view_type> //
-                     && !std::is_convertible_v<const T&, const CharT*>,
-                   size_type>
-  find(const T& x, size_type pos = 0) const noexcept {
+    requires(std::is_convertible_v<const T&, view_type> //
+             && !std::is_convertible_v<const T&, const CharT*>)
+  size_type find(const T& x, size_type pos = 0) const noexcept {
     return impl_->str.find(x, pos);
   }
 

--- a/libcaf_core/caf/cow_string.hpp
+++ b/libcaf_core/caf/cow_string.hpp
@@ -10,6 +10,7 @@
 #include "caf/ref_counted.hpp"
 #include "caf/string_algorithms.hpp"
 
+#include <concepts>
 #include <string>
 #include <string_view>
 
@@ -236,8 +237,8 @@ public:
   }
 
   template <class T>
-    requires(std::is_convertible_v<const T&, view_type> //
-             && !std::is_convertible_v<const T&, const CharT*>)
+    requires(std::convertible_to<const T&, view_type>
+             && !std::convertible_to<const T&, const CharT*>)
   size_type find(const T& x, size_type pos = 0) const noexcept {
     return impl_->str.find(x, pos);
   }

--- a/libcaf_core/caf/deserializer.hpp
+++ b/libcaf_core/caf/deserializer.hpp
@@ -11,6 +11,7 @@
 #include "caf/span.hpp"
 #include "caf/type_id.hpp"
 
+#include <concepts>
 #include <cstddef>
 #include <string>
 #include <tuple>
@@ -150,8 +151,7 @@ public:
   virtual bool value(uint64_t& x) = 0;
 
   /// @copydoc value
-  template <class T>
-    requires std::is_integral_v<T>
+  template <std::integral T>
   bool value(T& x) noexcept {
     auto tmp = detail::squashed_int_t<T>{0};
     if (value(tmp)) {

--- a/libcaf_core/caf/deserializer.hpp
+++ b/libcaf_core/caf/deserializer.hpp
@@ -151,7 +151,8 @@ public:
 
   /// @copydoc value
   template <class T>
-  std::enable_if_t<std::is_integral_v<T>, bool> value(T& x) noexcept {
+    requires std::is_integral_v<T>
+  bool value(T& x) noexcept {
     auto tmp = detail::squashed_int_t<T>{0};
     if (value(tmp)) {
       x = static_cast<T>(tmp);

--- a/libcaf_core/caf/detail/parse.hpp
+++ b/libcaf_core/caf/detail/parse.hpp
@@ -15,6 +15,7 @@
 #include "caf/parser_state.hpp"
 #include "caf/unit.hpp"
 
+#include <concepts>
 #include <cstdint>
 #include <cstring>
 #include <iterator>
@@ -71,8 +72,7 @@ CAF_CORE_EXPORT void parse(string_parser_state& ps, uint64_t& x);
 
 // -- non-fixed size integer types ---------------------------------------------
 
-template <class T>
-  requires std::is_integral_v<T>
+template <std::integral T>
 void parse(string_parser_state& ps, T& x) {
   using squashed_type = squashed_int_t<T>;
   return parse(ps, reinterpret_cast<squashed_type&>(x));

--- a/libcaf_core/caf/detail/parse.hpp
+++ b/libcaf_core/caf/detail/parse.hpp
@@ -72,7 +72,8 @@ CAF_CORE_EXPORT void parse(string_parser_state& ps, uint64_t& x);
 // -- non-fixed size integer types ---------------------------------------------
 
 template <class T>
-std::enable_if_t<std::is_integral_v<T>> parse(string_parser_state& ps, T& x) {
+  requires std::is_integral_v<T>
+void parse(string_parser_state& ps, T& x) {
   using squashed_type = squashed_int_t<T>;
   return parse(ps, reinterpret_cast<squashed_type&>(x));
 }

--- a/libcaf_core/caf/detail/parser/add_ascii.hpp
+++ b/libcaf_core/caf/detail/parser/add_ascii.hpp
@@ -6,6 +6,7 @@
 
 #include "caf/detail/parser/ascii_to_int.hpp"
 
+#include <concepts>
 #include <limits>
 #include <type_traits>
 
@@ -15,8 +16,7 @@ namespace caf::detail::parser {
 // @returns `false` on an overflow, otherwise `true`.
 // @pre `isdigit(c) || (Base == 16 && isxdigit(c))`
 // @warning can leave `x` in an intermediate state when retuning `false`
-template <int Base, class T>
-  requires std::is_integral_v<T>
+template <int Base, std::integral T>
 bool add_ascii(T& x, char c) {
   if (x > (std::numeric_limits<T>::max() / Base))
     return false;
@@ -29,8 +29,7 @@ bool add_ascii(T& x, char c) {
   return true;
 }
 
-template <int Base, class T>
-  requires std::is_floating_point_v<T>
+template <int Base, std::floating_point T>
 bool add_ascii(T& x, char c) {
   ascii_to_int<Base, T> f;
   x = (x * Base) + f(c);

--- a/libcaf_core/caf/detail/parser/add_ascii.hpp
+++ b/libcaf_core/caf/detail/parser/add_ascii.hpp
@@ -16,7 +16,8 @@ namespace caf::detail::parser {
 // @pre `isdigit(c) || (Base == 16 && isxdigit(c))`
 // @warning can leave `x` in an intermediate state when retuning `false`
 template <int Base, class T>
-bool add_ascii(T& x, char c, std::enable_if_t<std::is_integral_v<T>, int> = 0) {
+  requires std::is_integral_v<T>
+bool add_ascii(T& x, char c) {
   if (x > (std::numeric_limits<T>::max() / Base))
     return false;
   x *= static_cast<T>(Base);
@@ -29,8 +30,8 @@ bool add_ascii(T& x, char c, std::enable_if_t<std::is_integral_v<T>, int> = 0) {
 }
 
 template <int Base, class T>
-bool add_ascii(T& x, char c,
-               std::enable_if_t<std::is_floating_point_v<T>, int> = 0) {
+  requires std::is_floating_point_v<T>
+bool add_ascii(T& x, char c) {
   ascii_to_int<Base, T> f;
   x = (x * Base) + f(c);
   return true;

--- a/libcaf_core/caf/detail/parser/read_number.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_number.test.cpp
@@ -109,12 +109,14 @@ struct range_parser {
 };
 
 template <class T>
-std::enable_if_t<std::is_integral_v<T>, res_t> res(T x) {
+  requires std::is_integral_v<T>
+res_t res(T x) {
   return res_t{static_cast<int64_t>(x)};
 }
 
 template <class T>
-std::enable_if_t<std::is_floating_point_v<T>, res_t> res(T x) {
+  requires std::is_floating_point_v<T>
+res_t res(T x) {
   return res_t{static_cast<double>(x)};
 }
 

--- a/libcaf_core/caf/detail/parser/read_number.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_number.test.cpp
@@ -13,6 +13,7 @@
 #include "caf/parser_state.hpp"
 #include "caf/pec.hpp"
 
+#include <concepts>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -108,14 +109,12 @@ struct range_parser {
   }
 };
 
-template <class T>
-  requires std::is_integral_v<T>
+template <std::integral T>
 res_t res(T x) {
   return res_t{static_cast<int64_t>(x)};
 }
 
-template <class T>
-  requires std::is_floating_point_v<T>
+template <std::floating_point T>
 res_t res(T x) {
   return res_t{static_cast<double>(x)};
 }

--- a/libcaf_core/caf/detail/parser/read_number_or_timespan.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_number_or_timespan.test.cpp
@@ -9,6 +9,7 @@
 #include "caf/detail/nearly_equal.hpp"
 #include "caf/parser_state.hpp"
 
+#include <concepts>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -63,14 +64,12 @@ struct fixture {
   number_or_timespan_parser p;
 };
 
-template <class T>
-  requires std::is_integral_v<T>
+template <std::integral T>
 res_t res(T x) {
   return res_t{static_cast<int64_t>(x)};
 }
 
-template <class T>
-  requires std::is_floating_point_v<T>
+template <std::floating_point T>
 res_t res(T x) {
   return res_t{static_cast<double>(x)};
 }

--- a/libcaf_core/caf/detail/parser/read_number_or_timespan.test.cpp
+++ b/libcaf_core/caf/detail/parser/read_number_or_timespan.test.cpp
@@ -64,12 +64,14 @@ struct fixture {
 };
 
 template <class T>
-std::enable_if_t<std::is_integral_v<T>, res_t> res(T x) {
+  requires std::is_integral_v<T>
+res_t res(T x) {
   return res_t{static_cast<int64_t>(x)};
 }
 
 template <class T>
-std::enable_if_t<std::is_floating_point_v<T>, res_t> res(T x) {
+  requires std::is_floating_point_v<T>
+res_t res(T x) {
   return res_t{static_cast<double>(x)};
 }
 

--- a/libcaf_core/caf/detail/parser/sub_ascii.hpp
+++ b/libcaf_core/caf/detail/parser/sub_ascii.hpp
@@ -17,7 +17,8 @@ namespace caf::detail::parser {
 // @pre `isdigit(c) || (Base == 16 && isxdigit(c))`
 // @warning can leave `x` in an intermediate state when retuning `false`
 template <int Base, class T>
-bool sub_ascii(T& x, char c, std::enable_if_t<std::is_integral_v<T>, int> = 0) {
+  requires std::is_integral_v<T>
+bool sub_ascii(T& x, char c) {
   if (x < (std::numeric_limits<T>::min() / Base))
     return false;
   x *= static_cast<T>(Base);
@@ -30,8 +31,8 @@ bool sub_ascii(T& x, char c, std::enable_if_t<std::is_integral_v<T>, int> = 0) {
 }
 
 template <int Base, class T>
-bool sub_ascii(T& x, char c,
-               std::enable_if_t<std::is_floating_point_v<T>, int> = 0) {
+  requires std::is_floating_point_v<T>
+bool sub_ascii(T& x, char c) {
   ascii_to_int<Base, T> f;
   x = static_cast<T>((x * Base) - f(c));
   return true;

--- a/libcaf_core/caf/detail/parser/sub_ascii.hpp
+++ b/libcaf_core/caf/detail/parser/sub_ascii.hpp
@@ -7,6 +7,7 @@
 
 #include "caf/detail/parser/ascii_to_int.hpp"
 
+#include <concepts>
 #include <limits>
 #include <type_traits>
 
@@ -16,8 +17,7 @@ namespace caf::detail::parser {
 // @returns `false` on an underflow, otherwise `true`.
 // @pre `isdigit(c) || (Base == 16 && isxdigit(c))`
 // @warning can leave `x` in an intermediate state when retuning `false`
-template <int Base, class T>
-  requires std::is_integral_v<T>
+template <int Base, std::integral T>
 bool sub_ascii(T& x, char c) {
   if (x < (std::numeric_limits<T>::min() / Base))
     return false;
@@ -30,8 +30,7 @@ bool sub_ascii(T& x, char c) {
   return true;
 }
 
-template <int Base, class T>
-  requires std::is_floating_point_v<T>
+template <int Base, std::floating_point T>
 bool sub_ascii(T& x, char c) {
   ascii_to_int<Base, T> f;
   x = static_cast<T>((x * Base) - f(c));

--- a/libcaf_core/caf/detail/print.hpp
+++ b/libcaf_core/caf/detail/print.hpp
@@ -171,7 +171,8 @@ void print(Buffer& buf, bool x) {
 }
 
 template <class Buffer, class T>
-std::enable_if_t<std::is_integral_v<T>> print(Buffer& buf, T x) {
+  requires std::is_integral_v<T>
+void print(Buffer& buf, T x) {
   // An integer can at most have 20 digits (UINT64_MAX).
   char stack_buffer[24];
   char* p = stack_buffer;
@@ -215,7 +216,8 @@ std::enable_if_t<std::is_integral_v<T>> print(Buffer& buf, T x) {
 }
 
 template <class Buffer, class T>
-std::enable_if_t<std::is_floating_point_v<T>> print(Buffer& buf, T x) {
+  requires std::is_floating_point_v<T>
+void print(Buffer& buf, T x) {
   // TODO: Check whether to_chars is available on supported compilers and
   //       re-implement using the new API as soon as possible.
   auto str = std::to_string(x);

--- a/libcaf_core/caf/detail/print.hpp
+++ b/libcaf_core/caf/detail/print.hpp
@@ -9,6 +9,7 @@
 #include "caf/none.hpp"
 
 #include <chrono>
+#include <concepts>
 #include <cstdint>
 #include <ctime>
 #include <limits>
@@ -170,8 +171,7 @@ void print(Buffer& buf, bool x) {
   buf.insert(buf.end(), str.begin(), str.end());
 }
 
-template <class Buffer, class T>
-  requires std::is_integral_v<T>
+template <class Buffer, std::integral T>
 void print(Buffer& buf, T x) {
   // An integer can at most have 20 digits (UINT64_MAX).
   char stack_buffer[24];
@@ -215,8 +215,7 @@ void print(Buffer& buf, T x) {
   } while (p != stack_buffer);
 }
 
-template <class Buffer, class T>
-  requires std::is_floating_point_v<T>
+template <class Buffer, std::floating_point T>
 void print(Buffer& buf, T x) {
   // TODO: Check whether to_chars is available on supported compilers and
   //       re-implement using the new API as soon as possible.

--- a/libcaf_core/caf/detail/stringification_inspector.hpp
+++ b/libcaf_core/caf/detail/stringification_inspector.hpp
@@ -70,7 +70,8 @@ public:
   bool value(bool x);
 
   template <class Integral>
-  std::enable_if_t<std::is_integral_v<Integral>, bool> value(Integral x) {
+    requires std::is_integral_v<Integral>
+  bool value(Integral x) {
     if constexpr (std::is_signed_v<Integral>)
       return int_value(static_cast<int64_t>(x));
     else
@@ -113,9 +114,8 @@ public:
   }
 
   template <class T>
-  std::enable_if_t<
-    has_to_string_v<T> && !std::is_convertible_v<T, std::string_view>, bool>
-  builtin_inspect(const T& x) {
+    requires(has_to_string_v<T> && !std::is_convertible_v<T, std::string_view>)
+  bool builtin_inspect(const T& x) {
     auto str = to_string(x);
     if constexpr (std::is_convertible<decltype(str), const char*>::value) {
       const char* cstr = str;

--- a/libcaf_core/caf/detail/stringification_inspector.hpp
+++ b/libcaf_core/caf/detail/stringification_inspector.hpp
@@ -8,6 +8,7 @@
 #include "caf/fwd.hpp"
 #include "caf/save_inspector_base.hpp"
 
+#include <concepts>
 #include <cstddef>
 
 namespace caf::detail {
@@ -69,8 +70,7 @@ public:
 
   bool value(bool x);
 
-  template <class Integral>
-    requires std::is_integral_v<Integral>
+  template <std::integral Integral>
   bool value(Integral x) {
     if constexpr (std::is_signed_v<Integral>)
       return int_value(static_cast<int64_t>(x));
@@ -114,7 +114,7 @@ public:
   }
 
   template <class T>
-    requires(has_to_string_v<T> && !std::is_convertible_v<T, std::string_view>)
+    requires(has_to_string_v<T> && !std::convertible_to<T, std::string_view>)
   bool builtin_inspect(const T& x) {
     auto str = to_string(x);
     if constexpr (std::is_convertible<decltype(str), const char*>::value) {

--- a/libcaf_core/caf/detail/type_traits.hpp
+++ b/libcaf_core/caf/detail/type_traits.hpp
@@ -199,12 +199,11 @@ template <class T>
 class is_iterable {
   // this horrible code would just disappear if we had concepts
   template <class C>
-  static bool sfinae(
-    C* cc,
-    // check if 'C::begin()' returns a forward iterator
-    std::enable_if_t<is_forward_iterator_v<decltype(cc->begin())>>* = nullptr,
+    requires is_forward_iterator_v<decltype(std::declval<C*>()->begin())>
+  static bool sfinae(C* cc) {
     // check if begin() and end() both exist and are comparable
-    decltype(cc->begin() != cc->end())* = nullptr);
+    return cc->begin() != cc->end();
+  }
 
   // SFNINAE default
   static void sfinae(void*);
@@ -432,9 +431,6 @@ struct value_type_of<T*> {
 template <class T>
 using value_type_of_t = typename value_type_of<T>::type;
 
-template <class F, class T>
-using is_handler_for_ef = typename std::enable_if<is_handler_for_v<F, T>>::type;
-
 // Checks whether T has a member function named `push_back` that takes an
 // element of type `T::value_type`.
 template <class T>
@@ -495,7 +491,7 @@ CAF_HAS_ALIAS_TRAIT(mapped_type);
 
 CAF_HAS_ALIAS_TRAIT(handle_type);
 
-// -- constexpr functions for use in enable_if & friends -----------------------
+// -- constexpr functions for use in require clauses ---------------------------
 
 /// Checks whether T behaves like `std::map`.
 template <class T>

--- a/libcaf_core/caf/detail/unique_function.hpp
+++ b/libcaf_core/caf/detail/unique_function.hpp
@@ -83,10 +83,10 @@ public:
   }
 
   template <class T>
+  explicit unique_function(T f)
     requires(!std::is_convertible_v<T, raw_pointer>
-             && std::is_same_v<
-               decltype((std::declval<T&>())(std::declval<Ts>()...)), R>)
-  explicit unique_function(T f) : unique_function(make_wrapper(std::move(f))) {
+             && std::is_same_v<decltype(f(std::declval<Ts>()...)), R>)
+    : unique_function(make_wrapper(std::move(f))) {
     // nop
   }
 

--- a/libcaf_core/caf/detail/unique_function.hpp
+++ b/libcaf_core/caf/detail/unique_function.hpp
@@ -82,11 +82,10 @@ public:
     // nop
   }
 
-  template <class T,
-            class = std::enable_if_t<
-              !std::is_convertible_v<T, raw_pointer>
-              && std::is_same_v<
-                decltype((std::declval<T&>())(std::declval<Ts>()...)), R>>>
+  template <class T>
+    requires(!std::is_convertible_v<T, raw_pointer>
+             && std::is_same_v<
+               decltype((std::declval<T&>())(std::declval<Ts>()...)), R>)
   explicit unique_function(T f) : unique_function(make_wrapper(std::move(f))) {
     // nop
   }

--- a/libcaf_core/caf/error.hpp
+++ b/libcaf_core/caf/error.hpp
@@ -78,18 +78,21 @@ public:
 
   error& operator=(const error&);
 
-  template <class Enum, class = std::enable_if_t<is_error_code_enum_v<Enum>>>
+  template <class Enum>
+    requires is_error_code_enum_v<Enum>
   error(Enum code) : error(static_cast<uint8_t>(code), type_id_v<Enum>) {
     // nop
   }
 
-  template <class Enum, class = std::enable_if_t<is_error_code_enum_v<Enum>>>
+  template <class Enum>
+    requires is_error_code_enum_v<Enum>
   error(Enum code, message context)
     : error(static_cast<uint8_t>(code), type_id_v<Enum>, std::move(context)) {
     // nop
   }
 
-  template <class Enum, class = std::enable_if_t<is_error_code_enum_v<Enum>>>
+  template <class Enum>
+    requires is_error_code_enum_v<Enum>
   error(Enum code, std::string msg)
     : error(static_cast<uint8_t>(code), type_id_v<Enum>,
             make_message(std::move(msg))) {
@@ -229,14 +232,15 @@ CAF_CORE_EXPORT std::string to_string(const error& x);
 
 /// @relates error
 template <class Enum>
-std::enable_if_t<is_error_code_enum_v<Enum>, error> make_error(Enum code) {
+  requires is_error_code_enum_v<Enum>
+error make_error(Enum code) {
   return error{code};
 }
 
 /// @relates error
 template <class Enum, class T, class... Ts>
-std::enable_if_t<is_error_code_enum_v<Enum>, error>
-make_error(Enum code, T&& x, Ts&&... xs) {
+  requires is_error_code_enum_v<Enum>
+error make_error(Enum code, T&& x, Ts&&... xs) {
   return error{code, make_message(std::forward<T>(x), std::forward<Ts>(xs)...)};
 }
 
@@ -252,8 +256,8 @@ inline bool operator==(none_t, const error& x) {
 
 /// @relates error
 template <class Enum>
-std::enable_if_t<is_error_code_enum_v<Enum>, bool>
-operator==(const error& x, Enum y) {
+  requires is_error_code_enum_v<Enum>
+bool operator==(const error& x, Enum y) {
   auto code = static_cast<uint8_t>(y);
   return code == 0 ? !x
                    : x && x.code() == code && x.category() == type_id_v<Enum>;
@@ -261,8 +265,8 @@ operator==(const error& x, Enum y) {
 
 /// @relates error
 template <class Enum>
-std::enable_if_t<is_error_code_enum_v<Enum>, bool>
-operator==(Enum x, const error& y) {
+  requires is_error_code_enum_v<Enum>
+bool operator==(Enum x, const error& y) {
   return y == x;
 }
 
@@ -278,15 +282,15 @@ inline bool operator!=(none_t, const error& x) {
 
 /// @relates error
 template <class Enum>
-std::enable_if_t<is_error_code_enum_v<Enum>, bool>
-operator!=(const error& x, Enum y) {
+  requires is_error_code_enum_v<Enum>
+bool operator!=(const error& x, Enum y) {
   return !(x == y);
 }
 
 /// @relates error
 template <class Enum>
-std::enable_if_t<is_error_code_enum_v<Enum>, bool>
-operator!=(Enum x, const error& y) {
+  requires is_error_code_enum_v<Enum>
+bool operator!=(Enum x, const error& y) {
   return !(x == y);
 }
 

--- a/libcaf_core/caf/event_based_mail.hpp
+++ b/libcaf_core/caf/event_based_mail.hpp
@@ -95,9 +95,8 @@ public:
   }
 
   /// Tags the message as urgent, i.e., sends it with high priority.
-  template <message_priority P = Priority,
-            class E = std::enable_if_t<P == message_priority::normal>>
-  [[nodiscard]] auto urgent() && {
+  [[nodiscard]] auto urgent() &&
+    requires(Priority == message_priority::normal) {
     using result_t = event_based_mail_t<message_priority::high, Trait, Args...>;
     return result_t{self(), std::move(super::content_)};
   }

--- a/libcaf_core/caf/expected.hpp
+++ b/libcaf_core/caf/expected.hpp
@@ -15,6 +15,7 @@
 #include "caf/raise_error.hpp"
 #include "caf/unit.hpp"
 
+#include <concepts>
 #include <memory>
 #include <new>
 #include <ostream>
@@ -69,9 +70,9 @@ public:
   // -- constructors, destructors, and assignment operators --------------------
 
   template <class U>
-    requires(std::is_convertible_v<U, T> || is_error_code_enum_v<U>)
+    requires(std::convertible_to<U, T> || is_error_code_enum_v<U>)
   expected(U x) {
-    if constexpr (std::is_convertible_v<U, T>) {
+    if constexpr (std::convertible_to<U, T>) {
       has_value_ = true;
       new (std::addressof(value_)) T(std::move(x));
     } else {
@@ -155,8 +156,7 @@ public:
     return *this;
   }
 
-  template <class U>
-    requires std::is_convertible_v<U, T>
+  template <std::convertible_to<T> U>
   expected& operator=(U x) {
     return *this = T{std::move(x)};
   }

--- a/libcaf_core/caf/expected.hpp
+++ b/libcaf_core/caf/expected.hpp
@@ -957,13 +957,17 @@ template <class T>
 std::string to_string(const expected<T>& x) {
   if (x)
     return deep_to_string(*x);
-  return "!" + to_string(x.error());
+  std::string str = "!";
+  str += to_string(x.error());
+  return str;
 }
 
 inline std::string to_string(const expected<void>& x) {
   if (x)
     return "unit";
-  return "!" + to_string(x.error());
+  std::string str = "!";
+  str += to_string(x.error());
+  return str;
 }
 
 } // namespace caf

--- a/libcaf_core/caf/expected.hpp
+++ b/libcaf_core/caf/expected.hpp
@@ -68,8 +68,8 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  template <class U, class = std::enable_if_t<std::is_convertible_v<U, T>
-                                              || is_error_code_enum_v<U>>>
+  template <class U>
+    requires(std::is_convertible_v<U, T> || is_error_code_enum_v<U>)
   expected(U x) {
     if constexpr (std::is_convertible_v<U, T>) {
       has_value_ = true;
@@ -156,7 +156,8 @@ public:
   }
 
   template <class U>
-  std::enable_if_t<std::is_convertible_v<U, T>, expected&> operator=(U x) {
+    requires std::is_convertible_v<U, T>
+  expected& operator=(U x) {
     return *this = T{std::move(x)};
   }
 
@@ -171,7 +172,8 @@ public:
     return *this;
   }
 
-  template <class Enum, class = std::enable_if_t<is_error_code_enum_v<Enum>>>
+  template <class Enum>
+    requires is_error_code_enum_v<Enum>
   expected& operator=(Enum code) {
     return *this = make_error(code);
   }
@@ -191,8 +193,8 @@ public:
   // -- modifiers --------------------------------------------------------------
 
   template <class... Args>
-  std::enable_if_t<std::is_nothrow_constructible_v<T, Args...>, T&>
-  emplace(Args&&... args) noexcept {
+    requires std::is_nothrow_constructible_v<T, Args...>
+  T& emplace(Args&&... args) noexcept {
     destroy();
     has_value_ = true;
     new (std::addressof(value_)) T(std::forward<Args>(args)...);
@@ -575,15 +577,15 @@ bool operator==(const error& x, const expected<T>& y) {
 
 /// @relates expected
 template <class T, class Enum>
-std::enable_if_t<is_error_code_enum_v<Enum>, bool>
-operator==(const expected<T>& x, Enum y) {
+  requires is_error_code_enum_v<Enum>
+bool operator==(const expected<T>& x, Enum y) {
   return x == make_error(y);
 }
 
 /// @relates expected
 template <class T, class Enum>
-std::enable_if_t<is_error_code_enum_v<Enum>, bool>
-operator==(Enum x, const expected<T>& y) {
+  requires is_error_code_enum_v<Enum>
+bool operator==(Enum x, const expected<T>& y) {
   return y == make_error(x);
 }
 
@@ -620,15 +622,15 @@ bool operator!=(const error& x, const expected<T>& y) {
 
 /// @relates expected
 template <class T, class Enum>
-std::enable_if_t<is_error_code_enum_v<Enum>, bool>
-operator!=(const expected<T>& x, Enum y) {
+  requires is_error_code_enum_v<Enum>
+bool operator!=(const expected<T>& x, Enum y) {
   return !(x == y);
 }
 
 /// @relates expected
 template <class T, class Enum>
-std::enable_if_t<is_error_code_enum_v<Enum>, bool>
-operator!=(Enum x, const expected<T>& y) {
+  requires is_error_code_enum_v<Enum>
+bool operator!=(Enum x, const expected<T>& y) {
   return !(x == y);
 }
 
@@ -648,7 +650,8 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  template <class Enum, class = std::enable_if_t<is_error_code_enum_v<Enum>>>
+  template <class Enum>
+    requires is_error_code_enum_v<Enum>
   expected(Enum x) : error_(std::in_place, x) {
     // nop
   }
@@ -676,7 +679,8 @@ public:
     return *this;
   }
 
-  template <class Enum, class = std::enable_if_t<is_error_code_enum_v<Enum>>>
+  template <class Enum>
+    requires is_error_code_enum_v<Enum>
   expected& operator=(Enum code) {
     error_ = make_error(code);
     return *this;

--- a/libcaf_core/caf/flow/coordinator.hpp
+++ b/libcaf_core/caf/flow/coordinator.hpp
@@ -47,8 +47,8 @@ public:
 
   /// Creates a new @ref caf::flow::coordinated object on this coordinator.
   template <class Impl, class... Args>
-  [[nodiscard]] std::enable_if_t<std::is_base_of_v<coordinated, Impl>,
-                                 intrusive_ptr<Impl>>
+    requires std::is_base_of_v<coordinated, Impl>
+  [[nodiscard]] intrusive_ptr<Impl>
   add_child(std::in_place_type_t<Impl>, Args&&... args) {
     return make_counted<Impl>(this, std::forward<Args>(args)...);
   }
@@ -57,8 +57,8 @@ public:
   /// type depends on the @ref caf::flow::coordinated object and usually one of
   /// `observer<T>`, `observable<T>`, or `subscription`.
   template <class Impl, class... Args>
-  [[nodiscard]] std::enable_if_t<std::is_base_of_v<coordinated, Impl>,
-                                 typename Impl::handle_type>
+    requires std::is_base_of_v<coordinated, Impl>
+  [[nodiscard]] typename Impl::handle_type
   add_child_hdl(std::in_place_type_t<Impl> token, Args&&... args) {
     using handle_type = typename Impl::handle_type;
     return handle_type{add_child(token, std::forward<Args>(args)...)};
@@ -75,8 +75,8 @@ public:
   /// caf::flow::coordinated object at the end of the current cycle.
   /// @post `child == nullptr`
   template <class T>
-  std::enable_if_t<std::is_base_of_v<coordinated, T>>
-  release_later(intrusive_ptr<T>& child) {
+    requires std::is_base_of_v<coordinated, T>
+  void release_later(intrusive_ptr<T>& child) {
     auto ptr = coordinated_ptr{child.release(), false};
     release_later(ptr);
   }
@@ -85,7 +85,8 @@ public:
   /// object at the end of the current cycle.
   /// @post `child == nullptr`
   template <class Handle>
-  std::enable_if<Handle::holds_coordinated> release_later(Handle& hdl) {
+    requires Handle::holds_coordinated
+  void release_later(Handle& hdl) {
     auto ptr = coordinated_ptr{hdl.as_intrusive_ptr().release(), false};
     release_later(ptr);
   }

--- a/libcaf_core/caf/flow/fwd.hpp
+++ b/libcaf_core/caf/flow/fwd.hpp
@@ -106,8 +106,16 @@ struct has_impl_include {
   static constexpr bool value = false;
 };
 
+template <class, class T>
+struct assert_has_impl_include_oracle {
+  static constexpr bool value = has_impl_include<T>::value;
+  static_assert(value,
+                "include 'caf/scheduled_actor/flow.hpp' for this method");
+};
+
 template <class T>
-constexpr bool has_impl_include_v = has_impl_include<T>::value;
+constexpr bool assert_has_impl_include
+  = assert_has_impl_include_oracle<T, scheduled_actor>::value;
 
 } // namespace caf::flow
 

--- a/libcaf_core/caf/flow/fwd.hpp
+++ b/libcaf_core/caf/flow/fwd.hpp
@@ -6,23 +6,6 @@
 
 #include "caf/fwd.hpp"
 
-#include <type_traits>
-
-namespace caf::detail {
-
-/// Always evaluates to `Left`.
-template <class Left, class Right>
-struct left_oracle {
-  using type = Left;
-};
-
-/// Useful to force dependent evaluation of Left. For example in template
-/// functions where only Right is actually a template parameter.
-template <class Left, class Right>
-using left_t = typename left_oracle<Left, Right>::type;
-
-} // namespace caf::detail
-
 namespace caf::flow {
 
 class coordinator;
@@ -125,18 +108,6 @@ struct has_impl_include {
 
 template <class T>
 constexpr bool has_impl_include_v = has_impl_include<T>::value;
-
-template <class T>
-struct assert_scheduled_actor_hdr {
-  static constexpr bool value
-    = has_impl_include_v<detail::left_t<scheduled_actor, T>>;
-  static_assert(value,
-                "include 'caf/scheduled_actor/flow.hpp' for this method");
-};
-
-template <class T, class V = T>
-using assert_scheduled_actor_hdr_t
-  = std::enable_if_t<assert_scheduled_actor_hdr<T>::value, V>;
 
 } // namespace caf::flow
 

--- a/libcaf_core/caf/flow/observable.hpp
+++ b/libcaf_core/caf/flow/observable.hpp
@@ -197,7 +197,8 @@ public:
   observable_def(observable_def&&) = default;
   observable_def& operator=(observable_def&&) = default;
 
-  template <size_t N = sizeof...(Steps), class = std::enable_if_t<N == 0>>
+  template <size_t N = sizeof...(Steps)>
+    requires(N == 0)
   explicit observable_def(Materializer&& materializer)
     : materializer_(std::move(materializer)) {
     // nop

--- a/libcaf_core/caf/flow/observable.hpp
+++ b/libcaf_core/caf/flow/observable.hpp
@@ -197,9 +197,8 @@ public:
   observable_def(observable_def&&) = default;
   observable_def& operator=(observable_def&&) = default;
 
-  template <size_t N = sizeof...(Steps)>
-    requires(N == 0)
   explicit observable_def(Materializer&& materializer)
+    requires(sizeof...(Steps) == 0)
     : materializer_(std::move(materializer)) {
     // nop
   }

--- a/libcaf_core/caf/flow/observable_decl.hpp
+++ b/libcaf_core/caf/flow/observable_decl.hpp
@@ -16,6 +16,7 @@
 #include "caf/fwd.hpp"
 #include "caf/intrusive_ptr.hpp"
 
+#include <concepts>
 #include <cstddef>
 #include <tuple>
 #include <type_traits>
@@ -50,8 +51,7 @@ public:
     return *this;
   }
 
-  template <class Operator>
-    requires std::is_base_of_v<op::base<T>, Operator>
+  template <std::derived_from<op::base<T>> Operator>
   observable& operator=(intrusive_ptr<Operator> ptr) noexcept {
     pimpl_ = ptr;
     return *this;

--- a/libcaf_core/caf/flow/observable_decl.hpp
+++ b/libcaf_core/caf/flow/observable_decl.hpp
@@ -51,8 +51,8 @@ public:
   }
 
   template <class Operator>
-  std::enable_if_t<std::is_base_of_v<op::base<T>, Operator>, observable&>
-  operator=(intrusive_ptr<Operator> ptr) noexcept {
+    requires std::is_base_of_v<op::base<T>, Operator>
+  observable& operator=(intrusive_ptr<Operator> ptr) noexcept {
     pimpl_ = ptr;
     return *this;
   }

--- a/libcaf_core/caf/format_to_error.hpp
+++ b/libcaf_core/caf/format_to_error.hpp
@@ -12,8 +12,8 @@ namespace caf {
 /// Formats the given arguments into a string and returns an error with the
 /// specified code and the formatted string as message.
 template <class Enum, class... Args>
-std::enable_if_t<is_error_code_enum_v<Enum>, error>
-format_to_error(Enum code, std::string_view fstr, Args&&... args) {
+  requires is_error_code_enum_v<Enum>
+error format_to_error(Enum code, std::string_view fstr, Args&&... args) {
   return error{code, detail::format(fstr, std::forward<Args>(args)...)};
 }
 

--- a/libcaf_core/caf/hash/fnv.hpp
+++ b/libcaf_core/caf/hash/fnv.hpp
@@ -113,8 +113,8 @@ public:
   }
 
   template <class Integral>
-  std::enable_if_t<std::is_integral_v<Integral>, bool>
-  value(Integral x) noexcept {
+    requires std::is_integral_v<Integral>
+  bool value(Integral x) noexcept {
     auto begin = reinterpret_cast<const uint8_t*>(&x);
     append(begin, begin + sizeof(Integral));
     return true;

--- a/libcaf_core/caf/hash/fnv.hpp
+++ b/libcaf_core/caf/hash/fnv.hpp
@@ -10,6 +10,7 @@
 #include "caf/span.hpp"
 #include "caf/type_id.hpp"
 
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <string_view>
@@ -112,8 +113,7 @@ public:
     return true;
   }
 
-  template <class Integral>
-    requires std::is_integral_v<Integral>
+  template <std::integral Integral>
   bool value(Integral x) noexcept {
     auto begin = reinterpret_cast<const uint8_t*>(&x);
     append(begin, begin + sizeof(Integral));

--- a/libcaf_core/caf/hash/sha1.hpp
+++ b/libcaf_core/caf/hash/sha1.hpp
@@ -11,6 +11,7 @@
 #include "caf/type_id.hpp"
 
 #include <array>
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <string_view>
@@ -107,8 +108,7 @@ public:
     return true;
   }
 
-  template <class Integral>
-    requires std::is_integral_v<Integral>
+  template <std::integral Integral>
   bool value(Integral x) noexcept {
     auto begin = reinterpret_cast<const uint8_t*>(&x);
     append(begin, begin + sizeof(Integral));

--- a/libcaf_core/caf/hash/sha1.hpp
+++ b/libcaf_core/caf/hash/sha1.hpp
@@ -108,8 +108,8 @@ public:
   }
 
   template <class Integral>
-  std::enable_if_t<std::is_integral_v<Integral>, bool>
-  value(Integral x) noexcept {
+    requires std::is_integral_v<Integral>
+  bool value(Integral x) noexcept {
     auto begin = reinterpret_cast<const uint8_t*>(&x);
     append(begin, begin + sizeof(Integral));
     return true;

--- a/libcaf_core/caf/inspector_access.hpp
+++ b/libcaf_core/caf/inspector_access.hpp
@@ -125,14 +125,14 @@ bool load(Inspector& f, T& x, inspector_access_type::list) {
 }
 
 template <class Inspector, class T>
-std::enable_if_t<accepts_opaque_value_v<Inspector, T>, bool>
-load(Inspector& f, T& x, inspector_access_type::none) {
+  requires accepts_opaque_value_v<Inspector, T>
+bool load(Inspector& f, T& x, inspector_access_type::none) {
   return f.opaque_value(x);
 }
 
 template <class Inspector, class T>
-std::enable_if_t<!accepts_opaque_value_v<Inspector, T>, bool>
-load(Inspector&, T&, inspector_access_type::none) {
+  requires(!accepts_opaque_value_v<Inspector, T>)
+bool load(Inspector&, T&, inspector_access_type::none) {
   static_assert(
     detail::assertion_failed_v<T>,
     "please provide an inspect overload for T or specialize inspector_access");
@@ -218,14 +218,14 @@ bool save(Inspector& f, T& x, inspector_access_type::list) {
 }
 
 template <class Inspector, class T>
-std::enable_if_t<accepts_opaque_value_v<Inspector, T>, bool>
-save(Inspector& f, T& x, inspector_access_type::none) {
+  requires accepts_opaque_value_v<Inspector, T>
+bool save(Inspector& f, T& x, inspector_access_type::none) {
   return f.opaque_value(x);
 }
 
 template <class Inspector, class T>
-std::enable_if_t<!accepts_opaque_value_v<Inspector, T>, bool>
-save(Inspector&, T&, inspector_access_type::none) {
+  requires(!accepts_opaque_value_v<Inspector, T>)
+bool save(Inspector&, T&, inspector_access_type::none) {
   static_assert(
     detail::assertion_failed_v<T>,
     "please provide an inspect overload for T or specialize inspector_access");

--- a/libcaf_core/caf/intrusive_ptr.hpp
+++ b/libcaf_core/caf/intrusive_ptr.hpp
@@ -231,29 +231,29 @@ bool operator!=(std::nullptr_t, const intrusive_ptr<T>& x) {
 
 /// @relates intrusive_ptr
 template <class T, class U>
-std::enable_if_t<detail::is_comparable<T*, U*>::value, bool>
-operator==(const intrusive_ptr<T>& lhs, const U* rhs) {
+  requires detail::is_comparable<T*, U*>::value
+bool operator==(const intrusive_ptr<T>& lhs, const U* rhs) {
   return lhs.get() == rhs;
 }
 
 /// @relates intrusive_ptr
 template <class T, class U>
-std::enable_if_t<detail::is_comparable<T*, U*>::value, bool>
-operator==(const T* lhs, const intrusive_ptr<U>& rhs) {
+  requires detail::is_comparable<T*, U*>::value
+bool operator==(const T* lhs, const intrusive_ptr<U>& rhs) {
   return lhs == rhs.get();
 }
 
 /// @relates intrusive_ptr
 template <class T, class U>
-std::enable_if_t<detail::is_comparable<T*, U*>::value, bool>
-operator!=(const intrusive_ptr<T>& lhs, const U* rhs) {
+  requires detail::is_comparable<T*, U*>::value
+bool operator!=(const intrusive_ptr<T>& lhs, const U* rhs) {
   return lhs.get() != rhs;
 }
 
 /// @relates intrusive_ptr
 template <class T, class U>
-std::enable_if_t<detail::is_comparable<T*, U*>::value, bool>
-operator!=(const T* lhs, const intrusive_ptr<U>& rhs) {
+  requires detail::is_comparable<T*, U*>::value
+bool operator!=(const T* lhs, const intrusive_ptr<U>& rhs) {
   return lhs != rhs.get();
 }
 
@@ -261,15 +261,15 @@ operator!=(const T* lhs, const intrusive_ptr<U>& rhs) {
 
 /// @relates intrusive_ptr
 template <class T, class U>
-std::enable_if_t<detail::is_comparable_v<T*, U*>, bool>
-operator==(const intrusive_ptr<T>& x, const intrusive_ptr<U>& y) {
+  requires detail::is_comparable_v<T*, U*>
+bool operator==(const intrusive_ptr<T>& x, const intrusive_ptr<U>& y) {
   return x.get() == y.get();
 }
 
 /// @relates intrusive_ptr
 template <class T, class U>
-std::enable_if_t<detail::is_comparable_v<T*, U*>, bool>
-operator!=(const intrusive_ptr<T>& x, const intrusive_ptr<U>& y) {
+  requires detail::is_comparable_v<T*, U*>
+bool operator!=(const intrusive_ptr<T>& x, const intrusive_ptr<U>& y) {
   return x.get() != y.get();
 }
 

--- a/libcaf_core/caf/log/event.hpp
+++ b/libcaf_core/caf/log/event.hpp
@@ -237,8 +237,8 @@ public:
 
   /// Adds a boolean or integer field.
   template <class T>
-  std::enable_if_t<std::is_integral_v<T>, event_fields_builder&>
-  field(std::string_view key, T value) {
+    requires std::is_integral_v<T>
+  event_fields_builder& field(std::string_view key, T value) {
     auto& field = fields_.emplace_back(std::string_view{},
                                        lift_integral(value));
     field.key = deep_copy(key);
@@ -276,11 +276,10 @@ public:
 
   /// Adds nested fields.
   template <class SubFieldsInitializer>
-  auto field(std::string_view key, SubFieldsInitializer&& init) //
-    -> std::enable_if_t<
-      std::is_same_v<decltype(init(std::declval<event_fields_builder&>())),
-                     void>,
-      event_fields_builder&> {
+  event_fields_builder& field(std::string_view key, SubFieldsInitializer&& init)
+    requires(std::is_same_v<
+             decltype(init(std::declval<event_fields_builder&>())), void>)
+  {
     auto& field = fields_.emplace_back(std::string_view{}, std::nullopt);
     field.key = deep_copy(key);
     event_fields_builder nested_builder{resource()};
@@ -342,8 +341,8 @@ public:
 
   /// Adds a boolean or integer field.
   template <class T>
-  std::enable_if_t<std::is_integral_v<T>, event_sender&&>
-  field(std::string_view key, T value) && {
+    requires std::is_integral_v<T>
+  event_sender&& field(std::string_view key, T value) && {
     if (logger_)
       fields_.field(key, value);
     return std::move(*this);
@@ -375,11 +374,10 @@ public:
 
   /// Adds nested fields.
   template <class SubFieldsInitializer>
-  auto field(std::string_view key, SubFieldsInitializer&& init) //
-    -> std::enable_if_t<
-      std::is_same_v<decltype(init(std::declval<event_fields_builder&>())),
-                     void>,
-      event_sender&&> {
+  event_sender&& field(std::string_view key, SubFieldsInitializer&& init)
+    requires(std::is_same_v<
+             decltype(init(std::declval<event_fields_builder&>())), void>)
+  {
     if (logger_)
       fields_.field(key, std::forward<SubFieldsInitializer>(init));
     return std::move(*this);

--- a/libcaf_core/caf/log/event.hpp
+++ b/libcaf_core/caf/log/event.hpp
@@ -370,11 +370,8 @@ public:
   }
 
   /// Adds nested fields.
-  template <class SubFieldsInitializer>
-  event_sender&& field(std::string_view key, SubFieldsInitializer&& init)
-    requires(
-      std::same_as<decltype(init(std::declval<event_fields_builder&>())), void>)
-  {
+  template <std::invocable<event_fields_builder&> SubFieldsInitializer>
+  event_sender&& field(std::string_view key, SubFieldsInitializer&& init) {
     if (logger_)
       fields_.field(key, std::forward<SubFieldsInitializer>(init));
     return std::move(*this);

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -117,8 +117,8 @@ public:
     line_builder();
 
     template <class T>
-    std::enable_if_t<!std::is_pointer_v<T>, line_builder&&>
-    operator<<(const T& x) && {
+      requires(!std::is_pointer_v<T>)
+    line_builder&& operator<<(const T& x) && {
       if (!str_.empty())
         str_ += " ";
       str_ += deep_to_string(x);

--- a/libcaf_core/caf/mailbox_element.hpp
+++ b/libcaf_core/caf/mailbox_element.hpp
@@ -89,11 +89,9 @@ make_mailbox_element(strong_actor_ptr sender, message_id id, message content);
 
 /// @relates mailbox_element
 template <class T, class... Ts>
-std::enable_if_t<!std::is_same_v<std::decay_t<T>, message>
-                   || (sizeof...(Ts) > 0),
-                 mailbox_element_ptr>
-make_mailbox_element(strong_actor_ptr sender, message_id id, T&& x,
-                     Ts&&... xs) {
+  requires(!std::is_same_v<std::decay_t<T>, message> || (sizeof...(Ts) > 0))
+mailbox_element_ptr make_mailbox_element(strong_actor_ptr sender, message_id id,
+                                         T&& x, Ts&&... xs) {
   return make_mailbox_element(std::move(sender), id,
                               make_message(std::forward<T>(x),
                                            std::forward<Ts>(xs)...));

--- a/libcaf_core/caf/message.hpp
+++ b/libcaf_core/caf/message.hpp
@@ -264,15 +264,15 @@ message make_message_from_tuple(Tuple&& xs) {
 
 /// @relates message
 template <class Inspector>
-auto inspect(Inspector& f, message& x)
-  -> std::enable_if_t<Inspector::is_loading, decltype(x.load(f))> {
+  requires Inspector::is_loading
+auto inspect(Inspector& f, message& x) -> decltype(x.load(f)) {
   return x.load(f);
 }
 
 /// @relates message
 template <class Inspector>
-auto inspect(Inspector& f, message& x)
-  -> std::enable_if_t<!Inspector::is_loading, decltype(x.save(f))> {
+  requires(!Inspector::is_loading)
+auto inspect(Inspector& f, message& x) -> decltype(x.save(f)) {
   return x.save(f);
 }
 

--- a/libcaf_core/caf/metaprogramming.test.cpp
+++ b/libcaf_core/caf/metaprogramming.test.cpp
@@ -92,7 +92,8 @@ struct typed_beh {
   }
 
   template <class... Ts>
-  typename std::enable_if<sizeof...(Ifs) == sizeof...(Ts)>::type assign(Ts...) {
+    requires(sizeof...(Ifs) == sizeof...(Ts))
+  void assign(Ts...) {
     using expected = type_list<Ifs...>;
     using found = type_list<deduce_mpi_t<Ts>...>;
     pos = interface_mismatch_t<found, expected>::value;
@@ -100,7 +101,8 @@ struct typed_beh {
   }
 
   template <class... Ts>
-  typename std::enable_if<sizeof...(Ifs) != sizeof...(Ts)>::type assign(Ts...) {
+    requires(sizeof...(Ifs) != sizeof...(Ts))
+  void assign(Ts...) {
     // too many or too few handlers present
     pos = -1;
     valid = false;

--- a/libcaf_core/caf/raise_error.hpp
+++ b/libcaf_core/caf/raise_error.hpp
@@ -14,6 +14,7 @@
 #include "caf/detail/critical.hpp"
 #include "caf/detail/pp.hpp"
 
+#include <concepts>
 #include <type_traits>
 
 namespace caf::detail {
@@ -23,14 +24,12 @@ CAF_CORE_EXPORT void log_cstring_error(const char* cstring);
 #ifdef CAF_ENABLE_EXCEPTIONS
 
 template <class T>
-  requires std::is_constructible<T, const char*>::value
 [[noreturn]] void throw_impl(const char* msg) {
-  throw T{msg};
-}
-
-template <class T>
-[[noreturn]] void throw_impl(...) {
-  throw T{};
+  if constexpr (std::constructible_from<T, const char*>) {
+    throw T{msg};
+  } else {
+    throw T{};
+  }
 }
 
 #endif // CAF_ENABLE_EXCEPTIONS

--- a/libcaf_core/caf/raise_error.hpp
+++ b/libcaf_core/caf/raise_error.hpp
@@ -23,8 +23,8 @@ CAF_CORE_EXPORT void log_cstring_error(const char* cstring);
 #ifdef CAF_ENABLE_EXCEPTIONS
 
 template <class T>
-[[noreturn]] std::enable_if_t<std::is_constructible<T, const char*>::value>
-throw_impl(const char* msg) {
+  requires std::is_constructible<T, const char*>::value
+[[noreturn]] void throw_impl(const char* msg) {
   throw T{msg};
 }
 

--- a/libcaf_core/caf/response_handle.hpp
+++ b/libcaf_core/caf/response_handle.hpp
@@ -98,17 +98,15 @@ public:
     then(std::move(f), [self](error& err) { self->call_error_handler(err); });
   }
 
-  template <class T>
-    requires flow::has_impl_include_v<scheduled_actor>
-  flow::single<T> as_single() && {
+  template <class T, bool = flow::assert_has_impl_include<T>>
+  auto as_single() && {
     static_assert(std::is_same_v<response_type, type_list<T>>
                   || std::is_same_v<response_type, message>);
     return self_->template single_from_response<T>(policy_);
   }
 
-  template <class T>
-    requires flow::has_impl_include_v<scheduled_actor>
-  flow::observable<T> as_observable() && {
+  template <class T, bool = flow::assert_has_impl_include<T>>
+  auto as_observable() && {
     static_assert(std::is_same_v<response_type, type_list<T>>
                   || std::is_same_v<response_type, message>);
     return self_->template single_from_response<T>(policy_).as_observable();

--- a/libcaf_core/caf/result.hpp
+++ b/libcaf_core/caf/result.hpp
@@ -15,6 +15,7 @@
 #include "caf/type_list.hpp"
 #include "caf/variant_wrapper.hpp"
 
+#include <concepts>
 #include <type_traits>
 #include <variant>
 
@@ -190,8 +191,8 @@ public:
   using super::super;
 
   template <class U>
-    requires(std::is_constructible_v<T, U>
-             && !std::is_constructible_v<super, U>)
+    requires(std::constructible_from<T, U>
+             && !std::constructible_from<super, U>)
   result(U&& x)
     : super(detail::result_base_message_init{}, T{std::forward<U>(x)}) {
     // nop

--- a/libcaf_core/caf/result.hpp
+++ b/libcaf_core/caf/result.hpp
@@ -47,7 +47,8 @@ public:
 
   result_base& operator=(const result_base&) = default;
 
-  template <class Enum, class = std::enable_if_t<is_error_code_enum_v<Enum>>>
+  template <class Enum>
+    requires is_error_code_enum_v<Enum>
   result_base(Enum x) : content_(make_error(x)) {
     // nop
   }
@@ -188,9 +189,9 @@ public:
 
   using super::super;
 
-  template <class U,
-            class = std::enable_if_t<std::is_constructible_v<T, U>
-                                     && !std::is_constructible_v<super, U>>>
+  template <class U>
+    requires(std::is_constructible_v<T, U>
+             && !std::is_constructible_v<super, U>)
   result(U&& x)
     : super(detail::result_base_message_init{}, T{std::forward<U>(x)}) {
     // nop

--- a/libcaf_core/caf/resumable.hpp
+++ b/libcaf_core/caf/resumable.hpp
@@ -57,15 +57,15 @@ public:
 
 // enables intrusive_ptr<resumable> without introducing ambiguity
 template <class T>
-std::enable_if_t<std::is_same_v<T*, resumable*>>
-intrusive_ptr_add_ref(const T* ptr) {
+  requires std::is_same_v<T*, resumable*>
+void intrusive_ptr_add_ref(const T* ptr) {
   ptr->ref_resumable();
 }
 
 // enables intrusive_ptr<resumable> without introducing ambiguity
 template <class T>
-std::enable_if_t<std::is_same_v<T*, resumable*>>
-intrusive_ptr_release(const T* ptr) {
+  requires std::is_same_v<T*, resumable*>
+void intrusive_ptr_release(const T* ptr) {
   ptr->deref_resumable();
 }
 

--- a/libcaf_core/caf/resumable.hpp
+++ b/libcaf_core/caf/resumable.hpp
@@ -7,6 +7,7 @@
 #include "caf/detail/core_export.hpp"
 #include "caf/fwd.hpp"
 
+#include <concepts>
 #include <type_traits>
 
 namespace caf {
@@ -57,14 +58,14 @@ public:
 
 // enables intrusive_ptr<resumable> without introducing ambiguity
 template <class T>
-  requires std::is_same_v<T*, resumable*>
+  requires std::same_as<T*, resumable*>
 void intrusive_ptr_add_ref(const T* ptr) {
   ptr->ref_resumable();
 }
 
 // enables intrusive_ptr<resumable> without introducing ambiguity
 template <class T>
-  requires std::is_same_v<T*, resumable*>
+  requires std::same_as<T*, resumable*>
 void intrusive_ptr_release(const T* ptr) {
   ptr->deref_resumable();
 }

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -362,7 +362,7 @@ public:
   template <std::invocable<std::exception_ptr&> F>
     requires std::same_as<std::invoke_result_t<F, std::exception_ptr&>, error>
   void set_exception_handler(F fun) {
-    exception_handler_ = [fn{std::move(fun)}](local_actor*,
+    exception_handler_ = [fn{std::move(fun)}](scheduled_actor*,
                                               std::exception_ptr& x) mutable {
       return fn(x);
     };

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -266,9 +266,9 @@ public:
 
   /// Sets a custom handler for unexpected messages.
   template <class F>
+    requires std::is_invocable_r_v<skippable_result, F, message&>
   [[deprecated("use a handler for 'message' instead")]]
-  std::enable_if_t<std::is_invocable_r_v<skippable_result, F, message&>>
-  set_default_handler(F fun) {
+  void set_default_handler(F fun) {
     default_handler_ = [fn{std::move(fun)}](scheduled_actor*,
                                             message& xs) mutable {
       return fn(xs);
@@ -286,8 +286,9 @@ public:
 
   /// Sets a custom handler for error messages.
   template <class F>
+    requires std::is_invocable_v<F, error&>
   [[deprecated("use a handler for 'error' instead")]]
-  std::enable_if_t<std::is_invocable_v<F, error&>> set_error_handler(F fun) {
+  void set_error_handler(F fun) {
     error_handler_ = [fn{std::move(fun)}](scheduled_actor*, error& x) mutable {
       fn(x);
     };
@@ -304,8 +305,9 @@ public:
 
   /// Sets a custom handler for down messages.
   template <class F>
+    requires std::is_invocable_v<F, down_msg&>
   [[deprecated("use monitor with callback instead")]]
-  std::enable_if_t<std::is_invocable_v<F, down_msg&>> set_down_handler(F fun) {
+  void set_down_handler(F fun) {
     down_handler_ = [fn{std::move(fun)}](scheduled_actor*,
                                          down_msg& x) mutable { fn(x); };
   }
@@ -321,9 +323,9 @@ public:
 
   /// Sets a custom handler for down messages.
   template <class F>
+    requires std::is_invocable_v<F, node_down_msg&>
   [[deprecated("use a handler for 'node_down_msg' instead")]]
-  std::enable_if_t<std::is_invocable_v<F, node_down_msg&>>
-  set_node_down_handler(F fun) {
+  void set_node_down_handler(F fun) {
     node_down_handler_ = [fn{std::move(fun)}](scheduled_actor*,
                                               node_down_msg& x) mutable {
       fn(x);
@@ -341,8 +343,9 @@ public:
 
   /// Sets a custom handler for exit messages.
   template <class F>
+    requires std::is_invocable_v<F, exit_msg&>
   [[deprecated("use a handler for 'exit_msg' instead")]]
-  std::enable_if_t<std::is_invocable_v<F, exit_msg&>> set_exit_handler(F fun) {
+  void set_exit_handler(F fun) {
     exit_handler_ = [fn{std::move(fun)}](scheduled_actor*,
                                          exit_msg& x) mutable { fn(x); };
   }
@@ -360,9 +363,9 @@ public:
   /// Sets a custom exception handler for this actor. If multiple handlers are
   /// defined, only the functor that was added *last* is being executed.
   template <class F>
-  std::enable_if_t<std::is_invocable_r_v<error, F, std::exception_ptr&>>
-  set_exception_handler(F fun) {
-    exception_handler_ = [fn{std::move(fun)}](scheduled_actor*,
+    requires std::is_invocable_r_v<error, F, std::exception_ptr&>
+  void set_exception_handler(F fun) {
+    exception_handler_ = [fn{std::move(fun)}](local_actor*,
                                               std::exception_ptr& x) mutable {
       return fn(x);
     };
@@ -489,7 +492,8 @@ public:
   ///       The actor may increase (or decrease) the effective settings
   ///       depending on the amount of messages per batch or other factors.
   template <class T>
-  flow::assert_scheduled_actor_hdr_t<flow::observable<T>>
+    requires flow::has_impl_include_v<scheduled_actor>
+  flow::observable<T>
   observe(typed_stream<T> what, size_t buf_capacity, size_t demand_threshold);
 
   /// Lifts a stream into an @ref caf::flow::observable.
@@ -501,7 +505,8 @@ public:
   ///       The actor may increase (or decrease) the effective settings
   ///       depending on the amount of messages per batch or other factors.
   template <class T>
-  flow::assert_scheduled_actor_hdr_t<flow::observable<T>>
+    requires flow::has_impl_include_v<scheduled_actor>
+  flow::observable<T>
   observe_as(stream what, size_t buf_capacity, size_t demand_threshold);
 
   /// Deregisters a local stream. After calling this function, other actors can
@@ -516,27 +521,20 @@ public:
   /// Utility function that swaps `f` into a temporary before calling it
   /// and restoring `f` only if it has not been replaced by the user.
   template <class F, class... Ts>
-  auto call_handler(F& f, Ts&&... xs) -> std::enable_if_t<
-    !std::is_same_v<decltype(f(std::forward<Ts>(xs)...)), void>,
-    decltype(f(std::forward<Ts>(xs)...))> {
+  auto call_handler(F& f, Ts&&... xs) {
     using std::swap;
     F g;
     swap(f, g);
-    auto res = g(std::forward<Ts>(xs)...);
-    if (!f)
-      swap(g, f);
-    return res;
-  }
-
-  template <class F, class... Ts>
-  auto call_handler(F& f, Ts&&... xs) -> std::enable_if_t<
-    std::is_same_v<decltype(f(std::forward<Ts>(xs)...)), void>> {
-    using std::swap;
-    F g;
-    swap(f, g);
-    g(std::forward<Ts>(xs)...);
-    if (!f)
-      swap(g, f);
+    if constexpr (std::is_same_v<decltype(g(std::forward<Ts>(xs)...)), void>) {
+      g(std::forward<Ts>(xs)...);
+      if (!f)
+        swap(g, f);
+    } else {
+      auto res = g(std::forward<Ts>(xs)...);
+      if (!f)
+        swap(g, f);
+      return res;
+    }
   }
 
   void call_error_handler(error& err) override;
@@ -770,7 +768,8 @@ private:
   timeout_state timeout_state_;
 
   template <class T>
-  flow::assert_scheduled_actor_hdr_t<flow::single<T>>
+    requires flow::has_impl_include_v<scheduled_actor>
+  flow::single<T>
   single_from_response(message_id mid, disposable pending_timeout);
 
   void do_unstash(mailbox_element_ptr ptr) override;

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -488,9 +488,8 @@ public:
   /// @note Both @p buf_capacity and @p demand_threshold are considered hints.
   ///       The actor may increase (or decrease) the effective settings
   ///       depending on the amount of messages per batch or other factors.
-  template <class T>
-    requires flow::has_impl_include_v<scheduled_actor>
-  flow::observable<T>
+  template <class T, bool = flow::assert_has_impl_include<T>>
+  auto
   observe(typed_stream<T> what, size_t buf_capacity, size_t demand_threshold);
 
   /// Lifts a stream into an @ref caf::flow::observable.
@@ -501,10 +500,8 @@ public:
   /// @note Both @p buf_capacity and @p demand_threshold are considered hints.
   ///       The actor may increase (or decrease) the effective settings
   ///       depending on the amount of messages per batch or other factors.
-  template <class T>
-    requires flow::has_impl_include_v<scheduled_actor>
-  flow::observable<T>
-  observe_as(stream what, size_t buf_capacity, size_t demand_threshold);
+  template <class T, bool = flow::assert_has_impl_include<T>>
+  auto observe_as(stream what, size_t buf_capacity, size_t demand_threshold);
 
   /// Deregisters a local stream. After calling this function, other actors can
   /// no longer access the flow that has been attached to the stream. Current
@@ -764,10 +761,8 @@ private:
   /// Stores the current timeout state.
   timeout_state timeout_state_;
 
-  template <class T>
-    requires flow::has_impl_include_v<scheduled_actor>
-  flow::single<T>
-  single_from_response(message_id mid, disposable pending_timeout);
+  template <class T, bool = flow::assert_has_impl_include<T>>
+  auto single_from_response(message_id mid, disposable pending_timeout);
 
   void do_unstash(mailbox_element_ptr ptr) override;
 

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -32,6 +32,7 @@
 #include "caf/timespan.hpp"
 #include "caf/unordered_flat_map.hpp"
 
+#include <concepts>
 #include <forward_list>
 #include <type_traits>
 #include <unordered_map>
@@ -265,8 +266,8 @@ public:
   }
 
   /// Sets a custom handler for unexpected messages.
-  template <class F>
-    requires std::is_invocable_r_v<skippable_result, F, message&>
+  template <std::invocable<message&> F>
+    requires std::same_as<std::invoke_result_t<F, message&>, skippable_result>
   [[deprecated("use a handler for 'message' instead")]]
   void set_default_handler(F fun) {
     default_handler_ = [fn{std::move(fun)}](scheduled_actor*,
@@ -285,8 +286,7 @@ public:
   }
 
   /// Sets a custom handler for error messages.
-  template <class F>
-    requires std::is_invocable_v<F, error&>
+  template <std::invocable<error&> F>
   [[deprecated("use a handler for 'error' instead")]]
   void set_error_handler(F fun) {
     error_handler_ = [fn{std::move(fun)}](scheduled_actor*, error& x) mutable {
@@ -304,8 +304,7 @@ public:
   }
 
   /// Sets a custom handler for down messages.
-  template <class F>
-    requires std::is_invocable_v<F, down_msg&>
+  template <std::invocable<down_msg&> F>
   [[deprecated("use monitor with callback instead")]]
   void set_down_handler(F fun) {
     down_handler_ = [fn{std::move(fun)}](scheduled_actor*,
@@ -322,8 +321,7 @@ public:
   }
 
   /// Sets a custom handler for down messages.
-  template <class F>
-    requires std::is_invocable_v<F, node_down_msg&>
+  template <std::invocable<node_down_msg&> F>
   [[deprecated("use a handler for 'node_down_msg' instead")]]
   void set_node_down_handler(F fun) {
     node_down_handler_ = [fn{std::move(fun)}](scheduled_actor*,
@@ -342,8 +340,7 @@ public:
   }
 
   /// Sets a custom handler for exit messages.
-  template <class F>
-    requires std::is_invocable_v<F, exit_msg&>
+  template <std::invocable<exit_msg&> F>
   [[deprecated("use a handler for 'exit_msg' instead")]]
   void set_exit_handler(F fun) {
     exit_handler_ = [fn{std::move(fun)}](scheduled_actor*,
@@ -362,8 +359,8 @@ public:
 
   /// Sets a custom exception handler for this actor. If multiple handlers are
   /// defined, only the functor that was added *last* is being executed.
-  template <class F>
-    requires std::is_invocable_r_v<error, F, std::exception_ptr&>
+  template <std::invocable<std::exception_ptr&> F>
+    requires std::same_as<std::invoke_result_t<F, std::exception_ptr&>, error>
   void set_exception_handler(F fun) {
     exception_handler_ = [fn{std::move(fun)}](local_actor*,
                                               std::exception_ptr& x) mutable {

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -515,7 +515,9 @@ public:
   /// Utility function that swaps `f` into a temporary before calling it
   /// and restoring `f` only if it has not been replaced by the user.
   template <class F, class... Ts>
-  auto call_handler(F& f, Ts&&... xs) {
+  auto call_handler(F& f, Ts&&... xs)
+    requires std::invocable<F, Ts...>
+  {
     using std::swap;
     F g;
     swap(f, g);

--- a/libcaf_core/caf/scheduled_actor/flow.hpp
+++ b/libcaf_core/caf/scheduled_actor/flow.hpp
@@ -45,18 +45,20 @@ flow::single<T> scheduled_actor::single_from_response_impl(Policy& policy) {
 }
 
 template <class T>
-flow::assert_scheduled_actor_hdr_t<flow::observable<T>>
-scheduled_actor::observe(typed_stream<T> what, size_t buf_capacity,
-                         size_t demand_threshold) {
+  requires flow::has_impl_include_v<scheduled_actor>
+flow::observable<T> scheduled_actor::observe(typed_stream<T> what,
+                                             size_t buf_capacity,
+                                             size_t demand_threshold) {
   return do_observe(what.dynamically_typed(), buf_capacity, demand_threshold)
     .transform(detail::unbatch<T>{})
     .as_observable();
 }
 
 template <class T>
-flow::assert_scheduled_actor_hdr_t<flow::observable<T>>
-scheduled_actor::observe_as(stream what, size_t buf_capacity,
-                            size_t demand_threshold) {
+  requires flow::has_impl_include_v<scheduled_actor>
+flow::observable<T> scheduled_actor::observe_as(stream what,
+                                                size_t buf_capacity,
+                                                size_t demand_threshold) {
   if (what.template has_element_type<T>())
     return do_observe(what, buf_capacity, demand_threshold)
       .transform(detail::unbatch<T>{})
@@ -65,7 +67,8 @@ scheduled_actor::observe_as(stream what, size_t buf_capacity,
 }
 
 template <class T>
-flow::assert_scheduled_actor_hdr_t<flow::single<T>>
+  requires flow::has_impl_include_v<scheduled_actor>
+flow::single<T>
 scheduled_actor::single_from_response(message_id mid,
                                       disposable pending_timeout) {
   auto cell = make_counted<flow::op::cell<T>>(this);

--- a/libcaf_core/caf/scheduled_actor/flow.hpp
+++ b/libcaf_core/caf/scheduled_actor/flow.hpp
@@ -44,21 +44,17 @@ flow::single<T> scheduled_actor::single_from_response_impl(Policy& policy) {
   return flow::single<T>{std::move(cell)};
 }
 
-template <class T>
-  requires flow::has_impl_include_v<scheduled_actor>
-flow::observable<T> scheduled_actor::observe(typed_stream<T> what,
-                                             size_t buf_capacity,
-                                             size_t demand_threshold) {
+template <class T, bool>
+auto scheduled_actor::observe(typed_stream<T> what, size_t buf_capacity,
+                              size_t demand_threshold) {
   return do_observe(what.dynamically_typed(), buf_capacity, demand_threshold)
     .transform(detail::unbatch<T>{})
     .as_observable();
 }
 
-template <class T>
-  requires flow::has_impl_include_v<scheduled_actor>
-flow::observable<T> scheduled_actor::observe_as(stream what,
-                                                size_t buf_capacity,
-                                                size_t demand_threshold) {
+template <class T, bool>
+auto scheduled_actor::observe_as(stream what, size_t buf_capacity,
+                                 size_t demand_threshold) {
   if (what.template has_element_type<T>())
     return do_observe(what, buf_capacity, demand_threshold)
       .transform(detail::unbatch<T>{})
@@ -66,11 +62,9 @@ flow::observable<T> scheduled_actor::observe_as(stream what,
   return make_observable().fail<T>(make_error(sec::type_clash));
 }
 
-template <class T>
-  requires flow::has_impl_include_v<scheduled_actor>
-flow::single<T>
-scheduled_actor::single_from_response(message_id mid,
-                                      disposable pending_timeout) {
+template <class T, bool>
+auto scheduled_actor::single_from_response(message_id mid,
+                                           disposable pending_timeout) {
   auto cell = make_counted<flow::op::cell<T>>(this);
   auto bhvr = behavior{
     [this, cell](T& val) {

--- a/libcaf_core/caf/serializer.hpp
+++ b/libcaf_core/caf/serializer.hpp
@@ -127,7 +127,8 @@ public:
 
   /// @copydoc value
   template <class T>
-  std::enable_if_t<std::is_integral_v<T>, bool> value(T x) {
+    requires std::is_integral_v<T>
+  bool value(T x) {
     return value(static_cast<detail::squashed_int_t<T>>(x));
   }
 

--- a/libcaf_core/caf/serializer.hpp
+++ b/libcaf_core/caf/serializer.hpp
@@ -11,6 +11,7 @@
 #include "caf/sec.hpp"
 #include "caf/span.hpp"
 
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -126,8 +127,7 @@ public:
   virtual bool value(uint64_t x) = 0;
 
   /// @copydoc value
-  template <class T>
-    requires std::is_integral_v<T>
+  template <std::integral T>
   bool value(T x) {
     return value(static_cast<detail::squashed_int_t<T>>(x));
   }

--- a/libcaf_core/caf/span.hpp
+++ b/libcaf_core/caf/span.hpp
@@ -64,14 +64,14 @@ public:
     // nop
   }
 
-  template <class C, class = std::enable_if_t<
-                       detail::has_convertible_data_member_v<C, value_type>>>
+  template <class C>
+    requires detail::has_convertible_data_member_v<C, value_type>
   span(C& xs) noexcept : begin_(xs.data()), size_(xs.size()) {
     // nop
   }
 
-  template <class C, class = std::enable_if_t<
-                       detail::has_convertible_data_member_v<C, value_type>>>
+  template <class C>
+    requires detail::has_convertible_data_member_v<C, value_type>
   span(const C& xs) noexcept : begin_(xs.data()), size_(xs.size()) {
     // nop
   }

--- a/libcaf_core/caf/telemetry/collector/prometheus.cpp
+++ b/libcaf_core/caf/telemetry/collector/prometheus.cpp
@@ -59,8 +59,11 @@ template <class... Ts>
 void append(prometheus::char_buffer&, double, Ts&&...);
 
 template <class T, class... Ts>
-std::enable_if_t<std::is_integral_v<T>>
-append(prometheus::char_buffer& buf, T val, Ts&&... xs);
+  requires std::is_integral_v<T>
+void append(prometheus::char_buffer& buf, T val, Ts&&... xs) {
+  append(buf, std::to_string(val));
+  append(buf, std::forward<Ts>(xs)...);
+}
 
 template <class... Ts>
 void append(prometheus::char_buffer&, const metric_family*, Ts&&...);
@@ -117,13 +120,6 @@ void append(prometheus::char_buffer& buf, double val, Ts&&... xs) {
   } else {
     append(buf, std::to_string(val));
   }
-  append(buf, std::forward<Ts>(xs)...);
-}
-
-template <class T, class... Ts>
-std::enable_if_t<std::is_integral_v<T>>
-append(prometheus::char_buffer& buf, T val, Ts&&... xs) {
-  append(buf, std::to_string(val));
   append(buf, std::forward<Ts>(xs)...);
 }
 

--- a/libcaf_core/caf/telemetry/counter.hpp
+++ b/libcaf_core/caf/telemetry/counter.hpp
@@ -10,7 +10,6 @@
 #include "caf/telemetry/gauge.hpp"
 #include "caf/telemetry/label.hpp"
 
-#include <concepts>
 #include <type_traits>
 
 namespace caf::telemetry {

--- a/libcaf_core/caf/telemetry/counter.hpp
+++ b/libcaf_core/caf/telemetry/counter.hpp
@@ -59,14 +59,16 @@ public:
   /// Increments the counter by 1.
   /// @returns The new value of the counter.
   template <class T = ValueType>
-  std::enable_if_t<std::is_same_v<T, int64_t>, T> operator++() noexcept {
+    requires std::is_same_v<T, int64_t>
+  T operator++() noexcept {
     return ++gauge_;
   }
 
   /// Increments the counter by 1.
   /// @returns The old value of the counter.
   template <class T = ValueType>
-  std::enable_if_t<std::is_same_v<T, int64_t>, T> operator++(int) noexcept {
+    requires std::is_same_v<T, int64_t>
+  T operator++(int) noexcept {
     return gauge_++;
   }
 

--- a/libcaf_core/caf/telemetry/counter.hpp
+++ b/libcaf_core/caf/telemetry/counter.hpp
@@ -10,6 +10,7 @@
 #include "caf/telemetry/gauge.hpp"
 #include "caf/telemetry/label.hpp"
 
+#include <concepts>
 #include <type_traits>
 
 namespace caf::telemetry {
@@ -58,17 +59,17 @@ public:
 
   /// Increments the counter by 1.
   /// @returns The new value of the counter.
-  template <class T = ValueType>
-    requires std::is_same_v<T, int64_t>
-  T operator++() noexcept {
+  value_type operator++() noexcept
+    requires std::is_same_v<value_type, int64_t>
+  {
     return ++gauge_;
   }
 
   /// Increments the counter by 1.
   /// @returns The old value of the counter.
-  template <class T = ValueType>
-    requires std::is_same_v<T, int64_t>
-  T operator++(int) noexcept {
+  value_type operator++(int) noexcept
+    requires std::is_same_v<value_type, int64_t>
+  {
     return gauge_++;
   }
 

--- a/libcaf_core/caf/typed_actor.hpp
+++ b/libcaf_core/caf/typed_actor.hpp
@@ -18,6 +18,7 @@
 #include "caf/typed_actor_view_base.hpp"
 #include "caf/typed_behavior.hpp"
 
+#include <concepts>
 #include <cstddef>
 #include <functional>
 
@@ -136,9 +137,8 @@ public:
   }
 
   // Enable `handle_type{self}` for typed actor views.
-  template <class T>
-    requires(std::is_base_of_v<typed_actor_view_base, T>
-             && detail::tl_subset_of_v<signatures, typename T::signatures>)
+  template <std::derived_from<typed_actor_view_base> T>
+    requires detail::tl_subset_of_v<signatures, typename T::signatures>
   explicit typed_actor(T ptr) : ptr_(ptr.ctrl()) {
     // nop
   }

--- a/libcaf_core/caf/typed_actor.hpp
+++ b/libcaf_core/caf/typed_actor.hpp
@@ -120,35 +120,32 @@ public:
   typed_actor& operator=(typed_actor&&) = default;
   typed_actor& operator=(const typed_actor&) = default;
 
-  template <class... Ts,
-            class = std::enable_if_t<detail::tl_subset_of_v<
-              signatures, typename typed_actor<Ts...>::signatures>>>
+  template <class... Ts>
+    requires detail::tl_subset_of_v<signatures,
+                                    typename typed_actor<Ts...>::signatures>
   typed_actor(const typed_actor<Ts...>& other) : ptr_(other.ptr_) {
     // nop
   }
 
   // allow `handle_type{this}` for typed actors
-  template <class T,
-            class = std::enable_if_t<actor_traits<T>::is_statically_typed>,
-            class = std::enable_if_t<
-              detail::tl_subset_of_v<signatures, typename T::signatures>>>
+  template <class T>
+    requires(actor_traits<T>::is_statically_typed
+             && detail::tl_subset_of_v<signatures, typename T::signatures>)
   typed_actor(T* ptr) : ptr_(ptr->ctrl()) {
     CAF_ASSERT(ptr != nullptr);
   }
 
   // Enable `handle_type{self}` for typed actor views.
-  template <
-    class T,
-    class = std::enable_if_t<std::is_base_of_v<typed_actor_view_base, T>>,
-    class = std::enable_if_t<
-      detail::tl_subset_of_v<signatures, typename T::signatures>>>
+  template <class T>
+    requires(std::is_base_of_v<typed_actor_view_base, T>
+             && detail::tl_subset_of_v<signatures, typename T::signatures>)
   explicit typed_actor(T ptr) : ptr_(ptr.ctrl()) {
     // nop
   }
 
-  template <class... Ts,
-            class = std::enable_if_t<detail::tl_subset_of_v<
-              signatures, typename typed_actor<Ts...>::signatures>>>
+  template <class... Ts>
+    requires detail::tl_subset_of_v<signatures,
+                                    typename typed_actor<Ts...>::signatures>
   typed_actor& operator=(const typed_actor<Ts...>& other) {
     ptr_ = other.ptr_;
     return *this;

--- a/libcaf_core/caf/typed_actor_pointer.hpp
+++ b/libcaf_core/caf/typed_actor_pointer.hpp
@@ -27,15 +27,15 @@ public:
     // nop
   }
 
-  template <class Supertype,
-            class = std::enable_if_t<detail::tl_subset_of<
-              signatures, typename Supertype::signatures>::value>>
+  template <class Supertype>
+    requires detail::tl_subset_of<signatures,
+                                  typename Supertype::signatures>::value
   typed_actor_pointer(Supertype* selfptr) : view_(selfptr) {
     // nop
   }
 
-  template <class... OtherSigs, class = std::enable_if_t<detail::tl_subset_of<
-                                  signatures, type_list<OtherSigs...>>::value>>
+  template <class... OtherSigs>
+    requires detail::tl_subset_of<signatures, type_list<OtherSigs...>>::value
   typed_actor_pointer(typed_actor_pointer<OtherSigs...> other)
     : view_(other.internal_ptr()) {
     // nop
@@ -49,18 +49,15 @@ public:
 
   typed_actor_pointer& operator=(const typed_actor_pointer&) = default;
 
-  template <
-    class Supertype,
-    class = std::enable_if_t< //
-      detail::tl_subset_of_v<signatures, typename Supertype::signatures>>>
+  template <class Supertype>
+    requires detail::tl_subset_of_v<signatures, typename Supertype::signatures>
   typed_actor_pointer& operator=(Supertype* ptr) {
     view_.reset(ptr);
     return *this;
   }
 
-  template <class... OtherSigs,
-            class = std::enable_if_t< //
-              detail::tl_subset_of_v<signatures, type_list<OtherSigs...>>>>
+  template <class... OtherSigs>
+    requires detail::tl_subset_of_v<signatures, type_list<OtherSigs...>>
   typed_actor_pointer& operator=(typed_actor_pointer<OtherSigs...> other) {
     view_.reset(other.internal_ptr());
     return *this;

--- a/libcaf_core/caf/typed_actor_view.hpp
+++ b/libcaf_core/caf/typed_actor_view.hpp
@@ -23,8 +23,7 @@ namespace caf {
 /// Utility function to force the type of `self` to depend on `T` and to raise a
 /// compiler error if the user did not include 'caf/scheduled_actor/flow.hpp'.
 /// The function itself does nothing and simply returns `self`.
-template <class, class T>
-  requires flow::has_impl_include_v<T>
+template <class, class T, bool = flow::assert_has_impl_include<T>>
 auto typed_actor_view_flow_access(T* self) {
   return self;
 }

--- a/libcaf_core/caf/typed_actor_view.hpp
+++ b/libcaf_core/caf/typed_actor_view.hpp
@@ -23,10 +23,10 @@ namespace caf {
 /// Utility function to force the type of `self` to depend on `T` and to raise a
 /// compiler error if the user did not include 'caf/scheduled_actor/flow.hpp'.
 /// The function itself does nothing and simply returns `self`.
-template <class T>
-auto typed_actor_view_flow_access(caf::scheduled_actor* self) {
-  using Self = flow::assert_scheduled_actor_hdr_t<T, caf::scheduled_actor*>;
-  return static_cast<Self>(self);
+template <class, class T>
+  requires flow::has_impl_include_v<T>
+auto typed_actor_view_flow_access(T* self) {
+  return self;
 }
 
 template <class...>
@@ -346,9 +346,6 @@ public:
   /// @copydoc flow::coordinator::make_observable
   template <class T = none_t>
   auto make_observable() {
-    // Note: the template parameter T serves no purpose other than forcing the
-    //       compiler to delay evaluation of this function body by having
-    //       *something* to pass to `typed_actor_view_flow_access`.
     auto self = typed_actor_view_flow_access<T>(self_);
     return self->make_observable();
   }

--- a/libcaf_core/caf/typed_response_promise.hpp
+++ b/libcaf_core/caf/typed_response_promise.hpp
@@ -61,13 +61,15 @@ public:
 
   /// Satisfies the promise by sending a non-error response message.
   template <class... Us>
-  std::enable_if_t<(std::is_constructible_v<Ts, Us> && ...)> deliver(Us... xs) {
+    requires(std::is_constructible_v<Ts, Us> && ...)
+  void deliver(Us... xs) {
     promise_.deliver(Ts{std::forward<Us>(xs)}...);
   }
 
   /// Satisfies the promise by sending an empty response message.
   template <class L = type_list<Ts...>>
-  std::enable_if_t<std::is_same_v<L, type_list<void>>> deliver() {
+    requires std::is_same_v<L, type_list<void>>
+  void deliver() {
     promise_.deliver();
   }
 
@@ -80,8 +82,8 @@ public:
   /// Satisfies the promise by sending either an error or a non-error response
   /// message.
   template <class T>
-  std::enable_if_t<std::is_same_v<type_list<T>, type_list<Ts...>>>
-  deliver(expected<T> x) {
+    requires std::is_same_v<type_list<T>, type_list<Ts...>>
+  void deliver(expected<T> x) {
     promise_.deliver(std::move(x));
   }
 

--- a/libcaf_core/caf/typed_response_promise.hpp
+++ b/libcaf_core/caf/typed_response_promise.hpp
@@ -8,6 +8,7 @@
 #include "caf/response_promise.hpp"
 #include "caf/type_list.hpp"
 
+#include <concepts>
 #include <type_traits>
 
 namespace caf {
@@ -61,15 +62,15 @@ public:
 
   /// Satisfies the promise by sending a non-error response message.
   template <class... Us>
-    requires(std::is_constructible_v<Ts, Us> && ...)
+    requires(std::constructible_from<Ts, Us> && ...)
   void deliver(Us... xs) {
     promise_.deliver(Ts{std::forward<Us>(xs)}...);
   }
 
   /// Satisfies the promise by sending an empty response message.
-  template <class L = type_list<Ts...>>
-    requires std::is_same_v<L, type_list<void>>
-  void deliver() {
+  void deliver()
+    requires std::same_as<type_list<Ts...>, type_list<void>>
+  {
     promise_.deliver();
   }
 
@@ -82,7 +83,7 @@ public:
   /// Satisfies the promise by sending either an error or a non-error response
   /// message.
   template <class T>
-    requires std::is_same_v<type_list<T>, type_list<Ts...>>
+    requires std::same_as<type_list<T>, type_list<Ts...>>
   void deliver(expected<T> x) {
     promise_.deliver(std::move(x));
   }

--- a/libcaf_core/caf/unit.hpp
+++ b/libcaf_core/caf/unit.hpp
@@ -20,8 +20,8 @@ struct unit_t : detail::comparable<unit_t> {
 
   constexpr unit_t& operator=(const unit_t&) noexcept = default;
 
-  template <class T,
-            class = std::enable_if_t<!std::is_same_v<std::decay_t<T>, unit_t>>>
+  template <class T>
+    requires(!std::is_same_v<std::decay_t<T>, unit_t>)
   explicit constexpr unit_t(T&&) noexcept {
     // nop
   }

--- a/libcaf_core/caf/variant_wrapper.hpp
+++ b/libcaf_core/caf/variant_wrapper.hpp
@@ -18,44 +18,46 @@ struct is_variant_wrapper : std::false_type {};
 
 /// @relates is_variant_wrapper
 template <class T>
-constexpr bool is_variant_wrapper_v = is_variant_wrapper<T>::value;
+inline constexpr bool is_variant_wrapper_v = is_variant_wrapper<T>::value;
 
 /// @relates is_variant_wrapper
-template <class T>
-using enable_variant_wrapper_t = std::enable_if_t<is_variant_wrapper_v<T>>;
-
-/// @relates is_variant_wrapper
-template <class F, class V, class = enable_variant_wrapper_t<std::decay_t<V>>>
+template <class F, class V>
+  requires is_variant_wrapper_v<std::decay_t<V>>
 decltype(auto) visit(F&& f, V&& x) {
   return std::visit(std::forward<F>(f), std::forward<V>(x).get_data());
 }
 
 /// @relates is_variant_wrapper
-template <class T, class V, class = enable_variant_wrapper_t<V>>
+template <class T, class V>
+  requires is_variant_wrapper_v<V>
 bool holds_alternative(const V& x) noexcept {
   return std::holds_alternative<T>(x.get_data());
 }
 
 /// @relates is_variant_wrapper
-template <class T, class V, class = enable_variant_wrapper_t<V>>
+template <class T, class V>
+  requires is_variant_wrapper_v<V>
 T& get(V& x) {
   return std::get<T>(x.get_data());
 }
 
 /// @relates is_variant_wrapper
-template <class T, class V, class = enable_variant_wrapper_t<V>>
+template <class T, class V>
+  requires is_variant_wrapper_v<V>
 const T& get(const V& x) {
   return std::get<T>(x.get_data());
 }
 
 /// @relates is_variant_wrapper
-template <class T, class V, class = enable_variant_wrapper_t<V>>
+template <class T, class V>
+  requires is_variant_wrapper_v<V>
 T* get_if(V* ptr) noexcept {
   return std::get_if<T>(&ptr->get_data());
 }
 
 /// @relates is_variant_wrapper
-template <class T, class V, class = enable_variant_wrapper_t<V>>
+template <class T, class V>
+  requires is_variant_wrapper_v<V>
 const T* get_if(const V* ptr) noexcept {
   return std::get_if<T>(&ptr->get_data());
 }

--- a/libcaf_net/caf/net/multiplexer.cpp
+++ b/libcaf_net/caf/net/multiplexer.cpp
@@ -565,8 +565,8 @@ public:
 
   /// @copydoc write_to_pipe
   template <class Enum, class T>
-  std::enable_if_t<std::is_enum_v<Enum>, bool>
-  write_to_pipe(Enum opcode, T* ptr) {
+    requires std::is_enum_v<Enum>
+  bool write_to_pipe(Enum opcode, T* ptr) {
     return write_to_pipe(static_cast<uint8_t>(opcode), ptr);
   }
 

--- a/libcaf_test/caf/test/fixture/deterministic.hpp
+++ b/libcaf_test/caf/test/fixture/deterministic.hpp
@@ -66,8 +66,8 @@ private:
     }
 
     template <class U>
-    explicit value_predicate(
-      U value, std::enable_if_t<detail::is_comparable_v<T, U>>* = nullptr) {
+      requires detail::is_comparable_v<T, U>
+    explicit value_predicate(U value) {
       predicate_ = [value](const T& found) { return found == value; };
     }
 
@@ -78,11 +78,11 @@ private:
       };
     }
 
-    template <
-      class Predicate,
-      class = std::enable_if_t<std::is_same_v<
-        bool, decltype(std::declval<Predicate>()(std::declval<const T&>()))>>>
-    explicit value_predicate(Predicate predicate) {
+    template <class Predicate>
+    explicit value_predicate(Predicate predicate)
+      requires std::is_same_v<bool,
+                              decltype(predicate(std::declval<const T&>()))>
+    {
       predicate_ = std::move(predicate);
     }
 


### PR DESCRIPTION
- CAF now requires C++20 to build
- replace all uses of `enable_if` with `requires`
- use concepts from the STL where it makes the code more readable
- rewrite the `flow::has_impl_include` check to not require `enable_if` while still giving a clear and concise error message to the user