### PR TITLE
Minor additions to the CAF SSL wrapper API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   `produce_on` that allows actors to produce data without having to use a flow.
   This is the symmetric counterpart to `consume_on` on `consumer_resource<T>`
   and should only be used when flows are not suitable for the use case at hand.
+- The class `caf::net::ssl::context` now includes `set_cipher_list()` for
+  configuring the cipher list used by the SSL/TLS backend.
+- The class `caf::net::ssl::context` now has new `backend()` and
+  `backend_name()` functions to query which SSL/TLS library is in use and
+  `backend_version()` to retrieve the backend-specific version number.
+  Currently, only OpenSSL is supported as a backend implementation in CAF, but
+  the API has been designed to prepare for different backends in the future.
 
 ### Fixed
 

--- a/libcaf_net/CMakeLists.txt
+++ b/libcaf_net/CMakeLists.txt
@@ -19,6 +19,7 @@ caf_add_component(
     net.http.method
     net.http.status
     net.octet_stream.errc
+    net.ssl.backend
     net.ssl.dtls
     net.ssl.errc
     net.ssl.format

--- a/libcaf_net/caf/net/ssl/backend.hpp
+++ b/libcaf_net/caf/net/ssl/backend.hpp
@@ -1,0 +1,37 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+#include "caf/default_enum_inspect.hpp"
+#include "caf/detail/net_export.hpp"
+
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+namespace caf::net::ssl {
+
+/// Identifies the SSL/TLS implementation in use.
+enum class backend {
+  /// Denotes the OpenSSL library.
+  openssl,
+};
+
+/// @relates backend
+CAF_NET_EXPORT std::string to_string(backend);
+
+/// @relates backend
+CAF_NET_EXPORT bool from_string(std::string_view, backend&);
+
+/// @relates backend
+CAF_NET_EXPORT bool from_integer(std::underlying_type_t<backend>, backend&);
+
+/// @relates backend
+template <class Inspector>
+bool inspect(Inspector& f, backend& x) {
+  return default_enum_inspect(f, x);
+}
+
+} // namespace caf::net::ssl

--- a/libcaf_net/caf/net/ssl/context.cpp
+++ b/libcaf_net/caf/net/ssl/context.cpp
@@ -177,6 +177,23 @@ void context::verify_mode(verify_t flags) {
   SSL_CTX_set_verify(ptr, to_integer(flags), SSL_CTX_get_verify_callback(ptr));
 }
 
+ssl::backend context::backend() const noexcept {
+  return ssl::backend::openssl;
+}
+
+std::string context::backend_name() const noexcept {
+  return to_string(backend());
+}
+
+int context::backend_version() const noexcept {
+  return OPENSSL_VERSION_NUMBER;
+}
+
+bool context::set_cipher_list(const char* cipher_list) {
+  ERR_clear_error();
+  return SSL_CTX_set_cipher_list(native(pimpl_), cipher_list) == 1;
+}
+
 namespace {
 
 int c_password_callback(char* buf, int size, int rwflag, void* ptr) {

--- a/libcaf_net/caf/net/ssl/context.hpp
+++ b/libcaf_net/caf/net/ssl/context.hpp
@@ -7,6 +7,7 @@
 #include "caf/net/dsl/arg.hpp"
 #include "caf/net/fwd.hpp"
 #include "caf/net/socket_guard.hpp"
+#include "caf/net/ssl/backend.hpp"
 #include "caf/net/ssl/connection.hpp"
 #include "caf/net/ssl/dtls.hpp"
 #include "caf/net/ssl/format.hpp"
@@ -21,7 +22,7 @@
 
 #include <cstring>
 #include <string>
-#include <type_traits>
+#include <utility>
 
 namespace caf::net::ssl {
 
@@ -94,11 +95,33 @@ public:
   }
 
   /// Overrides the verification mode for this context.
-  /// @note calls @c SSL_CTX_set_verify
+  /// @note For OpenSSL, calls @c SSL_CTX_set_verify.
   void verify_mode(verify_t flags);
 
+  /// Returns the SSL/TLS library in use.
+  ssl::backend backend() const noexcept;
+
+  /// Returns the name of the SSL/TLS library in use.
+  std::string backend_name() const noexcept;
+
+  /// Returns the backend-specific version number.
+  /// @note For OpenSSL, this returns @c OPENSSL_VERSION_NUMBER
+  int backend_version() const noexcept;
+
+  /// Sets the cipher list for this context.
+  /// @param cipher_list Backend-specific cipher list string.
+  /// @returns `true` on success, `false` otherwise and `last_error` can be used
+  ///          to retrieve a human-readable error representation.
+  /// @note For OpenSSL, calls @c SSL_CTX_set_cipher_list.
+  [[nodiscard]] bool set_cipher_list(const char* cipher_list);
+
+  /// @copydoc set_cipher_list
+  [[nodiscard]] bool set_cipher_list(const std::string& cipher_list) {
+    return set_cipher_list(cipher_list.c_str());
+  }
+
   /// Overrides the callback to obtain the password for encrypted PEM files.
-  /// @note calls @c SSL_CTX_set_default_passwd_cb
+  /// @note For OpenSSL, calls @c SSL_CTX_set_default_passwd_cb.
   template <typename PasswordCallback>
   void password_callback(PasswordCallback callback) {
     password_callback_impl(password::make_callback(std::move(callback)));
@@ -106,7 +129,7 @@ public:
 
   /// Overrides the callback to obtain the password for encrypted PEM files with
   /// a function that always returns @p password.
-  /// @note calls @c SSL_CTX_set_default_passwd_cb
+  /// @note For OpenSSL, calls @c SSL_CTX_set_default_passwd_cb.
   void password(std::string password) {
     auto cb = [pw = std::move(password)](char* buf, int len,
                                          password::purpose) {
@@ -187,7 +210,7 @@ public:
   ///             e.g., `9d66eef0.0` and `9d66eef0.1`.
   /// @returns `true` on success, `false` otherwise and `last_error` can be used
   ///          to retrieve a human-readable error representation.
-  /// @note Calls @c SSL_CTX_load_verify_locations
+  /// @note For OpenSSL, calls @c SSL_CTX_load_verify_locations.
   [[nodiscard]] bool add_verify_path(const char* path);
 
   /// @copydoc add_verify_path
@@ -199,7 +222,7 @@ public:
   /// @param path Null-terminated string with a path to a single PEM file.
   /// @returns `true` on success, `false` otherwise and `last_error` can be used
   ///          to retrieve a human-readable error representation.
-  /// @note Calls @c SSL_CTX_load_verify_locations
+  /// @note For OpenSSL, calls @c SSL_CTX_load_verify_locations.
   [[nodiscard]] bool load_verify_file(const char* path);
 
   /// @copydoc load_verify_file
@@ -219,7 +242,7 @@ public:
   }
 
   /// Loads a certificate chain from a PEM-formatted file.
-  /// @note calls @c SSL_CTX_use_certificate_chain_file
+  /// @note For OpenSSL, calls @c SSL_CTX_use_certificate_chain_file.
   [[nodiscard]] bool use_certificate_chain_file(const char* path);
 
   /// @copydoc use_certificate_chain_file
@@ -469,7 +492,7 @@ inline auto use_certificate_file_if(dsl::arg::cstring path,
 }
 
 /// Loads a certificate chain from a PEM-formatted file.
-/// @note calls @c SSL_CTX_use_certificate_chain_file
+/// @note For OpenSSL, calls @c SSL_CTX_use_certificate_chain_file.
 /// @returns a function object for chaining `expected<T>::and_then()`.
 inline auto use_certificate_chain_file(dsl::arg::cstring path) {
   return [arg = std::move(path)](context ctx) mutable {
@@ -482,7 +505,7 @@ inline auto use_certificate_chain_file(dsl::arg::cstring path) {
 
 /// Loads a certificate chain from a PEM-formatted file if all arguments are
 /// non-null. Otherwise, does nothing.
-/// @note calls @c SSL_CTX_use_certificate_chain_file
+/// @note For OpenSSL, calls @c SSL_CTX_use_certificate_chain_file.
 /// @returns a function object for chaining `expected<T>::and_then()`.
 inline auto use_certificate_chain_file_if(dsl::arg::cstring path) {
   return [arg = std::move(path)](context ctx) mutable {


### PR DESCRIPTION
- The class `caf::net::ssl::context` now includes `set_cipher_list()` for configuring the cipher list used by the SSL/TLS backend.
- The class `caf::net::ssl::context` now has new `backend()` and `backend_name()` functions to query which SSL/TLS library is in use and `backend_version()` to retrieve the backend-specific version number. Currently, only OpenSSL is supported as a backend implementation in CAF, but the API has been designed to prepare for different backends in the future.