### PR TITLE
Remove resume_result from the code base

### DIFF
--- a/libcaf_core/caf/actor_clock.cpp
+++ b/libcaf_core/caf/actor_clock.cpp
@@ -48,7 +48,7 @@ public:
     deref();
   }
 
-  resume_result resume(scheduler*, uint64_t event_id) override {
+  void resume(scheduler*, uint64_t event_id) override {
     CAF_ASSERT(decorated_ != nullptr);
     WorkerPtr tmp;
     {
@@ -57,7 +57,7 @@ public:
     }
     if (event_id == resumable::dispose_event_id) {
       decorated_->dispose();
-      return resumable::done;
+      return;
     }
     if constexpr (std::is_same_v<WorkerPtr, weak_actor_ptr>) {
       if (auto ptr = actor_cast<strong_actor_ptr>(tmp)) {
@@ -69,7 +69,6 @@ public:
       if (tmp)
         do_run(tmp);
     }
-    return resumable::done;
   }
 
   state current_state() const noexcept override {

--- a/libcaf_core/caf/async/spsc_buffer.hpp
+++ b/libcaf_core/caf/async/spsc_buffer.hpp
@@ -448,7 +448,7 @@ public:
     return owner_ ? action::state::scheduled : action::state::disposed;
   }
 
-  resume_result resume(scheduler*, uint64_t) override {
+  void resume(scheduler*, uint64_t) override {
     on_wakeup_t on_wakeup;
     {
       std::unique_lock guard{mtx_};
@@ -457,7 +457,6 @@ public:
     if (on_wakeup) {
       (*on_wakeup)(*this);
     }
-    return resumable::done;
   }
 
   void ref_disposable() const noexcept override {
@@ -722,7 +721,7 @@ public:
     return owner_ ? action::state::scheduled : action::state::disposed;
   }
 
-  resume_result resume(scheduler*, uint64_t) override {
+  void resume(scheduler*, uint64_t) override {
     on_demand_t on_demand;
     size_t demand = 0;
     buffer_ptr_t buf;
@@ -748,7 +747,6 @@ public:
         buf->close();
       }
     }
-    return resumable::done;
   }
 
   void ref_disposable() const noexcept override {

--- a/libcaf_core/caf/blocking_actor.cpp
+++ b/libcaf_core/caf/blocking_actor.cpp
@@ -106,11 +106,11 @@ public:
     intrusive_ptr_add_ref(self->ctrl());
   }
 
-  resumable::resume_result resume(scheduler* ctx, uint64_t event_id) override {
+  void resume(scheduler* ctx, uint64_t event_id) override {
     CAF_PUSH_AID_FROM_PTR(self_);
     if (event_id == resumable::dispose_event_id) {
       self_->cleanup(make_error(exit_reason::user_shutdown), ctx);
-      return resumable::done;
+      return;
     }
     self_->context(ctx);
     self_->initialize();
@@ -136,7 +136,6 @@ public:
       [[maybe_unused]] auto count = sys.registry().dec_running();
       log::system::debug("actor {} decreased running count to {}", id, count);
     }
-    return resumable::done;
   }
 
   void ref_resumable() const noexcept final {

--- a/libcaf_core/caf/detail/beacon.cpp
+++ b/libcaf_core/caf/detail/beacon.cpp
@@ -37,11 +37,10 @@ action::state beacon::current_state() const noexcept {
   }
 }
 
-resumable::resume_result beacon::resume(scheduler*, uint64_t) {
+void beacon::resume(scheduler*, uint64_t) {
   std::unique_lock guard{mtx_};
   state_ = state::lit;
   cv_.notify_all();
-  return resumable::done;
 }
 
 } // namespace caf::detail

--- a/libcaf_core/caf/detail/beacon.hpp
+++ b/libcaf_core/caf/detail/beacon.hpp
@@ -31,7 +31,7 @@ public:
 
   action::state current_state() const noexcept override;
 
-  resume_result resume(scheduler*, uint64_t) override;
+  void resume(scheduler*, uint64_t) override;
 
   [[nodiscard]] state wait() {
     std::unique_lock guard{mtx_};

--- a/libcaf_core/caf/detail/cleanup_and_release.cpp
+++ b/libcaf_core/caf/detail/cleanup_and_release.cpp
@@ -31,11 +31,11 @@ void cleanup_and_release(resumable* ptr) {
     std::vector<resumable*> resumables;
   };
   dummy_scheduler dummy;
-  std::ignore = ptr->resume(&dummy, resumable::dispose_event_id);
+  ptr->resume(&dummy, resumable::dispose_event_id);
   while (!dummy.resumables.empty()) {
     auto sub = dummy.resumables.back();
     dummy.resumables.pop_back();
-    std::ignore = sub->resume(&dummy, resumable::dispose_event_id);
+    sub->resume(&dummy, resumable::dispose_event_id);
     intrusive_ptr_release(sub);
   }
   intrusive_ptr_release(ptr);

--- a/libcaf_core/caf/detail/monitor_action.hpp
+++ b/libcaf_core/caf/detail/monitor_action.hpp
@@ -68,10 +68,10 @@ public:
     return state_;
   }
 
-  resume_result resume(scheduler*, uint64_t event_id) override {
+  void resume(scheduler*, uint64_t event_id) override {
     if (event_id == resumable::dispose_event_id) {
       dispose();
-      return resumable::done;
+      return;
     }
     // We can only run a scheduled action.
     std::unique_lock guard{mtx_};
@@ -81,7 +81,6 @@ public:
       f_();
       f_.~function_wrapper();
     }
-    return resumable::done;
   }
 
   bool set_reason(error value) override {

--- a/libcaf_core/caf/detail/private_thread.cpp
+++ b/libcaf_core/caf/detail/private_thread.cpp
@@ -16,22 +16,16 @@ namespace caf::detail {
 
 void private_thread::run(actor_system* sys) {
   auto lg = log::core::trace("");
-  auto resume = [&sys](resumable* job) {
-    auto res = job->resume(&sys->scheduler(), resumable::default_event_id);
-    while (res == resumable::resume_later) {
-      res = job->resume(&sys->scheduler(), resumable::default_event_id);
-    }
-    return res;
-  };
   for (;;) {
     auto [job, done] = await();
     if (job) {
       CAF_ASSERT(job->pinned_scheduler() == nullptr);
-      resume(job);
+      job->resume(&sys->scheduler(), resumable::default_event_id);
       intrusive_ptr_release(job);
     }
-    if (done)
+    if (done) {
       return;
+    }
   }
 }
 

--- a/libcaf_core/caf/resumable.hpp
+++ b/libcaf_core/caf/resumable.hpp
@@ -14,15 +14,6 @@ namespace caf {
 /// A cooperatively scheduled entity.
 class CAF_CORE_EXPORT resumable {
 public:
-  /// Denotes the state in which a `resumable` returned from its `resume` call.
-  enum resume_result {
-    /// Indicates that the resumable has finished processing the event.
-    done,
-    /// Indicates that the resumable voluntarily released the CPU to let others
-    /// run instead and needs to be called again later for the same event.
-    resume_later,
-  };
-
   /// The event ID for the default event.
   static constexpr uint64_t default_event_id = 0;
 
@@ -36,16 +27,15 @@ public:
 
   virtual ~resumable();
 
-  /// Resume any pending computation until it is either finished
-  /// or needs to be re-scheduled later.
+  /// Runs a pending event on the resumable.
+  /// @param context The current scheduler that is running the resumable.
   /// @param event_id The event ID for the event that triggered the resume.
-  /// @returns The result of the resume.
   /// @note Separate events are scheduled independently. If a resumable supports
   ///       multiple types of events, it needs to be prepared that `resume` may
-  ///       be called concurrently for different event IDs.
+  ///       be called concurrently.
   /// @note The default CAF scheduler does not support event IDs and always uses
   ///       the default event ID.
-  virtual resume_result resume(scheduler*, uint64_t event_id) = 0;
+  virtual void resume(scheduler* context, uint64_t event_id) = 0;
 
   /// Returns the scheduler that this resumable is pinned to or `nullptr` if
   /// it can be scheduled on any scheduler.

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -212,7 +212,7 @@ public:
 
   void deref_resumable() const noexcept final;
 
-  resume_result resume(scheduler*, uint64_t) override;
+  void resume(scheduler*, uint64_t) override;
 
   // -- scheduler callbacks ----------------------------------------------------
 

--- a/libcaf_core/caf/scheduler.test.cpp
+++ b/libcaf_core/caf/scheduler.test.cpp
@@ -23,16 +23,17 @@ struct testee : resumable, ref_counted {
     : rendezvous(std::move(latch_handle)) {
   }
 
-  resume_result resume(scheduler*, uint64_t event_id) override {
+  void resume(scheduler* ctx, uint64_t event_id) override {
     if (event_id == resumable::dispose_event_id) {
       rendezvous->count_down();
-      return resumable::done;
+      return;
     }
     if (++runs == 10) {
       rendezvous->count_down();
-      return resumable::done;
+      return;
     }
-    return resumable::resume_later;
+    ref();
+    ctx->delay(this, resumable::default_event_id);
   }
 
   void ref_resumable() const noexcept final {
@@ -112,14 +113,13 @@ struct awaiting_testee : resumable, ref_counted {
     : rendezvous(std::move(latch_handle)) {
   }
 
-  resume_result resume(scheduler*, uint64_t event_id) override {
+  void resume(scheduler*, uint64_t event_id) override {
     if (event_id == resumable::dispose_event_id) {
       rendezvous->count_down();
-      return resumable::done;
+      return;
     }
     ++runs;
     rendezvous->count_down();
-    return resumable::done;
   }
 
   void ref_resumable() const noexcept final {

--- a/libcaf_io/caf/io/abstract_broker.cpp
+++ b/libcaf_io/caf/io/abstract_broker.cpp
@@ -328,13 +328,12 @@ void abstract_broker::close_all() {
     datagram_servants_.begin()->second->graceful_shutdown();
 }
 
-resumable::resume_result abstract_broker::resume(scheduler* sched,
-                                                 uint64_t event_id) {
+void abstract_broker::resume(scheduler* sched, uint64_t event_id) {
   CAF_ASSERT(sched != nullptr);
   // Cleanup (via dispose event) may happen from any context (e.g.,
   // cleanup_and_release with a dummy scheduler).
   CAF_ASSERT(sched == backend_ || event_id == resumable::dispose_event_id);
-  return scheduled_actor::resume(sched, event_id);
+  scheduled_actor::resume(sched, event_id);
 }
 
 scheduler* abstract_broker::pinned_scheduler() const noexcept {

--- a/libcaf_io/caf/io/abstract_broker.hpp
+++ b/libcaf_io/caf/io/abstract_broker.hpp
@@ -89,7 +89,7 @@ public:
 
   // -- overridden modifiers of resumable --------------------------------------
 
-  resume_result resume(scheduler*, uint64_t) override;
+  void resume(scheduler*, uint64_t) override;
 
   scheduler* pinned_scheduler() const noexcept final;
 

--- a/libcaf_io/caf/io/basp/worker.cpp
+++ b/libcaf_io/caf/io/basp/worker.cpp
@@ -42,9 +42,9 @@ void worker::launch(const node_id& last_hop, const basp::header& hdr,
 
 // -- implementation of resumable ----------------------------------------------
 
-resumable::resume_result worker::resume(scheduler* sched, uint64_t event_id) {
+void worker::resume(scheduler* sched, uint64_t event_id) {
   if (event_id == resumable::dispose_event_id) {
-    return resumable::done;
+    return;
   }
   proxy_registry::current(proxies_);
   auto guard = detail::scope_guard{[]() noexcept { //
@@ -52,7 +52,6 @@ resumable::resume_result worker::resume(scheduler* sched, uint64_t event_id) {
   }};
   handle_remote_message(*system_, sched);
   hub_->push(this);
-  return resumable::done;
 }
 
 } // namespace caf::io::basp

--- a/libcaf_io/caf/io/basp/worker.hpp
+++ b/libcaf_io/caf/io/basp/worker.hpp
@@ -49,7 +49,7 @@ public:
 
   // -- implementation of resumable --------------------------------------------
 
-  resume_result resume(scheduler* ctx, uint64_t) override;
+  void resume(scheduler* ctx, uint64_t) override;
 
 private:
   // -- constants and assertions -----------------------------------------------

--- a/libcaf_io/caf/io/basp_broker.cpp
+++ b/libcaf_io/caf/io/basp_broker.cpp
@@ -433,13 +433,12 @@ proxy_registry* basp_broker::proxy_registry_ptr() {
   return &instance.proxies();
 }
 
-resumable::resume_result basp_broker::resume(scheduler* ctx,
-                                             uint64_t event_id) {
+void basp_broker::resume(scheduler* ctx, uint64_t event_id) {
   proxy_registry::current(&instance.proxies());
   auto guard = detail::scope_guard{[]() noexcept { //
     proxy_registry::current(nullptr);
   }};
-  return super::resume(ctx, event_id);
+  super::resume(ctx, event_id);
 }
 
 strong_actor_ptr basp_broker::make_proxy(node_id nid, actor_id aid) {

--- a/libcaf_io/caf/io/basp_broker.hpp
+++ b/libcaf_io/caf/io/basp_broker.hpp
@@ -57,7 +57,7 @@ public:
 
   proxy_registry* proxy_registry_ptr() override;
 
-  resume_result resume(scheduler*, uint64_t) override;
+  void resume(scheduler*, uint64_t) override;
 
   // -- implementation of proxy_registry::backend ------------------------------
 

--- a/libcaf_io/caf/io/network/default_multiplexer.cpp
+++ b/libcaf_io/caf/io/network/default_multiplexer.cpp
@@ -605,13 +605,7 @@ bool default_multiplexer::poll_once(bool block) {
 
 void default_multiplexer::resume(intrusive_ptr<resumable> ptr) {
   auto lg = log::io::trace("");
-  switch (ptr->resume(this, resumable::default_event_id)) {
-    case resumable::resume_later:
-      // Delay resumable until next cycle.
-      internally_posted_.emplace_back(ptr.release(), false);
-      break;
-    default:; // Done. Release reference to resumable.
-  }
+  ptr->resume(this, resumable::default_event_id);
 }
 
 default_multiplexer::~default_multiplexer() {

--- a/libcaf_io/caf/io/network/multiplexer.hpp
+++ b/libcaf_io/caf/io/network/multiplexer.hpp
@@ -128,11 +128,10 @@ public:
       F f;
       impl(F&& mf) : f(std::move(mf)) {
       }
-      resume_result resume(scheduler*, uint64_t event_id) override {
+      void resume(scheduler*, uint64_t event_id) override {
         if (event_id != resumable::dispose_event_id) {
           f();
         }
-        return done;
       }
     };
     delay(new impl(std::move(fun)), resumable::default_event_id);

--- a/libcaf_test/caf/test/fixture/deterministic.cpp
+++ b/libcaf_test/caf/test/fixture/deterministic.cpp
@@ -527,10 +527,7 @@ bool deterministic::dispatch_message() {
     auto ev = std::move(events_.front());
     events_.pop_front();
     auto hdl = ev->target;
-    auto res = hdl->resume(&sys.scheduler(), resumable::default_event_id);
-    while (res == resumable::resume_later) {
-      res = hdl->resume(&sys.scheduler(), resumable::default_event_id);
-    }
+    hdl->resume(&sys.scheduler(), resumable::default_event_id);
     return true;
   }
   // Actor: we simply resume the next actor and it will pick up its message.


### PR DESCRIPTION
The `resume_result` allowed scheduled actors to tell the scheduler whether they could still be running or not via `resume_result::resume_later`. However, the return value makes no sense for other resumables such as an `action`. Hence, we remove `resume_result` from CAF since it leaks an implementation detail for a minor optimization from `scheduled_actor` into a generic interface.