### PR TITLE
Prevent type ID collisions in test files

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -39,3 +39,10 @@ jobs:
       - name: forbidden-includes
         run: |
           find libcaf_* -name '*hpp' -type f | grep -v 'caf/internal/' | xargs python3 scripts/forbidden-includes-check.py
+
+  type-id-block-offsets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: type-id-block-offsets
+        run: python3 scripts/get-next-free-block-offset.py 1>/dev/null && echo OK

--- a/libcaf_core/caf/async/blocking_producer.test.cpp
+++ b/libcaf_core/caf/async/blocking_producer.test.cpp
@@ -17,7 +17,8 @@
 #include <thread>
 
 // Some offset to avoid collisions with other type IDs.
-CAF_BEGIN_TYPE_ID_BLOCK(blocking_producer_test, caf::first_custom_type_id + 15)
+CAF_BEGIN_TYPE_ID_BLOCK(blocking_producer_test, caf::first_custom_type_id + 170,
+                        10)
   CAF_ADD_TYPE_ID(blocking_producer_test, (caf::cow_vector<int>) )
 CAF_END_TYPE_ID_BLOCK(blocking_producer_test)
 

--- a/libcaf_core/caf/async/producer_adapter.test.cpp
+++ b/libcaf_core/caf/async/producer_adapter.test.cpp
@@ -18,8 +18,11 @@
 #include <mutex>
 
 // Some offset to avoid collisions with other type IDs.
-CAF_BEGIN_TYPE_ID_BLOCK(producer_adapter_test, caf::first_custom_type_id + 10)
+CAF_BEGIN_TYPE_ID_BLOCK(producer_adapter_test, caf::first_custom_type_id + 180,
+                        10)
+
   CAF_ADD_TYPE_ID(producer_adapter_test, (caf::cow_vector<int>) )
+
 CAF_END_TYPE_ID_BLOCK(producer_adapter_test)
 
 using namespace caf;

--- a/libcaf_core/caf/config_value.test.cpp
+++ b/libcaf_core/caf/config_value.test.cpp
@@ -43,7 +43,7 @@ struct dummy_tag_type;
 
 } // namespace
 
-CAF_BEGIN_TYPE_ID_BLOCK(config_value_test, caf::first_custom_type_id + 75)
+CAF_BEGIN_TYPE_ID_BLOCK(config_value_test, caf::first_custom_type_id, 10)
 
   CAF_ADD_TYPE_ID(config_value_test, (my_request))
   CAF_ADD_TYPE_ID(config_value_test, (dummy_tag_type))

--- a/libcaf_core/caf/detail/meta_object.test.cpp
+++ b/libcaf_core/caf/detail/meta_object.test.cpp
@@ -23,8 +23,7 @@ struct i64_wrapper;
 
 } // namespace
 
-// +5 to avoid clash with caf.message_builder test
-CAF_BEGIN_TYPE_ID_BLOCK(meta_object_test, caf::first_custom_type_id + 5)
+CAF_BEGIN_TYPE_ID_BLOCK(meta_object_test, caf::first_custom_type_id + 190, 10)
   CAF_ADD_TYPE_ID(meta_object_test, (i32_wrapper))
   CAF_ADD_TYPE_ID(meta_object_test, (i64_wrapper))
 CAF_END_TYPE_ID_BLOCK(meta_object_test)

--- a/libcaf_core/caf/detail/stringification_inspector.test.cpp
+++ b/libcaf_core/caf/detail/stringification_inspector.test.cpp
@@ -100,7 +100,8 @@ auto do_render(const Args&... args) {
 
 } // namespace
 
-CAF_BEGIN_TYPE_ID_BLOCK(stringification_test, first_custom_type_id + 160)
+CAF_BEGIN_TYPE_ID_BLOCK(stringification_test, caf::first_custom_type_id + 200,
+                        10)
 
   CAF_ADD_TYPE_ID(stringification_test, (point2d))
   CAF_ADD_TYPE_ID(stringification_test, (rectangle))

--- a/libcaf_core/caf/dynamic_spawn.test.cpp
+++ b/libcaf_core/caf/dynamic_spawn.test.cpp
@@ -20,7 +20,7 @@
 #include <iostream>
 #include <stack>
 
