### PR TITLE
Minor additions to the CAF SSL wrapper API

### DIFF
--- a/libcaf_net/CMakeLists.txt
+++ b/libcaf_net/CMakeLists.txt
@@ -20,6 +20,7 @@ caf_add_component(
     net.http.method
     net.http.status
     net.octet_stream.errc
+    net.ssl.backend
     net.ssl.dtls
     net.ssl.errc
     net.ssl.format

--- a/libcaf_net/caf/net/ssl/backend.hpp
+++ b/libcaf_net/caf/net/ssl/backend.hpp
@@ -1,0 +1,37 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+#include "caf/default_enum_inspect.hpp"
+#include "caf/detail/net_export.hpp"
+
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+namespace caf::net::ssl {
+
+/// Identifies the SSL/TLS implementation in use.
+enum class backend {
+  /// Denotes the OpenSSL library.
+  openssl,
+};
+
+/// @relates backend
+CAF_NET_EXPORT std::string to_string(backend);
+
+/// @relates backend
+CAF_NET_EXPORT bool from_string(std::string_view, backend&);
+
+/// @relates backend
+CAF_NET_EXPORT bool from_integer(std::underlying_type_t<backend>, backend&);
+
+/// @relates backend
+template <class Inspector>
+bool inspect(Inspector& f, backend& x) {
+  return default_enum_inspect(f, x);
+}
+
+} // namespace caf::net::ssl

--- a/libcaf_net/caf/net/ssl/context.cpp
+++ b/libcaf_net/caf/net/ssl/context.cpp
@@ -178,6 +178,23 @@ void context::verify_mode(verify_t flags) {
   SSL_CTX_set_verify(ptr, to_integer(flags), SSL_CTX_get_verify_callback(ptr));
 }
 
+ssl::backend context::backend() const noexcept {
+  return ssl::backend::openssl;
+}
+
+std::string context::backend_name() const noexcept {
+  return to_string(backend());
+}
+
+int context::backend_version() const noexcept {
+  return OPENSSL_VERSION_NUMBER;
+}
+
+bool context::set_cipher_list(const char* cipher_list) {
+  ERR_clear_error();
+  return SSL_CTX_set_cipher_list(native(pimpl_), cipher_list) == 1;
+}
+
 namespace {
 
 int c_password_callback(char* buf, int size, int rwflag, void* ptr) {


### PR DESCRIPTION
Port #2177 to `main` (cherry picked from commit 460480731c759045dd18597538776894fed9c2b9).