### PR TITLE
Redesign the `resumable` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   `CAF_ENABLE_TRACE_LOGGING` to `ON`. When using the `configure` script, this
   can be achieved by passing the new `--enable-trace-logging` option to the
   script.
+- The classes `scheduler` and `resumable` have received a complete overhaul to
+  better hide implementation details and to improve maintainability.
 
 ### Deprecated
 

--- a/libcaf_core/caf/action.cpp
+++ b/libcaf_core/caf/action.cpp
@@ -8,10 +8,6 @@
 
 namespace caf {
 
-resumable::subtype_t action::impl::subtype() const noexcept {
-  return resumable::function_object;
-}
-
 void action::impl::ref_resumable() const noexcept {
   ref_disposable();
 }

--- a/libcaf_core/caf/action.test.cpp
+++ b/libcaf_core/caf/action.test.cpp
@@ -115,8 +115,6 @@ SCENARIO("actions can increase and decrease reference count") {
         auto fn = [] {};
         using impl_t = detail::default_action_impl<decltype(fn), true>;
         auto uut = action{make_counted<impl_t>(std::move(fn))};
-        check_eq(uut.as_intrusive_ptr()->subtype(),
-                 resumable::subtype_t::function_object);
         auto impl_ptr = dynamic_cast<impl_t*>(uut.as_intrusive_ptr().get());
         check(impl_ptr->unique());
         impl_ptr->ref_resumable();

--- a/libcaf_core/caf/actor_clock.cpp
+++ b/libcaf_core/caf/actor_clock.cpp
@@ -48,12 +48,16 @@ public:
     deref();
   }
 
-  resume_result resume(scheduler*, size_t) override {
+  resume_result resume(scheduler*, uint64_t event_id) override {
     CAF_ASSERT(decorated_ != nullptr);
     WorkerPtr tmp;
     {
       std::unique_lock guard(mtx_);
       tmp.swap(worker_);
+    }
+    if (event_id == resumable::dispose_event_id) {
+      decorated_->dispose();
+      return resumable::done;
     }
     if constexpr (std::is_same_v<WorkerPtr, weak_actor_ptr>) {
       if (auto ptr = actor_cast<strong_actor_ptr>(tmp)) {

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -9,6 +9,7 @@
 #include "caf/actor_config.hpp"
 #include "caf/actor_launcher.hpp"
 #include "caf/actor_system_module.hpp"
+#include "caf/callback.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/detail/format.hpp"
 #include "caf/detail/init_fun_factory.hpp"
@@ -566,6 +567,9 @@ public:
   /// @endcond
 
 private:
+  using launch_callback_ptr
+    = unique_callback_ptr<void(scheduled_actor*, caf::scheduler*)>;
+
   std::pair<event_based_actor*, actor_launcher>
     spawn_inactive_impl(spawn_options);
 
@@ -593,6 +597,8 @@ private:
   void set_scheduler(std::unique_ptr<caf::scheduler> ptr);
 
   void set_node(node_id id);
+
+  void set_launch_callback(launch_callback_ptr callback);
 
   // -- member variables -------------------------------------------------------
 

--- a/libcaf_core/caf/actor_system_config.cpp
+++ b/libcaf_core/caf/actor_system_config.cpp
@@ -85,6 +85,7 @@ constexpr const char* default_config_file = "caf-application.conf";
 } // namespace
 
 struct actor_system_config::fields {
+  size_t max_throughput = defaults::scheduler::max_throughput;
   std::vector<std::string> paths;
   module_factory_list module_factories;
   actor_factory_dictionary actor_factories;
@@ -120,8 +121,8 @@ actor_system_config::actor_system_config() {
   opt_group{custom_options_, "caf.scheduler"}
     .add<std::string>("policy", "'stealing' (default) or 'sharing'")
     .add<size_t>("max-threads", "maximum number of worker threads")
-    .add<size_t>("max-throughput",
-                 "nr. of messages actors can consume per run");
+    .add(fields_->max_throughput, "max-throughput",
+         "nr. of messages actors can consume per run");
   opt_group(custom_options_, "caf.work-stealing")
     .add<size_t>("aggressive-poll-attempts", "nr. of aggressive steal attempts")
     .add<size_t>("aggressive-steal-interval",
@@ -204,6 +205,10 @@ settings actor_system_config::dump_content() const {
   put_missing(console_group, "format", defaults::logger::console::format);
   put_missing(console_group, "excluded-components", std::vector<std::string>{});
   return result;
+}
+
+size_t actor_system_config::max_throughput() const noexcept {
+  return fields_->max_throughput;
 }
 
 // -- config file parsing ------------------------------------------------------

--- a/libcaf_core/caf/actor_system_config.hpp
+++ b/libcaf_core/caf/actor_system_config.hpp
@@ -65,13 +65,17 @@ public:
   /// values.
   virtual settings dump_content() const;
 
+  /// Returns the maximum throughput for messages, i.e., the maximum number of
+  /// messages that an actor is allowed to consume per run.
+  size_t max_throughput() const noexcept;
+
+  // -- modifiers --------------------------------------------------------------
+
   /// Sets a config by using its name `config_name` to `config_value`.
   template <class T>
   actor_system_config& set(std::string_view name, T&& value) {
     return set_impl(name, config_value{std::forward<T>(value)});
   }
-
-  // -- modifiers --------------------------------------------------------------
 
   /// Parses `args` as tuple of strings containing CLI options and `config` as
   /// configuration file.

--- a/libcaf_core/caf/async/spsc_buffer.hpp
+++ b/libcaf_core/caf/async/spsc_buffer.hpp
@@ -448,7 +448,7 @@ public:
     return owner_ ? action::state::scheduled : action::state::disposed;
   }
 
-  resume_result resume(scheduler*, size_t) override {
+  resume_result resume(scheduler*, uint64_t) override {
     on_wakeup_t on_wakeup;
     {
       std::unique_lock guard{mtx_};
@@ -722,7 +722,7 @@ public:
     return owner_ ? action::state::scheduled : action::state::disposed;
   }
 
-  resume_result resume(scheduler*, size_t) override {
+  resume_result resume(scheduler*, uint64_t) override {
     on_demand_t on_demand;
     size_t demand = 0;
     buffer_ptr_t buf;

--- a/libcaf_core/caf/blocking_actor.cpp
+++ b/libcaf_core/caf/blocking_actor.cpp
@@ -106,12 +106,12 @@ public:
     intrusive_ptr_add_ref(self->ctrl());
   }
 
-  resumable::subtype_t subtype() const noexcept final {
-    return resumable::function_object;
-  }
-
-  resumable::resume_result resume(scheduler* ctx, size_t) override {
+  resumable::resume_result resume(scheduler* ctx, uint64_t event_id) override {
     CAF_PUSH_AID_FROM_PTR(self_);
+    if (event_id == resumable::dispose_event_id) {
+      self_->cleanup(make_error(exit_reason::user_shutdown), ctx);
+      return resumable::done;
+    }
     self_->context(ctx);
     self_->initialize();
     error rsn;

--- a/libcaf_core/caf/callback.hpp
+++ b/libcaf_core/caf/callback.hpp
@@ -4,9 +4,7 @@
 
 #pragma once
 
-#include "caf/allowed_unsafe_message_type.hpp"
 #include "caf/detail/callable_trait.hpp"
-#include "caf/detail/concepts.hpp"
 
 #include <memory>
 

--- a/libcaf_core/caf/detail/abstract_worker.cpp
+++ b/libcaf_core/caf/detail/abstract_worker.cpp
@@ -18,10 +18,6 @@ abstract_worker::~abstract_worker() {
 
 // -- implementation of resumable ----------------------------------------------
 
-resumable::subtype_t abstract_worker::subtype() const noexcept {
-  return resumable::function_object;
-}
-
 void abstract_worker::ref_resumable() const noexcept {
   ref();
 }

--- a/libcaf_core/caf/detail/abstract_worker.hpp
+++ b/libcaf_core/caf/detail/abstract_worker.hpp
@@ -25,8 +25,6 @@ public:
 
   // -- implementation of resumable --------------------------------------------
 
-  subtype_t subtype() const noexcept final;
-
   void ref_resumable() const noexcept final;
 
   void deref_resumable() const noexcept final;

--- a/libcaf_core/caf/detail/beacon.cpp
+++ b/libcaf_core/caf/detail/beacon.cpp
@@ -37,7 +37,7 @@ action::state beacon::current_state() const noexcept {
   }
 }
 
-resumable::resume_result beacon::resume(scheduler*, size_t) {
+resumable::resume_result beacon::resume(scheduler*, uint64_t) {
   std::unique_lock guard{mtx_};
   state_ = state::lit;
   cv_.notify_all();

--- a/libcaf_core/caf/detail/beacon.hpp
+++ b/libcaf_core/caf/detail/beacon.hpp
@@ -31,7 +31,7 @@ public:
 
   action::state current_state() const noexcept override;
 
-  resume_result resume(scheduler*, size_t) override;
+  resume_result resume(scheduler*, uint64_t) override;
 
   [[nodiscard]] state wait() {
     std::unique_lock guard{mtx_};

--- a/libcaf_core/caf/detail/daemons.cpp
+++ b/libcaf_core/caf/detail/daemons.cpp
@@ -21,13 +21,14 @@ struct daemons::impl {
   }
 
   void on_start() {
-    cleaner = sys->spawn<hidden>([this](caf::event_based_actor* self) {
-      return behavior{
-        [this, self](actor hdl, int64_t id) {
-          self->monitor(hdl, [this, id](const error&) { cleanup(id); });
-        },
-      };
-    });
+    cleaner
+      = sys->spawn<hidden + lazy_init>([this](caf::event_based_actor* self) {
+          return behavior{
+            [this, self](actor hdl, int64_t id) {
+              self->monitor(hdl, [this, id](const error&) { cleanup(id); });
+            },
+          };
+        });
   }
 
   void on_stop() {

--- a/libcaf_core/caf/detail/monitor_action.hpp
+++ b/libcaf_core/caf/detail/monitor_action.hpp
@@ -68,7 +68,11 @@ public:
     return state_;
   }
 
-  resume_result resume(scheduler*, size_t) override {
+  resume_result resume(scheduler*, uint64_t event_id) override {
+    if (event_id == resumable::dispose_event_id) {
+      dispose();
+      return resumable::done;
+    }
     // We can only run a scheduled action.
     std::unique_lock guard{mtx_};
     if (state_ == action::state::scheduled) {

--- a/libcaf_core/caf/detail/private_thread.cpp
+++ b/libcaf_core/caf/detail/private_thread.cpp
@@ -17,16 +17,16 @@ namespace caf::detail {
 void private_thread::run(actor_system* sys) {
   auto lg = log::core::trace("");
   auto resume = [&sys](resumable* job) {
-    auto res = job->resume(&sys->scheduler(),
-                           std::numeric_limits<size_t>::max());
-    while (res == resumable::resume_later)
-      res = job->resume(&sys->scheduler(), std::numeric_limits<size_t>::max());
+    auto res = job->resume(&sys->scheduler(), resumable::default_event_id);
+    while (res == resumable::resume_later) {
+      res = job->resume(&sys->scheduler(), resumable::default_event_id);
+    }
     return res;
   };
   for (;;) {
     auto [job, done] = await();
     if (job) {
-      CAF_ASSERT(job->subtype() != resumable::io_actor);
+      CAF_ASSERT(job->pinned_scheduler() == nullptr);
       resume(job);
       intrusive_ptr_release(job);
     }

--- a/libcaf_core/caf/detail/private_thread_pool.test.cpp
+++ b/libcaf_core/caf/detail/private_thread_pool.test.cpp
@@ -52,10 +52,7 @@ SCENARIO("private threads rerun their resumable when it returns resume_later") {
     std::atomic<size_t> runs = 0;
     mutable std::atomic<size_t> refs_added = 0;
     mutable std::atomic<size_t> refs_released = 0;
-    subtype_t subtype() const noexcept override {
-      return resumable::function_object;
-    }
-    resume_result resume(scheduler*, size_t) override {
+    resume_result resume(scheduler*, uint64_t) override {
       return ++runs < 2 ? resumable::resume_later : resumable::done;
     }
     void ref_resumable() const noexcept final {

--- a/libcaf_core/caf/resumable.cpp
+++ b/libcaf_core/caf/resumable.cpp
@@ -12,8 +12,8 @@ resumable::~resumable() {
   // nop
 }
 
-resumable::subtype_t resumable::subtype() const noexcept {
-  return unspecified;
+scheduler* resumable::pinned_scheduler() const noexcept {
+  return nullptr;
 }
 
 } // namespace caf

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -9,6 +9,7 @@
 #include "caf/action.hpp"
 #include "caf/async/fwd.hpp"
 #include "caf/cow_string.hpp"
+#include "caf/defaults.hpp"
 #include "caf/detail/behavior_stack.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/detail/default_mailbox.hpp"
@@ -207,13 +208,11 @@ public:
 
   // -- overridden functions of resumable --------------------------------------
 
-  subtype_t subtype() const noexcept override;
-
   void ref_resumable() const noexcept final;
 
   void deref_resumable() const noexcept final;
 
-  resume_result resume(scheduler*, size_t) override;
+  resume_result resume(scheduler*, uint64_t) override;
 
   // -- scheduler callbacks ----------------------------------------------------
 
@@ -833,6 +832,10 @@ private:
   /// Cleans up any state associated to flows and streams and cancels all
   /// ongoing activities.
   void cancel_flows_and_streams();
+
+  /// The maximum throughput for resuming the actor, i.e., the maximum number of
+  /// messages that the actor is allowed to consume per resume.
+  size_t max_throughput_ = defaults::scheduler::max_throughput;
 
   /// Stores actions that the actor executes after processing the current
   /// message.

--- a/libcaf_core/caf/scheduler.hpp
+++ b/libcaf_core/caf/scheduler.hpp
@@ -27,12 +27,15 @@ public:
 
   /// Schedules @p what to run at some point in the future.
   /// @threadsafe
-  virtual void schedule(resumable* what) = 0;
+  virtual void schedule(resumable* what, uint64_t event_id) = 0;
 
   /// Delay the next execution of @p what. Unlike `schedule`, this function is
   /// not thread-safe and must be called only from the scheduler thread that is
   /// currently running.
-  virtual void delay(resumable* what) = 0;
+  virtual void delay(resumable* what, uint64_t event_id) = 0;
+
+  /// Returns `true` if this scheduler is part of the default system scheduler.
+  virtual bool is_system_scheduler() const noexcept = 0;
 
   /// Starts this scheduler and all of its workers.
   virtual void start() = 0;

--- a/libcaf_io/caf/io/abstract_broker.hpp
+++ b/libcaf_io/caf/io/abstract_broker.hpp
@@ -79,10 +79,6 @@ public:
   friend class doorman;
   friend class datagram_servant;
 
-  // -- overridden modifiers of abstract_actor ---------------------------------
-
-  bool enqueue(mailbox_element_ptr, scheduler*) override;
-
   // -- overridden modifiers of local_actor ------------------------------------
 
   void launch(scheduler* eu, bool lazy, bool hide) override;
@@ -93,7 +89,9 @@ public:
 
   // -- overridden modifiers of resumable --------------------------------------
 
-  resume_result resume(scheduler*, size_t) override;
+  resume_result resume(scheduler*, uint64_t) override;
+
+  scheduler* pinned_scheduler() const noexcept final;
 
   // -- modifiers --------------------------------------------------------------
 
@@ -330,10 +328,6 @@ public:
   // -- overridden observers of abstract_actor ---------------------------------
 
   const char* name() const override;
-
-  // -- overridden observers of resumable --------------------------------------
-
-  subtype_t subtype() const noexcept override;
 
   // -- observers --------------------------------------------------------------
 

--- a/libcaf_io/caf/io/basp/worker.hpp
+++ b/libcaf_io/caf/io/basp/worker.hpp
@@ -49,7 +49,7 @@ public:
 
   // -- implementation of resumable --------------------------------------------
 
-  resume_result resume(scheduler* ctx, size_t) override;
+  resume_result resume(scheduler* ctx, uint64_t) override;
 
 private:
   // -- constants and assertions -----------------------------------------------

--- a/libcaf_io/caf/io/basp_broker.cpp
+++ b/libcaf_io/caf/io/basp_broker.cpp
@@ -433,12 +433,13 @@ proxy_registry* basp_broker::proxy_registry_ptr() {
   return &instance.proxies();
 }
 
-resumable::resume_result basp_broker::resume(scheduler* ctx, size_t mt) {
+resumable::resume_result basp_broker::resume(scheduler* ctx,
+                                             uint64_t event_id) {
   proxy_registry::current(&instance.proxies());
   auto guard = detail::scope_guard{[]() noexcept { //
     proxy_registry::current(nullptr);
   }};
-  return super::resume(ctx, mt);
+  return super::resume(ctx, event_id);
 }
 
 strong_actor_ptr basp_broker::make_proxy(node_id nid, actor_id aid) {

--- a/libcaf_io/caf/io/basp_broker.hpp
+++ b/libcaf_io/caf/io/basp_broker.hpp
@@ -57,7 +57,7 @@ public:
 
   proxy_registry* proxy_registry_ptr() override;
 
-  resume_result resume(scheduler*, size_t) override;
+  resume_result resume(scheduler*, uint64_t) override;
 
   // -- implementation of proxy_registry::backend ------------------------------
 

--- a/libcaf_io/caf/io/network/default_multiplexer.hpp
+++ b/libcaf_io/caf/io/network/default_multiplexer.hpp
@@ -122,9 +122,9 @@ public:
   new_local_udp_endpoint(uint16_t port, const char* in = nullptr,
                          bool reuse_addr = false) override;
 
-  void schedule(resumable* ptr) override;
+  void schedule(resumable* ptr, uint64_t) override;
 
-  void delay(resumable* ptr) override;
+  void delay(resumable* ptr, uint64_t) override;
 
   explicit default_multiplexer(actor_system& sys);
 
@@ -248,9 +248,6 @@ private:
 
   /// Sequential ids for handles of datagram servants
   int64_t servant_ids_;
-
-  /// Maximum messages per resume run.
-  size_t max_throughput_;
 };
 
 inline connection_handle conn_hdl_from_socket(native_socket fd) {

--- a/libcaf_io/caf/io/network/multiplexer.cpp
+++ b/libcaf_io/caf/io/network/multiplexer.cpp
@@ -26,10 +26,6 @@ multiplexer::supervisor::~supervisor() {
   // nop
 }
 
-resumable::subtype_t multiplexer::runnable::subtype() const noexcept {
-  return resumable::function_object;
-}
-
 void multiplexer::runnable::ref_resumable() const noexcept {
   ref();
 }
@@ -44,6 +40,10 @@ void multiplexer::start() {
 
 void multiplexer::stop() {
   // nop
+}
+
+bool multiplexer::is_system_scheduler() const noexcept {
+  return false;
 }
 
 } // namespace caf::io::network

--- a/libcaf_test/caf/test/fixture/deterministic.hpp
+++ b/libcaf_test/caf/test/fixture/deterministic.hpp
@@ -308,6 +308,7 @@ public:
           ctx.fail({"no matching message found", loc_});
         return false;
       }
+      CAF_ASSERT(event->item != nullptr);
       if (!from_(event->item->sender) || !with_(event->item->payload)) {
         if (fail_on_mismatch)
           ctx.fail({"no matching message found", loc_});


### PR DESCRIPTION
- Introduce event IDs for `resume`: this addition allows an resumable to
  support multiple event types. The only use case we currently have is
  to have an explicit dispose event that we can use during shutdown. The
  scheduler API has been prepared to support user-defined event IDs but
  the default scheduler will ignore this parameter for now (and always
  pass the default event ID). We also introduce an initialization event
  ID, but this ID matters only when using the deterministic text
  fixture.
- Remove the max-throughput parameter from `resume`: this is an
  implementation detail of scheduled actors and should not leak into the
  scheduler/resumable API.
- Remove `awaiting_message`: returning `awaiting_message` from `resume`
  does exactly the same as returning `done`.
- Remove `shutdown_execution_unit`: abusing the return type of `resume`
  for shutdown logic is hacky and pollutes the interface. Using an
  explicit shutdown flag internally is much cleaner and does not leak
  internal implementation details into the public API.
- Remove `subtype`: the only use case we had for this tag was to make
  sure that brokers only run on the multiplexer and not on the system
  scheduler and that regular actors do not run on a multiplexer.
  However, pinning a resumable (broker) to their dedicated scheduler
  (multiplexer) is much more general and robust.
