### PR TITLE
Add new to_const_byte_span convenience function

### DIFF
--- a/examples/length_prefix_framing/chat-client.cpp
+++ b/examples/length_prefix_framing/chat-client.cpp
@@ -107,8 +107,7 @@ int caf_main(caf::actor_system& sys, const config& cfg) {
               .for_each([self](const lp::frame& frame) {
                 // Interpret the bytes as ASCII characters.
                 auto bytes = frame.bytes();
-                auto str = std::string_view{
-                  reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+                auto str = caf::to_string_view(bytes);
                 if (std::all_of(str.begin(), str.end(), ::isprint)) {
                   self->println("{}", str);
                 } else {

--- a/libcaf_core/caf/byte_span.cpp
+++ b/libcaf_core/caf/byte_span.cpp
@@ -26,4 +26,8 @@ std::string_view to_string_view(const_byte_span bytes) noexcept {
                           bytes.size()};
 }
 
+const_byte_span to_const_byte_span(std::string_view str) noexcept {
+  return {reinterpret_cast<const std::byte*>(str.data()), str.size()};
+}
+
 } // namespace caf

--- a/libcaf_core/caf/byte_span.hpp
+++ b/libcaf_core/caf/byte_span.hpp
@@ -28,4 +28,7 @@ CAF_CORE_EXPORT bool is_valid_ascii(const_byte_span) noexcept;
 /// Reinterprets the underlying data as a string view.
 CAF_CORE_EXPORT std::string_view to_string_view(const_byte_span) noexcept;
 
+/// Reinterprets the underlying data as a const byte span.
+CAF_CORE_EXPORT const_byte_span to_const_byte_span(std::string_view) noexcept;
+
 } // namespace caf

--- a/libcaf_core/caf/detail/base64.cpp
+++ b/libcaf_core/caf/detail/base64.cpp
@@ -89,10 +89,6 @@ bool decode_impl(std::string_view in, Storage& out) {
   return true;
 }
 
-std::string_view as_string_view(const_byte_span bytes) {
-  return {reinterpret_cast<const char*>(bytes.data()), bytes.size()};
-}
-
 } // namespace
 
 void base64::encode(std::string_view str, std::string& out) {
@@ -104,11 +100,11 @@ void base64::encode(std::string_view str, byte_buffer& out) {
 }
 
 void base64::encode(const_byte_span bytes, std::string& out) {
-  encode_impl(as_string_view(bytes), out);
+  encode_impl(to_string_view(bytes), out);
 }
 
 void base64::encode(const_byte_span bytes, byte_buffer& out) {
-  encode_impl(as_string_view(bytes), out);
+  encode_impl(to_string_view(bytes), out);
 }
 
 bool base64::decode(std::string_view in, std::string& out) {
@@ -120,11 +116,11 @@ bool base64::decode(std::string_view in, byte_buffer& out) {
 }
 
 bool base64::decode(const_byte_span bytes, std::string& out) {
-  return decode_impl(as_string_view(bytes), out);
+  return decode_impl(to_string_view(bytes), out);
 }
 
 bool base64::decode(const_byte_span bytes, byte_buffer& out) {
-  return decode_impl(as_string_view(bytes), out);
+  return decode_impl(to_string_view(bytes), out);
 }
 
 } // namespace caf::detail

--- a/libcaf_core/caf/json_reader.cpp
+++ b/libcaf_core/caf/json_reader.cpp
@@ -5,6 +5,7 @@
 #include "caf/json_reader.hpp"
 
 #include "caf/actor_control_block.hpp"
+#include "caf/byte_span.hpp"
 #include "caf/deserializer.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/detail/bounds_checker.hpp"
@@ -250,8 +251,7 @@ public:
   }
 
   bool load_bytes(const_byte_span bytes) override {
-    auto utf8 = std::string_view{reinterpret_cast<const char*>(bytes.data()),
-                                 bytes.size()};
+    auto utf8 = to_string_view(bytes);
     return load(utf8);
   }
 

--- a/libcaf_core/caf/json_writer.cpp
+++ b/libcaf_core/caf/json_writer.cpp
@@ -5,6 +5,7 @@
 #include "caf/json_writer.hpp"
 
 #include "caf/actor_control_block.hpp"
+#include "caf/byte_span.hpp"
 #include "caf/detail/append_hex.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/detail/print.hpp"
@@ -57,7 +58,7 @@ public:
   // -- properties -------------------------------------------------------------
 
   const_byte_span bytes() const override {
-    return {reinterpret_cast<const std::byte*>(buf_.data()), buf_.size()};
+    return to_const_byte_span(str());
   }
 
   [[nodiscard]] std::string_view str() const noexcept {

--- a/libcaf_io/caf/detail/prometheus_broker.cpp
+++ b/libcaf_io/caf/detail/prometheus_broker.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/detail/prometheus_broker.hpp"
 
+#include "caf/byte_span.hpp"
 #include "caf/log/io.hpp"
 #include "caf/string_algorithms.hpp"
 #include "caf/telemetry/dbl_gauge.hpp"
@@ -71,8 +72,7 @@ behavior prometheus_broker::make_behavior() {
         return;
       }
       req.insert(req.end(), msg.buf.begin(), msg.buf.end());
-      auto req_str = std::string_view{reinterpret_cast<char*>(req.data()),
-                                      req.size()};
+      auto req_str = to_string_view(const_byte_span{req});
       // Stop here if the header isn't complete yet.
       if (!ends_with(req_str, "\r\n\r\n"))
         return;

--- a/libcaf_net/caf/net/actor_shell.test.cpp
+++ b/libcaf_net/caf/net/actor_shell.test.cpp
@@ -107,11 +107,6 @@ actor_system_config& init(actor_system_config& cfg) {
   return cfg;
 }
 
-auto to_str(caf::byte_span buffer) {
-  return std::string_view{reinterpret_cast<const char*>(buffer.data()),
-                          buffer.size()};
-}
-
 struct fixture {
   fixture() : sys(init(cfg)) {
     auto fd_pair = net::make_stream_socket_pair();
@@ -155,7 +150,7 @@ TEST("actor shells can receive messages") {
   buf.resize(msg.size());
   auto n = net::read(fd2, buf);
   check_eq(n, static_cast<ptrdiff_t>(msg.size()));
-  check_eq(to_str(buf), msg);
+  check_eq(to_string_view(buf), msg);
 }
 
 TEST("actor shells can send asynchronous messages") {
@@ -202,7 +197,7 @@ TEST("actor shells can send request messages") {
   buf.resize(msg.size());
   auto n = net::read(fd2, buf);
   check_eq(n, static_cast<ptrdiff_t>(msg.size()));
-  check_eq(to_str(buf), msg);
+  check_eq(to_string_view(buf), msg);
 }
 
 TEST("actor shells can use flows") {
@@ -234,7 +229,7 @@ TEST("actor shells can use flows") {
   buf.resize(msg.size());
   auto n = net::read(fd2, buf);
   check_eq(n, static_cast<ptrdiff_t>(msg.size()));
-  check_eq(to_str(buf), msg);
+  check_eq(to_string_view(buf), msg);
 }
 
 } // WITH_FIXTURE(fixture)

--- a/libcaf_net/caf/net/http/async_client.test.cpp
+++ b/libcaf_net/caf/net/http/async_client.test.cpp
@@ -74,11 +74,6 @@ bool closed_within(stream_socket fd, std::chrono::milliseconds timeout) {
   return false;
 }
 
-auto to_str(caf::const_byte_span buffer) {
-  return std::string_view{reinterpret_cast<const char*>(buffer.data()),
-                          buffer.size()};
-}
-
 using field_map = unordered_flat_map<std::string, std::string>;
 
 struct fixture {
@@ -140,7 +135,7 @@ SCENARIO("the client sends HTTP requests") {
         buf.resize(want.size());
         auto res = net::read(fd1, buf);
         check_eq(res, static_cast<ptrdiff_t>(want.size()));
-        check_eq(to_str(buf), want);
+        check_eq(to_string_view(buf), want);
       }
     }
   }
@@ -159,7 +154,7 @@ SCENARIO("the client sends HTTP requests") {
         buf.resize(want.size());
         auto res = net::read(fd1, buf);
         check_eq(res, static_cast<ptrdiff_t>(want.size()));
-        check_eq(to_str(buf), want);
+        check_eq(to_string_view(buf), want);
       }
     }
   }
@@ -180,7 +175,7 @@ SCENARIO("the client sends HTTP requests") {
         buf.resize(want.size());
         auto res = net::read(fd1, buf);
         check_eq(res, static_cast<ptrdiff_t>(want.size()));
-        check_eq(to_str(buf), want);
+        check_eq(to_string_view(buf), want);
       }
     }
     WHEN("the client sends the message without a Content-Length") {
@@ -198,7 +193,7 @@ SCENARIO("the client sends HTTP requests") {
         buf.resize(want.size());
         auto res = net::read(fd1, buf);
         check_eq(res, static_cast<ptrdiff_t>(want.size()));
-        check_eq(to_str(buf), want);
+        check_eq(to_string_view(buf), want);
       }
     }
   }
