### PR TITLE
Remove nonsensical virtual specifier

### DIFF
--- a/libcaf_core/caf/binary_deserializer.hpp
+++ b/libcaf_core/caf/binary_deserializer.hpp
@@ -150,9 +150,9 @@ public:
 
   bool value(std::vector<bool>& x);
 
-  virtual bool value(strong_actor_ptr& ptr);
+  bool value(strong_actor_ptr& ptr);
 
-  virtual bool value(weak_actor_ptr& ptr);
+  bool value(weak_actor_ptr& ptr);
 
 private:
   /// Storage for the implementation object.

--- a/libcaf_core/caf/binary_serializer.hpp
+++ b/libcaf_core/caf/binary_serializer.hpp
@@ -136,9 +136,9 @@ public:
 
   bool value(const std::vector<bool>& x);
 
-  virtual bool value(const strong_actor_ptr& ptr);
+  bool value(const strong_actor_ptr& ptr);
 
-  virtual bool value(const weak_actor_ptr& ptr);
+  bool value(const weak_actor_ptr& ptr);
 
 private:
   /// Storage for the implementation object.


### PR DESCRIPTION
Recent clang versions rightfully complain that adding `virtual` to a member function of a `final` class makes little sense.