### PR TITLE
Revert "Avoid using init_fun for spawning function objects"

### DIFF
--- a/libcaf_core/caf/actor_traits.hpp
+++ b/libcaf_core/caf/actor_traits.hpp
@@ -96,10 +96,4 @@ template <class T>
 struct actor_traits
   : default_actor_traits<T, std::is_base_of_v<abstract_actor, T>> {};
 
-template <class T>
-concept blocking_actor_type = actor_traits<T>::is_blocking;
-
-template <class T>
-concept non_blocking_actor_type = actor_traits<T>::is_non_blocking;
-
 } // namespace caf

--- a/libcaf_core/caf/behavior.hpp
+++ b/libcaf_core/caf/behavior.hpp
@@ -37,11 +37,6 @@ public:
     // nop
   }
 
-  // Convenience overload to allow "unsafe" initialization of any behavior_type.
-  explicit behavior(unsafe_behavior_init_t) {
-    // nop
-  }
-
   /// Creates a behavior from `fun` without timeout.
   behavior(const message_handler& mh);
 

--- a/libcaf_core/caf/blocking_actor.cpp
+++ b/libcaf_core/caf/blocking_actor.cpp
@@ -175,7 +175,8 @@ void blocking_actor::await_all_other_actors_done() {
 
 void blocking_actor::act() {
   auto lg = log::core::trace("");
-  // Default implementation does nothing.
+  if (initial_behavior_fac_)
+    initial_behavior_fac_(this);
 }
 
 void blocking_actor::fail_state(error err) {

--- a/libcaf_core/caf/stateful_actor.hpp
+++ b/libcaf_core/caf/stateful_actor.hpp
@@ -4,16 +4,12 @@
 
 #pragma once
 
-#include "caf/actor_traits.hpp"
-#include "caf/behavior.hpp"
-#include "caf/callback.hpp"
 #include "caf/detail/concepts.hpp"
-#include "caf/detail/metaprogramming.hpp"
 #include "caf/fwd.hpp"
+#include "caf/sec.hpp"
 #include "caf/unsafe_behavior_init.hpp"
 
 #include <new>
-#include <tuple>
 #include <type_traits>
 
 namespace caf::detail {
@@ -28,37 +24,12 @@ public:
   typename Base::behavior_type make_behavior() override;
 };
 
-/// Conditional base type for `stateful_actor` that overrides `act` when using a
-/// blocking actor as base.
+/// Evaluates to either `stateful_actor_base<State, Base> `or `Base`, depending
+/// on whether `State::make_behavior()` exists.
 template <class State, class Base>
-class stateful_blocking_actor_base : public Base {
-public:
-  using Base::Base;
-
-  void act() override;
-};
-
-template <class State, class Base>
-struct stateful_actor_base_oracle {
-  using type = Base;
-};
-
-template <has_make_behavior State, non_blocking_actor_type Base>
-struct stateful_actor_base_oracle<State, Base> {
-  using type = stateful_actor_base<State, Base>;
-};
-
-template <has_make_behavior State, blocking_actor_type Base>
-struct stateful_actor_base_oracle<State, Base> {
-  using type = stateful_blocking_actor_base<State, Base>;
-};
-
-/// Evaluates to either `stateful_actor_base<State, Base>`,
-/// `stateful_blocking_actor_base<State, Base>`, or `Base`, depending on whether
-/// the state has `make_behavior()` and whether the base is a blocking actor.
-template <class State, class Base>
-using stateful_actor_base_t =
-  typename stateful_actor_base_oracle<State, Base>::type;
+using stateful_actor_base_t
+  = std::conditional_t<has_make_behavior<State>,
+                       stateful_actor_base<State, Base>, Base>;
 
 } // namespace caf::detail
 
@@ -124,75 +95,15 @@ namespace caf::detail {
 
 template <class State, class Base>
 typename Base::behavior_type stateful_actor_base<State, Base>::make_behavior() {
+  // When spawning function-based actors, CAF sets `initial_behavior_fac_` to
+  // wrap the function invocation. This always has the highest priority.
+  if (this->initial_behavior_fac_) {
+    auto res = this->initial_behavior_fac_(this);
+    this->initial_behavior_fac_ = nullptr;
+    return {unsafe_behavior_init, std::move(res)};
+  }
   auto dptr = static_cast<stateful_actor<State, Base>*>(this);
   return dptr->state().make_behavior();
 }
-
-template <class State, class Base>
-void stateful_blocking_actor_base<State, Base>::act() {
-  // We call `make_behavior()` only to invoke the user-defined callback. For
-  // blocking actors, this callback must return `void` and `make_behavior()`
-  // will thus always return a default-constructed (empty) behavior that we can
-  // safely discard.
-  auto dptr = static_cast<stateful_actor<State, Base>*>(this);
-  std::ignore = dptr->state().make_behavior();
-}
-
-template <class Self>
-struct functor_state {
-  using behavior_type = typename Self::behavior_type;
-
-  template <class Fn, class... Args>
-  explicit functor_state(Self* selfptr, Fn&& f, Args&&... args)
-    : self(selfptr) {
-    // Wrap the function invocation into a callback that we can call later in
-    // `make_behavior()` when launching the actor.
-    if constexpr (std::is_invocable_r_v<behavior_type, Fn, Self*, Args...>) {
-      static_assert(!actor_traits<Self>::is_blocking,
-                    "Blocking actors cannot return a behavior");
-      auto g = [f = std::forward<Fn>(f), ... args = std::forward<Args>(args)](
-                 Self* self) mutable -> behavior_type {
-        return f(self, std::move(args)...);
-      };
-      fn = make_type_erased_callback(std::move(g));
-    } else if constexpr (std::is_invocable_r_v<behavior_type, Fn, Args...>) {
-      static_assert(!actor_traits<Self>::is_blocking,
-                    "Blocking actors cannot return a behavior");
-      auto g = [f = std::forward<Fn>(f), ... args = std::forward<Args>(args)](
-                 Self*) mutable -> behavior_type {
-        return f(std::move(args)...);
-      };
-      fn = make_type_erased_callback(std::move(g));
-    } else if constexpr (std::is_invocable_r_v<void, Fn, Self*, Args...>) {
-      auto g = [f = std::forward<Fn>(f), ... args = std::forward<Args>(args)](
-                 Self* self) mutable -> behavior_type {
-        f(self, std::move(args)...);
-        return behavior_type{unsafe_behavior_init};
-      };
-      fn = make_type_erased_callback(std::move(g));
-    } else if constexpr (std::is_invocable_r_v<void, Fn, Args...>) {
-      auto g = [f = std::forward<Fn>(f), ... args = std::forward<Args>(args)](
-                 Self*) mutable -> behavior_type {
-        f(std::move(args)...);
-        return behavior_type{unsafe_behavior_init};
-      };
-      fn = make_type_erased_callback(std::move(g));
-    } else {
-      static_assert(detail::always_false<Fn>, "Invalid callable type");
-    }
-  }
-
-  behavior_type make_behavior() {
-    if (fn) {
-      auto res = (*fn)(self);
-      fn = nullptr;
-      return res;
-    }
-    return behavior_type{unsafe_behavior_init};
-  }
-
-  Self* self;
-  unique_callback_ptr<behavior_type(Self*)> fn;
-};
 
 } // namespace caf::detail

--- a/libcaf_core/caf/typed_behavior.hpp
+++ b/libcaf_core/caf/typed_behavior.hpp
@@ -186,10 +186,6 @@ public:
     // TODO: implement type checking.
   }
 
-  explicit typed_behavior(unsafe_behavior_init_t) {
-    // nop
-  }
-
   typed_behavior(unsafe_behavior_init_t, behavior x) : bhvr_(std::move(x)) {
     // nop
   }

--- a/libcaf_io/caf/io/broker.hpp
+++ b/libcaf_io/caf/io/broker.hpp
@@ -10,7 +10,6 @@
 #include "caf/io/scribe.hpp"
 
 #include "caf/detail/assert.hpp"
-#include "caf/detail/init_fun_factory.hpp"
 #include "caf/detail/io_export.hpp"
 #include "caf/dynamically_typed.hpp"
 #include "caf/extend.hpp"


### PR DESCRIPTION
Reverts actor-framework/actor-framework#2234

Apparently, this broke things for users even though all of our tests pass. Since the exact cause is unclear and we have no reproducer: reverting for now and we'll revisit this at some later time.