### PR TITLE
Fix potential deadlock in `monitor_action`

### DIFF
--- a/libcaf_core/caf/detail/monitor_action.hpp
+++ b/libcaf_core/caf/detail/monitor_action.hpp
@@ -70,9 +70,10 @@ public:
 
   resume_result resume(scheduler*, size_t) override {
     // We can only run a scheduled action.
-    std::lock_guard guard{mtx_};
+    std::unique_lock guard{mtx_};
     if (state_ == action::state::scheduled) {
       state_ = action::state::disposed;
+      guard.unlock();
       f_();
       f_.~function_wrapper();
     }


### PR DESCRIPTION
Pulling in the patch for CAF 1.2 from #2170 into `main`.