### PR TITLE
Implement `as_single` for the new mail API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   outperforming the previous version by an order of magnitude. It is worth
   noting that this is a purely internal change and does not affect the API.
 
+### Added
+
+- Requests that use the new `mail` API now support `as_single` for turning the
+  response handle into a `flow::single` object.
+
 ## [1.1.0] - 2025-07-25
 
 ### Changed


### PR DESCRIPTION
Adds the missing `as_single` to the new response handles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds as_single to mail response handles to return flow::single, updates tests (including error handling) and changelog.
> 
> - **Core/API**:
>   - Add `event_based_response_handle::as_single` (typed and dynamically typed variants) to convert mail responses to `flow::single<...>`.
>   - Introduce internal type deduction (`event_based_response_handle_single_t`) for `as_single` return types.
> - **Tests**:
>   - Add coverage for `.as_single` with valid and error responses in `libcaf_core/caf/event_based_mail.test.cpp`.
>   - Rename test section label to `.as_observable` (from `.to_observable`).
>   - Expand `libcaf_core/caf/flow/single.test.cpp` to subscribe directly to `single`, verify value delivery and error propagation via `set_error`.
> - **Docs/Changelog**:
>   - Note support for `as_single` on new `mail` API in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e011ee6bdb33dbfd60eb150a976feba9bb78998. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->