### PR TITLE
Fixes for SO_NOSIGPIPE handling

### DIFF
--- a/libcaf_io/caf/io/network/native_socket.cpp
+++ b/libcaf_io/caf/io/network/native_socket.cpp
@@ -81,8 +81,9 @@ const int ec_interrupted_syscall = EINTR;
 #endif
 
 // Platform-dependent setup for suppressing SIGPIPE.
-#if defined(CAF_MACOS) || defined(CAF_IOS) || defined(CAF_FREE_BSD)
-// Set the SO_NOSIGPIPE socket option on macOS, iOS and FreeBSD.
+#if defined(CAF_MACOS) || defined(CAF_IOS)                                     \
+  || (defined(CAF_BSD) && defined(SO_NOSIGPIPE))
+// Set the SO_NOSIGPIPE socket option on macOS, iOS, FreeBSD and NetBSD.
 const int no_sigpipe_socket_flag = SO_NOSIGPIPE;
 const int no_sigpipe_io_flag = 0;
 #elif defined(CAF_WINDOWS)
@@ -90,7 +91,7 @@ const int no_sigpipe_io_flag = 0;
 const int no_sigpipe_socket_flag = 0;
 const int no_sigpipe_io_flag = 0;
 #else
-// Pass MSG_NOSIGNAL to recv/send on Linux/Android/OpenBSD/NetBSD.
+// Pass MSG_NOSIGNAL to recv/send on Linux/Android/OpenBSD.
 const int no_sigpipe_socket_flag = 0;
 const int no_sigpipe_io_flag = MSG_NOSIGNAL;
 #endif

--- a/libcaf_net/caf/net/network_socket.cpp
+++ b/libcaf_net/caf/net/network_socket.cpp
@@ -43,7 +43,8 @@ uint16_t port_of(sockaddr& what) {
 
 namespace caf::net {
 
-#if defined(CAF_MACOS) || defined(CAF_IOS) || defined(CAF_BSD)
+#if defined(CAF_MACOS) || defined(CAF_IOS)                                     \
+  || (defined(CAF_BSD) && defined(SO_NOSIGPIPE))
 #  define CAF_HAS_NOSIGPIPE_SOCKET_FLAG
 #endif
 

--- a/libcaf_net/caf/net/udp_datagram_socket.cpp
+++ b/libcaf_net/caf/net/udp_datagram_socket.cpp
@@ -19,7 +19,7 @@
 namespace {
 
 #if defined(CAF_WINDOWS) || defined(CAF_MACOS) || defined(CAF_IOS)             \
-  || defined(CAF_BSD)
+  || (defined(CAF_BSD) && defined(SO_NOSIGPIPE))
 constexpr int no_sigpipe_io_flag = 0;
 #else
 constexpr int no_sigpipe_io_flag = MSG_NOSIGNAL;


### PR DESCRIPTION
NetBSD has SO_NOSIGPIPE. OpenBSD does not.