### PR TITLE
Connection tracking for outstanding HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   `caf::actor_system::running_actors_count`. Other methods for manipulating the
   count have been removed and replaced by private methods on the `actor_system`
   since they are meant for internal use only.
+- Outstanding `http::request` objects now keep their connection "alive" for the
+  purpose of `max_connections` tracking. Previously, only open sockets counted
+  against the limit, which could cause the server to accept new connections
+  while there were still pending requests being processed.
 
 ### Deprecated
 
@@ -106,6 +110,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   Further, users can optionally build CAF with `CAF_USE_STD_EXPECTED` enabled to
   have CAF use aliases to the standard library types instead of its own
   implementation (requires C++23).
+- The class `http::request` now has an `orphaned()` method that returns `true`
+  if the underlying connection has been shut down. This allows request handlers
+  to safely discard abandoned requests.
 
 ### Fixed
 

--- a/libcaf_net/CMakeLists.txt
+++ b/libcaf_net/CMakeLists.txt
@@ -30,6 +30,7 @@ caf_add_component(
     ${CAF_NET_HEADERS}
   SOURCES
     caf/detail/connection_acceptor.cpp
+    caf/detail/connection_guard.cpp
     caf/detail/flow_bridge_initializer.cpp
     caf/detail/rfc6455.cpp
     caf/detail/rfc6455.test.cpp

--- a/libcaf_net/caf/detail/connection_acceptor.hpp
+++ b/libcaf_net/caf/detail/connection_acceptor.hpp
@@ -6,6 +6,7 @@
 
 #include "caf/net/fwd.hpp"
 
+#include "caf/action.hpp"
 #include "caf/fwd.hpp"
 
 #include <memory>
@@ -21,7 +22,10 @@ public:
   virtual ~connection_acceptor();
 
   /// Callback from the socket manager for startup.
-  virtual error start(net::socket_manager*) = 0;
+  /// @param parent The socket manager that owns this acceptor.
+  /// @param on_conn_close Callback to invoke when a connection is fully closed
+  ///        (socket cleaned up AND all outstanding requests destroyed).
+  virtual error start(net::socket_manager* parent, action on_conn_close) = 0;
 
   /// Aborts the acceptor.
   virtual void abort(const error&) = 0;

--- a/libcaf_net/caf/detail/connection_guard.cpp
+++ b/libcaf_net/caf/detail/connection_guard.cpp
@@ -1,0 +1,13 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#include "caf/detail/connection_guard.hpp"
+
+namespace caf::detail {
+
+connection_guard::~connection_guard() {
+  // nop
+}
+
+} // namespace caf::detail

--- a/libcaf_net/caf/detail/connection_guard.hpp
+++ b/libcaf_net/caf/detail/connection_guard.hpp
@@ -1,0 +1,30 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+#include "caf/detail/net_export.hpp"
+#include "caf/intrusive_ptr.hpp"
+#include "caf/ref_counted.hpp"
+
+namespace caf::detail {
+
+/// Abstract interface for tracking connection lifetime. Implementations allow
+/// users to query whether the underlying connection has been orphaned, i.e.,
+/// the socket manager that created the connection has shut down.
+class CAF_NET_EXPORT connection_guard : public ref_counted {
+public:
+  ~connection_guard() override;
+
+  /// Returns `true` if the socket manager that created this guard has shut
+  /// down, `false` otherwise.
+  [[nodiscard]] virtual bool orphaned() const noexcept = 0;
+
+  /// Sets the orphaned flag to `true`.
+  virtual void set_orphaned() noexcept = 0;
+};
+
+using connection_guard_ptr = intrusive_ptr<connection_guard>;
+
+} // namespace caf::detail

--- a/libcaf_net/caf/net/http/request.hpp
+++ b/libcaf_net/caf/net/http/request.hpp
@@ -11,6 +11,7 @@
 #include "caf/async/execution_context.hpp"
 #include "caf/async/promise.hpp"
 #include "caf/byte_span.hpp"
+#include "caf/detail/connection_guard.hpp"
 #include "caf/detail/net_export.hpp"
 
 #include <cstdint>
@@ -65,9 +66,14 @@ public:
     return respond(code, content_type, as_bytes(std::span{content}));
   }
 
+  /// Returns `true` if the socket manager that created this request has shut
+  /// down, `false` otherwise.
+  [[nodiscard]] bool orphaned() const noexcept;
+
 private:
   request(request_header hdr, std::vector<std::byte> body,
-          async::promise<response> prom);
+          async::promise<response> prom,
+          detail::connection_guard_ptr conn_guard);
 
   impl* impl_ = nullptr;
 };

--- a/libcaf_net/caf/net/http/router.hpp
+++ b/libcaf_net/caf/net/http/router.hpp
@@ -12,10 +12,9 @@
 #include "caf/net/http/upper_layer.hpp"
 
 #include "caf/caf_deprecated.hpp"
+#include "caf/detail/connection_guard.hpp"
 #include "caf/detail/print.hpp"
 #include "caf/expected.hpp"
-#include "caf/intrusive_ptr.hpp"
-#include "caf/ref_counted.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -31,17 +30,20 @@ class CAF_NET_EXPORT router : public upper_layer::server {
 public:
   // -- constructors and destructors -------------------------------------------
 
-  router() = default;
+  router();
 
-  explicit router(std::vector<route_ptr> routes) : routes_(std::move(routes)) {
-    // nop
-  }
+  explicit router(std::vector<route_ptr> routes);
+
+  router(std::vector<route_ptr> routes, detail::connection_guard_ptr guard);
 
   ~router() override;
 
   // -- factories --------------------------------------------------------------
 
   static std::unique_ptr<router> make(std::vector<route_ptr> routes);
+
+  static std::unique_ptr<router> make(std::vector<route_ptr> routes,
+                                      detail::connection_guard_ptr guard);
 
   // -- properties -------------------------------------------------------------
 
@@ -105,6 +107,9 @@ private:
 
   /// Lazily initialized for allowing a @ref route to interact with actors.
   actor_shell_ptr shell_;
+
+  /// Tracks connection lifetime for outstanding requests.
+  detail::connection_guard_ptr guard_;
 };
 
 } // namespace caf::net::http

--- a/libcaf_net/caf/net/octet_stream/transport.cpp
+++ b/libcaf_net/caf/net/octet_stream/transport.cpp
@@ -318,7 +318,8 @@ public:
   }
 
   void abort(const error& reason) override {
-    up_->abort(reason);
+    if (up_)
+      up_->abort(reason);
     flags_.shutting_down = true;
   }
 
@@ -403,6 +404,9 @@ protected:
       log::net::debug("transport failed with reason: {}", reason);
       up_->abort(reason);
       up_.reset();
+      // Clear the write buffer since we can't send it anyway - this ensures
+      // finalized() returns true and cleanup() will be called.
+      write_buf_.clear();
       parent_->deregister();
       parent_->shutdown();
     }


### PR DESCRIPTION
Previously, the `max_connections` limit only considered open sockets. However, pending `http::request` objects should also keep a connection "alive" until responded to or dropped.

This change introduces a `connection_guard` abstraction that tracks when a connection is truly "done" - both the socket is closed AND all outstanding `http::request` objects are destroyed. The guard also allows requests to detect whether the underlying socket has already been closed. Users can query this state by calling `orphaned` on the request handle.

Other fixes:
- Transport::abort() now checks for null upper layer before calling
- Transport::fail() clears the write buffer to ensure cleanup runs