@@ -260,7 +255,7 @@ SCENARIO("the client parses HTTP response into header fields") {
         auto header_fields = res.header_fields();
         check_eq(header_fields[0], std::pair{"Content-Length"s, "13"s});
         check_eq(header_fields[1], std::pair{"Content-Type"s, "text/plain"s});
-        check_eq(to_str(res.body()), "Hello, world!"sv);
+        check_eq(to_string_view(res.body()), "Hello, world!"sv);
       }
       AND_THEN("the connection is closed") {
         check(closed_within(fd1, 1s));

--- a/libcaf_net/caf/net/http/client.test.cpp
+++ b/libcaf_net/caf/net/http/client.test.cpp
@@ -97,11 +97,6 @@ public:
   }
 };
 
-auto to_str(caf::byte_span buffer) {
-  return std::string_view{reinterpret_cast<const char*>(buffer.data()),
-                          buffer.size()};
-}
-
 struct fixture {
   fixture() {
     mpx = net::multiplexer::make(nullptr);
@@ -175,7 +170,7 @@ SCENARIO("the client sends HTTP requests") {
         buf.resize(want.size());
         auto res = net::read(fd1, buf);
         check_eq(res, static_cast<ptrdiff_t>(want.size()));
-        check_eq(to_str(buf), want);
+        check_eq(to_string_view(buf), want);
       }
     }
   }
