### PR TITLE
Deprecate previously overlooked functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   `CAF_LOG_DEBUG_IF`, `CAF_LOG_INFO`, `CAF_LOG_INFO_IF`, `CAF_LOG_WARNING`,
   `CAF_LOG_WARNING_IF`, `CAF_LOG_ERROR`, and `CAF_LOG_ERROR_IF`. Users should
   use the new logging API instead.
+- The member functions `anon_send`, `scheduled_anon_send`, and
+  `delayed_anon_send` of the class `local_actor` are now deprecated in favor of
+  using the free `anon_mail` function instead.
 
 ### Added
 

--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -178,6 +178,7 @@ public:
 
   template <message_priority Priority = message_priority::normal, class Handle,
             class T, class... Ts>
+  [[deprecated("use anon_mail instead")]]
   void anon_send(const Handle& receiver, T&& arg, Ts&&... args) {
     detail::send_type_check<none_t, Handle, T, Ts...>();
     do_anon_send(actor_cast<abstract_actor*>(receiver), Priority,
@@ -186,6 +187,7 @@ public:
 
   template <message_priority Priority = message_priority::normal, class Handle,
             class T, class... Ts>
+  [[deprecated("use anon_mail instead")]]
   disposable scheduled_anon_send(const Handle& receiver,
                                  actor_clock::time_point timeout, T&& arg,
                                  Ts&&... args) {
@@ -197,6 +199,7 @@ public:
 
   template <message_priority Priority = message_priority::normal, class Handle,
             class T, class... Ts>
+  [[deprecated("use anon_mail instead")]]
   disposable delayed_anon_send(const Handle& receiver,
                                actor_clock::duration_type timeout, T&& arg,
                                Ts&&... args) {


### PR DESCRIPTION
Looks like we've missed those in the 1.0 deprecation round.