### PR TITLE
No longer move the sender into response promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   more consistent.
 - The default maximum message size for the length-prefix framing has been
   reduced to 64 MB. This change was made to improve security by default.
+- Creating a response promise no longer invalidates `self->current_sender()`.
 
 ### Deprecated
 

--- a/libcaf_core/caf/response_promise.cpp
+++ b/libcaf_core/caf/response_promise.cpp
@@ -47,7 +47,7 @@ response_promise::response_promise(local_actor* self, strong_actor_ptr source,
 }
 
 response_promise::response_promise(local_actor* self, mailbox_element& src)
-  : response_promise(self, std::move(src.sender), src.mid) {
+  : response_promise(self, src.sender, src.mid) {
   // nop
 }
 


### PR DESCRIPTION
This changes removes a very minor optimization in CAF in favor of avoiding a pitfall for users.