### PR TITLE
Re-enable (typed) response promise tests

### DIFF
--- a/libcaf_core/caf/response_promise.test.cpp
+++ b/libcaf_core/caf/response_promise.test.cpp
@@ -122,24 +122,23 @@ SCENARIO("response promises allow delaying of response messages") {
           dispatch_messages();
         }
       }
-      // TODO: https://github.com/actor-framework/actor-framework/issues/2009
-      // WHEN("sending ok_atom to the dispatcher synchronously") {
-      //   auto res = self->request(hdl, infinite, ok_atom_v);
-      //   auto fetch_result = [&] {
-      //     message result;
-      //     res.receive([] {}, // void result
-      //                 [&](const error& reason) {
-      //                   result = make_message(reason);
-      //                 });
-      //     return result;
-      //   };
-      //   THEN("clients receive an empty response from the dispatcher") {
-      //     expect<ok_atom>().from(self).to(hdl);
-      //     expect<ok_atom>().from(hdl).to(adder_hdl);
-      //     dispatch_message();
-      //     check(fetch_result().empty());
-      //   }
-      // }
+      WHEN("sending ok_atom to the dispatcher synchronously") {
+        auto res = self->mail(ok_atom_v).request(hdl, infinite);
+        auto fetch_result = [&] {
+          message result;
+          std::move(res).receive([] {}, // void result
+                                 [&](const error& reason) {
+                                   result = make_message(reason);
+                                 });
+          return result;
+        };
+        THEN("clients receive an empty response from the dispatcher") {
+          expect<ok_atom>().from(self).to(hdl);
+          expect<ok_atom>().from(hdl).to(adder_hdl);
+          dispatch_message();
+          check(fetch_result().empty());
+        }
+      }
       WHEN("sending ok_atom to the dispatcher asynchronously") {
         THEN("clients receive no response from the dispatcher") {
           inject().with(ok_atom_v).from(self).to(hdl);

--- a/libcaf_core/caf/typed_response_promise.test.cpp
+++ b/libcaf_core/caf/typed_response_promise.test.cpp
@@ -127,24 +127,23 @@ SCENARIO("response promises allow delaying of response messages") {
           dispatch_messages();
         }
       }
-      // TODO: https://github.com/actor-framework/actor-framework/issues/2009
-      // WHEN("sending ok_atom to the dispatcher synchronously") {
-      //   auto res = self->request(hdl, infinite, ok_atom_v);
-      //   auto fetch_result = [&] {
-      //     message result;
-      //     res.receive([] {}, // void result
-      //                 [&](const error& reason) {
-      //                   result = make_message(reason);
-      //                 });
-      //     return result;
-      //   };
-      //   THEN("clients receive an empty response from the dispatcher") {
-      //     expect<ok_atom>().from(self).to(hdl);
-      //     expect<ok_atom>().from(hdl).to(adder_hdl);
-      //     dispatch_message();
-      //     check(fetch_result().empty());
-      //   }
-      // }
+      WHEN("sending ok_atom to the dispatcher synchronously") {
+        auto res = self->mail(ok_atom_v).request(hdl, infinite);
+        auto fetch_result = [&] {
+          message result;
+          std::move(res).receive([] {}, // void result
+                                 [&](const error& reason) {
+                                   result = make_message(reason);
+                                 });
+          return result;
+        };
+        THEN("clients receive an empty response from the dispatcher") {
+          expect<ok_atom>().from(self).to(hdl);
+          expect<ok_atom>().from(hdl).to(adder_hdl);
+          dispatch_message();
+          check(fetch_result().empty());
+        }
+      }
       WHEN("sending ok_atom to the dispatcher asynchronously") {
         THEN("clients receive no response from the dispatcher") {
           inject().with(ok_atom_v).from(self).to(hdl);


### PR DESCRIPTION
Back when discussing #2154 there where two TODOs left in the code. This is the followup. 
The fix was a mere `std::move(res).receive(...)`. Hope I'm not missing something obvious here. 
Related #2009 