### PR TITLE
Add `start_with` functions for LP and WS clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   `produce_on` that allows actors to produce data without having to use a flow.
   This is the symmetric counterpart to `consume_on` on `consumer_resource<T>`
   and should only be used when flows are not suitable for the use case at hand.
+- The classes `caf::net::lp::client_factory` and
+  `caf::net::web_socket::client_factory` now have a new member function
+  `start_with` that allows starting a connection with custom buffers. This
+  enables users to provide their own `async::consumer_resource` and
+  `async::producer_resource` instances instead of having the factory create them
+  automatically.
 
 ### Fixed
 

--- a/libcaf_net/caf/net/lp/client_factory.hpp
+++ b/libcaf_net/caf/net/lp/client_factory.hpp
@@ -49,14 +49,20 @@ public:
     auto [s2a_pull, s2a_push] = async::make_spsc_buffer_resource<frame>();
     auto [a2s_pull, a2s_push] = async::make_spsc_buffer_resource<frame>();
     // Wrap the trait and the buffers that belong to the socket.
-    auto res = base_config().visit(
-      [this, pull = a2s_pull, push = s2a_push](auto& data) mutable {
-        return this->do_start(data, std::move(pull), std::move(push));
-      });
+    auto res = start_with(std::move(a2s_pull), std::move(s2a_push));
     if (res) {
       on_start(std::move(s2a_pull), std::move(a2s_push));
     }
     return res;
+  }
+
+  /// Starts a connection with the length-prefixing protocol and custom buffers.
+  [[nodiscard]] expected<disposable>
+  start_with(async::consumer_resource<frame> pull,
+             async::producer_resource<frame> push) {
+    return base_config().visit([this, &pull, &push](auto& data) {
+      return this->do_start(data, std::move(pull), std::move(push));
+    });
   }
 
 protected:

--- a/libcaf_net/caf/net/web_socket/client_factory.hpp
+++ b/libcaf_net/caf/net/web_socket/client_factory.hpp
@@ -40,7 +40,7 @@ public:
 
   ~client_factory() override;
 
-  /// Starts a connection with the length-prefixing protocol.
+  /// Starts a connection with the WebSocket protocol.
   template <class OnStart>
   [[nodiscard]] expected<disposable> start(OnStart on_start) {
     static_assert(std::is_invocable_v<OnStart, pull_t, push_t>);
@@ -48,14 +48,20 @@ public:
     auto [s2a_pull, s2a_push] = async::make_spsc_buffer_resource<frame>();
     auto [a2s_pull, a2s_push] = async::make_spsc_buffer_resource<frame>();
     // Wrap the trait and the buffers that belong to the socket.
-    auto res = base_config().visit(
-      [this, pull = a2s_pull, push = s2a_push](auto& data) mutable {
-        return this->do_start(data, std::move(pull), std::move(push));
-      });
+    auto res = start_with(std::move(a2s_pull), std::move(s2a_push));
     if (res) {
       on_start(std::move(s2a_pull), std::move(a2s_push));
     }
     return res;
+  }
+
+  /// Starts a connection with the WebSocket protocol and custom buffers.
+  [[nodiscard]] expected<disposable>
+  start_with(async::consumer_resource<frame> pull,
+             async::producer_resource<frame> push) {
+    return base_config().visit([this, &pull, &push](auto& data) {
+      return this->do_start(data, std::move(pull), std::move(push));
+    });
   }
 
 protected:


### PR DESCRIPTION
The classes `caf::net::lp::client_factory` and `caf::net::web_socket::client_factory` now have a new member function `start_with` that allows starting a connection with custom buffers. This enables users to provide their own `async::consumer_resource` and `async::producer_resource` instances instead of having the factory create them automatically.