### PR TITLE
Move SpawnServ and ConfigServ to the I/O module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Removed the deprecated `actor_ostream` class and the `aout` utility. They have
   been deprecated since CAF 1.0.0. Users should now use `println` instead, which
   is available on actors as well as on the `actor_system`.
+- The getters `spawn_serv` and `config_serv` have been removed from the public
+  interface of `actor_system`. These actors are an implementation detail of the
+  I/O module and should not be accessed directly by users.
 
 ## [1.1.0] - 2025-07-25
 

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -303,13 +303,6 @@ public:
   /// in its destructor before shutting down.
   void await_actors_before_shutdown(bool new_value);
 
-  /// Returns the internal actor for dynamic spawn operations.
-  const strong_actor_ptr& spawn_serv() const;
-
-  /// Returns the internal actor for storing the runtime configuration
-  /// for this actor system.
-  const strong_actor_ptr& config_serv() const;
-
   /// Returns the metrics registry for this system.
   telemetry::metric_registry& metrics() noexcept;
 


### PR DESCRIPTION
These two actors are not used outside of the I/O module and thus should not be spawned when not loading the I/O module. Further, they should they have getters in the public API.