### PR TITLE
Fix newly found typos

### DIFF
--- a/.typos-config.toml
+++ b/.typos-config.toml
@@ -1,5 +1,11 @@
 [files]
-extend-exclude = ["*.pem", "libcaf_net/test/pem.cpp", "Jenkinsfile"]
+extend-exclude = [
+    "*.pem",
+    "Jenkinsfile",
+    "libcaf_core/caf/detail/parser/read_bool.hpp",
+    "libcaf_core/caf/detail/parser/read_bool.test.cpp",
+    "libcaf_net/test/pem.cpp",
+]
 
 [default.extend-words]
 PN = "PN"
@@ -7,5 +13,4 @@ Yout = "Yout"
 aout = "aout"
 caf = "caf"
 ws = "ws"
-fals = "fals"
 parametrized = "parametrized"

--- a/libcaf_core/caf/chunked_string.hpp
+++ b/libcaf_core/caf/chunked_string.hpp
@@ -121,12 +121,12 @@ public:
 
   explicit chunked_string_builder_output_iterator(
     chunked_string_builder* builder) noexcept
-    : buiilder_(builder) {
+    : builder_(builder) {
     // nop
   }
 
   chunked_string_builder_output_iterator& operator=(char ch) {
-    buiilder_->append(ch);
+    builder_->append(ch);
     return *this;
   }
 
@@ -143,7 +143,7 @@ public:
   }
 
 private:
-  chunked_string_builder* buiilder_;
+  chunked_string_builder* builder_;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/policy/select_all.test.cpp
+++ b/libcaf_core/caf/policy/select_all.test.cpp
@@ -132,7 +132,7 @@ TEST("select_all combines two integer results into one vector") {
     // expect<int>().with(5). from(server2).to(client);
     dispatch_messages();
     log::test::debug(
-      "request.await froces responses into reverse request order");
+      "request.await forces responses into reverse request order");
     check_eq(results, int_list({5, 3}));
   }
 }

--- a/libcaf_core/caf/policy/select_any.test.cpp
+++ b/libcaf_core/caf/policy/select_any.test.cpp
@@ -108,7 +108,7 @@ TEST("select_any picks the first arriving integer") {
     // expect<int>().with(5). from(server2).to(client);
     dispatch_messages();
     log::test::debug(
-      "request.await froces responses into reverse request order");
+      "request.await forces responses into reverse request order");
     check_eq(result, 5);
   }
 }

--- a/libcaf_core/caf/typed_event_based_actor.test.cpp
+++ b/libcaf_core/caf/typed_event_based_actor.test.cpp
@@ -254,7 +254,7 @@ TEST("spawning a typed actor and sending messages") {
   }
 }
 
-TEST("chainging the behavior at runtime and skipping messages") {
+TEST("changing the behavior at runtime and skipping messages") {
   auto et = sys.spawn(actor_from_state<event_testee_state>);
   typed_actor<result<std::string>(get_state_atom)> sub_et = et;
   SECTION("et->message_types() returns an interface description") {

--- a/libcaf_io/caf/io/basp/all.hpp
+++ b/libcaf_io/caf/io/basp/all.hpp
@@ -109,7 +109,7 @@
 ///
 ///   This field contains the ID of the sending actor or 0 for anonymously
 ///   sent messages. The *full address* of an actor is the combination of
-///   the node ID and the actor ID. Thus, every actor can be unambigiously
+///   the node ID and the actor ID. Thus, every actor can be unambiguously
 ///   identified by combining these two IDs.
 ///
 /// - **Destination Actor ID**: 4 bytes.

--- a/libcaf_net/caf/internal/lp_flow_bridge.cpp
+++ b/libcaf_net/caf/internal/lp_flow_bridge.cpp
@@ -85,7 +85,7 @@ public:
 
   using accept_event_t = net::accept_event<net::lp::frame>;
 
-  server_flow_bridge(internal::lp_prodcuer_ptr producer)
+  server_flow_bridge(internal::lp_producer_ptr producer)
     : producer_(std::move(producer)) {
     // nop
   }
@@ -106,7 +106,7 @@ public:
   }
 
 private:
-  internal::lp_prodcuer_ptr producer_;
+  internal::lp_producer_ptr producer_;
 };
 
 } // namespace
