### PR TITLE
Add new API for thread-local current actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   urgent warnings. Of course, we recommend using this macro only for a short
   transition period since deprecated APIs will usually be removed in the next
   major release.
+- The new static method `caf::abstract_actor::current()` grants users
+  access to the actor currently associated with the calling thread (returns
+  `nullptr` if no actor is associated with the thread).
 
 ### Fixed
 
@@ -116,6 +119,10 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - The getters `spawn_serv` and `config_serv` have been removed from the public
   interface of `actor_system`. These actors are an implementation detail of the
   I/O module and should not be accessed directly by users.
+- The method `logger::thread_local_aid(actor_id)` as well as the macros
+  `CAF_PUSH_AID`, `CAF_PUSH_AID_FROM_PTR` and `CAF_SET_AID` have been removed.
+  They were technically part of the public API but were never intended to be
+  called by users.
 
 ## [1.1.0] - 2025-07-25
 

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -69,6 +69,7 @@ caf_add_component(
     ${CAF_CORE_HEADERS}
   SOURCES
     caf/abstract_actor.cpp
+    caf/abstract_actor.test.cpp
     caf/abstract_blocking_actor.cpp
     caf/abstract_mailbox.cpp
     caf/abstract_scheduled_actor.cpp
@@ -168,6 +169,7 @@ caf_add_component(
     caf/detail/counted_disposable.cpp
     caf/detail/counted_disposable.test.cpp
     caf/detail/critical.cpp
+    caf/detail/current_actor.cpp
     caf/detail/daemons.cpp
     caf/detail/default_mailbox.cpp
     caf/detail/default_mailbox.test.cpp

--- a/libcaf_core/caf/abstract_actor.cpp
+++ b/libcaf_core/caf/abstract_actor.cpp
@@ -13,6 +13,7 @@
 #include "caf/config.hpp"
 #include "caf/default_attachable.hpp"
 #include "caf/detail/assert.hpp"
+#include "caf/detail/current_actor.hpp"
 #include "caf/log/core.hpp"
 #include "caf/mailbox_element.hpp"
 #include "caf/system_messages.hpp"
@@ -25,7 +26,7 @@ namespace caf {
 // -- constructors, destructors, and assignment operators ----------------------
 
 abstract_actor::abstract_actor(actor_config& cfg) : flags_(cfg.flags) {
-  // nop
+  detail::current_actor(this);
 }
 
 abstract_actor::~abstract_actor() {
@@ -136,10 +137,14 @@ actor_addr abstract_actor::address() const noexcept {
   return actor_addr{actor_control_block::from(this), add_ref};
 }
 
+abstract_actor* abstract_actor::current() noexcept {
+  return detail::current_actor();
+}
+
 // -- callbacks ----------------------------------------------------------------
 
 void abstract_actor::on_unreachable() {
-  CAF_PUSH_AID_FROM_PTR(this);
+  detail::current_actor_guard ctx_guard{this};
   cleanup(make_error(exit_reason::unreachable), nullptr);
 }
 

--- a/libcaf_core/caf/abstract_actor.hpp
+++ b/libcaf_core/caf/abstract_actor.hpp
@@ -130,6 +130,10 @@ public:
   /// Returns the logical actor address.
   actor_addr address() const noexcept;
 
+  /// Returns the actor currently associated to the calling thread or `nullptr`
+  /// if none is associated.
+  static abstract_actor* current() noexcept;
+
   // -- messaging --------------------------------------------------------------
 
   /// Enqueues a new message wrapped in a `mailbox_element` to the actor.
@@ -270,6 +274,9 @@ protected:
 
   // -- constructors, destructors, and assignment operators --------------------
 
+  /// @note calls `detail::current_actor(this)`; re-setting the current actor
+  ///       needs to be done by the outer scope (usually taken care of by
+  ///       `detail::make_actor_util`)
   explicit abstract_actor(actor_config& cfg);
 
   // -- attachables ------------------------------------------------------------

--- a/libcaf_core/caf/abstract_actor.test.cpp
+++ b/libcaf_core/caf/abstract_actor.test.cpp
@@ -1,0 +1,55 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#include "caf/abstract_actor.hpp"
+
+#include "caf/test/test.hpp"
+
+#include "caf/actor_system.hpp"
+#include "caf/actor_system_config.hpp"
+#include "caf/event_based_actor.hpp"
+#include "caf/scoped_actor.hpp"
+
+using namespace caf;
+
+TEST("abstract_actor::current returns nullptr outside of any actor context") {
+  check_eq(abstract_actor::current(), nullptr);
+}
+
+TEST("abstract_actor::current returns the actor pointer from within an actor") {
+  actor_system_config cfg;
+  actor_system sys{cfg};
+  auto ok = std::make_shared<bool>(false);
+  sys.spawn([ok](event_based_actor* self) {
+    *ok = (self == abstract_actor::current());
+  });
+  sys.await_all_actors_done();
+  check(*ok);
+}
+
+TEST("abstract_actor::current returns the scoped_actor pointer") {
+  actor_system_config cfg;
+  actor_system sys{cfg};
+  scoped_actor self{sys};
+  check_eq(abstract_actor::current(), self.ptr());
+}
+
+TEST("current reflects context changes with nested scoped_actors") {
+  actor_system_config cfg;
+  actor_system sys{cfg};
+  auto* before = abstract_actor::current();
+  check_eq(before, nullptr);
+  {
+    scoped_actor outer{sys};
+    check_eq(abstract_actor::current(), outer.ptr());
+    {
+      scoped_actor inner{sys};
+      check_eq(abstract_actor::current(), inner.ptr());
+    }
+    // After inner is destroyed, current should be restored to outer.
+    check_eq(abstract_actor::current(), outer.ptr());
+  }
+  // After outer is destroyed, current should be restored to nullptr.
+  check_eq(abstract_actor::current(), before);
+}

--- a/libcaf_core/caf/actor_pool.cpp
+++ b/libcaf_core/caf/actor_pool.cpp
@@ -7,6 +7,7 @@
 #include "caf/anon_mail.hpp"
 #include "caf/default_attachable.hpp"
 #include "caf/detail/assert.hpp"
+#include "caf/detail/current_actor.hpp"
 #include "caf/detail/sync_request_bouncer.hpp"
 #include "caf/mailbox_element.hpp"
 
@@ -122,7 +123,7 @@ const char* actor_pool::name() const {
 }
 
 void actor_pool::on_cleanup([[maybe_unused]] const error& reason) {
-  CAF_PUSH_AID_FROM_PTR(this);
+  detail::current_actor_guard ctx_guard{this};
   CAF_LOG_TERMINATE_EVENT(this, reason);
 }
 

--- a/libcaf_core/caf/blocking_actor.cpp
+++ b/libcaf_core/caf/blocking_actor.cpp
@@ -7,6 +7,7 @@
 #include "caf/actor_system.hpp"
 #include "caf/anon_mail.hpp"
 #include "caf/detail/assert.hpp"
+#include "caf/detail/current_actor.hpp"
 #include "caf/detail/default_invoke_result_visitor.hpp"
 #include "caf/detail/invoke_result_visitor.hpp"
 #include "caf/detail/private_thread.hpp"
@@ -106,7 +107,7 @@ public:
   }
 
   void resume(scheduler* ctx, uint64_t event_id) override {
-    CAF_PUSH_AID_FROM_PTR(self_);
+    detail::current_actor_guard ctx_guard{self_};
     if (event_id == resumable::dispose_event_id) {
       self_->cleanup(make_error(exit_reason::user_shutdown), ctx);
       return;
@@ -148,7 +149,7 @@ private:
 } // namespace
 
 void blocking_actor::launch(scheduler*, bool) {
-  CAF_PUSH_AID_FROM_PTR(this);
+  detail::current_actor_guard ctx_guard{this};
   auto lg = log::core::trace("");
   CAF_ASSERT(getf(is_blocking_flag));
   // Try to acquire a thread before incrementing the running count, since this

--- a/libcaf_core/caf/detail/current_actor.cpp
+++ b/libcaf_core/caf/detail/current_actor.cpp
@@ -1,0 +1,32 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#include "caf/detail/current_actor.hpp"
+
+namespace caf::detail {
+
+namespace {
+
+thread_local abstract_actor* current_actor_ptr;
+
+} // namespace
+
+abstract_actor* current_actor() noexcept {
+  return current_actor_ptr;
+}
+
+void current_actor(abstract_actor* ptr) noexcept {
+  current_actor_ptr = ptr;
+}
+
+current_actor_guard::current_actor_guard(abstract_actor* ptr) noexcept
+  : prev_(current_actor_ptr) {
+  current_actor_ptr = ptr;
+}
+
+current_actor_guard::~current_actor_guard() noexcept {
+  current_actor_ptr = prev_;
+}
+
+} // namespace caf::detail

--- a/libcaf_core/caf/detail/current_actor.hpp
+++ b/libcaf_core/caf/detail/current_actor.hpp
@@ -1,0 +1,30 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+#include "caf/detail/core_export.hpp"
+#include "caf/fwd.hpp"
+
+namespace caf::detail {
+
+CAF_CORE_EXPORT abstract_actor* current_actor() noexcept;
+
+CAF_CORE_EXPORT void current_actor(abstract_actor* ptr) noexcept;
+
+class CAF_CORE_EXPORT current_actor_guard {
+public:
+  [[nodiscard]] explicit current_actor_guard(abstract_actor* ptr) noexcept;
+
+  current_actor_guard(const current_actor_guard&) = delete;
+
+  current_actor_guard& operator=(const current_actor_guard&) = delete;
+
+  ~current_actor_guard() noexcept;
+
+private:
+  abstract_actor* prev_;
+};
+
+} // namespace caf::detail

--- a/libcaf_core/caf/forwarding_actor_proxy.cpp
+++ b/libcaf_core/caf/forwarding_actor_proxy.cpp
@@ -7,6 +7,7 @@
 #include "caf/add_ref.hpp"
 #include "caf/anon_mail.hpp"
 #include "caf/detail/assert.hpp"
+#include "caf/detail/current_actor.hpp"
 #include "caf/log/core.hpp"
 #include "caf/mailbox_element.hpp"
 #include "caf/system_messages.hpp"
@@ -45,7 +46,7 @@ bool forwarding_actor_proxy::forward_msg(strong_actor_ptr sender,
 }
 
 bool forwarding_actor_proxy::enqueue(mailbox_element_ptr what, scheduler*) {
-  CAF_PUSH_AID(0);
+  detail::current_actor_guard ctx_guard{nullptr};
   CAF_ASSERT(what);
   return forward_msg(std::move(what->sender), what->mid,
                      std::move(what->payload));

--- a/libcaf_core/caf/logger.hpp
+++ b/libcaf_core/caf/logger.hpp
@@ -226,9 +226,6 @@ public:
   /// Returns the ID of the actor currently associated to the calling thread.
   static actor_id thread_local_aid();
 
-  /// Associates an actor ID to the calling thread and returns the last value.
-  static actor_id thread_local_aid(actor_id aid) noexcept;
-
   /// Returns whether the logger is configured to accept input for given
   /// component and log level.
   virtual bool accepts(unsigned level, std::string_view component_name) = 0;
@@ -337,21 +334,6 @@ private:
         loglvl, component, (caf::logger::line_builder{} << message).get());    \
     }                                                                          \
   } while (false)
-
-#define CAF_PUSH_AID(aarg)                                                     \
-  caf::actor_id CAF_PP_UNIFYN(caf_aid_tmp)                                     \
-    = caf::logger::thread_local_aid(aarg);                                     \
-  auto CAF_PP_UNIFYN(caf_aid_tmp_guard)                                        \
-    = caf::detail::scope_guard([=]() noexcept {                                \
-        caf::logger::thread_local_aid(CAF_PP_UNIFYN(caf_aid_tmp));             \
-      })
-
-#define CAF_PUSH_AID_FROM_PTR(some_ptr)                                        \
-  auto CAF_PP_UNIFYN(caf_aid_ptr) = some_ptr;                                  \
-  CAF_PUSH_AID(CAF_PP_UNIFYN(caf_aid_ptr) ? CAF_PP_UNIFYN(caf_aid_ptr)->id()   \
-                                          : 0)
-
-#define CAF_SET_AID(aid_arg) caf::logger::thread_local_aid(aid_arg)
 
 #define CAF_SET_LOGGER_SYS(ptr) caf::logger::current_logger(ptr)
 

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -12,6 +12,7 @@
 #include "caf/defaults.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/detail/critical.hpp"
+#include "caf/detail/current_actor.hpp"
 #include "caf/detail/default_invoke_result_visitor.hpp"
 #include "caf/detail/mailbox_factory.hpp"
 #include "caf/detail/private_thread.hpp"
@@ -219,7 +220,7 @@ const char* scheduled_actor::name() const {
 }
 
 void scheduled_actor::launch(scheduler* sched, bool lazy) {
-  CAF_PUSH_AID_FROM_PTR(this);
+  detail::current_actor_guard ctx_guard{this};
   auto lg = log::core::trace("lazy = {}", lazy);
   if (auto* pinned = pinned_scheduler(); pinned != nullptr) {
     sched = pinned;
@@ -265,7 +266,7 @@ void scheduled_actor::deref_resumable() const noexcept {
 }
 
 void scheduled_actor::resume(scheduler* sched, uint64_t event_id) {
-  CAF_PUSH_AID(id());
+  detail::current_actor_guard ctx_guard{this};
   auto lg = log::core::trace("event-id = {}", event_id);
   if (event_id == resumable::dispose_event_id) {
     cleanup(make_error(exit_reason::user_shutdown), sched);

--- a/libcaf_core/caf/scoped_actor.hpp
+++ b/libcaf_core/caf/scoped_actor.hpp
@@ -61,7 +61,7 @@ private:
     return self_.get();
   }
 
-  actor_id prev_; // used for logging/debugging purposes only
+  abstract_actor* prev_; // previous current actor, restored in destructor
   strong_actor_ptr self_;
 };
 

--- a/libcaf_io/caf/io/abstract_broker.cpp
+++ b/libcaf_io/caf/io/abstract_broker.cpp
@@ -9,6 +9,7 @@
 #include "caf/byte_span.hpp"
 #include "caf/config.hpp"
 #include "caf/detail/assert.hpp"
+#include "caf/detail/current_actor.hpp"
 #include "caf/detail/scope_guard.hpp"
 #include "caf/detail/sync_request_bouncer.hpp"
 #include "caf/event_based_actor.hpp"
@@ -19,7 +20,7 @@
 namespace caf::io {
 
 void abstract_broker::launch(scheduler* sched, bool lazy) {
-  CAF_PUSH_AID_FROM_PTR(this);
+  detail::current_actor_guard ctx_guard{this};
   CAF_ASSERT(sched != nullptr);
   CAF_ASSERT(dynamic_cast<network::multiplexer*>(sched) != nullptr);
   backend_ = static_cast<network::multiplexer*>(sched);


### PR DESCRIPTION
Add `abstract_actor::current()` to allow users to retrieve the actor that's currently running on the calling thread.