### PR TITLE
Implement blocking fan_out_request

### DIFF
--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -119,6 +119,7 @@ caf_add_component(
     caf/binary_serializer.cpp
     caf/blocking_actor.cpp
     caf/blocking_actor.test.cpp
+    caf/blocking_fan_out_request.test.cpp
     caf/blocking_mail.test.cpp
     caf/byte_reader.cpp
     caf/byte_span.cpp

--- a/libcaf_core/caf/abstract_blocking_actor.hpp
+++ b/libcaf_core/caf/abstract_blocking_actor.hpp
@@ -18,6 +18,9 @@ public:
   template <class...>
   friend class blocking_response_handle;
 
+  template <class, class...>
+  friend class blocking_fan_out_response_handle;
+
   using super = local_actor;
 
   using super::super;

--- a/libcaf_core/caf/blocking_fan_out_request.test.cpp
+++ b/libcaf_core/caf/blocking_fan_out_request.test.cpp
@@ -1,0 +1,816 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#include "caf/test/test.hpp"
+
+#include "caf/actor_system.hpp"
+#include "caf/actor_system_config.hpp"
+#include "caf/blocking_actor.hpp"
+#include "caf/blocking_mail.hpp"
+#include "caf/event_based_actor.hpp"
+#include "caf/scoped_actor.hpp"
+#include "caf/typed_actor.hpp"
+#include "caf/typed_event_based_actor.hpp"
+
+#include <iostream>
+#include <numeric>
+
+using namespace caf;
+using namespace std::literals;
+
+namespace {
+
+struct config : actor_system_config {
+  config() {
+    set("caf.scheduler.max-threads", 2u);
+  }
+};
+
+struct fixture {
+  config cfg;
+  actor_system sys{cfg};
+};
+
+template <typename Fn>
+actor make_server(caf::actor_system& sys, Fn fn) {
+  auto sf = [fn]() -> behavior {
+    return {
+      [fn](int x, int y) { return fn(x, y); },
+    };
+  };
+  return sys.spawn(sf);
+}
+
+// Typed actor interfaces for the fan_out_request test.
+using typed_worker_actor = typed_actor<result<int>(int, int)>;
+using typed_worker_behavior = typed_worker_actor::behavior_type;
+using typed_worker_two_values_actor = typed_actor<result<int, int>(int, int)>;
+using typed_worker_two_values_behavior
+  = typed_worker_two_values_actor::behavior_type;
+using typed_worker_void_actor = typed_actor<result<void>(int, int)>;
+using typed_worker_void_behavior = typed_worker_void_actor::behavior_type;
+
+template <typename Fn>
+typed_worker_actor make_typed_server(caf::actor_system& sys, Fn fn) {
+  auto sf = [fn]() -> typed_worker_behavior {
+    return {[fn](int x, int y) { return fn(x, y); }};
+  };
+  return sys.spawn(sf);
+}
+
+template <typename Fn>
+typed_worker_two_values_actor
+make_typed_server_two_values(caf::actor_system& sys, Fn fn) {
+  auto sf = [fn]() -> typed_worker_two_values_behavior {
+    return {[fn](int x, int y) -> result<int, int> { return fn(x, y); }};
+  };
+  return sys.spawn(sf);
+}
+
+template <typename Fn>
+typed_worker_void_actor make_typed_server_void(caf::actor_system& sys, Fn fn) {
+  auto sf = [fn]() -> typed_worker_void_behavior {
+    return {[fn](int x, int y) -> result<void> {
+      fn(x, y);
+      return {};
+    }};
+  };
+  return sys.spawn(sf);
+}
+
+} // namespace
+
+WITH_FIXTURE(fixture) {
+
+TEST("fan_out_request with a single result") {
+  scoped_actor self{sys};
+  std::vector<actor> workers{
+    make_server(sys, [](int x, int y) { return x + y; }),
+    make_server(sys, [](int x, int y) { return x + y; }),
+    make_server(sys, [](int x, int y) { return x + y; }),
+  };
+  auto sum = std::make_shared<int>(0);
+  auto err = std::make_shared<error>();
+  SECTION("receive with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 1s, policy::select_all_tag)
+      .receive(
+        [this, sum](std::vector<int> results) {
+          for (auto result : results)
+            check_eq(result, 3);
+          *sum = std::accumulate(results.begin(), results.end(), 0);
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(*sum, 9);
+    check_eq(*err, error{});
+  }
+  SECTION("receive to expected with policy select_all") {
+    auto res = self->mail(1, 2)
+                 .fan_out_request(workers, 1s, policy::select_all_tag)
+                 .receive<int>();
+    if (check_has_value(res)) {
+      check_eq(res->size(), 3u);
+      for (const auto& val : *res) {
+        check_eq(val, 3);
+      }
+    }
+  }
+  SECTION("receive with policy select_any") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 1s, policy::select_any_tag)
+      .receive([sum](int result) { *sum = result; },
+               [err](error& e) { *err = std::move(e); });
+    check_eq(*sum, 3);
+    check_eq(*err, error{});
+  }
+  SECTION("receive to expected with policy select_any") {
+    auto res = self->mail(1, 2)
+                 .fan_out_request(workers, 1s, policy::select_any_tag)
+                 .receive<int>();
+    check_eq(res, 3);
+  }
+}
+
+TEST("fan_out_request with void result") {
+  scoped_actor self{sys};
+  std::vector<actor> workers{
+    make_server(sys, [](int, int) {}),
+    make_server(sys, [](int, int) {}),
+    make_server(sys, [](int, int) {}),
+  };
+  auto ran = std::make_shared<bool>(false);
+  auto err = std::make_shared<error>();
+  SECTION("receive with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 1s, policy::select_all_tag)
+      .receive([ran]() { *ran = true; },
+               [err](error& e) { *err = std::move(e); });
+    check(*ran);
+    check_eq(*err, error{});
+  }
+  SECTION("receive to expected with policy select_all") {
+    auto res = self->mail(1, 2)
+                 .fan_out_request(workers, 1s, policy::select_all_tag)
+                 .receive();
+    check_has_value(res);
+  }
+  SECTION("receive with policy select_any") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 1s, policy::select_any_tag)
+      .receive([ran]() { *ran = true; },
+               [err](error& e) { *err = std::move(e); });
+    check(*ran);
+    check_eq(*err, error{});
+  }
+  SECTION("receive to expected with policy select_any") {
+    auto res = self->mail(1, 2)
+                 .fan_out_request(workers, 1s, policy::select_any_tag)
+                 .receive();
+    check_has_value(res);
+  }
+}
+
+TEST("fan_out_request with multiple results") {
+  scoped_actor self{sys};
+  std::vector<actor> workers{
+    make_server(sys, [](int x, int y) { return make_message(y, x); }),
+    make_server(sys, [](int x, int y) { return make_message(y, x); }),
+    make_server(sys, [](int x, int y) { return make_message(y, x); }),
+  };
+  auto swapped_values = std::make_shared<std::vector<std::pair<int, int>>>();
+  auto single_result = std::make_shared<std::pair<int, int>>();
+  auto err = std::make_shared<error>();
+  SECTION("receive with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 1s, policy::select_all_tag)
+      .receive(
+        [swapped_values](std::vector<std::tuple<int, int>> results) {
+          for (auto result : results) {
+            swapped_values->emplace_back(std::get<0>(result),
+                                         std::get<1>(result));
+          }
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(swapped_values->size(), 3u);
+    for (const auto& pair : *swapped_values) {
+      check_eq(pair.first, 2);
+      check_eq(pair.second, 1);
+    }
+    check_eq(*err, error{});
+  }
+  SECTION("receive to expected with policy select_all") {
+    auto res = self->mail(1, 2)
+                 .fan_out_request(workers, 1s, policy::select_all_tag)
+                 .receive<int, int>();
+    if (check_has_value(res)) {
+      check_eq(res->size(), 3u);
+      for (const auto& pair : *res) {
+        check_eq(std::get<0>(pair), 2);
+        check_eq(std::get<1>(pair), 1);
+      }
+    }
+  }
+  SECTION("receive with policy select_any") {
+    self->mail(3, 5)
+      .fan_out_request(workers, 1s, policy::select_any_tag)
+      .receive(
+        [single_result](int first, int second) {
+          *single_result = std::make_pair(first, second);
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(single_result->first, 5);
+    check_eq(single_result->second, 3);
+    check_eq(*err, error{});
+  }
+  SECTION("receive to expected with policy select_any") {
+    auto res = self->mail(3, 5)
+                 .fan_out_request(workers, 1s, policy::select_any_tag)
+                 .receive<int, int>();
+    if (check_has_value(res)) {
+      check_eq(std::get<0>(*res), 5);
+      check_eq(std::get<1>(*res), 3);
+    }
+  }
+}
+
+TEST("fan_out_request with type mismatch") {
+  scoped_actor self{sys};
+  std::vector<actor> workers{
+    make_server(sys, [](int x, int y) { return std::to_string(x + y); }),
+    make_server(sys, [](int x, int y) { return std::to_string(x + y); }),
+    make_server(sys, [](int x, int y) { return std::to_string(x + y); }),
+  };
+  auto err = std::make_shared<error>();
+  SECTION("receive with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 1s, policy::select_all_tag)
+      .receive(
+        [this](std::vector<int> results) {
+          fail("expected an error, got: {}", results);
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(*err, make_error(sec::unexpected_response));
+  }
+  SECTION("receive with policy select_any") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 1s, policy::select_any_tag)
+      .receive([this](
+                 int results) { fail("expected an error, got: {}", results); },
+               [err](error& e) { *err = std::move(e); });
+    check_eq(*err, make_error(sec::unexpected_response));
+  }
+}
+
+TEST("fan_out_request with timeout") {
+  scoped_actor self{sys};
+  auto dummy = [](event_based_actor* self) -> behavior {
+    auto res = std::make_shared<response_promise>();
+    return {
+      [self, res](int, int) {
+        *res = self->make_response_promise();
+        return *res;
+      },
+    };
+  };
+  std::vector<actor> workers{sys.spawn(dummy), sys.spawn(dummy),
+                             sys.spawn(dummy)};
+  auto sum = std::make_shared<int>(0);
+  auto err = std::make_shared<error>();
+  SECTION("timeout with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 10ms, policy::select_all_tag)
+      .receive(
+        [sum, this](std::vector<int> results) {
+          for (auto result : results)
+            check_eq(result, 3);
+          *sum = std::accumulate(results.begin(), results.end(), 0);
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(*err, make_error(sec::request_timeout));
+  }
+  SECTION("timeout with policy select_any") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 10ms, policy::select_any_tag)
+      .receive([sum](int result) { *sum = result; },
+               [err](error& e) { *err = std::move(e); });
+    check_eq(*err, make_error(sec::request_timeout));
+  }
+  for (const auto& worker : workers) {
+    self->send_exit(worker, exit_reason::user_shutdown);
+  }
+}
+
+TEST("typed fan_out_request with a single result") {
+  scoped_actor self{sys};
+  std::vector<typed_worker_actor> workers{
+    make_typed_server(sys, [](int x, int y) { return x + y; }),
+    make_typed_server(sys, [](int x, int y) { return x + y; }),
+    make_typed_server(sys, [](int x, int y) { return x + y; }),
+  };
+  auto sum = std::make_shared<int>(0);
+  auto err = std::make_shared<error>();
+  SECTION("receive with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 1s, policy::select_all_tag)
+      .receive(
+        [sum, this](std::vector<int> results) {
+          for (auto result : results)
+            check_eq(result, 3);
+          *sum = std::accumulate(results.begin(), results.end(), 0);
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(*sum, 9);
+    check_eq(*err, error{});
+  }
+  SECTION("receive to expected with policy select_all") {
+    auto res = self->mail(1, 2)
+                 .fan_out_request(workers, 1s, policy::select_all_tag)
+                 .receive();
+    if (check_has_value(res)) {
+      check_eq(res->size(), 3u);
+      for (const auto& val : *res) {
+        check_eq(val, 3);
+      }
+    }
+  }
+  SECTION("receive with policy select_any") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 1s, policy::select_any_tag)
+      .receive([sum](int result) { *sum = result; },
+               [err](error& e) { *err = std::move(e); });
+    check_eq(*sum, 3);
+    check_eq(*err, error{});
+  }
+  SECTION("receive to expected with policy select_any") {
+    auto res = self->mail(1, 2)
+                 .fan_out_request(workers, 1s, policy::select_any_tag)
+                 .receive();
+    check_eq(res, 3);
+  }
+}
+
+TEST("typed fan_out_request with multiple results") {
+  scoped_actor self{sys};
+  std::vector<typed_worker_two_values_actor> workers{
+    make_typed_server_two_values(
+      sys, [](int x, int y) { return result<int, int>(y, x); }),
+    make_typed_server_two_values(
+      sys, [](int x, int y) { return result<int, int>(y, x); }),
+    make_typed_server_two_values(
+      sys, [](int x, int y) { return result<int, int>(y, x); }),
+  };
+  auto swapped_values = std::make_shared<std::vector<std::pair<int, int>>>();
+  auto single_result = std::make_shared<std::pair<int, int>>();
+  auto err = std::make_shared<error>();
+  SECTION("receive with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 1s, policy::select_all_tag)
+      .receive(
+        [swapped_values](std::vector<std::tuple<int, int>> results) {
+          for (auto result : results) {
+            swapped_values->emplace_back(std::get<0>(result),
+                                         std::get<1>(result));
+          }
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(swapped_values->size(), 3u);
+    for (const auto& pair : *swapped_values) {
+      check_eq(pair.first, 2);
+      check_eq(pair.second, 1);
+    }
+    check_eq(*err, error{});
+  }
+  SECTION("receive to expected with policy select_all") {
+    auto res = self->mail(1, 2)
+                 .fan_out_request(workers, 1s, policy::select_all_tag)
+                 .receive();
+    if (check_has_value(res)) {
+      check_eq(res->size(), 3u);
+      for (const auto& pair : *res) {
+        check_eq(std::get<0>(pair), 2);
+        check_eq(std::get<1>(pair), 1);
+      }
+    }
+  }
+  SECTION("receive with policy select_any") {
+    self->mail(3, 5)
+      .fan_out_request(workers, 1s, policy::select_any_tag)
+      .receive(
+        [single_result](int first, int second) {
+          *single_result = std::make_pair(first, second);
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(single_result->first, 5);
+    check_eq(single_result->second, 3);
+    check_eq(*err, error{});
+  }
+  SECTION("receive to expected with policy select_any") {
+    auto res = self->mail(3, 5)
+                 .fan_out_request(workers, 1s, policy::select_any_tag)
+                 .receive();
+    if (check_has_value(res)) {
+      check_eq(std::get<0>(*res), 5);
+      check_eq(std::get<1>(*res), 3);
+    }
+  }
+}
+
+TEST("typed fan_out_request with void result") {
+  scoped_actor self{sys};
+  std::vector<typed_worker_void_actor> workers{
+    make_typed_server_void(sys, [](int, int) {}),
+    make_typed_server_void(sys, [](int, int) {}),
+    make_typed_server_void(sys, [](int, int) {}),
+  };
+  auto ran = std::make_shared<bool>(false);
+  auto err = std::make_shared<error>();
+  SECTION("receive with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 1s, policy::select_all_tag)
+      .receive([ran]() { *ran = true; },
+               [err](error& e) { *err = std::move(e); });
+    check(*ran);
+    check_eq(*err, error{});
+  }
+  SECTION("receive to expected with policy select_all") {
+    auto res = self->mail(1, 2)
+                 .fan_out_request(workers, 1s, policy::select_all_tag)
+                 .receive();
+    check_has_value(res);
+  }
+  SECTION("receive with policy select_any") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 1s, policy::select_any_tag)
+      .receive([ran]() { *ran = true; },
+               [err](error& e) { *err = std::move(e); });
+    check(*ran);
+    check_eq(*err, error{});
+  }
+  SECTION("receive to expected with policy select_any") {
+    auto res = self->mail(1, 2)
+                 .fan_out_request(workers, 1s, policy::select_any_tag)
+                 .receive();
+    check_has_value(res);
+  }
+}
+
+TEST("typed fan_out_request with error responses") {
+  scoped_actor self{sys};
+  std::vector<typed_worker_actor> error_workers{
+    make_typed_server(sys,
+                      [](int, int) -> result<int> {
+                        return caf::error(sec::logic_error);
+                      }),
+    make_typed_server(sys,
+                      [](int, int) -> result<int> {
+                        return caf::error(sec::logic_error);
+                      }),
+    make_typed_server(sys,
+                      [](int, int) -> result<int> {
+                        return caf::error(sec::logic_error);
+                      }),
+  };
+  auto err = std::make_shared<error>();
+  SECTION("receive with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(error_workers, 1s, policy::select_all_tag)
+      .receive(
+        [this](std::vector<int> results) {
+          fail("expected an error, got: {}", results);
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(*err, make_error(sec::logic_error));
+  }
+  SECTION("receive with policy select_any") {
+    self->mail(1, 2)
+      .fan_out_request(error_workers, 1s, policy::select_any_tag)
+      .receive([this](
+                 int results) { fail("expected an error, got: {}", results); },
+               [err](error& e) { *err = std::move(e); });
+    check_eq(*err, make_error(sec::logic_error));
+  }
+}
+
+TEST("delayed fan_out_request with a single result") {
+  scoped_actor self{sys};
+  std::vector<actor> workers{
+    make_server(sys, [](int x, int y) { return x + y; }),
+    make_server(sys, [](int x, int y) { return x + y; }),
+    make_server(sys, [](int x, int y) { return x + y; }),
+  };
+  auto sum = std::make_shared<int>(0);
+  auto err = std::make_shared<error>();
+  SECTION("receive with policy select_all") {
+    self->mail(1, 2)
+      .delay(100ms)
+      .fan_out_request(workers, 1s, policy::select_all_tag)
+      .receive(
+        [sum, this](std::vector<int> results) {
+          for (auto result : results)
+            check_eq(result, 3);
+          *sum = std::accumulate(results.begin(), results.end(), 0);
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(*sum, 9);
+    check_eq(*err, error{});
+  }
+  SECTION("receive with policy select_any") {
+    self->mail(1, 2)
+      .delay(100ms)
+      .fan_out_request(workers, 1s, policy::select_any_tag)
+      .receive([sum](int result) { *sum = result; },
+               [err](error& e) { *err = std::move(e); });
+    check_eq(*sum, 3);
+    check_eq(*err, error{});
+  }
+}
+
+TEST("delayed fan_out_request with void result") {
+  scoped_actor self{sys};
+  std::vector<actor> workers{
+    make_server(sys, [](int, int) {}),
+    make_server(sys, [](int, int) {}),
+    make_server(sys, [](int, int) {}),
+  };
+  auto ran = std::make_shared<bool>(false);
+  auto err = std::make_shared<error>();
+  SECTION("receive with policy select_all") {
+    self->mail(1, 2)
+      .delay(100ms)
+      .fan_out_request(workers, 1s, policy::select_all_tag)
+      .receive([ran]() { *ran = true; },
+               [err](error& e) { *err = std::move(e); });
+    check(*ran);
+    check_eq(*err, error{});
+  }
+  SECTION("receive with policy select_any") {
+    self->mail(1, 2)
+      .delay(100ms)
+      .fan_out_request(workers, 1s, policy::select_any_tag)
+      .receive([ran]() { *ran = true; },
+               [err](error& e) { *err = std::move(e); });
+    check(*ran);
+    check_eq(*err, error{});
+  }
+}
+
+TEST("delayed fan_out_request with multiple results") {
+  scoped_actor self{sys};
+  std::vector<actor> workers{
+    make_server(sys, [](int x, int y) { return make_message(y, x); }),
+    make_server(sys, [](int x, int y) { return make_message(y, x); }),
+    make_server(sys, [](int x, int y) { return make_message(y, x); }),
+  };
+  auto swapped_values = std::make_shared<std::vector<std::pair<int, int>>>();
+  auto single_result = std::make_shared<std::pair<int, int>>();
+  auto err = std::make_shared<error>();
+  SECTION("receive with policy select_all") {
+    self->mail(1, 2)
+      .delay(100ms)
+      .fan_out_request(workers, 1s, policy::select_all_tag)
+      .receive(
+        [swapped_values](std::vector<std::tuple<int, int>> results) {
+          for (auto result : results) {
+            swapped_values->emplace_back(std::get<0>(result),
+                                         std::get<1>(result));
+          }
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(swapped_values->size(), 3u);
+    for (const auto& pair : *swapped_values) {
+      check_eq(pair.first, 2);
+      check_eq(pair.second, 1);
+    }
+    check_eq(*err, error{});
+  }
+  SECTION("receive with policy select_any") {
+    self->mail(3, 5)
+      .delay(100ms)
+      .fan_out_request(workers, 1s, policy::select_any_tag)
+      .receive(
+        [single_result](int first, int second) {
+          *single_result = std::make_pair(first, second);
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(single_result->first, 5);
+    check_eq(single_result->second, 3);
+    check_eq(*err, error{});
+  }
+}
+
+TEST("typed delayed fan_out_request with a single result") {
+  scoped_actor self{sys};
+  std::vector<typed_worker_actor> workers{
+    make_typed_server(sys, [](int x, int y) { return x + y; }),
+    make_typed_server(sys, [](int x, int y) { return x + y; }),
+    make_typed_server(sys, [](int x, int y) { return x + y; }),
+  };
+  auto sum = std::make_shared<int>(0);
+  auto err = std::make_shared<error>();
+  SECTION("receive with policy select_all") {
+    self->mail(1, 2)
+      .delay(100ms)
+      .fan_out_request(workers, 1s, policy::select_all_tag)
+      .receive(
+        [sum, this](std::vector<int> results) {
+          for (auto result : results)
+            check_eq(result, 3);
+          *sum = std::accumulate(results.begin(), results.end(), 0);
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(*sum, 9);
+    check_eq(*err, error{});
+  }
+  SECTION("receive with policy select_any") {
+    self->mail(1, 2)
+      .delay(100ms)
+      .fan_out_request(workers, 1s, policy::select_any_tag)
+      .receive([sum](int result) { *sum = result; },
+               [err](error& e) { *err = std::move(e); });
+    check_eq(*sum, 3);
+    check_eq(*err, error{});
+  }
+}
+
+TEST("typed delayed fan_out_request with multiple results") {
+  scoped_actor self{sys};
+  std::vector<typed_worker_two_values_actor> workers{
+    make_typed_server_two_values(
+      sys, [](int x, int y) { return result<int, int>(y, x); }),
+    make_typed_server_two_values(
+      sys, [](int x, int y) { return result<int, int>(y, x); }),
+    make_typed_server_two_values(
+      sys, [](int x, int y) { return result<int, int>(y, x); }),
+  };
+  auto swapped_values = std::make_shared<std::vector<std::pair<int, int>>>();
+  auto single_result = std::make_shared<std::pair<int, int>>();
+  auto err = std::make_shared<error>();
+  SECTION("receive with policy select_all") {
+    self->mail(1, 2)
+      .delay(100ms)
+      .fan_out_request(workers, 1s, policy::select_all_tag)
+      .receive(
+        [swapped_values](std::vector<std::tuple<int, int>> results) {
+          for (auto result : results) {
+            swapped_values->emplace_back(std::get<0>(result),
+                                         std::get<1>(result));
+          }
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(swapped_values->size(), 3u);
+    for (const auto& pair : *swapped_values) {
+      check_eq(pair.first, 2);
+      check_eq(pair.second, 1);
+    }
+    check_eq(*err, error{});
+  }
+  SECTION("receive with policy select_any") {
+    self->mail(3, 5)
+      .delay(100ms)
+      .fan_out_request(workers, 1s, policy::select_any_tag)
+      .receive(
+        [single_result](int first, int second) {
+          *single_result = std::make_pair(first, second);
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(single_result->first, 5);
+    check_eq(single_result->second, 3);
+    check_eq(*err, error{});
+  }
+  SECTION("receive with policy select_all returning an expected") {
+    auto swapped_values = self->mail(1, 2)
+                            .delay(100ms)
+                            .fan_out_request(workers, 1s,
+                                             policy::select_all_tag)
+                            .receive();
+    check_has_value(swapped_values);
+    check_eq(swapped_values->size(), 3u);
+    for (const auto& pair : *swapped_values) {
+      check_eq(std::get<0>(pair), 2);
+      check_eq(std::get<1>(pair), 1);
+    }
+  }
+  SECTION("receive with policy select_any returning an expected") {
+    auto swapped_values = self->mail(3, 5)
+                            .delay(100ms)
+                            .fan_out_request(workers, 1s,
+                                             policy::select_any_tag)
+                            .receive();
+    check_has_value(swapped_values);
+    check_eq(std::get<0>(*swapped_values), 5);
+    check_eq(std::get<1>(*swapped_values), 3);
+  }
+}
+
+TEST("typed delayed fan_out_request with void result") {
+  scoped_actor self{sys};
+  std::vector<typed_worker_void_actor> workers{
+    make_typed_server_void(sys, [](int, int) {}),
+    make_typed_server_void(sys, [](int, int) {}),
+    make_typed_server_void(sys, [](int, int) {}),
+  };
+  auto ran = std::make_shared<bool>(false);
+  auto err = std::make_shared<error>();
+  SECTION("receive with policy select_all") {
+    self->mail(1, 2)
+      .delay(100ms)
+      .fan_out_request(workers, 1s, policy::select_all_tag)
+      .receive([ran]() { *ran = true; },
+               [err](error& e) { *err = std::move(e); });
+    check(*ran);
+    check_eq(*err, error{});
+  }
+  SECTION("receive with policy select_any") {
+    self->mail(1, 2)
+      .delay(100ms)
+      .fan_out_request(workers, 1s, policy::select_any_tag)
+      .receive([ran]() { *ran = true; },
+               [err](error& e) { *err = std::move(e); });
+    check(*ran);
+    check_eq(*err, error{});
+  }
+}
+
+TEST("fan_out_request with one worker returning an error") {
+  scoped_actor self{sys};
+  std::vector<actor> workers{
+    make_server(sys, [](int x, int y) { return x + y; }),
+    make_server(sys,
+                [](int, int) -> result<int> {
+                  return caf::error(sec::logic_error);
+                }),
+    make_server(sys, [](int x, int y) { return x + y; }),
+  };
+  auto sum = std::make_shared<int>(0);
+  auto err = std::make_shared<error>();
+  SECTION("receive with policy select_all") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 1s, policy::select_all_tag)
+      .receive(
+        [this](std::vector<int> results) {
+          fail("expected an error, got: {}", results);
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(*err, make_error(sec::logic_error));
+  }
+  SECTION("receive with policy select_any") {
+    self->mail(1, 2)
+      .fan_out_request(workers, 1s, policy::select_any_tag)
+      .receive([sum](int result) { *sum = result; },
+               [err](error& e) { *err = std::move(e); });
+    check_eq(*sum, 3);
+    check_eq(*err, error{});
+  }
+}
+
+TEST("delayed fan_out_request with timeout") {
+  scoped_actor self{sys};
+  auto dummy = [](event_based_actor* self) -> behavior {
+    auto res = std::make_shared<response_promise>();
+    return {
+      [self, res](int, int) {
+        *res = self->make_response_promise();
+        return *res;
+      },
+    };
+  };
+  std::vector<actor> workers{sys.spawn(dummy), sys.spawn(dummy),
+                             sys.spawn(dummy)};
+  auto sum = std::make_shared<int>(0);
+  auto err = std::make_shared<error>();
+  SECTION("timeout with policy select_all") {
+    auto start = std::chrono::steady_clock::now();
+    self->mail(1, 2)
+      .delay(100ms)
+      .fan_out_request(workers, 100ms, policy::select_all_tag)
+      .receive(
+        [sum, this](std::vector<int> results) {
+          for (auto result : results)
+            check_eq(result, 3);
+          *sum = std::accumulate(results.begin(), results.end(), 0);
+        },
+        [err](error& e) { *err = std::move(e); });
+    check_eq(*err, make_error(sec::request_timeout));
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    check_ge(elapsed, 200ms);
+    check_le(elapsed, 220ms);
+  }
+  SECTION("timeout with policy select_any") {
+    auto start = std::chrono::steady_clock::now();
+    self->mail(1, 2)
+      .delay(100ms)
+      .fan_out_request(workers, 100ms, policy::select_any_tag)
+      .receive([sum](int result) { *sum = result; },
+               [err](error& e) { *err = std::move(e); });
+    check_eq(*err, make_error(sec::request_timeout));
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    check_ge(elapsed, 200ms);
+    check_le(elapsed, 220ms);
+  }
+  for (const auto& worker : workers) {
+    self->send_exit(worker, exit_reason::user_shutdown);
+  }
+}
+
+} // WITH_FIXTURE(fixture)

--- a/libcaf_core/caf/blocking_fan_out_response_handle.hpp
+++ b/libcaf_core/caf/blocking_fan_out_response_handle.hpp
@@ -1,0 +1,346 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+#include "caf/abstract_blocking_actor.hpp"
+#include "caf/actor_clock.hpp"
+#include "caf/detail/metaprogramming.hpp"
+#include "caf/detail/response_type_check.hpp"
+#include "caf/message_id.hpp"
+#include "caf/policy/select_all.hpp"
+#include "caf/policy/select_any.hpp"
+#include "caf/sec.hpp"
+
+#include <type_traits>
+
+namespace caf::detail {
+
+template <class Policy, class Result>
+struct blocking_fan_out_response_handle_oracle;
+
+template <class Policy>
+struct blocking_fan_out_response_handle_oracle<Policy, message> {
+  using type = blocking_fan_out_response_handle<Policy, message>;
+};
+
+template <class Policy>
+struct blocking_fan_out_response_handle_oracle<Policy, type_list<void>> {
+  using type = blocking_fan_out_response_handle<Policy>;
+};
+
+template <class Policy, class... Results>
+struct blocking_fan_out_response_handle_oracle<Policy, type_list<Results...>> {
+  using type = blocking_fan_out_response_handle<Policy, Results...>;
+};
+
+template <class Policy, class Result>
+using blocking_fan_out_response_handle_t =
+  typename blocking_fan_out_response_handle_oracle<Policy, Result>::type;
+
+template <class Policy, class Result>
+struct blocking_fan_out_delayed_response_handle_oracle;
+
+template <class Policy>
+struct blocking_fan_out_delayed_response_handle_oracle<Policy, message> {
+  using type = blocking_fan_out_delayed_response_handle<Policy, message>;
+};
+
+template <class Policy>
+struct blocking_fan_out_delayed_response_handle_oracle<Policy,
+                                                       type_list<void>> {
+  using type = blocking_fan_out_delayed_response_handle<Policy>;
+};
+
+template <class Policy, class... Results>
+struct blocking_fan_out_delayed_response_handle_oracle<Policy,
+                                                       type_list<Results...>> {
+  using type = blocking_fan_out_delayed_response_handle<Policy, Results...>;
+};
+
+template <class Policy, class Result>
+using blocking_fan_out_delayed_response_handle_t =
+  typename blocking_fan_out_delayed_response_handle_oracle<Policy,
+                                                           Result>::type;
+
+} // namespace caf::detail
+
+namespace caf {
+
+/// Holds state for a blocking response handles.
+struct blocking_fan_out_response_handle_state {
+  /// Points to the parent actor.
+  abstract_blocking_actor* self;
+
+  /// Stores the ID of the message we are waiting for.
+  std::vector<message_id> mids;
+
+  /// Timeout for the response.
+  disposable in_flight;
+
+  /// Deadline for the response.
+  actor_clock::time_point deadline;
+};
+
+/// This helper class identifies an expected response message and enables
+/// `request(...).receive(...)`.
+template <class Policy, class... Results>
+class blocking_fan_out_response_handle {
+public:
+  // -- constants --------------------------------------------------------------
+
+  static constexpr bool is_dynamically_typed
+    = std::is_same_v<type_list<Results...>, type_list<message>>;
+
+  static constexpr bool is_statically_typed = !is_dynamically_typed;
+
+  static constexpr bool is_select_all
+    = std::is_same_v<Policy, policy::select_all_tag_t>;
+
+  static constexpr bool is_select_any
+    = std::is_same_v<Policy, policy::select_any_tag_t>;
+
+  static_assert(is_select_all || is_select_any);
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  blocking_fan_out_response_handle(abstract_blocking_actor* self,
+                                   std::vector<message_id> mids,
+                                   disposable in_flight,
+                                   actor_clock::time_point deadline)
+    : state_{self, std::move(mids), in_flight, deadline} {
+    // nop
+  }
+
+  // -- receive ----------------------------------------------------------------
+
+  template <class OnValue, class OnError>
+  void receive(OnValue on_value, OnError on_error) &&
+    requires is_select_all
+  {
+    detail::fan_out_response_type_check<Policy, OnValue, OnError, Results...>();
+    using helper_type = detail::select_all_helper_t<std::decay_t<OnValue>>;
+    helper_type helper{state_.mids.size(), state_.in_flight,
+                       std::forward<OnValue>(on_value)};
+    auto pending = helper.pending;
+    auto error_handler
+      = [pending{helper.pending}, timeout{state_.in_flight},
+         g{std::forward<OnError>(on_error)}](error& err) mutable {
+          auto lg = log::core::trace("pending = {}", *pending);
+          if (*pending > 0) {
+            timeout.dispose();
+            *pending = 0;
+            g(err);
+          }
+        };
+    auto bhvr = behavior{std::move(helper), std::move(error_handler)};
+    for (auto mid : state_.mids) {
+      auto now = std::chrono::steady_clock::now();
+      auto remaining = state_.deadline > now
+                         ? (state_.deadline - now)
+                         : std::chrono::steady_clock::duration::zero();
+      state_.self->do_receive(mid, bhvr, remaining);
+    }
+  }
+
+  template <class OnValue, class OnError>
+  void receive(OnValue on_value, OnError on_error) &&
+    requires is_select_any
+  {
+    detail::fan_out_response_type_check<Policy, OnValue, OnError, Results...>();
+    using helper = caf::detail::select_any_factory<std::decay_t<OnValue>>;
+    auto pending = std::make_shared<size_t>(state_.mids.size());
+    auto result_handler = helper::make(pending, state_.in_flight,
+                                       std::forward<OnValue>(on_value));
+    auto error_handler
+      = [p{std::move(pending)}, timeout{state_.in_flight},
+         g{std::forward<OnError>(on_error)}](error& err) mutable {
+          if (*p == 0) {
+            // nop
+          } else if (*p == 1) {
+            timeout.dispose();
+            g(err);
+          } else {
+            --*p;
+          }
+        };
+    auto bhvr = behavior{std::move(result_handler), std::move(error_handler)};
+    for (const auto& mid : state_.mids) {
+      auto now = std::chrono::steady_clock::now();
+      auto remaining = state_.deadline > now
+                         ? (state_.deadline - now)
+                         : std::chrono::steady_clock::duration::zero();
+      state_.self->do_receive(mid, bhvr, remaining);
+    }
+  }
+
+  auto receive() &&
+    requires is_statically_typed
+  {
+    return std::move(*this).template do_receive<Results...>();
+  }
+
+  template <class... Ts>
+  auto receive() &&
+    requires is_dynamically_typed
+  {
+    return std::move(*this).template do_receive<Ts...>();
+  }
+
+private:
+  template<class... Ts>
+  auto do_receive() &&
+    requires (is_select_all && sizeof...(Ts) == 0)
+  {
+    expected<void> result;
+    std::move(*this).receive(
+      []() {
+        // nop - expected<void> already set.
+      },
+      [&result](error& err) { result = std::move(err); });
+    return result;
+  }
+
+  template<class... Ts>
+  auto do_receive() &&
+    requires (is_select_all && sizeof...(Ts) == 1)
+  {
+    expected<std::vector<Ts...>> result = error{};
+    std::move(*this).receive(
+      [&result](std::vector<Ts...> args) {
+        result = std::move(args);
+      },
+      [&result](error& err) { result = std::move(err); });
+    return result;
+  }
+
+  template<class... Ts>
+  auto do_receive() &&
+    requires (is_select_all && sizeof...(Ts) > 1)
+  {
+    expected<std::vector<std::tuple<Ts...>>> result = error{}; 
+    std::move(*this).receive(
+      [&result](std::vector<std::tuple<Ts...>> args) {
+        result = std::move(args);
+      },
+      [&result](error& err) { result = std::move(err); });
+    return result;
+  }
+
+  template<class... Ts>
+  auto do_receive() &&
+    requires (is_select_any)
+  {
+    using expected_type = detail::to_expected<Ts...>;
+    expected_type result{error{}};
+    std::move(*this).receive(
+      [&result](Ts... args) {
+        result = expected_type{std::in_place, std::move(args)...};
+      },
+      [&result](error& err) { result = std::move(err); });
+    return std::move(result);
+  }
+
+  /// Holds the state for the handle.
+  blocking_fan_out_response_handle_state state_;
+};
+
+/// Similar to `blocking_response_handle`, but also holds the `disposable`
+/// for the delayed request message.
+template <class Policy, class... Results>
+class blocking_fan_out_delayed_response_handle {
+public:
+  using decorated_type = blocking_fan_out_response_handle<Policy, Results...>;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  blocking_fan_out_delayed_response_handle(abstract_blocking_actor* self,
+                                           std::vector<message_id> mids,
+                                           disposable in_flight,
+                                           actor_clock::time_point deadline,
+                                           disposable pending_request)
+    : decorated(self, std::move(mids), in_flight, deadline),
+      pending_request(std::move(pending_request)) {
+    // nop
+  }
+
+  // -- receive ----------------------------------------------------------------
+
+  template <class OnValue, class OnError>
+  void receive(OnValue on_value, OnError on_error) && {
+    std::move(decorated).receive(std::move(on_value), std::move(on_error));
+  }
+
+  auto receive() && {
+    return std::move(decorated).receive();
+  }
+
+  /// The wrapped handle type.
+  decorated_type decorated;
+
+  /// Stores a handle to the in-flight request if the request messages was
+  /// delayed/scheduled.
+  disposable pending_request;
+};
+
+// tuple-like access for blocking_fan_out_delayed_response_handle
+
+template <size_t I, class Policy, class... Results>
+decltype(auto)
+get(caf::blocking_fan_out_delayed_response_handle<Policy, Results...>& x) {
+  if constexpr (I == 0) {
+    return x.decorated;
+  } else {
+    static_assert(I == 1);
+    return x.pending_request;
+  }
+}
+
+template <size_t I, class Policy, class... Results>
+decltype(auto) get(
+  const caf::blocking_fan_out_delayed_response_handle<Policy, Results...>& x) {
+  if constexpr (I == 0) {
+    return x.decorated;
+  } else {
+    static_assert(I == 1);
+    return x.pending_request;
+  }
+}
+
+template <size_t I, class Policy, class... Results>
+decltype(auto)
+get(caf::blocking_fan_out_delayed_response_handle<Policy, Results...>&& x) {
+  if constexpr (I == 0) {
+    return std::move(x.decorated);
+  } else {
+    static_assert(I == 1);
+    return std::move(x.pending_request);
+  }
+}
+
+} // namespace caf
+
+// enable structured bindings for blocking_fan_out_delayed_response_handle
+
+namespace std {
+
+template <class Policy, class... Results>
+struct tuple_size<
+  caf::blocking_fan_out_delayed_response_handle<Policy, Results...>> {
+  static constexpr size_t value = 2;
+};
+
+template <class Policy, class... Results>
+struct tuple_element<
+  0, caf::blocking_fan_out_delayed_response_handle<Policy, Results...>> {
+  using type = caf::blocking_fan_out_response_handle<Policy, Results...>;
+};
+
+template <class Policy, class... Results>
+struct tuple_element<
+  1, caf::blocking_fan_out_delayed_response_handle<Policy, Results...>> {
+  using type = caf::disposable;
+};
+
+} // namespace std

--- a/libcaf_core/caf/blocking_response_handle.hpp
+++ b/libcaf_core/caf/blocking_response_handle.hpp
@@ -6,6 +6,7 @@
 
 #include "caf/abstract_blocking_actor.hpp"
 #include "caf/actor_traits.hpp"
+#include "caf/blocking_actor.hpp"
 #include "caf/catch_all.hpp"
 #include "caf/detail/metaprogramming.hpp"
 #include "caf/detail/response_type_check.hpp"

--- a/libcaf_core/caf/event_based_fan_out_response_handle.hpp
+++ b/libcaf_core/caf/event_based_fan_out_response_handle.hpp
@@ -205,12 +205,11 @@ private:
                                         std::forward<F>(f));
     auto error_handler = [p{std::move(pending)},
                           timeouts{state_.pending_timeout},
-                          g{std::forward<OnError>(g)}](error&) mutable {
+                          g{std::forward<OnError>(g)}](error& err) mutable {
       if (*p == 0) {
         // nop
       } else if (*p == 1) {
         timeouts.dispose();
-        auto err = make_error(sec::all_requests_failed);
         g(err);
       } else {
         --*p;

--- a/libcaf_core/caf/event_based_mail.test.cpp
+++ b/libcaf_core/caf/event_based_mail.test.cpp
@@ -1027,7 +1027,7 @@ TEST("send fan_out_request messages that return a result using typed actors") {
               [err](error& e) { *err = std::move(e); });
     });
     dispatch_messages();
-    check_eq(*err, error{sec::all_requests_failed});
+    check_eq(*err, error{sec::logic_error});
     check_eq(*sum, 0);
   }
 }
@@ -1315,7 +1315,7 @@ TEST("send fan_out_request messages with invalid setups") {
     expect<int, int>().with(1, 2).from(sender).to(workers[2]);
     expect<std::string>().with("3").from(workers[1]).to(sender);
     expect<std::string>().with("3").from(workers[2]).to(sender);
-    check_eq(*err, make_error(sec::all_requests_failed));
+    check_eq(*err, make_error(sec::unexpected_response));
   }
   SECTION("await with policy select_all") {
     auto sender = sys.spawn([workers, err](event_based_actor* self) {
@@ -1355,7 +1355,7 @@ TEST("send fan_out_request messages with invalid setups") {
     expect<int, int>().with(1, 2).from(sender).to(workers[0]);
     expect<std::string>().with("3").from(workers[1]).to(sender);
     expect<std::string>().with("3").from(workers[0]).to(sender);
-    check_eq(*err, make_error(sec::all_requests_failed));
+    check_eq(*err, make_error(sec::unexpected_response));
   }
 }
 

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -57,6 +57,8 @@ class unordered_flat_map;
 // -- variadic templates -------------------------------------------------------
 
 template <class...> class blocking_delayed_response_handle;
+template <class, class...> class blocking_fan_out_response_handle;
+template <class, class...> class blocking_fan_out_delayed_response_handle;
 template <class...> class blocking_response_handle;
 template <class...> class const_typed_message_view;
 template <class...> class cow_tuple;


### PR DESCRIPTION
Implemented the blocking stuff. 
There was a small issue I've had with `do_receive`, since it receives a single message. It behaved weirdly with `timespan`s, so I switched to using `time_point`s. Alternatively, I could've implemented a new `receive_cond` that awaits `n` messages, but then I'd have to move from `abstract_blocking_actor*` to the concrete `blocking_actor*` implementation. 
Relates #2009. 