@@ -123,7 +123,7 @@ make_lp_flow_bridge(async::consumer_resource<net::lp::frame> pull,
 }
 
 std::unique_ptr<net::lp::upper_layer>
-make_lp_flow_bridge(lp_prodcuer_ptr producer) {
+make_lp_flow_bridge(lp_producer_ptr producer) {
   using impl_t = net::lp::server_flow_bridge;
   return std::make_unique<impl_t>(std::move(producer));
 }

--- a/libcaf_net/caf/internal/lp_flow_bridge.hpp
+++ b/libcaf_net/caf/internal/lp_flow_bridge.hpp
@@ -20,10 +20,10 @@ std::unique_ptr<net::lp::upper_layer>
 make_lp_flow_bridge(async::consumer_resource<chunk> pull,
                     async::producer_resource<chunk> push);
 
-using lp_prodcuer_ptr
+using lp_producer_ptr
   = std::shared_ptr<async::blocking_producer<net::accept_event<chunk>>>;
 
 std::unique_ptr<net::lp::upper_layer>
-make_lp_flow_bridge(lp_prodcuer_ptr producer);
+make_lp_flow_bridge(lp_producer_ptr producer);
 
 } // namespace caf::internal

--- a/manual/core/Metrics.rst
+++ b/manual/core/Metrics.rst
@@ -368,7 +368,7 @@ same pattern as the member functions for counters and gauges.
                             string_view helptext, string_view unit = "1",
                             bool is_sum = false);
 
-Compared to the member functions for counters and guages, histograms require one
+Compared to the member functions for counters and gauges, histograms require one
 addition argument for the default bucket upper bounds.
 
 .. warning::
@@ -378,8 +378,8 @@ addition argument for the default bucket upper bounds.
 CAF automatically adds one additional bucket for observing all values between
 the last upper bound and *infinity* (``double``) or *INT_MAX* (``int64_t``). For
 example, passing ``[10, 100, 1000]`` as upper bounds creates four buckets in
-total. The first bucket captues all values with ``x ≤ 10``. The second bucket
-captues all values with ``10 < x ≤ 100``. The third bucket captures all values
+total. The first bucket captures all values with ``x ≤ 10``. The second bucket
+captures all values with ``10 < x ≤ 100``. The third bucket captures all values
 with ``100 < x ≤ 1000``. Finally, the fourth bucket (added automatically)
 captures all values with ``1000 < x ≤ INT_MAX``.
 


### PR DESCRIPTION
Fix some typos and suppress typos from the noisy `read_bool` files.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes various typos across code, tests, docs; renames internal `lp_prodcuer_ptr` to `lp_producer_ptr`; expands typo checker excludes.
> 
> - **Core**:
>   - Fix `chunked_string_builder_output_iterator` member name from `buiilder_` to `builder_` and update usages in `libcaf_core/caf/chunked_string.hpp`.
> - **Net (internal LP flow bridge)**:
>   - Rename type alias and parameters from `lp_prodcuer_ptr` to `lp_producer_ptr` in `libcaf_net/caf/internal/lp_flow_bridge.hpp` and `.cpp`.
> - **Tests**:
>   - Fix typos in log/test strings and test name in `select_all.test.cpp`, `select_any.test.cpp`, and `typed_event_based_actor.test.cpp`.
> - **I/O Docs**:
>   - Fix wording in `libcaf_io/caf/io/basp/all.hpp` comment (`unambiguously`).
> - **Manual**:
>   - Fix spelling in `manual/core/Metrics.rst` (e.g., `gauges`, `captures`).
> - **Tooling**:
>   - Update `.typos-config.toml` excludes to suppress `read_bool` files and clean up word list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63f102a930f1c64e208b14f682e5bb4327021106. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->