### PR TITLE
Fix handling of HTTP server request overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,10 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Fix a heap-buffer-overflow in the test runner on missing CLI arguments. For
   example, running `caf-core-test -s` previously crashed (`-s` requires an
   argument, #2384).
+- When using the HTTP server API with an SPSC buffer, the HTTP server now
+  responds with `503 Service Unavailable` when encountering backpressure from
+  the consumer, i.e., if the HTTP client sends requests faster than the server
+  can process them.
 
 ### Removed
 

--- a/libcaf_core/caf/async/spsc_buffer.hpp
+++ b/libcaf_core/caf/async/spsc_buffer.hpp
@@ -82,6 +82,13 @@ public:
     bool producer_blocked : 1;
   };
 
+  /// @param capacity The maximum number of items the buffer can hold. Treated
+  ///                 as a "soft limit" by `push`, i.e., the buffer may
+  ///                 temporarily hold more items than the capacity unless the
+  ///                 producer only calls `try_push`, which treats the capacity
+  ///                 as a hard limit.
+  /// @param min_pull_size The minimum number of items the consumer must pull
+  ///                      before the producer is signaled to produce more.
   spsc_buffer(size_t capacity, size_t min_pull_size)
     : capacity_(capacity), min_pull_size_(min_pull_size) {
     memset(&flags_, 0, sizeof(flags));
@@ -97,6 +104,9 @@ public:
   /// Appends to the buffer and calls `on_producer_wakeup` on the consumer if
   /// the buffer becomes non-empty.
   /// @returns the remaining capacity after inserting the items.
+  /// @note Items are always copied into the buffer, even after reaching the
+  ///       capacity. This allows the buffer to absorb small bursts of items
+  ///       without forcing external buffering.
   size_t push(std::span<const T> items) {
     lock_type guard{mtx_};
     CAF_ASSERT(producer_ != nullptr);
@@ -113,6 +123,9 @@ public:
   /// Appends to the buffer and calls `on_producer_wakeup` on the consumer if
   /// the buffer becomes non-empty.
   /// @returns the remaining capacity after inserting the items.
+  /// @note Items are always copied into the buffer, even after reaching the
+  ///       capacity. This allows the buffer to absorb small bursts of items
+  ///       without forcing external buffering.
   size_t push(const T& item) {
     return push(std::span{&item, 1});
   }

--- a/libcaf_net/caf/net/http/with.cpp
+++ b/libcaf_net/caf/net/http/with.cpp
@@ -67,7 +67,7 @@ public:
   }
 
   bool push(const net::http::request& item) override {
-    return buf_->push(item);
+    return buf_->try_push(item) == async::write_result::ok;
   }
 
 private:
@@ -245,9 +245,10 @@ public:
       auto producer = make_http_request_producer({mpx, add_ref},
                                                  push.try_open());
       auto new_route = make_route([producer](responder& res) {
-        if (!producer->push(responder{res}.to_request())) {
-          auto err = make_error(sec::runtime_error, "flow disconnected");
-          res.router()->abort_and_shutdown(err);
+        auto req = responder{res}.to_request();
+        if (!producer->push(req)) {
+          req.respond(status::service_unavailable, "text/plain",
+                      "service unavailable: request could not be queued");
         }
       });
       if (!new_route) {


### PR DESCRIPTION
- `http_request_producer_impl::push` has a bug: the SPSC buffer returning 0 does not mean the item has been rejected but merely that the capacity reached zero
- if the server received too many requests, it killed all in-flight requests that were still pending in the buffer

This set of changes introduces `try_push` on SPSC buffers that rejects additional items when at or above capacity. Further, the HTTP server now sends an error only in response to the rejected request. Pending requests are unaffected.