@@ -197,7 +192,7 @@ SCENARIO("the client sends HTTP requests") {
         buf.resize(want.size());
         auto res = net::read(fd1, buf);
         check_eq(res, static_cast<ptrdiff_t>(want.size()));
-        check_eq(to_str(buf), want);
+        check_eq(to_string_view(buf), want);
       }
     }
   }
@@ -221,7 +216,7 @@ SCENARIO("the client sends HTTP requests") {
         buf.resize(want.size());
         auto res = net::read(fd1, buf);
         check_eq(res, static_cast<ptrdiff_t>(want.size()));
-        check_eq(to_str(buf), want);
+        check_eq(to_string_view(buf), want);
       }
     }
   }
@@ -253,7 +248,7 @@ SCENARIO("the client sends HTTP requests") {
         buf.resize(want.size());
         auto res = net::read(fd1, buf);
         check_eq(res, static_cast<ptrdiff_t>(want.size()));
-        check_eq(to_str(buf), want);
+        check_eq(to_string_view(buf), want);
       }
     }
   }
@@ -274,7 +269,7 @@ OUTLINE("sending all available HTTP methods") {
         buf.resize(want.size());
         auto res = net::read(fd1, buf);
         check_eq(res, static_cast<ptrdiff_t>(want.size()));
-        check_eq(to_str(buf), want);
+        check_eq(to_string_view(buf), want);
       }
     }
   }