-CAF_BEGIN_TYPE_ID_BLOCK(dynamic_spawn_test, caf::first_custom_type_id + 105)
+CAF_BEGIN_TYPE_ID_BLOCK(dynamic_spawn_test, caf::first_custom_type_id + 20, 10)
 
   CAF_ADD_ATOM(dynamic_spawn_test, abc_atom)
   CAF_ADD_ATOM(dynamic_spawn_test, name_atom)

--- a/libcaf_core/caf/json_builder.test.cpp
+++ b/libcaf_core/caf/json_builder.test.cpp
@@ -20,14 +20,16 @@ using namespace std::literals;
 
 namespace {
 
+struct circle;
 struct my_request;
 struct rectangle;
 struct point;
 
 } // namespace
 
-CAF_BEGIN_TYPE_ID_BLOCK(json_builder_test, caf::first_custom_type_id + 85)
+CAF_BEGIN_TYPE_ID_BLOCK(json_builder_test, caf::first_custom_type_id + 30, 10)
 
+  CAF_ADD_TYPE_ID(json_builder_test, (circle))
   CAF_ADD_TYPE_ID(json_builder_test, (my_request))
   CAF_ADD_TYPE_ID(json_builder_test, (rectangle))
   CAF_ADD_TYPE_ID(json_builder_test, (point))
