### PR TITLE
Remove obsolete code

### DIFF
--- a/libcaf_core/caf/abstract_mailbox.hpp
+++ b/libcaf_core/caf/abstract_mailbox.hpp
@@ -73,11 +73,6 @@ public:
   bool empty() {
     return size() == 0;
   }
-
-  /// @private
-  /// @note Only used by the legacy test framework. Remove when dropping support
-  ///       for it.
-  virtual mailbox_element* peek(message_id id) = 0;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/detail/abstract_worker_hub.cpp
+++ b/libcaf_core/caf/detail/abstract_worker_hub.cpp
@@ -71,8 +71,4 @@ abstract_worker* abstract_worker_hub::pop_impl() {
   }
 }
 
-abstract_worker* abstract_worker_hub::peek_impl() {
-  return head_.load();
-}
-
 } // namespace caf::detail

--- a/libcaf_core/caf/detail/abstract_worker_hub.hpp
+++ b/libcaf_core/caf/detail/abstract_worker_hub.hpp
@@ -45,11 +45,6 @@ protected:
   ///          hub is currently empty.
   abstract_worker* pop_impl();
 
-  /// Checks which worker would `pop` currently return.
-  /// @returns the next available worker (in LIFO order) or `nullptr` if the
-  ///          hub is currently empty.
-  abstract_worker* peek_impl();
-
   // -- member variables -------------------------------------------------------
 
   std::atomic<abstract_worker*> head_;

--- a/libcaf_core/caf/detail/default_mailbox.cpp
+++ b/libcaf_core/caf/detail/default_mailbox.cpp
@@ -21,24 +21,6 @@ void default_mailbox::push_front(mailbox_element_ptr ptr) {
     normal_queue_.push_front(ptr.release());
 }
 
-mailbox_element* default_mailbox::peek(message_id id) {
-  if (inbox_.closed() || inbox_.blocked()) {
-    return nullptr;
-  }
-  fetch_more();
-  if (id.is_async()) {
-    if (!urgent_queue_.empty())
-      return urgent_queue_.front();
-    if (!normal_queue_.empty())
-      return normal_queue_.front();
-    return nullptr;
-  }
-  auto pred = [id](mailbox_element& x) { return x.mid == id; };
-  if (auto result = urgent_queue_.find_if(pred))
-    return result;
-  return normal_queue_.find_if(pred);
-}
-
 mailbox_element_ptr default_mailbox::pop_front() {
   for (;;) {
     if (auto result = urgent_queue_.pop_front())

--- a/libcaf_core/caf/detail/default_mailbox.hpp
+++ b/libcaf_core/caf/detail/default_mailbox.hpp
@@ -27,8 +27,6 @@ public:
 
   default_mailbox& operator=(const default_mailbox&) = delete;
 
-  mailbox_element* peek(message_id id) override;
-
   intrusive::inbox_result push_back(mailbox_element_ptr ptr) override;
 
   void push_front(mailbox_element_ptr ptr) override;

--- a/libcaf_core/caf/detail/worker_hub.hpp
+++ b/libcaf_core/caf/detail/worker_hub.hpp
@@ -36,13 +36,6 @@ public:
   worker_type* pop() {
     return static_cast<worker_type*>(super::pop_impl());
   }
-
-  /// Checks which worker would `pop` currently return.
-  /// @returns the next available worker (in LIFO order) or `nullptr` if the
-  ///          hub is currently empty.
-  worker_type* peek() {
-    return static_cast<worker_type*>(super::peek_impl());
-  }
 };
 
 } // namespace caf::detail

--- a/libcaf_core/caf/intrusive/linked_list.hpp
+++ b/libcaf_core/caf/intrusive/linked_list.hpp
@@ -183,11 +183,6 @@ public:
     return promote(tail_.next);
   }
 
-  /// Like `front`, but returns `nullptr` if the list is empty.
-  pointer peek() noexcept {
-    return size_ > 0 ? front() : nullptr;
-  }
-
   // -- insertion --------------------------------------------------------------
 
   /// Appends `ptr` to the list.

--- a/libcaf_core/caf/intrusive/linked_list.test.cpp
+++ b/libcaf_core/caf/intrusive/linked_list.test.cpp
@@ -43,7 +43,6 @@ TEST("a default default-constructed list is empty") {
   list_type uut;
   check_eq(uut.empty(), true);
   check_eq(uut.size(), 0u);
-  check_eq(uut.peek(), nullptr);
   check_eq(uut.begin(), uut.end());
 }
 
@@ -96,13 +95,6 @@ TEST("lists are movable") {
     check_eq(uut.empty(), false);
     check_eq(deep_to_string(uut), "[1, 2, 3]");
   }
-}
-
-TEST("peek returns a pointer to the first element without removing it") {
-  list_type uut;
-  check_eq(uut.peek(), nullptr);
-  fill(uut, 1, 2, 3);
-  check_eq(uut.peek()->value, 1);
 }
 
 TEST("the size of the list is the number of elements") {

--- a/libcaf_core/caf/local_actor.cpp
+++ b/libcaf_core/caf/local_actor.cpp
@@ -150,14 +150,6 @@ const char* local_actor::name() const {
   return "user.local-actor";
 }
 
-error local_actor::save_state(serializer&, const unsigned int) {
-  CAF_RAISE_ERROR("local_actor::serialize called");
-}
-
-error local_actor::load_state(deserializer&, const unsigned int) {
-  CAF_RAISE_ERROR("local_actor::deserialize called");
-}
-
 void local_actor::do_delegate_error() {
   auto& sender = current_element_->sender;
   auto& mid = current_element_->mid;

--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -303,16 +303,6 @@ public:
 
   const char* name() const override;
 
-  /// Serializes the state of this actor to `sink`. This function is
-  /// only called if this actor has set the `is_serializable` flag.
-  /// The default implementation throws a `std::logic_error`.
-  virtual error save_state(serializer& sink, unsigned int version);
-
-  /// Deserializes the state of this actor from `source`. This function is
-  /// only called if this actor has set the `is_serializable` flag.
-  /// The default implementation throws a `std::logic_error`.
-  virtual error load_state(deserializer& source, unsigned int version);
-
   /// Returns the currently defined fail state. If this reason is not
   /// `none` then the actor will terminate with this error after executing
   /// the current message handler.

--- a/libcaf_test/caf/test/fixture/deterministic.cpp
+++ b/libcaf_test/caf/test/fixture/deterministic.cpp
@@ -112,13 +112,6 @@ public:
     deref();
   }
 
-  mailbox_element* peek(message_id) override {
-    // Note: this function only exists for backwards compatibility with the old
-    // unit testing framework. It is not used by the new test runner and thus
-    // not implemented.
-    CAF_RAISE_ERROR(std::logic_error, "peek not supported by this mailbox");
-  }
-
 private:
   bool blocked_ = false;
   bool closed_ = false;


### PR DESCRIPTION
Leftover from removing the legacy unit test framework and other stale code.