### PR TITLE
Fix alignment on 32bit ARM architecture

### DIFF
--- a/libcaf_core/caf/async/batch.hpp
+++ b/libcaf_core/caf/async/batch.hpp
@@ -194,7 +194,7 @@ private:
     type_id_t item_type_;
     size_t item_size_;
     size_t size_;
-    std::byte storage_[];
+    alignas(max_align_t) std::byte storage_[];
   };
 
   explicit batch(intrusive_ptr<data> ptr) : data_(std::move(ptr)) {

--- a/libcaf_core/caf/detail/message_data.hpp
+++ b/libcaf_core/caf/detail/message_data.hpp
@@ -184,7 +184,7 @@ private:
   mutable std::atomic<size_t> rc_;
   type_id_list types_;
   size_t constructed_elements_;
-  std::byte storage_[];
+  alignas(max_align_t) std::byte storage_[];
 };
 
 // -- related non-members ------------------------------------------------------

--- a/libcaf_core/caf/detail/padded_size.hpp
+++ b/libcaf_core/caf/detail/padded_size.hpp
@@ -10,9 +10,8 @@ namespace caf::detail {
 
 /// Calculates the size for `T` including padding for aligning to `max_align_t`.
 template <class T>
-constexpr size_t padded_size_v
-  = ((sizeof(T) / alignof(max_align_t))
-     + static_cast<size_t>(sizeof(T) % alignof(max_align_t) != 0))
-    * alignof(max_align_t);
+constexpr size_t padded_size_v = (sizeof(T) + alignof(std::max_align_t) - 1)
+                                 / alignof(std::max_align_t)
+                                 * alignof(max_align_t);
 
 } // namespace caf::detail


### PR DESCRIPTION
on 32bit ARM architecture the size of `std::size_t` and pointers is only 32bit but the aligned of some types is still 64bit. 

adding `alignas(max_align_t)` to the raw storage ensures that it starts accordingly.