### PR TITLE
fix websocket handshake response headers check

### DIFF
--- a/libcaf_net/caf/net/web_socket/handshake.cpp
+++ b/libcaf_net/caf/net/web_socket/handshake.cpp
@@ -226,11 +226,11 @@ struct response_checker {
       auto [field, value] = split_by(line, ":");
       field = trim(field);
       value = trim(value);
-      if (field == "Upgrade")
+      if (icase_equal(field, "upgrade"))
         has_upgrade_field = icase_equal(value, "websocket");
-      else if (field == "Connection")
+      else if (icase_equal(field, "connection"))
         has_connection_field = icase_equal(value, "upgrade");
-      else if (field == "Sec-WebSocket-Accept")
+      else if (icase_equal(field, "sec-websocket-accept"))
         has_ws_accept_field = value == ws_key;
     }
   }


### PR DESCRIPTION
HTTP header names are not case-sensitive according to HTTP specifications (RFC 9110 and prior RFCs). However, the original code used conditional statements like `if (field == “Upgrade”)`, which caused handshake failures with certain servers. 