### PR TITLE
Revisit the `intrusive_ptr` API and introduce tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,16 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   has been default-constructed or holds a valid error code.
 - The methods `or_else` and `eval` on `caf::error` are now deprecated since they
   overlap with methods such as `transform` and `and_then` on `caf::expected`.
+- The constructors and assignment operators of `caf::intrusive_ptr` and
+  `caf::weak_intrusive_ptr` that accept a boolean flag to control whether the
+  reference count should be increased or not have been deprecated. Users should
+  use the new `add_ref` and `adopt_ref` tags instead.
 
 ### Added
 
+- CAF's intrusive pointer API now uses explicit `add_ref` and `adopt_ref` tags
+  to control whether the reference count should be increased or not instead of
+  relying on boolean flags.
 - Added `monitor` API to WebSocket and HTTP servers in the `with` DSL (#2026).
 - When starting a server or client using length-prefix framing, users can now
   specify the maximum message size via `max_message_size` and the number of

--- a/libcaf_core/caf/abstract_actor.cpp
+++ b/libcaf_core/caf/abstract_actor.cpp
@@ -9,6 +9,7 @@
 #include "caf/actor_control_block.hpp"
 #include "caf/actor_registry.hpp"
 #include "caf/actor_system.hpp"
+#include "caf/add_ref.hpp"
 #include "caf/config.hpp"
 #include "caf/default_attachable.hpp"
 #include "caf/detail/assert.hpp"
@@ -133,7 +134,7 @@ actor_control_block* abstract_actor::ctrl() const {
 }
 
 actor_addr abstract_actor::address() const noexcept {
-  return actor_addr{actor_control_block::from(this)};
+  return actor_addr{actor_control_block::from(this), add_ref};
 }
 
 // -- callbacks ----------------------------------------------------------------

--- a/libcaf_core/caf/actor.cpp
+++ b/libcaf_core/caf/actor.cpp
@@ -26,11 +26,22 @@ actor::actor(const scoped_actor& x) : ptr_(actor_cast<strong_actor_ptr>(x)) {
   // nop
 }
 
-actor::actor(actor_control_block* ptr) : ptr_(ptr) {
+actor::actor(actor_control_block* ptr) : ptr_(ptr, add_ref) {
   // nop
 }
 
-actor::actor(actor_control_block* ptr, bool add_ref) : ptr_(ptr, add_ref) {
+CAF_PUSH_DEPRECATED_WARNING
+actor::actor(actor_control_block* ptr, bool increase_ref_count)
+  : ptr_(ptr, increase_ref_count) {
+  // nop
+}
+CAF_POP_WARNINGS
+
+actor::actor(actor_control_block* ptr, add_ref_t) : ptr_(ptr, add_ref) {
+  // nop
+}
+
+actor::actor(actor_control_block* ptr, adopt_ref_t) : ptr_(ptr, adopt_ref) {
   // nop
 }
 

--- a/libcaf_core/caf/actor.hpp
+++ b/libcaf_core/caf/actor.hpp
@@ -7,6 +7,8 @@
 #include "caf/abstract_actor.hpp"
 #include "caf/actor_control_block.hpp"
 #include "caf/actor_traits.hpp"
+#include "caf/add_ref.hpp"
+#include "caf/adopt_ref.hpp"
 #include "caf/config.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/detail/comparable.hpp"
@@ -55,7 +57,7 @@ public:
 
   template <class T>
     requires actor_traits<T>::is_dynamically_typed
-  actor(T* ptr) : ptr_(ptr->ctrl()) {
+  actor(T* ptr) : ptr_(ptr->ctrl(), add_ref) {
     CAF_ASSERT(ptr != nullptr);
   }
 
@@ -123,7 +125,12 @@ public:
 
   intptr_t compare(const strong_actor_ptr&) const noexcept;
 
+  [[deprecated("construct using add_ref or adopt_ref instead")]]
   actor(actor_control_block*, bool);
+
+  actor(actor_control_block*, add_ref_t);
+
+  actor(actor_control_block*, adopt_ref_t);
 
   /// @endcond
 
@@ -155,6 +162,7 @@ private:
     return ptr_.release();
   }
 
+  [[deprecated("construct using add_ref or adopt_ref instead")]]
   actor(actor_control_block*);
 
   strong_actor_ptr ptr_;

--- a/libcaf_core/caf/actor_addr.cpp
+++ b/libcaf_core/caf/actor_addr.cpp
@@ -5,6 +5,7 @@
 #include "caf/actor_addr.hpp"
 
 #include "caf/actor.hpp"
+#include "caf/config.hpp"
 #include "caf/deserializer.hpp"
 #include "caf/local_actor.hpp"
 #include "caf/node_id.hpp"
@@ -22,12 +23,24 @@ actor_addr& actor_addr::operator=(std::nullptr_t) {
   return *this;
 }
 
-actor_addr::actor_addr(actor_control_block* ptr) : ptr_(ptr) {
+actor_addr::actor_addr(actor_control_block* ptr) : ptr_(ptr, add_ref) {
   // nop
 }
 
-actor_addr::actor_addr(actor_control_block* ptr, bool add_ref)
+CAF_PUSH_DEPRECATED_WARNING
+actor_addr::actor_addr(actor_control_block* ptr, bool increase_ref_count)
+  : ptr_(ptr, increase_ref_count) {
+  // nop
+}
+CAF_POP_WARNINGS
+
+actor_addr::actor_addr(actor_control_block* ptr, add_ref_t)
   : ptr_(ptr, add_ref) {
+  // nop
+}
+
+actor_addr::actor_addr(actor_control_block* ptr, adopt_ref_t)
+  : ptr_(ptr, adopt_ref) {
   // nop
 }
 

--- a/libcaf_core/caf/actor_addr.hpp
+++ b/libcaf_core/caf/actor_addr.hpp
@@ -6,6 +6,8 @@
 
 #include "caf/abstract_actor.hpp"
 #include "caf/actor_control_block.hpp"
+#include "caf/add_ref.hpp"
+#include "caf/adopt_ref.hpp"
 #include "caf/detail/comparable.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/fwd.hpp"
@@ -106,7 +108,12 @@ public:
     x.ptr_.reset();
   }
 
+  [[deprecated("construct using add_ref or adopt_ref instead")]]
   actor_addr(actor_control_block*, bool);
+
+  actor_addr(actor_control_block*, add_ref_t);
+
+  actor_addr(actor_control_block*, adopt_ref_t);
 
   actor_control_block* get() const noexcept {
     return ptr_.get();
@@ -123,6 +130,7 @@ private:
     return ptr_.get_locked();
   }
 
+  [[deprecated("construct using add_ref or adopt_ref instead")]]
   actor_addr(actor_control_block*);
 
   weak_actor_ptr ptr_;

--- a/libcaf_core/caf/actor_cast.hpp
+++ b/libcaf_core/caf/actor_cast.hpp
@@ -67,12 +67,12 @@ template <class To, class From>
 class actor_cast_access<To, From, raw_ptr_cast> {
 public:
   To operator()(actor_control_block* x) const {
-    return To{x};
+    return To{x, add_ref};
   }
 
   To operator()(abstract_actor* x) const {
     if (x != nullptr) {
-      return To{x->ctrl()};
+      return To{x->ctrl(), add_ref};
     }
     return To{};
   }
@@ -80,7 +80,7 @@ public:
   template <class T>
     requires(!std::is_pointer_v<T>)
   To operator()(const T& x) const {
-    return To{x.get()};
+    return To{x.get(), add_ref};
   }
 };
 
@@ -127,7 +127,7 @@ template <class To, class From>
 class actor_cast_access<To, From, weak_ptr_downgrade_cast> {
 public:
   To operator()(const From& x) const {
-    return x.get();
+    return {x.get(), add_ref};
   }
 };
 
@@ -135,7 +135,7 @@ template <class To, class From>
 class actor_cast_access<To, From, weak_ptr_upgrade_cast> {
 public:
   To operator()(const From& x) const {
-    return {x.get_locked(), false};
+    return {x.get_locked(), adopt_ref};
   }
 };
 
@@ -143,11 +143,11 @@ template <class To, class From>
 class actor_cast_access<To, From, neutral_cast> {
 public:
   To operator()(const From& x) const {
-    return To{x.get()};
+    return To{x.get(), add_ref};
   }
 
   To operator()(From&& x) const {
-    return {x.release(), false};
+    return {x.release(), adopt_ref};
   }
 };
 

--- a/libcaf_core/caf/actor_control_block.cpp
+++ b/libcaf_core/caf/actor_control_block.cpp
@@ -7,6 +7,7 @@
 #include "caf/abstract_actor.hpp"
 #include "caf/actor_registry.hpp"
 #include "caf/actor_system.hpp"
+#include "caf/add_ref.hpp"
 #include "caf/detail/aligned_alloc.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/log/core.hpp"
@@ -19,7 +20,7 @@
 namespace caf {
 
 actor_addr actor_control_block::address() noexcept {
-  return {this, true};
+  return {this, add_ref};
 }
 
 bool actor_control_block::enqueue(mailbox_element_ptr what, scheduler* sched) {

--- a/libcaf_core/caf/actor_system.cpp
+++ b/libcaf_core/caf/actor_system.cpp
@@ -804,7 +804,8 @@ intrusive_ptr<actor_companion> actor_system::make_companion() {
   actor_config cfg;
   cfg.mbox_factory = mailbox_factory();
   auto hdl = spawn_class<actor_companion, no_spawn_options>(cfg);
-  return intrusive_ptr<actor_companion>{actor_cast<actor_companion*>(hdl)};
+  return intrusive_ptr<actor_companion>{actor_cast<actor_companion*>(hdl),
+                                        add_ref};
 }
 
 void actor_system::thread_started(thread_owner owner) {

--- a/libcaf_core/caf/add_ref.hpp
+++ b/libcaf_core/caf/add_ref.hpp
@@ -1,0 +1,17 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+namespace caf {
+
+/// Tag type to indicate that an intrusive smart pointer should add a new
+/// reference, i.e., increase the reference count of the managed object by one.
+struct add_ref_t {};
+
+/// Tag to indicate that an intrusive smart pointer should add a new reference,
+/// i.e., increase the reference count of the managed object by one.
+inline constexpr add_ref_t add_ref = {};
+
+} // namespace caf

--- a/libcaf_core/caf/adopt_ref.hpp
+++ b/libcaf_core/caf/adopt_ref.hpp
@@ -1,0 +1,19 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+namespace caf {
+
+/// Tag type to indicate that an intrusive smart pointer should adopt the
+/// reference, i.e., store the pointer without increasing the reference count of
+/// the managed object.
+struct adopt_ref_t {};
+
+/// Tag to indicate that an intrusive smart pointer should adopt the reference,
+/// i.e., store the pointer without increasing the reference count of the
+/// managed object.
+inline constexpr adopt_ref_t adopt_ref = {};
+
+} // namespace caf

--- a/libcaf_core/caf/async/batch.cpp
+++ b/libcaf_core/caf/async/batch.cpp
@@ -179,7 +179,7 @@ bool batch::load_impl(Inspector& source) {
   intrusive_ptr<batch::data> ptr{new (vptr)
                                    batch::data(dynamic_item_destructor,
                                                item_type, meta->simple_size, 0),
-                                 false};
+                                 adopt_ref};
   auto* storage = ptr->storage_;
   for (auto i = size_t{0}; i < len; ++i) {
     meta->default_construct(storage);

--- a/libcaf_core/caf/async/batch.hpp
+++ b/libcaf_core/caf/async/batch.hpp
@@ -96,7 +96,7 @@ public:
     intrusive_ptr<batch::data> ptr{
       new (vptr) batch::data(destroy_items, type_id_or_invalid<value_type>(),
                              sizeof(value_type), 0),
-      false};
+      adopt_ref};
     auto* storage = ptr->storage_;
     for (const auto& item : items) {
       new (storage) value_type(item);

--- a/libcaf_core/caf/async/blocking_consumer.hpp
+++ b/libcaf_core/caf/async/blocking_consumer.hpp
@@ -28,7 +28,7 @@ public:
     impl& operator=(const impl&) = delete;
 
     explicit impl(spsc_buffer_ptr<T> buf) : buf_(std::move(buf)) {
-      buf_->set_consumer(this);
+      buf_->set_consumer({this, add_ref});
     }
 
     template <class ErrorPolicy, class TimePoint>

--- a/libcaf_core/caf/async/blocking_producer.hpp
+++ b/libcaf_core/caf/async/blocking_producer.hpp
@@ -28,7 +28,7 @@ public:
     impl& operator=(const impl&) = delete;
 
     explicit impl(spsc_buffer_ptr<T> buf) : buf_(std::move(buf)) {
-      buf_->set_producer(this);
+      buf_->set_producer({this, add_ref});
     }
 
     bool push(std::span<const T> items) {

--- a/libcaf_core/caf/async/consumer_adapter.hpp
+++ b/libcaf_core/caf/async/consumer_adapter.hpp
@@ -31,7 +31,7 @@ public:
       : buf_(std::move(buf)),
         ctx_(std::move(ctx)),
         do_wakeup_(std::move(do_wakeup)) {
-      buf_->set_consumer(this);
+      buf_->set_consumer({this, add_ref});
     }
 
     ~impl() override {

--- a/libcaf_core/caf/async/future.hpp
+++ b/libcaf_core/caf/async/future.hpp
@@ -54,7 +54,7 @@ public:
       }
     };
     auto cb_action = make_single_shot_action(std::move(cb));
-    if (!cell_->subscribe(ctx_, cb_action))
+    if (!cell_->subscribe({ctx_, add_ref}, cb_action))
       ctx_->schedule(cb_action);
     auto res = std::move(cb_action).as_disposable();
     ctx_->watch(res);

--- a/libcaf_core/caf/async/producer_adapter.hpp
+++ b/libcaf_core/caf/async/producer_adapter.hpp
@@ -32,7 +32,7 @@ public:
         ctx_(std::move(ctx)),
         do_resume_(std::move(do_resume)),
         do_cancel_(std::move(do_cancel)) {
-      buf_->set_producer(this);
+      buf_->set_producer({this, add_ref});
     }
 
     size_t push(std::span<const T> items) {

--- a/libcaf_core/caf/async/publisher.hpp
+++ b/libcaf_core/caf/async/publisher.hpp
@@ -57,8 +57,9 @@ public:
     auto* parent = decorated.parent();
     auto flag = disposable::make_flag();
     parent->watch(flag);
-    auto pimpl = make_counted<default_impl>(parent, std::move(decorated),
-                                            std::move(flag));
+    auto pimpl
+      = make_counted<default_impl>(execution_context_ptr{parent, add_ref},
+                                   std::move(decorated), std::move(flag));
     return publisher{std::move(pimpl)};
   }
 

--- a/libcaf_core/caf/async_mail.hpp
+++ b/libcaf_core/caf/async_mail.hpp
@@ -134,7 +134,8 @@ public:
     if (!receiver)
       return;
     auto* ptr = actor_cast<abstract_actor*>(receiver);
-    ptr->enqueue(make_mailbox_element(self_->ctrl(), make_message_id(Priority),
+    ptr->enqueue(make_mailbox_element({self_->ctrl(), add_ref},
+                                      make_message_id(Priority),
                                       std::move(content_)),
                  self_->context());
   }

--- a/libcaf_core/caf/binary_deserializer.cpp
+++ b/libcaf_core/caf/binary_deserializer.cpp
@@ -425,7 +425,7 @@ public:
     if (!value(tmp)) {
       return false;
     }
-    ptr.reset(tmp.get());
+    ptr.reset(tmp.get(), add_ref);
     return true;
   }
 

--- a/libcaf_core/caf/blocking_mail.hpp
+++ b/libcaf_core/caf/blocking_mail.hpp
@@ -117,11 +117,12 @@ public:
     auto mid = self()->new_request_id(Priority);
     if (receiver) {
       auto* ptr = actor_cast<abstract_actor*>(receiver);
-      ptr->enqueue(make_mailbox_element(self()->ctrl(), mid,
+      ptr->enqueue(make_mailbox_element({self()->ctrl(), add_ref}, mid,
                                         std::move(super::content_)),
                    self()->context());
     } else {
-      self()->enqueue(make_mailbox_element(self()->ctrl(), mid.response_id(),
+      self()->enqueue(make_mailbox_element({self()->ctrl(), add_ref},
+                                           mid.response_id(),
                                            make_error(sec::invalid_request)),
                       self()->context());
     }

--- a/libcaf_core/caf/chunk.hpp
+++ b/libcaf_core/caf/chunk.hpp
@@ -107,12 +107,13 @@ public:
 
   chunk() noexcept = default;
 
-  explicit chunk(const_byte_span buffer) : data_(data::make(buffer), false) {
+  explicit chunk(const_byte_span buffer)
+    : data_(data::make(buffer), adopt_ref) {
     // nop
   }
 
   explicit chunk(std::span<const const_byte_span> buffers)
-    : data_(data::make(buffers), false) {
+    : data_(data::make(buffers), adopt_ref) {
     // nop
   }
 

--- a/libcaf_core/caf/config_value.cpp
+++ b/libcaf_core/caf/config_value.cpp
@@ -480,7 +480,7 @@ config_value::parse_msg_impl(std::string_view str,
       CAF_ASSERT(unused == ls_size);
       intrusive_ptr<detail::message_data> ptr;
       if (auto vptr = malloc(sizeof(detail::message_data) + ls.data_size()))
-        ptr.reset(new (vptr) detail::message_data(ls), false);
+        ptr.reset(new (vptr) detail::message_data(ls), adopt_ref);
       else
         return false;
       auto pos = ptr->storage();
@@ -492,7 +492,7 @@ config_value::parse_msg_impl(std::string_view str,
           return false;
         pos += meta.padded_size;
       }
-      result.reset(ptr.release(), false);
+      result.reset(ptr.release(), adopt_ref);
       return reader.end_sequence();
     };
     if (std::ranges::any_of(allowed_types, converts))

--- a/libcaf_core/caf/deserializer.cpp
+++ b/libcaf_core/caf/deserializer.cpp
@@ -85,7 +85,7 @@ bool deserializer::value(weak_actor_ptr& ptr) {
   if (!value(tmp)) {
     return false;
   }
-  ptr.reset(tmp.get());
+  ptr.reset(tmp.get(), add_ref);
   return true;
 }
 

--- a/libcaf_core/caf/detail/behavior_impl.cpp
+++ b/libcaf_core/caf/detail/behavior_impl.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/detail/behavior_impl.hpp"
 
+#include "caf/add_ref.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/message_handler.hpp"
 
@@ -80,7 +81,7 @@ void behavior_impl::handle_timeout() {
 
 behavior_impl::pointer behavior_impl::or_else(const pointer& other) {
   CAF_ASSERT(other != nullptr);
-  return make_counted<combinator>(this, other);
+  return make_counted<combinator>(pointer{this, add_ref}, other);
 }
 
 } // namespace caf::detail

--- a/libcaf_core/caf/detail/counted_disposable.cpp
+++ b/libcaf_core/caf/detail/counted_disposable.cpp
@@ -54,8 +54,8 @@ private:
 
 disposable counted_disposable::acquire() {
   ++count_;
-  return disposable{
-    make_counted<nested_disposable>(intrusive_ptr<counted_disposable>(this))};
+  return disposable{make_counted<nested_disposable>(
+    intrusive_ptr<counted_disposable>(this, add_ref))};
 }
 
 void counted_disposable::dispose() {

--- a/libcaf_core/caf/detail/message_data.cpp
+++ b/libcaf_core/caf/detail/message_data.cpp
@@ -53,7 +53,7 @@ message_data* message_data::copy() const {
   auto vptr = malloc(total_size);
   if (vptr == nullptr)
     CAF_RAISE_ERROR(std::bad_alloc, "bad_alloc");
-  intrusive_ptr<message_data> ptr{new (vptr) message_data(types_), false};
+  intrusive_ptr<message_data> ptr{new (vptr) message_data(types_), adopt_ref};
   auto src = storage();
   auto dst = ptr->storage();
   for (auto id : types_) {
@@ -75,7 +75,7 @@ message_data::make_uninitialized(type_id_list types) {
   auto vptr = malloc(total_size);
   if (vptr == nullptr)
     CAF_RAISE_ERROR(std::bad_alloc, "bad_alloc");
-  return {new (vptr) message_data(types), false};
+  return {new (vptr) message_data(types), adopt_ref};
 }
 
 std::byte* message_data::at(size_t index) noexcept {

--- a/libcaf_core/caf/detail/stream_bridge.cpp
+++ b/libcaf_core/caf/detail/stream_bridge.cpp
@@ -179,8 +179,8 @@ disposable stream_bridge::subscribe(flow::observer<async::batch> out) {
   }
   auto self = self_ptr();
   auto local_id = self->new_u64_id();
-  unsafe_send_as(self, src_,
-                 stream_open_msg{stream_id_, self->ctrl(), local_id});
+  unsafe_send_as(
+    self, src_, stream_open_msg{stream_id_, {self->ctrl(), add_ref}, local_id});
   auto sub = make_counted<stream_bridge_sub>(self, std::move(src_), out,
                                              local_id, buf_capacity_,
                                              request_threshold_);

--- a/libcaf_core/caf/disposable.hpp
+++ b/libcaf_core/caf/disposable.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "caf/add_ref.hpp"
+#include "caf/adopt_ref.hpp"
 #include "caf/detail/comparable.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/intrusive_ptr.hpp"
@@ -45,6 +47,14 @@ public:
 
   explicit disposable(intrusive_ptr<impl> pimpl) noexcept
     : pimpl_(std::move(pimpl)) {
+    // nop
+  }
+
+  disposable(impl* pimpl, adopt_ref_t) noexcept : pimpl_(pimpl, adopt_ref) {
+    // nop
+  }
+
+  disposable(impl* pimpl, add_ref_t) noexcept : pimpl_(pimpl, add_ref) {
     // nop
   }
 

--- a/libcaf_core/caf/event_based_mail.hpp
+++ b/libcaf_core/caf/event_based_mail.hpp
@@ -226,11 +226,12 @@ public:
           make_message(make_error(sec::request_timeout)));
       }
       auto* ptr = actor_cast<abstract_actor*>(receiver);
-      ptr->enqueue(make_mailbox_element(self()->ctrl(), mid,
+      ptr->enqueue(make_mailbox_element({self()->ctrl(), add_ref}, mid,
                                         std::move(super::content_)),
                    self()->context());
     } else {
-      self()->enqueue(make_mailbox_element(self()->ctrl(), mid.response_id(),
+      self()->enqueue(make_mailbox_element({self()->ctrl(), add_ref},
+                                           mid.response_id(),
                                            make_error(sec::invalid_request)),
                       self()->context());
     }
@@ -273,7 +274,7 @@ public:
       if (!dest)
         continue;
       auto req_id = self()->new_request_id(Priority);
-      dest->enqueue(make_mailbox_element(self()->ctrl(), req_id,
+      dest->enqueue(make_mailbox_element({self()->ctrl(), add_ref}, req_id,
                                          super::content_),
                     self()->context());
       pending_msgs.emplace_back(
@@ -282,7 +283,8 @@ public:
     }
     if (ids.empty()) {
       auto req_id = self()->new_request_id(Priority);
-      self()->enqueue(make_mailbox_element(self()->ctrl(), req_id.response_id(),
+      self()->enqueue(make_mailbox_element({self()->ctrl(), add_ref},
+                                           req_id.response_id(),
                                            make_error(sec::invalid_argument)),
                       self()->context());
       ids.emplace_back(req_id.response_id());

--- a/libcaf_core/caf/flow/coordinator.hpp
+++ b/libcaf_core/caf/flow/coordinator.hpp
@@ -76,7 +76,7 @@ public:
   template <class T>
     requires std::is_base_of_v<coordinated, T>
   void release_later(intrusive_ptr<T>& child) {
-    auto ptr = coordinated_ptr{child.release(), false};
+    auto ptr = coordinated_ptr{child.release(), adopt_ref};
     release_later(ptr);
   }
 

--- a/libcaf_core/caf/flow/op/cache.hpp
+++ b/libcaf_core/caf/flow/op/cache.hpp
@@ -41,7 +41,7 @@ public:
       return;
     }
     demand_ = n;
-    auto self = intrusive_ptr<cache_sub>{this};
+    auto self = intrusive_ptr<cache_sub>{this, add_ref};
     parent_->delay_fn([self] { self->update(); });
   }
 

--- a/libcaf_core/caf/flow/op/cell.hpp
+++ b/libcaf_core/caf/flow/op/cell.hpp
@@ -151,7 +151,7 @@ public:
   void request(size_t) override {
     if (!listening_) {
       listening_ = true;
-      auto self = cell_listener_ptr<T>{this};
+      auto self = cell_listener_ptr<T>{this, add_ref};
       parent_->delay_fn([state = state_, self]() mutable { //
         state->listen(std::move(self));
       });
@@ -188,7 +188,7 @@ public:
 private:
   void do_dispose(bool from_external) override {
     if (state_) {
-      state_->drop(this);
+      state_->drop({this, add_ref});
       state_ = nullptr;
     }
     if (out_) {

--- a/libcaf_core/caf/flow/op/concat.hpp
+++ b/libcaf_core/caf/flow/op/concat.hpp
@@ -51,7 +51,9 @@ public:
       return;
     ++key_;
     using fwd_impl = forwarder<T, concat_sub, size_t>;
-    auto fwd = parent_->add_child(std::in_place_type<fwd_impl>, this, key_);
+    auto fwd = parent_->add_child(std::in_place_type<fwd_impl>,
+                                  intrusive_ptr<concat_sub>{this, add_ref},
+                                  key_);
     what.pimpl()->subscribe(fwd->as_observer());
   }
 

--- a/libcaf_core/caf/flow/op/from_generator.hpp
+++ b/libcaf_core/caf/flow/op/from_generator.hpp
@@ -82,7 +82,7 @@ private:
     if (!running_) {
       running_ = true;
       parent_->delay_fn(
-        [strong_this = intrusive_ptr<from_generator_sub>{this}] { //
+        [strong_this = intrusive_ptr<from_generator_sub>{this, add_ref}] { //
           strong_this->do_run();
         });
     }

--- a/libcaf_core/caf/flow/op/from_resource.hpp
+++ b/libcaf_core/caf/flow/op/from_resource.hpp
@@ -35,7 +35,7 @@ public:
 
   from_resource_sub(coordinator* parent, buffer_ptr buf,
                     observer<value_type> out)
-    : parent_(parent), buf_(buf), out_(std::move(out)) {
+    : parent_(parent, add_ref), buf_(buf), out_(std::move(out)) {
     parent_->ref_execution_context();
   }
 
@@ -189,7 +189,7 @@ private:
   }
 
   intrusive_ptr<from_resource_sub> strong_this() {
-    return {this};
+    return {this, add_ref};
   }
 
   /// Stores the @ref coordinator that runs this flow. Unlike other observables,

--- a/libcaf_core/caf/flow/op/from_steps.hpp
+++ b/libcaf_core/caf/flow/op/from_steps.hpp
@@ -219,7 +219,7 @@ private:
   }
 
   intrusive_ptr<from_steps_sub> strong_this() {
-    return {this};
+    return {this, add_ref};
   }
 
   coordinator* parent_;

--- a/libcaf_core/caf/flow/op/interval.cpp
+++ b/libcaf_core/caf/flow/op/interval.cpp
@@ -56,7 +56,7 @@ public:
       return;
     }
     pending_ = parent_->delay_until_fn(
-      timeout, [sptr = intrusive_ptr<interval_sub>{this}] { //
+      timeout, [sptr = intrusive_ptr<interval_sub>{this, add_ref}] { //
         sptr->fire();
       });
   }

--- a/libcaf_core/caf/flow/op/mcast.hpp
+++ b/libcaf_core/caf/flow/op/mcast.hpp
@@ -226,7 +226,7 @@ public:
 
   void on_disposed(state_type* ptr, bool from_external) final {
     super::parent_->delay_fn(
-      [mc = strong_this(), sptr = state_ptr_type{ptr}, from_external] {
+      [mc = strong_this(), sptr = state_ptr_type{ptr, add_ref}, from_external] {
         if (auto i = std::ranges::find(mc->states_, sptr);
             i != mc->states_.end()) {
           // We don't care about preserving the order of elements in the vector.
@@ -247,7 +247,7 @@ protected:
 
 private:
   intrusive_ptr<mcast> strong_this() {
-    return {this};
+    return {this, add_ref};
   }
 
   /// Called whenever a state is disposed.

--- a/libcaf_core/caf/flow/op/merge.hpp
+++ b/libcaf_core/caf/flow/op/merge.hpp
@@ -88,7 +88,8 @@ public:
     auto key = next_key_++;
     inputs_.emplace(key, merge_input<T>{});
     using fwd_impl = forwarder<T, merge_sub, size_t>;
-    auto fwd = parent_->add_child(std::in_place_type<fwd_impl>, this, key);
+    auto fwd = parent_->add_child(std::in_place_type<fwd_impl>,
+                                  intrusive_ptr<merge_sub>{this, add_ref}, key);
     what.pimpl()->subscribe(fwd->as_observer());
   }
 

--- a/libcaf_core/caf/flow/op/on_backpressure_buffer.hpp
+++ b/libcaf_core/caf/flow/op/on_backpressure_buffer.hpp
@@ -47,7 +47,7 @@ public:
       return;
     demand_ += new_demand;
     if (demand_ == new_demand && !buffer_.empty()) {
-      parent_->delay_fn([strong_this = intrusive_ptr{this}] { //
+      parent_->delay_fn([strong_this = intrusive_ptr{this, add_ref}] { //
         strong_this->on_request();
       });
     }

--- a/libcaf_core/caf/flow/op/on_error_resume_next.hpp
+++ b/libcaf_core/caf/flow/op/on_error_resume_next.hpp
@@ -89,7 +89,7 @@ public:
     sub_.release_later();
     if (fallback_ && predicate_(what)) {
       parent_->delay_fn(
-        [sptr = intrusive_ptr{this}, fallback = std::move(fallback_)] {
+        [sptr = intrusive_ptr{this, add_ref}, fallback = std::move(fallback_)] {
           sptr->do_resume_next(fallback);
         });
     } else {

--- a/libcaf_core/caf/flow/op/publish.hpp
+++ b/libcaf_core/caf/flow/op/publish.hpp
@@ -81,7 +81,7 @@ public:
     }
     if (!conn_ || conn_->disposed()) {
       in_.cancel(); // Make sure stale state is cleaned up.
-      auto sub = source_->subscribe(observer<T>{this});
+      auto sub = source_->subscribe(observer<T>{this, add_ref});
       conn_ = make_counted<detail::counted_disposable>(std::move(sub));
     }
     return conn_->acquire();

--- a/libcaf_core/caf/flow/op/retry.hpp
+++ b/libcaf_core/caf/flow/op/retry.hpp
@@ -86,7 +86,8 @@ public:
       return;
     sub_.release_later();
     if (predicate_(what)) {
-      parent_->delay_fn([sptr = intrusive_ptr{this}] { sptr->do_retry(); });
+      parent_->delay_fn(
+        [sptr = intrusive_ptr{this, add_ref}] { sptr->do_retry(); });
     } else {
       out_.on_error(what);
     }

--- a/libcaf_core/caf/flow/op/zip_with.hpp
+++ b/libcaf_core/caf/flow/op/zip_with.hpp
@@ -68,7 +68,9 @@ public:
       using index_type = decltype(index);
       using value_type = typename std::decay_t<decltype(input)>::value_type;
       using fwd_impl = forwarder<value_type, zip_with_sub, index_type>;
-      auto fwd = parent_->add_child(std::in_place_type<fwd_impl>, this, index);
+      auto fwd = parent_->add_child(std::in_place_type<fwd_impl>,
+                                    intrusive_ptr<zip_with_sub>{this, add_ref},
+                                    index);
       std::get<index_type::value>(srcs).subscribe(fwd->as_observer());
     });
   }

--- a/libcaf_core/caf/flow/scoped_coordinator.cpp
+++ b/libcaf_core/caf/flow/scoped_coordinator.cpp
@@ -11,7 +11,7 @@ namespace caf::flow {
 // -- factories ----------------------------------------------------------------
 
 intrusive_ptr<scoped_coordinator> scoped_coordinator::make() {
-  return {new scoped_coordinator, false};
+  return {new scoped_coordinator, adopt_ref};
 }
 
 // -- execution ----------------------------------------------------------------

--- a/libcaf_core/caf/flow/subscription.cpp
+++ b/libcaf_core/caf/flow/subscription.cpp
@@ -30,7 +30,7 @@ void subscription::impl_base::deref_coordinated() const noexcept {
 
 void subscription::impl_base::dispose() {
   if (!disposed()) {
-    parent()->delay_fn([sptr = intrusive_ptr<impl_base>{this}] { //
+    parent()->delay_fn([sptr = intrusive_ptr<impl_base>{this, add_ref}] { //
       sptr->do_dispose(true);
     });
   }

--- a/libcaf_core/caf/flow/subscription.hpp
+++ b/libcaf_core/caf/flow/subscription.hpp
@@ -102,7 +102,7 @@ public:
   class CAF_CORE_EXPORT fwd_impl final : public impl_base {
   public:
     fwd_impl(coordinator* parent, listener* src, coordinated* snk)
-      : parent_(parent), src_(src), snk_(snk) {
+      : parent_(parent), src_(src, add_ref), snk_(snk, add_ref) {
       // nop
     }
 
@@ -135,7 +135,7 @@ public:
     static subscription make_unsafe(coordinator* parent, listener* src,
                                     coordinated* snk) {
       intrusive_ptr<subscription::impl> ptr{new fwd_impl(parent, src, snk),
-                                            false};
+                                            adopt_ref};
       return subscription{std::move(ptr)};
     }
 
@@ -201,7 +201,7 @@ public:
     if (pimpl_) {
       // Defend against impl::cancel() indirectly calling member functions on
       // this object again.
-      auto ptr = intrusive_ptr<impl>{pimpl_.release(), false};
+      auto ptr = intrusive_ptr<impl>{pimpl_.release(), adopt_ref};
       auto* parent = ptr->parent();
       ptr->cancel();
       parent->release_later(ptr);

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -154,6 +154,8 @@ class stateful_actor;
 
 // -- structs ------------------------------------------------------------------
 
+struct add_ref_t;
+struct adopt_ref_t;
 struct down_msg;
 struct dynamically_typed;
 struct exit_msg;
@@ -191,6 +193,7 @@ enum class exit_reason : uint8_t;
 enum class invoke_message_result;
 enum class pec : uint8_t;
 enum class sec : uint8_t;
+enum class term;
 enum class thread_owner;
 
 // -- aliases ------------------------------------------------------------------

--- a/libcaf_core/caf/intrusive_cow_ptr.hpp
+++ b/libcaf_core/caf/intrusive_cow_ptr.hpp
@@ -77,8 +77,18 @@ public:
     // nop
   }
 
-  explicit intrusive_cow_ptr(pointer ptr, bool add_ref = true) noexcept
-    : ptr_(ptr, add_ref) {
+  [[deprecated("construct using add_ref or adopt_ref instead")]]
+  explicit intrusive_cow_ptr(pointer ptr,
+                             bool increase_ref_count = true) noexcept
+    : ptr_(ptr, increase_ref_count) {
+    // nop
+  }
+
+  intrusive_cow_ptr(pointer ptr, add_ref_t) noexcept : ptr_(ptr, add_ref) {
+    // nop
+  }
+
+  intrusive_cow_ptr(pointer ptr, adopt_ref_t) noexcept : ptr_(ptr, adopt_ref) {
     // nop
   }
 
@@ -121,9 +131,24 @@ public:
     ptr_.swap(other.ptr_);
   }
 
+  void reset() noexcept {
+    ptr_.reset();
+  }
+
   /// Replaces the managed object.
-  void reset(pointer p = nullptr, bool add_ref = true) noexcept {
-    ptr_.reset(p, add_ref);
+  [[deprecated("use 'reset(ptr, add_ref)' or 'reset(ptr, adopt_ref)' instead")]]
+  void reset(pointer ptr, bool inc_ref_count = true) noexcept {
+    ptr_.reset(ptr, inc_ref_count);
+  }
+
+  /// Replaces the managed object.
+  void reset(pointer ptr, add_ref_t) noexcept {
+    ptr_.reset(ptr, add_ref);
+  }
+
+  /// Replaces the managed object.
+  void reset(pointer ptr, adopt_ref_t) noexcept {
+    ptr_.reset(ptr, adopt_ref);
   }
 
   /// Returns the raw pointer without modifying reference

--- a/libcaf_core/caf/intrusive_ptr.test.cpp
+++ b/libcaf_core/caf/intrusive_ptr.test.cpp
@@ -6,6 +6,8 @@
 
 #include "caf/test/test.hpp"
 
+#include "caf/config.hpp"
+
 // this test doesn't verify thread-safety of intrusive_ptr
 // however, it is thread safe since it uses atomic operations only
 
@@ -14,6 +16,8 @@
 
 #include <cstddef>
 #include <vector>
+
+CAF_PUSH_DEPRECATED_WARNING
 
 using namespace caf;
 
@@ -69,20 +73,6 @@ public:
   }
 };
 
-class0ptr get_test_rc() {
-  return make_counted<class0>();
-}
-
-class0ptr get_test_ptr() {
-  return get_test_rc();
-}
-
-void check_class_instances() {
-  auto& this_test = test::runnable::current();
-  this_test.check_eq(class0_instances, 0);
-  this_test.check_eq(class1_instances, 0);
-}
-
 } // namespace
 
 TEST("make_counted") {
@@ -91,40 +81,57 @@ TEST("make_counted") {
     check_eq(class0_instances, 1);
     check(p->unique());
   }
-  check_class_instances();
+  check_eq(class0_instances, 0);
 }
 
 TEST("reset") {
-  {
-    class0ptr p;
-    p.reset(new class0, false);
-    check_eq(class0_instances, 1);
-    check(p->unique());
+  SECTION("no arguments") {
+    auto ptr = make_counted<class0>();
+    ptr.reset();
+    check_eq(class0_instances, 0);
+    check_eq(ptr.get(), nullptr);
   }
-  check_class_instances();
-}
-
-TEST("get_test_rc") {
-  {
-    class0ptr p1;
-    p1 = get_test_rc();
-    class0ptr p2 = p1;
+  SECTION("passing pointer and adopt_ref") {
+    class0ptr ptr;
+    ptr.reset(new class0, adopt_ref);
     check_eq(class0_instances, 1);
-    check_eq(p1->unique(), false);
+    check(ptr->unique());
   }
-  check_class_instances();
+  SECTION("passing pointer and false") {
+    class0ptr ptr;
+    ptr.reset(new class0, false);
+    check_eq(class0_instances, 1);
+    check(ptr->unique());
+  }
+  SECTION("passing pointer and add_ref") {
+    auto* raw_ptr = new class0;
+    class0ptr ptr;
+    ptr.reset(raw_ptr, add_ref);
+    check_eq(class0_instances, 1);
+    raw_ptr->deref();
+    check(ptr->unique());
+  }
+  SECTION("passing pointer and true") {
+    auto* raw_ptr = new class0;
+    class0ptr ptr;
+    ptr.reset(raw_ptr, true);
+    check_eq(class0_instances, 1);
+    raw_ptr->deref();
+    check(ptr->unique());
+  }
+  check_eq(class0_instances, 0);
 }
 
 TEST("list") {
   {
     std::vector<class0ptr> pl;
-    pl.push_back(get_test_ptr());
-    pl.push_back(get_test_rc());
+    pl.push_back(make_counted<class0>());
+    pl.push_back(make_counted<class0>());
     pl.push_back(pl.front()->create());
     check(pl.front()->unique());
     check_eq(class0_instances, 3);
   }
-  check_class_instances();
+  check_eq(class0_instances, 0);
 }
 
 TEST("full_test") {
@@ -134,7 +141,7 @@ TEST("full_test") {
     check_eq(p1->unique(), true);
     check_eq(class0_instances, 1);
     check_eq(class1_instances, 0);
-    p1.reset(new class1, false);
+    p1.reset(new class1, adopt_ref);
     check_eq(p1->is_subtype(), true);
     check_eq(p1->unique(), true);
     check_eq(class0_instances, 0);
@@ -146,5 +153,372 @@ TEST("full_test") {
     check_eq(class1_instances, 1);
     check_eq(p1, static_cast<class0*>(p2.get()));
   }
-  check_class_instances();
+  check_eq(class0_instances, 0);
+  check_eq(class1_instances, 0);
 }
+
+TEST("default and nullptr construction") {
+  SECTION("default constructor creates null pointer") {
+    class0ptr ptr;
+    check_eq(ptr.get(), nullptr);
+    check(!ptr);
+    check_eq(static_cast<bool>(ptr), false);
+  }
+  SECTION("nullptr_t constructor creates null pointer") {
+    class0ptr ptr{nullptr};
+    check_eq(ptr.get(), nullptr);
+    check(!ptr);
+  }
+  check_eq(class0_instances, 0);
+}
+
+TEST("construction with add_ref") {
+  auto* raw = new class0;
+  {
+    class0ptr ptr{raw, add_ref};
+    check_eq(class0_instances, 1);
+    check(!ptr->unique());
+  }
+  // ptr released one ref, but raw still holds its initial ref
+  raw->deref();
+  check_eq(class0_instances, 0);
+}
+
+TEST("construction with adopt_ref") {
+  {
+    class0ptr ptr{new class0, adopt_ref};
+    check_eq(class0_instances, 1);
+    check(ptr->unique());
+  }
+  check_eq(class0_instances, 0);
+}
+
+TEST("move constructor") {
+  {
+    auto p1 = make_counted<class0>();
+    check_eq(class0_instances, 1);
+    class0ptr p2{std::move(p1)};
+    check_eq(p1.get(), nullptr);
+    check_ne(p2.get(), nullptr);
+    check(p2->unique());
+    check_eq(class0_instances, 1);
+  }
+  check_eq(class0_instances, 0);
+}
+
+TEST("copy constructor") {
+  {
+    auto p1 = make_counted<class0>();
+    check(p1->unique());
+    class0ptr p2{p1};
+    check_eq(p1.get(), p2.get());
+    check(!p1->unique());
+    check(!p2->unique());
+    check_eq(class0_instances, 1);
+  }
+  check_eq(class0_instances, 0);
+}
+
+TEST("converting constructor from derived type") {
+  {
+    auto derived = make_counted<class1>();
+    check_eq(class1_instances, 1);
+    class0ptr base{std::move(derived)};
+    check_eq(derived.get(), nullptr);
+    check(base->is_subtype());
+    check(base->unique());
+    check_eq(class1_instances, 1);
+  }
+  check_eq(class1_instances, 0);
+}
+
+TEST("swap") {
+  {
+    auto p1 = make_counted<class0>();
+    auto p2 = make_counted<class0>();
+    auto* raw1 = p1.get();
+    auto* raw2 = p2.get();
+    check_eq(class0_instances, 2);
+    p1.swap(p2);
+    check_eq(p1.get(), raw2);
+    check_eq(p2.get(), raw1);
+    check(p1->unique());
+    check(p2->unique());
+  }
+  check_eq(class0_instances, 0);
+}
+
+TEST("detach") {
+  SECTION("from non-null pointer") {
+    auto ptr = make_counted<class0>();
+    auto* raw = ptr.get();
+    check_eq(class0_instances, 1);
+    auto* detached = ptr.detach();
+    check_eq(detached, raw);
+    check_eq(ptr.get(), nullptr);
+    check_eq(class0_instances, 1);
+    detached->deref();
+  }
+  SECTION("from null pointer") {
+    class0ptr ptr;
+    auto* detached = ptr.detach();
+    check_eq(detached, nullptr);
+  }
+  check_eq(class0_instances, 0);
+}
+
+TEST("release is alias for detach") {
+  {
+    auto ptr = make_counted<class0>();
+    auto* raw = ptr.get();
+    auto* released = ptr.release();
+    check_eq(released, raw);
+    check_eq(ptr.get(), nullptr);
+    released->deref();
+  }
+  check_eq(class0_instances, 0);
+}
+
+TEST("emplace") {
+  {
+    class0ptr ptr;
+    ptr.emplace();
+    check_ne(ptr.get(), nullptr);
+    check(ptr->unique());
+    check_eq(class0_instances, 1);
+    // emplace again replaces the object
+    auto* old_raw = ptr.get();
+    ptr.emplace();
+    check_ne(ptr.get(), old_raw);
+    check(ptr->unique());
+    check_eq(class0_instances, 1);
+  }
+  check_eq(class0_instances, 0);
+}
+
+TEST("assignment from nullptr") {
+  {
+    auto ptr = make_counted<class0>();
+    check_eq(class0_instances, 1);
+    ptr = nullptr;
+    check_eq(ptr.get(), nullptr);
+    check_eq(class0_instances, 0);
+  }
+}
+
+TEST("move assignment") {
+  {
+    auto p1 = make_counted<class0>();
+    auto p2 = make_counted<class0>();
+    auto* raw2 = p2.get();
+    check_eq(class0_instances, 2);
+    p1 = std::move(p2);
+    // p1's old object is released, p2's object is moved to p1
+    // p2 now holds p1's old object (swap semantics)
+    check_eq(p1.get(), raw2);
+    check_eq(class0_instances, 2);
+  }
+  check_eq(class0_instances, 0);
+}
+
+TEST("copy assignment") {
+  SECTION("from non-null to non-null") {
+    auto p1 = make_counted<class0>();
+    auto p2 = make_counted<class0>();
+    check_eq(class0_instances, 2);
+    p1 = p2;
+    check_eq(p1.get(), p2.get());
+    check(!p1->unique());
+    check_eq(class0_instances, 1);
+  }
+  SECTION("self-assignment") {
+    auto p1 = make_counted<class0>();
+    auto* raw = p1.get();
+    auto& p1_ref = p1;
+    p1 = p1_ref;
+    check_eq(p1.get(), raw);
+    check(p1->unique());
+    check_eq(class0_instances, 1);
+  }
+  check_eq(class0_instances, 0);
+}
+
+TEST("pointer access operators") {
+  auto ptr = make_counted<class0>();
+  SECTION("get returns raw pointer") {
+    check_ne(ptr.get(), nullptr);
+  }
+  SECTION("operator-> returns raw pointer") {
+    check_eq(ptr.operator->(), ptr.get());
+    check_eq(ptr->is_subtype(), false);
+  }
+  SECTION("operator* returns reference") {
+    check_eq(&(*ptr), ptr.get());
+  }
+}
+
+TEST("boolean conversion") {
+  SECTION("null pointer is false") {
+    class0ptr ptr;
+    check(!ptr);
+    check_eq(static_cast<bool>(ptr), false);
+    if (ptr) {
+      fail("null pointer should not convert to true");
+    }
+  }
+  SECTION("non-null pointer is true") {
+    auto ptr = make_counted<class0>();
+    check(!!ptr);
+    check_eq(static_cast<bool>(ptr), true);
+    if (!ptr) {
+      fail("non-null pointer should convert to true");
+    }
+  }
+}
+
+TEST("compare") {
+  auto p1 = make_counted<class0>();
+  auto p2 = make_counted<class0>();
+  SECTION("compare with raw pointer") {
+    check_eq(p1.compare(p1.get()), 0);
+    check_ne(p1.compare(p2.get()), 0);
+  }
+  SECTION("compare with intrusive_ptr") {
+    check_eq(p1.compare(p1), 0);
+    check_ne(p1.compare(p2), 0);
+  }
+  SECTION("compare with nullptr_t") {
+    class0ptr null_ptr;
+    check_eq(null_ptr.compare(nullptr), 0);
+    check_ne(p1.compare(nullptr), 0);
+  }
+}
+
+TEST("downcast") {
+  SECTION("successful downcast") {
+    class0ptr base = make_counted<class1>();
+    auto derived = base.downcast<class1>();
+    check_ne(derived.get(), nullptr);
+    check(!base->unique());
+    check(!derived->unique());
+    check_eq(class1_instances, 1);
+  }
+  SECTION("failed downcast") {
+    auto base = make_counted<class0>();
+    auto derived = base.downcast<class1>();
+    check_eq(derived.get(), nullptr);
+    check(base->unique());
+    check_eq(class0_instances, 1);
+  }
+  SECTION("downcast from null") {
+    class0ptr base;
+    auto derived = base.downcast<class1>();
+    check_eq(derived.get(), nullptr);
+  }
+  check_eq(class0_instances, 0);
+  check_eq(class1_instances, 0);
+}
+
+TEST("upcast") {
+  SECTION("lvalue upcast adds reference") {
+    auto derived = make_counted<class1>();
+    class0ptr base = derived.upcast<class0>();
+    check_ne(base.get(), nullptr);
+    check(!derived->unique());
+    check_eq(base.get(), derived.get());
+    check_eq(class1_instances, 1);
+  }
+  SECTION("rvalue upcast moves ownership") {
+    auto derived = make_counted<class1>();
+    auto* raw = derived.get();
+    class0ptr base = std::move(derived).upcast<class0>();
+    check_eq(derived.get(), nullptr);
+    check_eq(base.get(), raw);
+    check(base->unique());
+    check_eq(class1_instances, 1);
+  }
+  SECTION("upcast from null") {
+    class1ptr derived;
+    class0ptr base = derived.upcast<class0>();
+    check_eq(base.get(), nullptr);
+  }
+  check_eq(class1_instances, 0);
+}
+
+TEST("comparison operators with nullptr") {
+  class0ptr null_ptr;
+  auto valid_ptr = make_counted<class0>();
+  SECTION("operator== with nullptr") {
+    check(null_ptr == nullptr);
+    check(nullptr == null_ptr);
+    check(!(valid_ptr == nullptr));
+    check(!(nullptr == valid_ptr));
+  }
+  SECTION("operator!= with nullptr") {
+    check(!(null_ptr != nullptr));
+    check(!(nullptr != null_ptr));
+    check(valid_ptr != nullptr);
+    check(nullptr != valid_ptr);
+  }
+}
+
+TEST("comparison operators with raw pointer") {
+  auto p1 = make_counted<class0>();
+  auto p2 = make_counted<class0>();
+  SECTION("operator== with raw pointer") {
+    check(p1 == p1.get());
+    check(p1.get() == p1);
+    check(!(p1 == p2.get()));
+    check(!(p2.get() == p1));
+  }
+  SECTION("operator!= with raw pointer") {
+    check(!(p1 != p1.get()));
+    check(!(p1.get() != p1));
+    check(p1 != p2.get());
+    check(p2.get() != p1);
+  }
+}
+
+TEST("comparison operators between intrusive_ptrs") {
+  auto p1 = make_counted<class0>();
+  auto p2 = make_counted<class0>();
+  class0ptr p1_copy = p1;
+  SECTION("operator==") {
+    check(p1 == p1);
+    check(p1 == p1_copy);
+    check(!(p1 == p2));
+  }
+  SECTION("operator!=") {
+    check(!(p1 != p1));
+    check(!(p1 != p1_copy));
+    check(p1 != p2);
+  }
+  SECTION("operator< provides ordering") {
+    // Just verify it compiles and provides consistent ordering
+    auto less_result = p1 < p2;
+    auto greater_result = p2 < p1;
+    // exactly one should be true, or they're equal (which they're not)
+    check(less_result != greater_result);
+  }
+}
+
+TEST("comparison operators with derived type pointers") {
+  class0ptr base = make_counted<class0>();
+  class1ptr derived = make_counted<class1>();
+  // Should compile and compare correctly
+  check(base != derived);
+  check(!(base == derived));
+}
+
+TEST("to_string") {
+  auto ptr = make_counted<class0>();
+  auto str = to_string(ptr);
+  // Should be a hex representation of the pointer
+  check(!str.empty());
+  // Null pointer should also work
+  class0ptr null_ptr;
+  auto null_str = to_string(null_ptr);
+  check(!null_str.empty());
+}
+
+CAF_POP_WARNINGS

--- a/libcaf_core/caf/json_array.hpp
+++ b/libcaf_core/caf/json_array.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "caf/add_ref.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/detail/json.hpp"
 #include "caf/fwd.hpp"
@@ -50,7 +51,7 @@ public:
     const_iterator& operator=(const const_iterator&) = default;
 
     json_value value() const noexcept {
-      return json_value{std::addressof(*iter_), storage_};
+      return json_value{std::addressof(*iter_), {storage_, add_ref}};
     }
 
     json_value operator*() const noexcept {

--- a/libcaf_core/caf/json_object.hpp
+++ b/libcaf_core/caf/json_object.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "caf/add_ref.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/detail/json.hpp"
 #include "caf/fwd.hpp"
@@ -51,7 +52,7 @@ public:
     }
 
     json_value value() const noexcept {
-      return json_value{iter_->val, storage_};
+      return json_value{iter_->val, {storage_, add_ref}};
     }
 
     value_type operator*() const noexcept {

--- a/libcaf_core/caf/local_actor.cpp
+++ b/libcaf_core/caf/local_actor.cpp
@@ -92,7 +92,7 @@ disposable local_actor::request_response_timeout(timespan timeout,
     return {};
   auto t = clock().now() + timeout;
   return clock().schedule_message(
-    t, strong_actor_ptr{ctrl()},
+    t, strong_actor_ptr{ctrl(), add_ref},
     make_mailbox_element(nullptr, mid.response_id(),
                          make_error(sec::request_timeout)));
 }
@@ -155,7 +155,7 @@ void local_actor::do_delegate_error() {
   auto& mid = current_element_->mid;
   if (!sender || mid.is_response() || mid.is_answered())
     return;
-  sender->enqueue(make_mailbox_element(ctrl(), mid.response_id(),
+  sender->enqueue(make_mailbox_element({ctrl(), add_ref}, mid.response_id(),
                                        make_error(sec::invalid_delegate)),
                   context());
   mid.mark_as_answered();

--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -171,10 +171,10 @@ public:
   template <class Handle>
   void send_exit(const Handle& receiver, error reason) {
     if (receiver)
-      receiver->enqueue(make_mailbox_element(ctrl(), make_message_id(),
-                                             exit_msg{address(),
-                                                      std::move(reason)}),
-                        context());
+      receiver->enqueue(
+        make_mailbox_element({ctrl(), add_ref}, make_message_id(),
+                             exit_msg{address(), std::move(reason)}),
+        context());
   }
 
   template <message_priority Priority = message_priority::normal, class Handle,

--- a/libcaf_core/caf/log/event.cpp
+++ b/libcaf_core/caf/log/event.cpp
@@ -53,7 +53,7 @@ chunked_string deep_copy_impl(std::pmr::memory_resource* resource,
 
 event_ptr event::with_message(std::string_view msg, keep_timestamp_t) const {
   // Note: can't use make_counted here because the constructor is private.
-  auto copy = event_ptr{new event, false};
+  auto copy = event_ptr{new event, adopt_ref};
   auto* resource = &copy->resource_;
   copy->level_ = level_;
   copy->component_ = component_;

--- a/libcaf_core/caf/logger.cpp
+++ b/libcaf_core/caf/logger.cpp
@@ -697,11 +697,17 @@ logger* logger::current_logger() {
 }
 
 void logger::current_logger(actor_system* sys) {
-  current_logger_ptr.reset(sys != nullptr ? &sys->logger() : nullptr);
+  if (sys != nullptr)
+    current_logger_ptr.reset(&sys->logger(), add_ref);
+  else
+    current_logger_ptr.reset();
 }
 
 void logger::current_logger(logger* ptr) {
-  current_logger_ptr.reset(ptr);
+  if (ptr != nullptr)
+    current_logger_ptr.reset(ptr, add_ref);
+  else
+    current_logger_ptr.reset();
 }
 
 void logger::current_logger(std::nullptr_t) {

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -420,12 +420,11 @@ private:
           caf_logger_instance                                                  \
           && caf_logger_instance->accepts(::caf::log::level::debug,            \
                                           CAF_LOG_FLOW_COMPONENT)) {           \
-        caf_logger_instance->log(::caf::log::level::debug,                     \
-                                 CAF_LOG_FLOW_COMPONENT,                       \
-                                 "SEND ; TO = {}; FROM = {}; CONTENT = {}",    \
-                                 ::caf::strong_actor_ptr{this->ctrl()},        \
-                                 ptr->sender,                                  \
-                                 ::caf::deep_to_string(ptr->content()));       \
+        caf_logger_instance->log(                                              \
+          ::caf::log::level::debug, CAF_LOG_FLOW_COMPONENT,                    \
+          "SEND ; TO = {}; FROM = {}; CONTENT = {}",                           \
+          ::caf::strong_actor_ptr{this->ctrl(), ::caf::add_ref}, ptr->sender,  \
+          ::caf::deep_to_string(ptr->content()));                              \
       }                                                                        \
     } while (false)
 

--- a/libcaf_core/caf/make_actor.hpp
+++ b/libcaf_core/caf/make_actor.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "caf/adopt_ref.hpp"
 #include "caf/config.hpp"
 #include "caf/detail/aligned_alloc.hpp"
 #include "caf/detail/assert.hpp"
@@ -68,12 +69,12 @@ R make_actor(actor_id aid, node_id nid, actor_system* sys, Ts&&... xs) {
     lptr->log(log::level::debug, CAF_LOG_FLOW_COMPONENT,
               "SPAWN ; ID = {}; NAME = {}; TYPE = {}; ARGS = {}; NODE = {}",
               aid, obj->name(), detail::pretty_type_name(typeid(T)), args, nid);
-    return {ctrl, false};
+    return {ctrl, adopt_ref};
   }
 #endif
   CAF_PUSH_AID(aid);
   detail::make_actor_util::create_actor<T>(obj_mem, std::forward<Ts>(xs)...);
-  return {ctrl, false};
+  return {ctrl, adopt_ref};
 }
 
 } // namespace caf

--- a/libcaf_core/caf/make_copy_on_write.hpp
+++ b/libcaf_core/caf/make_copy_on_write.hpp
@@ -12,7 +12,7 @@ namespace caf {
 /// @relates intrusive_cow_ptr
 template <class T, class... Ts>
 intrusive_cow_ptr<T> make_copy_on_write(Ts&&... xs) {
-  return intrusive_cow_ptr<T>(new T(std::forward<Ts>(xs)...), false);
+  return intrusive_cow_ptr<T>{new T(std::forward<Ts>(xs)...), adopt_ref};
 }
 
 } // namespace caf

--- a/libcaf_core/caf/make_counted.hpp
+++ b/libcaf_core/caf/make_counted.hpp
@@ -14,9 +14,9 @@ namespace caf {
 
 /// Constructs an object of type `T` in an `intrusive_ptr`.
 /// @relates ref_counted
-template <class T, class... Ts>
-intrusive_ptr<T> make_counted(Ts&&... xs) {
-  return intrusive_ptr<T>(new T(std::forward<Ts>(xs)...), false);
+template <class T, class... Args>
+intrusive_ptr<T> make_counted(Args&&... args) {
+  return intrusive_ptr<T>{new T(std::forward<Args>(args)...), adopt_ref};
 }
 
 } // namespace caf

--- a/libcaf_core/caf/message.cpp
+++ b/libcaf_core/caf/message.cpp
@@ -78,7 +78,7 @@ bool load_data(Deserializer& source, message::data_ptr& data) {
     if (auto vptr = malloc(sizeof(detail::message_data) + data_size)) {
       // We don't need to worry about exceptions here: the message_data
       // constructor as well as `move_to_list` are `noexcept`.
-      ptr.reset(new (vptr) detail::message_data(ids.move_to_list()), false);
+      ptr.reset(new (vptr) detail::message_data(ids.move_to_list()), adopt_ref);
     } else {
       STOP(sec::runtime_error, "unable to allocate memory");
     }
@@ -95,7 +95,7 @@ bool load_data(Deserializer& source, message::data_ptr& data) {
         return false;
       pos += meta.padded_size;
     }
-    data.reset(ptr.release(), false);
+    data.reset(ptr.release(), adopt_ref);
     return source.end_tuple() && source.end_field() && source.end_object();
   }
   // For human-readable data formats, we serialize messages as a single list of
@@ -174,7 +174,7 @@ bool load_data(Deserializer& source, message::data_ptr& data) {
     if (auto vptr = malloc(sizeof(detail::message_data) + data_size)) {
       // We don't need to worry about exceptions here: the message_data
       // constructor as well as `move_to_list` are `noexcept`.
-      ptr.reset(new (vptr) detail::message_data(ids.move_to_list()), false);
+      ptr.reset(new (vptr) detail::message_data(ids.move_to_list()), adopt_ref);
     } else {
       STOP(sec::runtime_error, "unable to allocate memory");
     }
@@ -185,7 +185,7 @@ bool load_data(Deserializer& source, message::data_ptr& data) {
       ptr->inc_constructed_elements();
       pos += x.meta->padded_size;
     }
-    data.reset(ptr.release(), false);
+    data.reset(ptr.release(), adopt_ref);
     return true;
   } else {
     data.reset();

--- a/libcaf_core/caf/message_builder.cpp
+++ b/libcaf_core/caf/message_builder.cpp
@@ -31,7 +31,7 @@ message to_message_impl(size_t storage_size, TypeListBuilder& types,
     raw_ptr = new (vptr) message_data(types.move_to_list());
   else
     raw_ptr = new (vptr) message_data(types.copy_to_list());
-  intrusive_cow_ptr<message_data> ptr{raw_ptr, false};
+  intrusive_cow_ptr<message_data> ptr{raw_ptr, adopt_ref};
   auto storage = raw_ptr->storage();
   for (auto& element : elements) {
     if constexpr (Policy == move_msg) {

--- a/libcaf_core/caf/response_promise.cpp
+++ b/libcaf_core/caf/response_promise.cpp
@@ -40,7 +40,7 @@ response_promise::response_promise(local_actor* self, strong_actor_ptr source,
   // anonymous messages since there's nowhere to send the message to anyway.
   if (requires_response(mid)) {
     state_ = make_counted<state>();
-    state_->self = self->ctrl();
+    state_->self.reset(self->ctrl(), add_ref);
     state_->source.swap(source);
     state_->id = mid;
   }
@@ -106,7 +106,7 @@ void response_promise::respond_to(local_actor* self, mailbox_element* request,
   if (request && requires_response(*request)
       && has_response_receiver(*request)) {
     state tmp;
-    tmp.self = self->ctrl();
+    tmp.self.reset(self->ctrl(), add_ref);
     tmp.source.swap(request->sender);
     tmp.id = request->mid;
     tmp.deliver_impl(std::move(response));
@@ -119,7 +119,7 @@ void response_promise::respond_to(local_actor* self, mailbox_element* request,
   if (request && requires_response(*request)
       && has_response_receiver(*request)) {
     state tmp;
-    tmp.self = self->ctrl();
+    tmp.self.reset(self->ctrl(), add_ref);
     tmp.source.swap(request->sender);
     tmp.id = request->mid;
     tmp.deliver_impl(make_message(std::move(response)));

--- a/libcaf_core/caf/send.hpp
+++ b/libcaf_core/caf/send.hpp
@@ -6,6 +6,7 @@
 
 #include "caf/actor_addr.hpp"
 #include "caf/actor_cast.hpp"
+#include "caf/add_ref.hpp"
 #include "caf/fwd.hpp"
 #include "caf/mailbox_element.hpp"
 #include "caf/message_id.hpp"
@@ -23,7 +24,7 @@ template <message_priority Priority = message_priority::normal, class Source,
 void unsafe_send_as(Source* src, const Dest& receiver, T&& arg, Ts&&... args) {
   if (receiver)
     receiver->enqueue(
-      make_mailbox_element(src->ctrl(), make_message_id(Priority),
+      make_mailbox_element({src->ctrl(), add_ref}, make_message_id(Priority),
                            std::forward<T>(arg), std::forward<Ts>(args)...),
       nullptr);
 }

--- a/libcaf_core/caf/uri.cpp
+++ b/libcaf_core/caf/uri.cpp
@@ -83,7 +83,7 @@ void uri::impl_type::copy_members_from(const impl_type& other) {
   fragment = other.fragment;
 }
 
-uri::uri() : impl_(&default_instance) {
+uri::uri() : impl_(&default_instance, add_ref) {
   // nop
 }
 

--- a/libcaf_core/caf/uri.hpp
+++ b/libcaf_core/caf/uri.hpp
@@ -306,7 +306,7 @@ struct inspector_access<uri> : inspector_access_base<uri> {
     } else {
       if constexpr (Inspector::is_loading)
         if (!x.impl_->unique())
-          x.impl_.reset(new uri::impl_type, false);
+          x.impl_.reset(new uri::impl_type, adopt_ref);
       return inspect(f, *x.impl_);
     }
   }

--- a/libcaf_io/caf/io/abstract_broker.hpp
+++ b/libcaf_io/caf/io/abstract_broker.hpp
@@ -385,7 +385,7 @@ protected:
     auto i = elements.find(hdl);
     if (i == elements.end())
       return nullptr;
-    return std::addressof(*(i->second));
+    return i->second;
   }
 
 private:

--- a/libcaf_io/caf/io/basp_broker.cpp
+++ b/libcaf_io/caf/io/basp_broker.cpp
@@ -270,7 +270,7 @@ behavior basp_broker::make_behavior() {
       // deserialized and delivered.
       auto& q = instance.queue();
       auto msg_id = q.new_id();
-      q.push(context(), msg_id, ctrl(),
+      q.push(context(), msg_id, {ctrl(), add_ref},
              make_mailbox_element(nullptr, make_message_id(), delete_atom_v,
                                   msg.handle));
     },
@@ -284,7 +284,7 @@ behavior basp_broker::make_behavior() {
       // Same reasoning as in connection_closed_msg.
       auto& q = instance.queue();
       auto msg_id = q.new_id();
-      q.push(context(), msg_id, ctrl(),
+      q.push(context(), msg_id, {ctrl(), add_ref},
              make_mailbox_element(nullptr, make_message_id(), delete_atom_v,
                                   msg.handle));
     },
@@ -461,7 +461,7 @@ strong_actor_ptr basp_broker::make_proxy(node_id nid, actor_id aid) {
   auto res = make_actor<forwarding_actor_proxy, strong_actor_ptr>(aid, nid,
                                                                   &(system()),
                                                                   cfg, this);
-  strong_actor_ptr selfptr{ctrl()};
+  strong_actor_ptr selfptr{ctrl(), add_ref};
   res->get()->attach_functor([=](const error& rsn) {
     mm->backend().post([=] {
       // using res->id() instead of aid keeps this actor instance alive
@@ -723,7 +723,7 @@ scheduler* basp_broker::current_scheduler() {
 }
 
 strong_actor_ptr basp_broker::this_actor() {
-  return ctrl();
+  return {ctrl(), add_ref};
 }
 
 } // namespace caf::io

--- a/libcaf_io/caf/io/broker_servant.hpp
+++ b/libcaf_io/caf/io/broker_servant.hpp
@@ -76,7 +76,7 @@ protected:
 
   bool invoke_mailbox_element(scheduler* ctx) {
     // hold on to a strong reference while "messing" with the parent actor
-    strong_actor_ptr ptr_guard{this->parent()->ctrl()};
+    strong_actor_ptr ptr_guard{this->parent()->ctrl(), add_ref};
     auto prev = activity_tokens_;
     invoke_mailbox_element_impl(ctx, value_);
     // only consume an activity token if actor did not produce them now

--- a/libcaf_io/caf/io/network/acceptor.cpp
+++ b/libcaf_io/caf/io/network/acceptor.cpp
@@ -22,7 +22,7 @@ void acceptor::start(acceptor_manager* mgr) {
 
 void acceptor::activate(acceptor_manager* mgr) {
   if (!mgr_) {
-    mgr_.reset(mgr);
+    mgr_.reset(mgr, add_ref);
     event_handler::activate();
   }
 }

--- a/libcaf_io/caf/io/network/datagram_handler.cpp
+++ b/libcaf_io/caf/io/network/datagram_handler.cpp
@@ -47,7 +47,7 @@ void datagram_handler::start(datagram_manager* mgr) {
 
 void datagram_handler::activate(datagram_manager* mgr) {
   if (!reader_) {
-    reader_.reset(mgr);
+    reader_.reset(mgr, add_ref);
     event_handler::activate();
     prepare_next_read();
   }

--- a/libcaf_io/caf/io/network/datagram_servant_impl.cpp
+++ b/libcaf_io/caf/io/network/datagram_servant_impl.cpp
@@ -38,7 +38,7 @@ bool datagram_servant_impl::new_endpoint(network::receive_buffer& buf) {
   auto& dm = handler_.backend();
   auto hdl = datagram_handle::from_int(dm.next_endpoint_id());
   add_endpoint(handler_.sending_endpoint(), hdl);
-  parent()->add_hdl_for_datagram_servant(this, hdl);
+  parent()->add_hdl_for_datagram_servant({this, add_ref}, hdl);
   return consume(&dm, hdl, buf);
 }
 
@@ -69,7 +69,7 @@ void datagram_servant_impl::graceful_shutdown() {
 
 void datagram_servant_impl::flush() {
   auto lg = log::io::trace("");
-  handler_.flush(this);
+  handler_.flush({this, add_ref});
 }
 
 std::string datagram_servant_impl::addr(datagram_handle hdl) const {
@@ -101,7 +101,7 @@ std::vector<datagram_handle> datagram_servant_impl::hdls() const {
 
 void datagram_servant_impl::add_endpoint(const ip_endpoint& ep,
                                          datagram_handle hdl) {
-  handler_.add_endpoint(hdl, ep, this);
+  handler_.add_endpoint(hdl, ep, {this, add_ref});
 }
 
 void datagram_servant_impl::remove_endpoint(datagram_handle hdl) {

--- a/libcaf_io/caf/io/network/default_multiplexer.cpp
+++ b/libcaf_io/caf/io/network/default_multiplexer.cpp
@@ -635,7 +635,7 @@ void default_multiplexer::schedule(resumable* ptr, uint64_t) {
   if (std::this_thread::get_id() != thread_id()) {
     wr_dispatch_request(ptr);
   } else {
-    internally_posted_.emplace_back(ptr, false);
+    internally_posted_.emplace_back(ptr, adopt_ref);
   }
 }
 

--- a/libcaf_io/caf/io/network/manager.cpp
+++ b/libcaf_io/caf/io/network/manager.cpp
@@ -19,7 +19,10 @@ manager::~manager() {
 }
 
 void manager::set_parent(abstract_broker* ptr) {
-  parent_ = ptr != nullptr ? ptr->ctrl() : nullptr;
+  if (ptr != nullptr)
+    parent_.reset(ptr->ctrl(), add_ref);
+  else
+    parent_.reset();
 }
 
 abstract_broker* manager::parent() {

--- a/libcaf_io/caf/io/network/pipe_reader.cpp
+++ b/libcaf_io/caf/io/network/pipe_reader.cpp
@@ -51,7 +51,7 @@ void pipe_reader::handle_event(operation op) {
   if (op == operation::read) {
     auto ptr = try_read_next();
     if (ptr != nullptr)
-      backend().resume({ptr, false});
+      backend().resume({ptr, adopt_ref});
   }
   // else: ignore errors
 }

--- a/libcaf_io/caf/io/network/scribe_impl.cpp
+++ b/libcaf_io/caf/io/network/scribe_impl.cpp
@@ -48,7 +48,7 @@ void scribe_impl::graceful_shutdown() {
 
 void scribe_impl::flush() {
   auto lg = log::io::trace("");
-  stream_.flush(this);
+  stream_.flush({this, add_ref});
 }
 
 std::string scribe_impl::addr() const {

--- a/libcaf_io/caf/io/network/stream.cpp
+++ b/libcaf_io/caf/io/network/stream.cpp
@@ -35,7 +35,7 @@ void stream::start(stream_manager* mgr) {
 
 void stream::activate(stream_manager* mgr) {
   if (!reader_) {
-    reader_.reset(mgr);
+    reader_.reset(mgr, add_ref);
     event_handler::activate();
     prepare_next_read();
   }

--- a/libcaf_net/caf/internal/accept_handler.cpp
+++ b/libcaf_net/caf/internal/accept_handler.cpp
@@ -44,7 +44,7 @@ public:
     self_ref_ = owner->as_disposable();
     if (!monitored_actors_.empty()) {
       monitor_callback_ = make_action([this] { owner_->shutdown(); });
-      auto ctx = async::execution_context_ptr{owner_->mpx_ptr()};
+      auto ctx = async::execution_context_ptr{owner_->mpx_ptr(), add_ref};
       for (auto& hdl : monitored_actors_) {
         CAF_ASSERT(hdl);
         hdl->get()->attach_functor([ctx, cb = monitor_callback_] {

--- a/libcaf_net/caf/internal/flow_bridge_base.hpp
+++ b/libcaf_net/caf/internal/flow_bridge_base.hpp
@@ -49,7 +49,9 @@ public:
       if (running())
         prepare_send();
     });
-    in_ = consumer_type::make(pull.try_open(), mpx, std::move(do_wakeup));
+    in_ = consumer_type::make(pull.try_open(),
+                              async::execution_context_ptr{mpx, add_ref},
+                              std::move(do_wakeup));
     if (!in_) {
       auto err = make_error(sec::runtime_error,
                             "flow bridge failed to open the input resource");
@@ -63,8 +65,9 @@ public:
         down_->shutdown();
       }
     });
-    out_ = producer_type::make(push.try_open(), mpx, std::move(do_resume),
-                               std::move(do_cancel));
+    out_ = producer_type::make(push.try_open(),
+                               async::execution_context_ptr{mpx, add_ref},
+                               std::move(do_resume), std::move(do_cancel));
     if (!out_) {
       auto err = make_error(sec::runtime_error,
                             "flow bridge failed to open the output resource");

--- a/libcaf_net/caf/net/abstract_actor_shell.cpp
+++ b/libcaf_net/caf/net/abstract_actor_shell.cpp
@@ -21,7 +21,7 @@ namespace caf::net {
 
 abstract_actor_shell::abstract_actor_shell(actor_config& cfg,
                                            socket_manager* owner)
-  : super(cfg), manager_(owner) {
+  : super(cfg), manager_(owner, add_ref) {
   mailbox_.try_block();
   resume_ = make_action([this] {
     for (;;) {

--- a/libcaf_net/caf/net/http/with.cpp
+++ b/libcaf_net/caf/net/http/with.cpp
@@ -168,7 +168,8 @@ public:
   template <class Acceptor>
   expected<disposable> do_start_server(Acceptor& acc) {
     if (push) {
-      auto producer = make_http_request_producer(mpx, push.try_open());
+      auto producer = make_http_request_producer({mpx, add_ref},
+                                                 push.try_open());
       auto new_route = make_route([producer](responder& res) {
         if (!producer->push(responder{res}.to_request())) {
           auto err = make_error(sec::runtime_error, "flow disconnected");

--- a/libcaf_net/caf/net/socket_manager.cpp
+++ b/libcaf_net/caf/net/socket_manager.cpp
@@ -307,7 +307,7 @@ private:
   }
 
   intrusive_ptr<socket_manager_impl> strong_this() {
-    return intrusive_ptr<socket_manager_impl>{this};
+    return intrusive_ptr<socket_manager_impl>{this, add_ref};
   }
 
   // -- member variables -------------------------------------------------------

--- a/libcaf_net/caf/net/web_socket/frame.hpp
+++ b/libcaf_net/caf/net/web_socket/frame.hpp
@@ -33,22 +33,22 @@ public:
   }
 
   explicit frame(const_byte_span buffer)
-    : data_(chunk::data::make(buffer), false) {
+    : data_(chunk::data::make(buffer), adopt_ref) {
     // nop
   }
 
   explicit frame(std::span<const const_byte_span> buffers)
-    : data_(chunk::data::make(buffers), false) {
+    : data_(chunk::data::make(buffers), adopt_ref) {
     // nop
   }
 
   explicit frame(std::string_view text)
-    : data_(chunk::data::make(text), false) {
+    : data_(chunk::data::make(text), adopt_ref) {
     // nop
   }
 
   explicit frame(std::span<const std::string_view> texts)
-    : data_(chunk::data::make(texts), false) {
+    : data_(chunk::data::make(texts), adopt_ref) {
     // nop
   }
 

--- a/libcaf_openssl/caf/openssl/middleman_actor.cpp
+++ b/libcaf_openssl/caf/openssl/middleman_actor.cpp
@@ -152,7 +152,7 @@ public:
 
   void flush() override {
     auto lg = log::openssl::trace("");
-    stream_.flush(this);
+    stream_.flush({this, add_ref});
   }
 
   std::string addr() const override {
@@ -177,7 +177,7 @@ public:
     // This schedules the scribe in case SSL still needs to call SSL_connect
     // or SSL_accept. Otherwise, the backend simply removes the socket for
     // write operations after the first "nop write".
-    stream_.force_empty_write(this);
+    stream_.force_empty_write({this, add_ref});
   }
 
   void add_to_loop() override {

--- a/libcaf_test/caf/test/fixture/deterministic.hpp
+++ b/libcaf_test/caf/test/fixture/deterministic.hpp
@@ -40,7 +40,7 @@ private:
   /// Wraps a resumable pointer and a mailbox element pointer.
   struct scheduling_event {
     scheduling_event(resumable* target, mailbox_element_ptr payload)
-      : target(target), item(std::move(payload)) {
+      : target(target, add_ref), item(std::move(payload)) {
       // nop
     }
 


### PR DESCRIPTION
Using explicit `add_ref` and `adopt_ref` tags for the `intrusive_ptr` API makes client code more readable and expressive and also avoids unnecessary run-time checks.