### PR TITLE
Restructure the deterministic fixture

### DIFF
--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -502,10 +502,8 @@ public:
 
   void release_private_thread(detail::private_thread*);
 
-  using custom_setup_fn = void (*)(actor_system&, actor_system_config&, void*);
-
-  actor_system(actor_system_config& cfg, custom_setup_fn custom_setup,
-               void* custom_setup_data, version::abi_token = make_abi_token());
+  explicit actor_system(std::unique_ptr<detail::actor_system_impl> impl,
+                        version::abi_token = make_abi_token());
 
   /// @endcond
 
@@ -551,12 +549,6 @@ private:
   void do_launch(local_actor* ptr, caf::scheduler* ctx, spawn_options options);
 
   // -- callbacks for actor_system_access --------------------------------------
-
-  void set_logger(intrusive_ptr<detail::asynchronous_logger> ptr);
-
-  void set_clock(std::unique_ptr<actor_clock> ptr);
-
-  void set_scheduler(std::unique_ptr<caf::scheduler> ptr);
 
   void set_node(node_id id);
 

--- a/libcaf_core/caf/detail/actor_system_access.cpp
+++ b/libcaf_core/caf/detail/actor_system_access.cpp
@@ -4,24 +4,9 @@
 
 #include "caf/detail/actor_system_access.hpp"
 
-#include "caf/actor_clock.hpp"
 #include "caf/actor_system.hpp"
-#include "caf/logger.hpp"
-#include "caf/scheduler.hpp"
 
 namespace caf::detail {
-
-void actor_system_access::logger(intrusive_ptr<asynchronous_logger> ptr) {
-  sys_->set_logger(std::move(ptr));
-}
-
-void actor_system_access::clock(std::unique_ptr<actor_clock> ptr) {
-  sys_->set_clock(std::move(ptr));
-}
-
-void actor_system_access::scheduler(std::unique_ptr<caf::scheduler> ptr) {
-  sys_->set_scheduler(std::move(ptr));
-}
 
 void actor_system_access::node(node_id id) {
   sys_->set_node(id);

--- a/libcaf_core/caf/detail/actor_system_access.hpp
+++ b/libcaf_core/caf/detail/actor_system_access.hpp
@@ -19,14 +19,6 @@ public:
     // nop
   }
 
-  void logger(intrusive_ptr<asynchronous_logger> ptr);
-
-  void clock(std::unique_ptr<actor_clock> ptr);
-
-  void scheduler(std::unique_ptr<caf::scheduler> ptr);
-
-  void printer(strong_actor_ptr ptr);
-
   void node(node_id id);
 
   detail::mailbox_factory* mailbox_factory();

--- a/libcaf_core/caf/detail/actor_system_impl.hpp
+++ b/libcaf_core/caf/detail/actor_system_impl.hpp
@@ -18,8 +18,6 @@ namespace caf::detail {
 /// Abstract base type for actor system implementations.
 class CAF_CORE_EXPORT actor_system_impl {
 public:
-  using custom_setup_fn = void (*)(actor_system&, actor_system_config&, void*);
-
   // -- constructors, destructors, and assignment operators --------------------
 
   actor_system_impl() = default;
@@ -33,9 +31,7 @@ public:
   virtual telemetry::actor_metrics make_actor_metrics(std::string_view name)
     = 0;
 
-  virtual void start(actor_system& owner, custom_setup_fn custom_setup,
-                     void* custom_setup_data)
-    = 0;
+  virtual void start(actor_system& owner) = 0;
 
   virtual void stop() = 0;
 
@@ -100,12 +96,6 @@ public:
     = 0;
 
   virtual void do_print(term color, const char* buf, size_t num_bytes) = 0;
-
-  virtual void set_logger(intrusive_ptr<asynchronous_logger> ptr) = 0;
-
-  virtual void set_clock(std::unique_ptr<actor_clock> ptr) = 0;
-
-  virtual void set_scheduler(std::unique_ptr<caf::scheduler> ptr) = 0;
 
   virtual void set_node(node_id id) = 0;
 

--- a/libcaf_test/caf/test/reporter.cpp
+++ b/libcaf_test/caf/test/reporter.cpp
@@ -430,6 +430,16 @@ public:
       do_print(field);
   }
 
+  /// Prints a message to the output stream if `verbosity() >= level`.
+  void println(unsigned level, std::string_view msg) override {
+    if (level_ < level) {
+      return;
+    }
+    set_live();
+    detail::format_to(colored(), "{0:{1}}${2}({3}): {4}\n", ' ', indent_,
+                      color_by_log_level(level), log_level_names_[level], msg);
+  }
+
   void print_actor_output(local_actor* self, std::string_view msg) override {
     if (level_ < log::level::info)
       return;

--- a/libcaf_test/caf/test/reporter.hpp
+++ b/libcaf_test/caf/test/reporter.hpp
@@ -75,6 +75,9 @@ public:
     = 0;
 
   /// Prints a message to the output stream if `verbosity() >= level`.
+  virtual void println(unsigned level, std::string_view msg) = 0;
+
+  /// Prints a message to the output stream if `verbosity() >= level`.
   virtual void print(const log::event& event) = 0;
 
   /// Prints a message to the output stream if `verbosity() >= level`.


### PR DESCRIPTION
After introducing the `actor_system_impl`, we can now get rid of the roundabout way for setting up the deterministic fixture and instead simply implement a new private `actor_system_impl` subclass for the fixture.

Relates #2115.