--- a/libcaf_net/caf/net/http/server.test.cpp
+++ b/libcaf_net/caf/net/http/server.test.cpp
@@ -93,11 +93,6 @@ public:
   }
 };
 
-auto to_str(caf::byte_span buffer) {
-  return std::string_view{reinterpret_cast<const char*>(buffer.data()),
-                          buffer.size()};
-}
-
 struct fixture {
   fixture() {
     mpx = net::multiplexer::make(nullptr);
@@ -196,7 +191,7 @@ SCENARIO("the server parses HTTP GET requests into header fields") {
         byte_buffer buf;
         buf.resize(response.size());
         net::read(fd1, buf);
-        check_eq(to_str(buf), response);
+        check_eq(to_string_view(buf), response);
       }
     }
   }
@@ -234,7 +229,7 @@ SCENARIO("the client receives a chunked HTTP response") {
         byte_buffer buf;
         buf.resize(response.size());
         net::read(fd1, buf);
-        check_eq(to_str(buf), response);
+        check_eq(to_string_view(buf), response);
       }
     }
   }

--- a/libcaf_net/caf/net/typed_actor_shell.test.cpp
+++ b/libcaf_net/caf/net/typed_actor_shell.test.cpp
@@ -123,11 +123,6 @@ actor_system_config& init(actor_system_config& cfg) {
   return cfg;
 }
 
-auto to_str(caf::byte_span buffer) {
-  return std::string_view{reinterpret_cast<const char*>(buffer.data()),
-                          buffer.size()};
-}
-
 struct fixture {
   fixture() : sys(init(cfg)) {
     auto fd_pair = net::make_stream_socket_pair();
@@ -171,7 +166,7 @@ TEST("actor shells can receive messages") {
   buf.resize(msg.size());
   auto n = net::read(fd2, buf);
   check_eq(n, static_cast<ptrdiff_t>(msg.size()));
-  check_eq(to_str(buf), msg);
+  check_eq(to_string_view(buf), msg);
 }
 
 TEST("actor shells can send asynchronous messages") {
@@ -218,7 +213,7 @@ TEST("actor shells can send request messages") {
   buf.resize(msg.size());
   auto n = net::read(fd2, buf);
   check_eq(n, static_cast<ptrdiff_t>(msg.size()));
-  check_eq(to_str(buf), msg);
+  check_eq(to_string_view(buf), msg);
 }
 
 TEST("actor shells can use flows") {
@@ -250,7 +245,7 @@ TEST("actor shells can use flows") {
   buf.resize(msg.size());
   auto n = net::read(fd2, buf);
   check_eq(n, static_cast<ptrdiff_t>(msg.size()));
-  check_eq(to_str(buf), msg);
+  check_eq(to_string_view(buf), msg);
 }
 
 } // WITH_FIXTURE(fixture)

--- a/libcaf_net/caf/net/udp_datagram_socket.test.cpp
+++ b/libcaf_net/caf/net/udp_datagram_socket.test.cpp
@@ -89,8 +89,7 @@ TEST("read and write") {
   auto write_res = write(send_socket, as_bytes(std::span{hello_test}), ep);
   check_eq(write_res, static_cast<ptrdiff_t>(hello_test.size()));
   check_eq(read_from_socket(receive_socket, buf), none);
-  std::string_view received{reinterpret_cast<const char*>(buf.data()),
-                            buf.size()};
+  auto received = to_string_view(buf);
   check_eq(received, hello_test);
 }
 


### PR DESCRIPTION
We already have `to_string_view` to go from a `span<const byte>` to a `string_view`. This is the inverse.