### PR TITLE
Improve diagnostics when using typed actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - The default maximum message size for the length-prefix framing has been
   reduced to 64 MB. This change was made to improve security by default.
 - Creating a response promise no longer invalidates `self->current_sender()`.
+- Improved compile-time error messages when passing ill-formed message handler
+  signatures to typed actors.
 
 ### Deprecated
 

--- a/libcaf_core/caf/detail/consumer.hpp
+++ b/libcaf_core/caf/detail/consumer.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <type_traits>
 #include <utility>
+#include <variant>
 
 namespace caf::detail {
 

--- a/libcaf_core/caf/detail/to_statically_typed_trait.hpp
+++ b/libcaf_core/caf/detail/to_statically_typed_trait.hpp
@@ -4,30 +4,34 @@
 
 #pragma once
 
+#include "caf/detail/type_list.hpp"
 #include "caf/statically_typed.hpp"
 
 #include <type_traits>
 
 namespace caf::detail {
 
-template <class, bool>
-struct to_statically_typed_trait_oracle;
+template <class Trait>
+concept typed_actor_trait = detail::is_type_list_v<typename Trait::signatures>;
 
-template <class T>
-struct to_statically_typed_trait_oracle<T, true> {
-  using type = statically_typed<T>;
+template <class...>
+struct to_statically_typed_trait;
+
+template <message_handler_signature... Signatures>
+struct to_statically_typed_trait<Signatures...> {
+  using type = statically_typed<Signatures...>;
 };
 
-template <class T>
-struct to_statically_typed_trait_oracle<T, false> {
-  using type = T;
+template <typed_actor_trait Trait>
+struct to_statically_typed_trait<Trait> {
+  using type = Trait;
 };
 
 /// Converts a template parameter pack of signatures to a trait type wrapping
 /// the given signatures.
 /// @note used for backwards compatibility when declaring typed interfaces.
-template <class T>
+template <class... Ts>
 using to_statically_typed_trait_t =
-  typename to_statically_typed_trait_oracle<T, std::is_function_v<T>>::type;
+  typename to_statically_typed_trait<Ts...>::type;
 
 } // namespace caf::detail

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "caf/detail/core_export.hpp"
+#include "caf/typed_actor_pack.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -12,7 +13,6 @@
 #include <span>
 #include <string_view>
 #include <utility>
-#include <variant>
 #include <vector>
 
 namespace caf {
@@ -62,15 +62,17 @@ template <class...> class cow_tuple;
 template <class...> class delegated;
 template <class...> class event_based_delayed_response_handle;
 template <class...> class event_based_response_handle;
-template <class, class...> class event_based_fan_out_response_handle;
 template <class...> class result;
-template <class...> class typed_actor;
-template <class...> class typed_actor_pointer;
-template <class...> class typed_actor_view;
-template <class...> class typed_behavior;
-template <class...> class typed_event_based_actor;
 template <class...> class typed_message_view;
 template <class...> class typed_response_promise;
+
+template <class... Ts> requires typed_actor_pack<Ts...> class typed_actor;
+template <class... Ts> requires typed_actor_pack<Ts...> class typed_actor_pointer;
+template <class... Ts> requires typed_actor_pack<Ts...> class typed_actor_view;
+template <class... Ts> requires typed_actor_pack<Ts...> class typed_behavior;
+template <class... Ts> requires typed_actor_pack<Ts...> class typed_event_based_actor;
+
+template <class, class...> class event_based_fan_out_response_handle;
 
 // clang-format on
 

--- a/libcaf_core/caf/infer_handle.hpp
+++ b/libcaf_core/caf/infer_handle.hpp
@@ -6,12 +6,10 @@
 
 #include "caf/actor.hpp"
 #include "caf/actor_addr.hpp"
+#include "caf/fwd.hpp"
 #include "caf/typed_behavior.hpp"
 
 namespace caf {
-
-template <class... Sigs>
-class typed_event_based_actor;
 
 namespace io {
 

--- a/libcaf_core/caf/inspector_access.hpp
+++ b/libcaf_core/caf/inspector_access.hpp
@@ -24,6 +24,7 @@
 #include <string_view>
 #include <tuple>
 #include <utility>
+#include <variant>
 
 namespace caf::detail {
 

--- a/libcaf_core/caf/statically_typed.hpp
+++ b/libcaf_core/caf/statically_typed.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <caf/fwd.hpp>
 #include <caf/type_list.hpp>
 
 namespace caf {
@@ -11,9 +12,9 @@ namespace caf {
 /// A statically typed trait type wrapping the given parameter pack of
 /// signatures as a type list.
 /// @note used for backwards compatibility when declaring typed interfaces.
-template <class... Sigs>
+template <message_handler_signature... Signatures>
 struct statically_typed {
-  using signatures = type_list<Sigs...>;
+  using signatures = type_list<Signatures...>;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/typed_actor_pack.hpp
+++ b/libcaf_core/caf/typed_actor_pack.hpp
@@ -1,0 +1,70 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+namespace caf {
+
+template <class... Ts>
+class result;
+
+template <class... Ts>
+struct type_list;
+
+} // namespace caf
+
+namespace caf::detail {
+
+template <class T>
+struct is_message_handler_signature_oracle {
+  static constexpr bool value = false;
+};
+
+template <class... Results, class... Args>
+struct is_message_handler_signature_oracle<result<Results...>(Args...)> {
+  static constexpr bool value = true;
+};
+
+} // namespace caf::detail
+
+namespace caf {
+
+template <class T>
+concept message_handler_signature
+  = detail::is_message_handler_signature_oracle<T>::value;
+
+} // namespace caf
+
+namespace caf::detail {
+
+template <class T>
+struct typed_actor_trait_checker;
+
+template <class... Ts>
+struct typed_actor_trait_checker<type_list<Ts...>> {
+  // The only use case for this template is to be used in the
+  // `message_handler_signature` concept. If this template is instantiated,
+  // we want to "deep check" the signatures as well to raise compile-time errors
+  // early in case the trait contains any invalid signatures. If we would simply
+  // assign the result of that to `value` instead of using `static_assert`,
+  // the user would not see which signature is invalid.
+  static_assert((message_handler_signature<Ts> && ...));
+  static constexpr bool value = true;
+};
+
+} // namespace caf::detail
+
+namespace caf {
+
+/// Checks whether `Ts...` is a valid template parameter pack for `typed_actor`.
+template <class... Ts>
+concept typed_actor_pack =
+  // Either we have exactly one trait argument.
+  (sizeof...(Ts) == 1
+   && (detail::typed_actor_trait_checker<typename Ts::signatures>::value
+       && ...))
+  // Or we have at least one message handler signature.
+  || (sizeof...(Ts) > 0 && (message_handler_signature<Ts> && ...));
+
+} // namespace caf

--- a/libcaf_core/caf/typed_actor_pointer.hpp
+++ b/libcaf_core/caf/typed_actor_pointer.hpp
@@ -10,15 +10,13 @@
 
 namespace caf {
 
-template <class...>
-class typed_actor_pointer;
-
 /// Provides a view to an actor that implements this messaging interface without
 /// knowledge of the actual type.
-template <class TraitOrSignature>
-class typed_actor_pointer<TraitOrSignature> : public typed_actor_view_base {
+template <class... Ts>
+  requires typed_actor_pack<Ts...>
+class typed_actor_pointer : public typed_actor_view_base {
 public:
-  using trait = detail::to_statically_typed_trait_t<TraitOrSignature>;
+  using trait = detail::to_statically_typed_trait_t<Ts...>;
 
   /// Stores the template parameter pack.
   using signatures = typename trait::signatures;
@@ -63,11 +61,11 @@ public:
     return *this;
   }
 
-  typed_actor_view<trait>* operator->() {
+  typed_actor_view<Ts...>* operator->() {
     return &view_;
   }
 
-  const typed_actor_view<trait>* operator->() const {
+  const typed_actor_view<Ts...>* operator->() const {
     return &view_;
   }
 
@@ -99,19 +97,7 @@ public:
   }
 
 private:
-  typed_actor_view<trait> view_;
-};
-
-/// Provides a view to an actor that implements this messaging interface without
-/// knowledge of the actual type.
-/// @note This is a specialization for backwards compatibility with pre v1.0
-///       releases. Please use the trait based implementation.
-template <class T1, class T2, class... Ts>
-class typed_actor_pointer<T1, T2, Ts...>
-  : public typed_actor_pointer<statically_typed<T1, T2, Ts...>> {
-  using super = typed_actor_pointer<statically_typed<T1, T2, Ts...>>;
-
-  using super::super;
+  typed_actor_view<Ts...> view_;
 };
 
 } // namespace caf


### PR DESCRIPTION
Introduce a new `requires` clause to `typed_actor` and supporting classes that checks validity of all message handler signatures.

Closes #2158.