@@ -58,6 +60,17 @@ struct point {
 template <class Inspector>
 bool inspect(Inspector& f, point& x) {
   return f.object(x).fields(f.field("x", x.x), f.field("y", x.y));
+}
+
+struct circle {
+  point center;
+  int32_t radius;
+};
+
+template <class Inspector>
+bool inspect(Inspector& f, circle& x) {
+  return f.object(x).fields(f.field("center", x.center),
+                            f.field("radius", x.radius));
 }
 
 struct rectangle {
@@ -288,7 +301,7 @@ TEST("begin field") {
   check(builder.begin_object(1, "circle"));
   SECTION("is present") {
     SECTION("missing index") {
-      auto circle_type = std::vector<uint16_t>{295};
+      auto circle_type = std::vector<uint16_t>{type_id_v<circle>};
       check(!builder.begin_field("foo", true, std::span{circle_type}, 1));
     }
     SECTION("missing query type") {
@@ -296,7 +309,7 @@ TEST("begin field") {
       check(!builder.begin_field("foo", true, std::span{circle_type}, 0));
     }
     SECTION("present query type") {
-      auto circle_type = std::vector<uint16_t>{295};
+      auto circle_type = std::vector<uint16_t>{type_id_v<circle>};
       check(builder.begin_field("foo", true, std::span{circle_type}, 0));
       check(builder.value(42));
       check(builder.end_field());
@@ -307,7 +320,7 @@ TEST("begin field") {
     }
   }
   SECTION("is not present") {
-    auto circle_type = std::vector<uint16_t>{295};
+    auto circle_type = std::vector<uint16_t>{type_id_v<circle>};
     SECTION("don't skip empty fields") {
       builder.skip_empty_fields(false);
       check(builder.begin_field("foo", false, std::span{circle_type}, 0));
@@ -332,7 +345,7 @@ TEST("begin field") {
 
 TEST("begin associative array") {
   SECTION("valid associative array") {
-    auto circle_type = std::vector<uint16_t>{295};
+    auto circle_type = std::vector<uint16_t>{type_id_v<circle>};
     check(builder.begin_tuple(1));
     check(builder.begin_associative_array(1));
     builder.skip_empty_fields(false);
@@ -351,7 +364,7 @@ TEST("begin associative array") {
 TEST("begin sequence") {
   SECTION("valid array") {
     builder.skip_empty_fields(false);
-    auto circle_type = std::vector<uint16_t>{295};
+    auto circle_type = std::vector<uint16_t>{type_id_v<circle>};
     check(builder.begin_sequence(1));
     check(builder.begin_sequence(1));
     check(!builder.begin_field("foo", false, std::span{circle_type}, 0));
@@ -369,7 +382,7 @@ TEST("begin sequence") {
 }
 
 TEST("unexpected object") {
-  auto circle_type = std::vector<uint16_t>{295};
+  auto circle_type = std::vector<uint16_t>{type_id_v<circle>};
   check(!builder.begin_field("foo", false, std::span{circle_type}, 0));
 }
 

--- a/libcaf_core/caf/json_reader.test.cpp
+++ b/libcaf_core/caf/json_reader.test.cpp
@@ -32,7 +32,7 @@ struct widget;
 
 } // namespace
 
-CAF_BEGIN_TYPE_ID_BLOCK(json_reader_test, caf::first_custom_type_id + 95)
+CAF_BEGIN_TYPE_ID_BLOCK(json_reader_test, caf::first_custom_type_id + 40, 10)
 
   CAF_ADD_TYPE_ID(json_reader_test, (circle))
   CAF_ADD_TYPE_ID(json_reader_test, (dummy_struct))

--- a/libcaf_core/caf/json_writer.test.cpp
+++ b/libcaf_core/caf/json_writer.test.cpp
@@ -27,7 +27,7 @@ struct widget;
 
 } // namespace
 
-CAF_BEGIN_TYPE_ID_BLOCK(json_write_test, caf::first_custom_type_id + 60)
+CAF_BEGIN_TYPE_ID_BLOCK(json_write_test, caf::first_custom_type_id + 50, 10)
 
   CAF_ADD_TYPE_ID(json_write_test, (circle))
   CAF_ADD_TYPE_ID(json_write_test, (dummy_struct))

--- a/libcaf_core/caf/message.test.cpp
+++ b/libcaf_core/caf/message.test.cpp
@@ -34,7 +34,7 @@ struct s3;
 
 } // namespace
 
-CAF_BEGIN_TYPE_ID_BLOCK(message_test, caf::first_custom_type_id + 50)
+CAF_BEGIN_TYPE_ID_BLOCK(message_test, caf::first_custom_type_id + 80, 10)
 
   CAF_ADD_TYPE_ID(message_test, (s1))
   CAF_ADD_TYPE_ID(message_test, (s2))

--- a/libcaf_core/caf/message_builder.test.cpp
+++ b/libcaf_core/caf/message_builder.test.cpp
@@ -56,7 +56,8 @@ bool inspect(Inspector& f, counted_int_ptr& x) {
   }
 }
 
-CAF_BEGIN_TYPE_ID_BLOCK(message_builder_test, caf::first_custom_type_id)
+CAF_BEGIN_TYPE_ID_BLOCK(message_builder_test, caf::first_custom_type_id + 60,
+                        10)
 
   CAF_ADD_TYPE_ID(message_builder_test, (counted_int))
   CAF_ADD_TYPE_ID(message_builder_test, (counted_int_ptr))

--- a/libcaf_core/caf/message_lifetime.test.cpp
+++ b/libcaf_core/caf/message_lifetime.test.cpp
@@ -41,7 +41,8 @@ struct fail_on_copy {
   }
 };
 
-CAF_BEGIN_TYPE_ID_BLOCK(message_lifetime_test, caf::first_custom_type_id + 70)
+CAF_BEGIN_TYPE_ID_BLOCK(message_lifetime_test, caf::first_custom_type_id + 70,
+                        10)
 
   CAF_ADD_TYPE_ID(message_lifetime_test, (fail_on_copy))
 

--- a/libcaf_core/caf/serial_reply.test.cpp
+++ b/libcaf_core/caf/serial_reply.test.cpp
@@ -12,7 +12,7 @@
 
 using namespace caf;
 
-CAF_BEGIN_TYPE_ID_BLOCK(serial_reply_test, caf::first_custom_type_id + 30)
+CAF_BEGIN_TYPE_ID_BLOCK(serial_reply_test, caf::first_custom_type_id + 90, 10)
 
   CAF_ADD_ATOM(serial_reply_test, sub0_atom)
   CAF_ADD_ATOM(serial_reply_test, sub1_atom)

--- a/libcaf_core/caf/serialization.test.cpp
+++ b/libcaf_core/caf/serialization.test.cpp
@@ -32,7 +32,7 @@ struct c_array;
 
 } // namespace
 
-CAF_BEGIN_TYPE_ID_BLOCK(serialization_test, caf::first_custom_type_id + 25)
+CAF_BEGIN_TYPE_ID_BLOCK(serialization_test, caf::first_custom_type_id + 100, 10)
 
   CAF_ADD_TYPE_ID(serialization_test, (nasty))
   CAF_ADD_TYPE_ID(serialization_test, (weekday))

--- a/libcaf_core/caf/settings.test.cpp
+++ b/libcaf_core/caf/settings.test.cpp
@@ -90,7 +90,7 @@ bool inspect(Inspector& f, dummy_struct& x) {
 
 } // namespace
 
-CAF_BEGIN_TYPE_ID_BLOCK(settings_test, caf::first_custom_type_id + 40)
+CAF_BEGIN_TYPE_ID_BLOCK(settings_test, caf::first_custom_type_id + 110, 10)
 
   CAF_ADD_TYPE_ID(settings_test, (dummy_struct))
 

--- a/libcaf_core/caf/type_id_list.test.cpp
+++ b/libcaf_core/caf/type_id_list.test.cpp
@@ -39,7 +39,7 @@ bool inspect(Inspector& f, protocol& x) {
 // https://github.com/actor-framework/actor-framework/issues/1195. We don't need
 // to actually use these types, only check whether the code compiles.
 
-CAF_BEGIN_TYPE_ID_BLOCK(type_id_test, caf::first_custom_type_id + 20)
+CAF_BEGIN_TYPE_ID_BLOCK(type_id_test, caf::first_custom_type_id + 120, 10)
 
   CAF_ADD_TYPE_ID(type_id_test, (detail::my_secret))
   CAF_ADD_TYPE_ID(type_id_test, (io::protocol))

--- a/libcaf_core/caf/typed_actor.test.cpp
+++ b/libcaf_core/caf/typed_actor.test.cpp
@@ -229,7 +229,7 @@ using a1970 = typed_actor<t1970>;
 
 } // namespace
 
-CAF_BEGIN_TYPE_ID_BLOCK(typed_actor_test, caf::first_custom_type_id + 130)
+CAF_BEGIN_TYPE_ID_BLOCK(typed_actor_test, caf::first_custom_type_id + 130, 20)
 
   CAF_ADD_TYPE_ID(typed_actor_test, (s01))
   CAF_ADD_TYPE_ID(typed_actor_test, (s02))

--- a/libcaf_core/caf/typed_event_based_actor.test.cpp
+++ b/libcaf_core/caf/typed_event_based_actor.test.cpp
@@ -59,7 +59,7 @@ using server_actor = caf::typed_actor<server_trait>;
 #define ADD_TYPE_ID(type) CAF_ADD_TYPE_ID(typed_event_based_actor_test, type)
 
 CAF_BEGIN_TYPE_ID_BLOCK(typed_event_based_actor_test,
-                        caf::first_custom_type_id + 110)
+                        caf::first_custom_type_id + 220, 10)
   ADD_TYPE_ID((my_request))
   ADD_TYPE_ID((int_actor))
   ADD_TYPE_ID((float_actor))

--- a/libcaf_core/caf/typed_spawn.test.cpp
+++ b/libcaf_core/caf/typed_spawn.test.cpp
@@ -35,7 +35,7 @@ using float_actor = caf::typed_actor<caf::result<void>(float)>;
 
 } // namespace
 
-CAF_BEGIN_TYPE_ID_BLOCK(typed_spawn_test, caf::first_custom_type_id + 120)
+CAF_BEGIN_TYPE_ID_BLOCK(typed_spawn_test, caf::first_custom_type_id + 150, 10)
 
   CAF_ADD_TYPE_ID(typed_spawn_test, (my_request))
   CAF_ADD_TYPE_ID(typed_spawn_test, (int_actor))

--- a/libcaf_core/caf/typed_stream.test.cpp
+++ b/libcaf_core/caf/typed_stream.test.cpp
@@ -15,7 +15,7 @@
 using namespace caf;
 using namespace std::literals;
 
-CAF_BEGIN_TYPE_ID_BLOCK(typed_stream_test, caf::first_custom_type_id + 115)
+CAF_BEGIN_TYPE_ID_BLOCK(typed_stream_test, caf::first_custom_type_id + 160, 10)
 
   CAF_ADD_TYPE_ID(typed_stream_test, (caf::typed_stream<int32_t>) )
 

--- a/libcaf_net/caf/net/typed_actor_shell.test.cpp
+++ b/libcaf_net/caf/net/typed_actor_shell.test.cpp
@@ -41,7 +41,8 @@ using testee_actor = typed_actor<testee_trait>;
 
 } // namespace
 
-CAF_BEGIN_TYPE_ID_BLOCK(typed_actor_shell_test, caf::first_custom_type_id + 10)
+CAF_BEGIN_TYPE_ID_BLOCK(typed_actor_shell_test, caf::first_custom_type_id + 210,
+                        10)
   CAF_ADD_TYPE_ID(typed_actor_shell_test, (testee_actor))
 CAF_END_TYPE_ID_BLOCK(typed_actor_shell_test)
 

--- a/libcaf_test/caf/test/fixture/deterministic.test.cpp
+++ b/libcaf_test/caf/test/fixture/deterministic.test.cpp
@@ -42,7 +42,8 @@ bool operator==(my_int lhs, int rhs) noexcept {
 
 } // namespace
 
-CAF_BEGIN_TYPE_ID_BLOCK(deterministic_fixture_test, caf::first_custom_type_id)
+CAF_BEGIN_TYPE_ID_BLOCK(deterministic_fixture_test,
+                        caf::first_custom_type_id + 230, 10)
 
   CAF_ADD_TYPE_ID(deterministic_fixture_test, (my_int))
 

--- a/scripts/get-next-free-block-offset.py
+++ b/scripts/get-next-free-block-offset.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python
+# get-next-free-block-offset.py
+#
+# Scans *.test.cpp files recursively for CAF_BEGIN_TYPE_ID_BLOCK(...) entries,
+# validates and extracts (OFFSET, SIZE), checks for overlaps, and prints the
+# next free offset (max(OFFSET + SIZE)) on success.
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+
+MACRO_NAME = "CAF_BEGIN_TYPE_ID_BLOCK"
+
+# Second-parameter format:
+#   caf::first_custom_type_id
+#   caf::first_custom_type_id + 123
+SECOND_PARAM_RE = re.compile(
+    r"^\s*caf::first_custom_type_id\s*(?:\+\s*(\d+)\s*)?$"
+)
+
+# Third parameter (SIZE) must be a plain integer (allow whitespace).
+SIZE_RE = re.compile(r"^\s*(\d+)\s*$")
+
+
+@dataclass(frozen=True)
+class Block:
+    filename: str
+    line: int
+    offset: int
+    size: int
+
+    @property
+    def start(self) -> int:
+        return self.offset
+
+    @property
+    def end(self) -> int:
+        return self.offset + self.size
+
+
+def iter_test_cpp_files(root: str) -> List[str]:
+    out: List[str] = []
+    for dirpath, _, filenames in os.walk(root):
+        for fn in filenames:
+            if fn.endswith(".test.cpp"):
+                out.append(os.path.join(dirpath, fn))
+    return out
+
+
+def line_number_at(text: str, idx: int) -> int:
+    # 1-based
+    return text.count("\n", 0, idx) + 1
+
+
+def extract_macro_calls(text: str, filename: str) -> List[Tuple[str, int]]:
+    """
+    Returns list of tuples: (argument_string_inside_parentheses, start_line_number).
+    Handles macro calls spanning multiple lines by balancing parentheses.
+    """
+    calls: List[Tuple[str, int]] = []
+    search_from = 0
+
+    while True:
+        pos = text.find(MACRO_NAME, search_from)
+        if pos == -1:
+            break
+
+        # Find the opening '(' after the macro name.
+        i = pos + len(MACRO_NAME)
+        n = len(text)
+        while i < n and text[i].isspace():
+            i += 1
+        if i >= n or text[i] != "(":
+            search_from = pos + 1
+            continue
+
+        start_line = line_number_at(text, pos)
+
+        # Consume until matching ')'
+        i += 1  # move past '('
+        depth = 1
+        arg_start = i
+        while i < n and depth > 0:
+            ch = text[i]
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+
+        if depth != 0:
+            raise RuntimeError(
+                f"{filename}:{start_line}: unterminated {MACRO_NAME}(...) call"
+            )
+
+        arg_str = text[arg_start:i]
+        calls.append((arg_str, start_line))
+        search_from = i + 1
+
+    return calls
+
+
+def split_top_level_args(arg_str: str) -> List[str]:
+    """
+    Splits by commas at top level (paren depth 0) within the argument string.
+    """
+    args: List[str] = []
+    buf: List[str] = []
+    depth = 0
+
+    for ch in arg_str:
+        if ch == "(":
+            depth += 1
+            buf.append(ch)
+        elif ch == ")":
+            depth = max(0, depth - 1)
+            buf.append(ch)
+        elif ch == "," and depth == 0:
+            args.append("".join(buf).strip())
+            buf = []
+        else:
+            buf.append(ch)
+
+    tail = "".join(buf).strip()
+    if tail:
+        args.append(tail)
+
+    return args
+
+
+def parse_block_from_args(args: List[str], filename: str, line: int) -> Optional[Block]:
+    if len(args) < 3:
+        # Not enough arguments: raise an error since the macro pattern was successfully matched.
+        raise ValueError(
+            f"{filename}:{line}: {MACRO_NAME} expects at least 3 arguments, got {len(args)}"
+        )
+
+    # args[0] is the name, not relevant.
+    second = args[1]
+    third = args[2]
+
+    m = SECOND_PARAM_RE.match(second)
+    if not m:
+        raise ValueError(
+            f"{filename}:{line}: invalid 2nd parameter: {second!r}. "
+            "Expected 'caf::first_custom_type_id' optionally '+ NUM'."
+        )
+    offset = int(m.group(1) or "0")
+
+    m2 = SIZE_RE.match(third)
+    if not m2:
+        raise ValueError(
+            f"{filename}:{line}: invalid 3rd parameter (SIZE): {third!r}. "
+            "Expected a plain integer."
+        )
+    size = int(m2.group(1))
+    if size <= 0:
+        raise ValueError(
+            f"{filename}:{line}: invalid 3rd parameter (SIZE): {third!r}. "
+            "SIZE must be a positive integer greater than zero."
+        )
+
+    return Block(filename=filename, line=line, offset=offset, size=size)
+
+
+def check_no_overlap(blocks: List[Block]) -> None:
+    blocks_sorted = sorted(blocks, key=lambda b: (b.start, b.end))
+    prev: Optional[Block] = None
+    for b in blocks_sorted:
+        if prev is not None and b.start < prev.end:
+            raise RuntimeError(
+                "Overlapping CAF_BEGIN_TYPE_ID_BLOCK ranges:\n"
+                f"  - {prev.filename}:{prev.line}: offset={prev.offset}, size={prev.size} "
+                f"(range [{prev.start}, {prev.end}))\n"
+                f"  - {b.filename}:{b.line}: offset={b.offset}, size={b.size} "
+                f"(range [{b.start}, {b.end}))"
+            )
+        prev = b
+
+
+def main() -> int:
+    root = os.getcwd()
+    files = iter_test_cpp_files(root)
+
+    blocks: List[Block] = []
+
+    for path in files:
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                text = f.read()
+        except OSError as e:
+            raise RuntimeError(f"Failed to read {path}: {e}") from e
+
+        for arg_str, start_line in extract_macro_calls(text, path):
+            args = split_top_level_args(arg_str)
+            blk = parse_block_from_args(args, path, start_line)
+            if blk is not None:
+                blocks.append(blk)
+
+    if blocks:
+        check_no_overlap(blocks)
+        next_free = max(b.end for b in blocks)
+    else:
+        next_free = 0
+
+    print(next_free)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as e:
+        raise SystemExit(f"ERROR: {e}")


### PR DESCRIPTION
Add explicit size parameter to CAF_BEGIN_TYPE_ID_BLOCK to detect and prevent overlapping type ID ranges between test files.
- Extend CAF_BEGIN_TYPE_ID_BLOCK macro to accept an optional third parameter specifying the maximum block size
- Add static_assert in CAF_END_TYPE_ID_BLOCK to verify blocks don't exceed their declared size
- Reassign all test file type ID block offsets to non-overlapping ranges with explicit size limits
- Add scripts/get-next-free-block-offset.py to detect overlaps and find the next available offset
- Add CI check to validate type ID block offsets don't overlap