### PR TITLE
Fix remaining deprecated boolean conversions on error

### DIFF
--- a/libcaf_core/caf/async/spsc_buffer.hpp
+++ b/libcaf_core/caf/async/spsc_buffer.hpp
@@ -235,7 +235,7 @@ public:
     CAF_ASSERT(consumer_ != nullptr);
     CAF_ASSERT(consumer_buf_.empty());
     if constexpr (std::is_same_v<Policy, prioritize_errors_t>) {
-      if (err_) {
+      if (err_.valid()) {
         consumer_ = nullptr;
         dst.on_error(err_);
         return {false, 0};

--- a/libcaf_core/caf/detail/default_thread_count.cpp
+++ b/libcaf_core/caf/detail/default_thread_count.cpp
@@ -56,7 +56,7 @@ size_t default_thread_count() {
       // No CPU limit imposed
       return fallback;
     }
-    if (auto err = detail::parse(quota_str, quota); err) {
+    if (auto err = detail::parse(quota_str, quota); err.valid()) {
       return fallback;
     }
   } else { // cgroup v1

--- a/libcaf_core/caf/flow/op/buffer.hpp
+++ b/libcaf_core/caf/flow/op/buffer.hpp
@@ -209,14 +209,14 @@ private:
       case state::running: {
         if (!buf_.empty()) {
           if (demand_ == 0) {
-            state_ = err_ ? state::aborted : state::completed;
+            state_ = err_.valid() ? state::aborted : state::completed;
             return;
           }
           Trait f;
           out_.on_next(f(buf_));
           buf_.clear();
         }
-        if (!err_)
+        if (err_.empty())
           out_.on_complete();
         else
           out_.on_error(err_);
@@ -238,7 +238,7 @@ private:
     }
     if (!buf_.empty())
       do_emit();
-    if (!err_)
+    if (err_.empty())
       out_.on_complete();
     else
       out_.on_error(err_);

--- a/libcaf_core/caf/flow/op/debounce.hpp
+++ b/libcaf_core/caf/flow/op/debounce.hpp
@@ -161,7 +161,7 @@ private:
     pending_.dispose();
     fire_action_.dispose();
     sub_.cancel();
-    if (!err_)
+    if (err_.empty())
       out_.on_complete();
     else
       out_.on_error(err_);

--- a/libcaf_core/caf/flow/op/sample.hpp
+++ b/libcaf_core/caf/flow/op/sample.hpp
@@ -167,17 +167,17 @@ private:
   void shutdown() {
     value_sub_.cancel();
     control_sub_.cancel();
-    if (!err_)
+    if (err_.empty())
       out_.on_complete();
     else
       out_.on_error(err_);
-    state_ = err_ ? state::aborted : state::disposed;
+    state_ = err_.valid() ? state::aborted : state::disposed;
   }
 
   void on_request() {
     if (demand_ == 0 || !buf_.has_value())
       return;
-    if (!err_)
+    if (err_.empty())
       out_.on_complete();
     else
       out_.on_error(err_);

--- a/libcaf_core/caf/flow/op/throttle_first.hpp
+++ b/libcaf_core/caf/flow/op/throttle_first.hpp
@@ -168,17 +168,17 @@ private:
   void shutdown() {
     value_sub_.cancel();
     control_sub_.cancel();
-    if (!err_)
+    if (err_.empty())
       out_.on_complete();
     else
       out_.on_error(err_);
-    state_ = err_ ? state::aborted : state::disposed;
+    state_ = err_.valid() ? state::aborted : state::disposed;
   }
 
   void on_request() {
     if (demand_ == 0 || !buf_.has_value())
       return;
-    if (!err_)
+    if (err_.empty())
       out_.on_complete();
     else
       out_.on_error(err_);

--- a/libcaf_core/caf/flow/op/zip_with.hpp
+++ b/libcaf_core/caf/flow/op/zip_with.hpp
@@ -158,7 +158,7 @@ public:
   template <size_t I>
   void fwd_on_error(zip_index<I> index, const error& what) {
     if (out_) {
-      if (!err_)
+      if (err_.empty())
         err_ = what;
       auto& input = at(index);
       if (input.sub)
@@ -185,7 +185,7 @@ private:
       input.buf.clear();
     });
     if (from_external) {
-      if (!err_)
+      if (err_.empty())
         err_ = make_error(sec::disposed);
       out_.on_error(err_);
     } else {
@@ -212,7 +212,7 @@ private:
       input.buf.clear();
     });
     // Set out_ to null and emit the final event.
-    if (!err_)
+    if (err_.empty())
       out_.on_complete();
     else
       out_.on_error(err_);


### PR DESCRIPTION
We had some remaining boolean conversion that trigger build warnings. 