### PR TITLE
Prevent detaching in the deterministic fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   use the new `add_ref` and `adopt_ref` tags instead.
 - Deprecate all member functions in `caf::expected` that are not present in
   `std::expected`.
+- The enumerator `spawn_options::priority_aware_flag` is a relict of pre-0.18
+  versions of CAF and had no effect for a long time. It is now deprecated and
+  will be removed in the next major release.
 
 ### Added
 

--- a/libcaf_core/caf/abstract_actor.hpp
+++ b/libcaf_core/caf/abstract_actor.hpp
@@ -15,6 +15,7 @@
 #include "caf/mailbox_element.hpp"
 #include "caf/message_id.hpp"
 #include "caf/node_id.hpp"
+#include "caf/spawn_options.hpp"
 
 #include <atomic>
 #include <condition_variable>
@@ -159,47 +160,51 @@ public:
 
   /// @cond
 
-  /// Indicates that the actor system shall not wait for this actor to
-  /// finish execution on shutdown.
-  static constexpr int is_hidden_flag = 0b0000'0000'0001;
-
-  /// Indicates that the actor is registered at the actor system.
-  static constexpr int is_registered_flag = 0b0000'0000'0010;
-
-  /// Indicates that the actor has been initialized.
-  static constexpr int is_initialized_flag = 0b0000'0000'0100;
-
-  /// Indicates that the actor uses blocking message handlers.
-  static constexpr int is_blocking_flag = 0b0000'0000'1000;
+  // note: the lowest byte is reserved for the spawn_options flags
 
   /// Indicates that the actor runs in its own thread.
-  static constexpr int is_detached_flag = 0b0000'0001'0000;
+  static constexpr int is_detached_flag
+    = static_cast<int>(spawn_options::detach_flag);
+
+  /// Indicates that the actor system shall not wait for this actor to
+  /// finish execution on shutdown.
+  static constexpr int is_hidden_flag
+    = static_cast<int>(spawn_options::hide_flag);
+
+  /// Indicates that the actor is registered at the actor system.
+  static constexpr int is_registered_flag = 0x0100;
+
+  /// Indicates that the actor has been initialized.
+  static constexpr int is_initialized_flag = 0x0200;
+
+  /// Indicates that the actor uses blocking message handlers.
+  static constexpr int is_blocking_flag = 0x0400;
 
   /// Indicates that the actor collects metrics.
-  static constexpr int collects_metrics_flag = 0b0000'0010'0000;
+  static constexpr int collects_metrics_flag = 0x0800;
 
   /// Indicates that the actor has terminated and waits for its destructor to
   /// run.
-  static constexpr int is_terminated_flag = 0b0000'1000'0000;
+  static constexpr int is_terminated_flag = 0x1000;
 
   /// Indicates that the actor is currently shutting down and thus may no longer
   /// set a new behavior.
-  static constexpr int is_shutting_down_flag = 0b0001'0000'0000;
+  static constexpr int is_shutting_down_flag = 0x2000;
 
   /// Indicates that the actor is currently inactive.
-  static constexpr int is_inactive_flag = 0b0010'0000'0000;
+  static constexpr int is_inactive_flag = 0x4000;
 
-  void setf(int flag) {
+  void setf(int flag) noexcept {
     auto x = flags();
     flags(x | flag);
   }
 
-  void unsetf(int flag) {
+  void unsetf(int flag) noexcept {
     auto x = flags();
     flags(x & ~flag);
   }
 
-  bool getf(int flag) const {
+  bool getf(int flag) const noexcept {
     return (flags() & flag) != 0;
   }
 

--- a/libcaf_core/caf/actor_companion.cpp
+++ b/libcaf_core/caf/actor_companion.cpp
@@ -32,8 +32,14 @@ bool actor_companion::enqueue(mailbox_element_ptr ptr, scheduler*) {
   }
 }
 
-void actor_companion::launch(scheduler*, bool) {
-  // nop
+bool actor_companion::initialize(scheduler*) {
+  setf(is_initialized_flag);
+  return true;
+}
+
+void actor_companion::launch([[maybe_unused]] detail::private_thread* worker,
+                             scheduler*) {
+  CAF_ASSERT(worker == nullptr);
 }
 
 void actor_companion::on_exit() {
@@ -44,6 +50,10 @@ void actor_companion::on_exit() {
   }
   if (on_exit_)
     on_exit_();
+}
+
+behavior actor_companion::type_erased_initial_behavior() {
+  return {};
 }
 
 } // namespace caf

--- a/libcaf_core/caf/actor_companion.hpp
+++ b/libcaf_core/caf/actor_companion.hpp
@@ -51,7 +51,9 @@ public:
 
   bool enqueue(mailbox_element_ptr ptr, scheduler* sched) override;
 
-  void launch(scheduler* sched, bool lazy) override;
+  bool initialize(scheduler*) override;
+
+  void launch(detail::private_thread* worker, scheduler* ctx) override;
 
   void on_exit() override;
 
@@ -96,6 +98,8 @@ public:
   }
 
 private:
+  behavior type_erased_initial_behavior() final;
+
   // set by parent to define custom enqueue action
   enqueue_handler on_enqueue_;
 

--- a/libcaf_core/caf/actor_config.cpp
+++ b/libcaf_core/caf/actor_config.cpp
@@ -8,8 +8,9 @@
 
 namespace caf {
 
-actor_config::actor_config(scheduler* sptr, local_actor* aptr)
-  : sched(sptr), parent(aptr) {
+actor_config::actor_config(spawn_options options, scheduler* sptr,
+                           local_actor* aptr)
+  : sched(sptr), parent(aptr), flags(static_cast<int>(options)) {
   // nop
 }
 

--- a/libcaf_core/caf/actor_config.hpp
+++ b/libcaf_core/caf/actor_config.hpp
@@ -7,6 +7,7 @@
 #include "caf/detail/core_export.hpp"
 #include "caf/detail/unique_function.hpp"
 #include "caf/fwd.hpp"
+#include "caf/spawn_options.hpp"
 
 #include <string>
 
@@ -21,7 +22,7 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  explicit actor_config(scheduler* sched = nullptr,
+  explicit actor_config(spawn_options options, scheduler* sched = nullptr,
                         local_actor* parent = nullptr);
 
   // -- member variables -------------------------------------------------------

--- a/libcaf_core/caf/actor_config.test.cpp
+++ b/libcaf_core/caf/actor_config.test.cpp
@@ -14,7 +14,7 @@
 using namespace caf;
 
 TEST("default constructor initializes members to nullptr") {
-  actor_config cfg;
+  actor_config cfg{no_spawn_options};
   check(cfg.sched == nullptr);
   check(cfg.parent == nullptr);
   check(cfg.init_fun.is_nullptr());
@@ -25,7 +25,7 @@ TEST("default constructor initializes members to nullptr") {
 TEST("constructor with scheduler sets sched member") {
   actor_system_config sys_cfg;
   actor_system sys{sys_cfg};
-  actor_config cfg{&sys.scheduler()};
+  actor_config cfg{no_spawn_options, &sys.scheduler()};
   check(cfg.sched == &sys.scheduler());
   check(cfg.parent == nullptr);
   check_eq(cfg.flags, 0);
@@ -35,37 +35,37 @@ TEST("constructor with scheduler and parent sets both members") {
   actor_system_config sys_cfg;
   actor_system sys{sys_cfg};
   scoped_actor self{sys};
-  actor_config cfg{&sys.scheduler(), self.ptr()};
+  actor_config cfg{no_spawn_options, &sys.scheduler(), self.ptr()};
   check(cfg.sched == &sys.scheduler());
   check(cfg.parent == self.ptr());
   check_eq(cfg.flags, 0);
 }
 
 TEST("to_string with no flags returns empty parentheses") {
-  actor_config cfg;
+  actor_config cfg{no_spawn_options};
   check_eq(to_string(cfg), "actor_config()");
 }
 
 TEST("to_string with detached_flag") {
-  actor_config cfg;
+  actor_config cfg{no_spawn_options};
   cfg.add_flag(abstract_actor::is_detached_flag);
   check_eq(to_string(cfg), "actor_config(detached_flag)");
 }
 
 TEST("to_string with blocking_flag") {
-  actor_config cfg;
+  actor_config cfg{no_spawn_options};
   cfg.add_flag(abstract_actor::is_blocking_flag);
   check_eq(to_string(cfg), "actor_config(blocking_flag)");
 }
 
 TEST("to_string with hidden_flag") {
-  actor_config cfg;
+  actor_config cfg{no_spawn_options};
   cfg.add_flag(abstract_actor::is_hidden_flag);
   check_eq(to_string(cfg), "actor_config(hidden_flag)");
 }
 
 TEST("to_string with detached and blocking flags") {
-  actor_config cfg;
+  actor_config cfg{no_spawn_options};
   cfg.add_flag(abstract_actor::is_detached_flag)
     .add_flag(abstract_actor::is_blocking_flag);
   auto result = to_string(cfg);
@@ -77,7 +77,7 @@ TEST("to_string with detached and blocking flags") {
 }
 
 TEST("to_string with all three flags") {
-  actor_config cfg;
+  actor_config cfg{no_spawn_options};
   cfg.add_flag(abstract_actor::is_detached_flag)
     .add_flag(abstract_actor::is_blocking_flag)
     .add_flag(abstract_actor::is_hidden_flag);
@@ -90,7 +90,7 @@ TEST("to_string with all three flags") {
 }
 
 TEST("add_flag returns reference for chaining") {
-  actor_config cfg;
+  actor_config cfg{no_spawn_options};
   auto& ref = cfg.add_flag(abstract_actor::is_detached_flag);
   check_eq(&ref, &cfg);
   check_eq(cfg.flags, abstract_actor::is_detached_flag);

--- a/libcaf_core/caf/actor_factory.hpp
+++ b/libcaf_core/caf/actor_factory.hpp
@@ -112,7 +112,7 @@ actor_factory make_actor_factory(F fun) {
         return result;
       },
     };
-    handle hdl = sys.spawn_class<impl, no_spawn_options>(cfg);
+    handle hdl = sys.spawn_class<impl>(cfg);
     return {actor_cast<strong_actor_ptr>(std::move(hdl)),
             sys.message_types<handle>()};
   };
@@ -126,7 +126,7 @@ struct dyn_spawn_class_helper {
   actor_system& sys;
   actor_config& cfg;
   void operator()(Ts... xs) {
-    result = sys.spawn_class<T, no_spawn_options>(cfg, xs...);
+    result = sys.spawn_class<T>(cfg, xs...);
   }
 };
 

--- a/libcaf_core/caf/actor_factory.test.cpp
+++ b/libcaf_core/caf/actor_factory.test.cpp
@@ -9,6 +9,7 @@
 #include "caf/all.hpp"
 #include "caf/config.hpp"
 #include "caf/log/test.hpp"
+#include "caf/spawn_options.hpp"
 #include "caf/type_id.hpp"
 
 using namespace caf;
@@ -26,7 +27,7 @@ struct fixture {
     log::test::debug("set aut");
     strong_actor_ptr res;
     std::set<std::string> ifs;
-    actor_config actor_cfg{&system.scheduler()};
+    actor_config actor_cfg{no_spawn_options, &system.scheduler()};
     auto aut = system.spawn<actor>("test_actor", std::move(args));
     if (expect_fail) {
       test::runnable::current().require(!aut);

--- a/libcaf_core/caf/actor_from_state.hpp
+++ b/libcaf_core/caf/actor_from_state.hpp
@@ -58,9 +58,9 @@ public:
   using handle_type = infer_handle_from_behavior_t<behavior_type>;
 
 private:
-  template <spawn_options Os, class... Args>
+  template <class... Args>
   static auto do_spawn(actor_system& sys, actor_config& cfg, Args&&... args) {
-    return sys.template spawn_impl<stateful_actor<State, base_type>, Os>(
+    return sys.template spawn_impl<stateful_actor<State, base_type>>(
       cfg, std::forward<Args>(args)...);
   }
 };

--- a/libcaf_core/caf/actor_pool.cpp
+++ b/libcaf_core/caf/actor_pool.cpp
@@ -81,7 +81,7 @@ actor_pool::~actor_pool() {
 }
 
 actor actor_pool::make(actor_system& sys, policy pol) {
-  actor_config cfg{&sys.scheduler()};
+  actor_config cfg{no_spawn_options, &sys.scheduler()};
   auto res = make_actor<actor_pool, actor>(sys.next_actor_id(), sys.node(),
                                            &sys, cfg);
   auto ptr = actor_cast<actor_pool*>(res);

--- a/libcaf_core/caf/blocking_actor.hpp
+++ b/libcaf_core/caf/blocking_actor.hpp
@@ -57,6 +57,11 @@ public:
   /// Declared message passing interface.
   using signatures = none_t;
 
+  // -- constants --------------------------------------------------------------
+
+  static constexpr auto forced_spawn_options = spawn_options::detach_flag
+                                               + spawn_options::blocking_flag;
+
   // -- nested classes ---------------------------------------------------------
 
   /// Represents pre- and postconditions for receive loops.
@@ -168,7 +173,11 @@ public:
 
   const char* name() const override;
 
-  void launch(scheduler* sched, bool lazy) override;
+  bool initialize(scheduler* sched) override;
+
+  bool launch_delayed() override;
+
+  void launch(detail::private_thread* worker, scheduler* ctx) override;
 
   // -- virtual modifiers ------------------------------------------------------
 

--- a/libcaf_core/caf/detail/actor_system_impl.hpp
+++ b/libcaf_core/caf/detail/actor_system_impl.hpp
@@ -100,6 +100,10 @@ public:
   virtual void set_node(node_id id) = 0;
 
   virtual void message_rejected(abstract_actor*) = 0;
+
+  virtual void
+  launch(local_actor* ptr, caf::scheduler* ctx, spawn_options options)
+    = 0;
 };
 
 } // namespace caf::detail

--- a/libcaf_core/caf/event_based_actor.cpp
+++ b/libcaf_core/caf/event_based_actor.cpp
@@ -18,23 +18,6 @@ event_based_actor::~event_based_actor() {
   // nop
 }
 
-void event_based_actor::initialize() {
-  auto lg = log::core::trace("subtype = {}",
-                             detail::pretty_type_name(typeid(*this)).c_str());
-  super::initialize();
-  setf(is_initialized_flag);
-  auto bhvr = make_behavior();
-  if (!bhvr) {
-    log::core::debug("make_behavior() did not return a behavior: alive = {}",
-                     alive());
-  }
-  if (bhvr) {
-    // make_behavior() did return a behavior instead of using become()
-    log::core::debug("make_behavior() did return a valid behavior");
-    become(std::move(bhvr));
-  }
-}
-
 behavior event_based_actor::make_behavior() {
   auto lg = log::core::trace("");
   behavior res;
@@ -43,6 +26,10 @@ behavior event_based_actor::make_behavior() {
     initial_behavior_fac_ = nullptr;
   }
   return res;
+}
+
+behavior event_based_actor::type_erased_initial_behavior() {
+  return make_behavior();
 }
 
 } // namespace caf

--- a/libcaf_core/caf/event_based_actor.hpp
+++ b/libcaf_core/caf/event_based_actor.hpp
@@ -44,10 +44,6 @@ public:
 
   ~event_based_actor() override;
 
-  // -- overridden functions of local_actor ------------------------------------
-
-  void initialize() override;
-
   // -- messaging --------------------------------------------------------------
 
   /// Starts a new message.
@@ -82,6 +78,9 @@ public:
 protected:
   /// Returns the initial actor behavior.
   virtual behavior make_behavior();
+
+private:
+  behavior type_erased_initial_behavior() final;
 };
 
 } // namespace caf

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -192,6 +192,7 @@ enum class exit_reason : uint8_t;
 enum class invoke_message_result;
 enum class pec : uint8_t;
 enum class sec : uint8_t;
+enum class spawn_options : int;
 enum class term;
 enum class thread_owner;
 

--- a/libcaf_core/caf/local_actor.cpp
+++ b/libcaf_core/caf/local_actor.cpp
@@ -127,10 +127,6 @@ void local_actor::do_delegate_error() {
   mid.mark_as_answered();
 }
 
-void local_actor::initialize() {
-  auto lg = log::core::trace("id = {}, name = {}", id(), name());
-}
-
 void local_actor::on_cleanup([[maybe_unused]] const error& reason) {
   auto lg = log::core::trace("reason = {}", reason);
   if (auto* running_count = metrics_.running_count) {

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -110,6 +110,10 @@ public:
     dropped
   };
 
+  // -- constants --------------------------------------------------------------
+
+  static constexpr auto forced_spawn_options = spawn_options::no_flags;
+
   // -- nested and member types ------------------------------------------------
 
   /// Base type.
@@ -203,7 +207,11 @@ public:
 
   const char* name() const override;
 
-  void launch(scheduler* sched, bool lazy) override;
+  bool initialize(scheduler* ctx) override;
+
+  bool launch_delayed() final;
+
+  void launch(detail::private_thread* worker, scheduler* ctx) override;
 
   void on_cleanup(const error& reason) override;
 
@@ -722,6 +730,8 @@ private:
 
   disposable do_monitor(abstract_actor* ptr,
                         detail::abstract_monitor_action_ptr on_down);
+
+  virtual behavior type_erased_initial_behavior() = 0;
 
   /// Encodes how an actor is currently handling timeouts.
   enum class timeout_mode {

--- a/libcaf_core/caf/spawn_options.hpp
+++ b/libcaf_core/caf/spawn_options.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "caf/caf_deprecated.hpp"
+
 namespace caf {
 
 /// @addtogroup ActorCreation
@@ -12,15 +14,16 @@ namespace caf {
 /// Stores options passed to the `spawn` function family.
 enum class spawn_options : int {
   no_flags = 0x00,
+  priority_aware_flag CAF_DEPRECATED("no longer has any effect") = 0x00,
   link_flag = 0x01,
-  detach_flag = 0x04,
-  hide_flag = 0x08,
-  priority_aware_flag = 0x20,
-  lazy_init_flag = 0x40
+  detach_flag = 0x02,
+  hide_flag = 0x04,
+  lazy_init_flag = 0x08,
+  blocking_flag = 0x80,
 };
 
 /// Concatenates two @ref spawn_options.
-constexpr spawn_options operator+(spawn_options x, spawn_options y) {
+constexpr spawn_options operator+(spawn_options x, spawn_options y) noexcept {
   return static_cast<spawn_options>(static_cast<int>(x) | static_cast<int>(y));
 }
 
@@ -45,7 +48,8 @@ constexpr spawn_options lazy_init = spawn_options::lazy_init_flag;
 /// @param haystack Bitmask to search in.
 /// @param needle Flag to search for.
 /// @returns `true` if `needle` is set in `haystack`, otherwise `false`.
-constexpr bool has_spawn_option(spawn_options haystack, spawn_options needle) {
+constexpr bool has_spawn_option(spawn_options haystack,
+                                spawn_options needle) noexcept {
   return (static_cast<int>(haystack) & static_cast<int>(needle)) != 0;
 }
 
@@ -53,35 +57,33 @@ constexpr bool has_spawn_option(spawn_options haystack, spawn_options needle) {
 /// @param opts Bitmask to search in.
 /// @returns `true` if the @ref detached flag is set in `opts`, otherwise
 ///          `false`.
-constexpr bool has_detach_flag(spawn_options opts) {
+constexpr bool has_detach_flag(spawn_options opts) noexcept {
   return has_spawn_option(opts, detached);
 }
 
-/// Obsolete, since the `priority_aware` flag no longer exists.
-/// @param opts Bitmask to search in.
-/// @returns `true`.
-constexpr bool has_priority_aware_flag([[maybe_unused]] spawn_options opts) {
+CAF_DEPRECATED("the priority_aware flag no longer exists")
+constexpr bool has_priority_aware_flag(spawn_options) noexcept {
   return true;
 }
 
 /// Checks whether the @ref hidden flag is set in `opts`.
 /// @param opts Bitmask to search in.
 /// @returns `true` if the @ref hidden flag is set in `opts`, otherwise
-constexpr bool has_hide_flag(spawn_options opts) {
+constexpr bool has_hide_flag(spawn_options opts) noexcept {
   return has_spawn_option(opts, hidden);
 }
 
 /// Checks whether the @ref linked flag is set in `opts`.
 /// @param opts Bitmask to search in.
 /// @returns `true` if the @ref linked flag is set in `opts`, otherwise
-constexpr bool has_link_flag(spawn_options opts) {
+constexpr bool has_link_flag(spawn_options opts) noexcept {
   return has_spawn_option(opts, linked);
 }
 
 /// Checks whether the @ref lazy_init flag is set in `opts`.
 /// @param opts Bitmask to search in.
 /// @returns `true` if the @ref lazy_init flag is set in `opts`, otherwise
-constexpr bool has_lazy_init_flag(spawn_options opts) {
+constexpr bool has_lazy_init_flag(spawn_options opts) noexcept {
   return has_spawn_option(opts, lazy_init);
 }
 
@@ -89,11 +91,11 @@ constexpr bool has_lazy_init_flag(spawn_options opts) {
 
 /// @cond
 
-constexpr bool is_unbound(spawn_options opts) {
+constexpr bool is_unbound(spawn_options opts) noexcept {
   return !has_link_flag(opts);
 }
 
-constexpr spawn_options make_unbound(spawn_options opts) {
+constexpr spawn_options make_unbound(spawn_options opts) noexcept {
   return static_cast<spawn_options>(
     (static_cast<int>(opts) & ~static_cast<int>(linked)));
 }

--- a/libcaf_core/caf/typed_event_based_actor.hpp
+++ b/libcaf_core/caf/typed_event_based_actor.hpp
@@ -48,22 +48,6 @@ public:
     return this->system().message_types(token);
   }
 
-  void initialize() override {
-    auto lg = log::core::trace("");
-    super::initialize();
-    this->setf(abstract_actor::is_initialized_flag);
-    auto bhvr = make_behavior();
-    if (!bhvr) {
-      log::core::debug("make_behavior() did not return a behavior: alive = {}",
-                       this->alive());
-    }
-    if (bhvr) {
-      // make_behavior() did return a behavior instead of using become()
-      log::core::debug("make_behavior() did return a valid behavior");
-      this->do_become(std::move(bhvr.unbox()), true);
-    }
-  }
-
   // -- messaging --------------------------------------------------------------
 
   /// Starts a new message.
@@ -103,6 +87,11 @@ protected:
         this->do_become(std::move(bhvr), true);
     }
     return behavior_type::make_empty_behavior();
+  }
+
+private:
+  behavior type_erased_initial_behavior() final {
+    return make_behavior().unbox();
   }
 };
 

--- a/libcaf_io/caf/io/abstract_broker.cpp
+++ b/libcaf_io/caf/io/abstract_broker.cpp
@@ -19,16 +19,16 @@
 
 namespace caf::io {
 
-void abstract_broker::launch(scheduler* sched, bool lazy) {
-  detail::current_actor_guard ctx_guard{this};
-  CAF_ASSERT(sched != nullptr);
-  CAF_ASSERT(dynamic_cast<network::multiplexer*>(sched) != nullptr);
-  backend_ = static_cast<network::multiplexer*>(sched);
-  auto lg = log::io::trace("lazy = {}", lazy);
-  if (lazy && mailbox().try_block())
-    return;
+void abstract_broker::launch(caf::detail::private_thread* worker,
+                             scheduler* ctx) {
+  caf::detail::current_actor_guard ctx_guard{this};
+  CAF_ASSERT(ctx != nullptr);
+  CAF_ASSERT(dynamic_cast<network::multiplexer*>(ctx) != nullptr);
+  backend_ = static_cast<network::multiplexer*>(ctx);
+  auto lg = log::io::trace("");
+  (void) worker; // Brokers run on the multiplexer.
   intrusive_ptr_add_ref(ctrl());
-  sched->delay(this, resumable::initialization_event_id);
+  ctx->delay(this, resumable::initialization_event_id);
 }
 
 void abstract_broker::on_cleanup(const error& reason) {

--- a/libcaf_io/caf/io/abstract_broker.hpp
+++ b/libcaf_io/caf/io/abstract_broker.hpp
@@ -63,6 +63,8 @@ class middleman;
 class CAF_IO_EXPORT abstract_broker : public scheduled_actor,
                                       public prohibit_top_level_spawn_marker {
 public:
+  static constexpr auto forced_spawn_options = spawn_options::no_flags;
+
   abstract_broker(abstract_broker&&) = delete;
 
   abstract_broker(const abstract_broker&&) = delete;
@@ -81,7 +83,7 @@ public:
 
   // -- overridden modifiers of local_actor ------------------------------------
 
-  void launch(scheduler* sched, bool lazy) override;
+  void launch(caf::detail::private_thread* worker, scheduler* ctx) override;
 
   // -- overridden modifiers of abstract_broker --------------------------------
 

--- a/libcaf_io/caf/io/basp_broker.cpp
+++ b/libcaf_io/caf/io/basp_broker.cpp
@@ -457,7 +457,7 @@ strong_actor_ptr basp_broker::make_proxy(node_id nid, actor_id aid) {
   // use a direct route if possible, i.e., when talking to a third node
   // create proxy and add functor that will be called if we
   // receive a basp::down_message
-  actor_config cfg;
+  actor_config cfg{no_spawn_options};
   auto res = make_actor<forwarding_actor_proxy, strong_actor_ptr>(aid, nid,
                                                                   &(system()),
                                                                   cfg, this);

--- a/libcaf_io/caf/io/broker.cpp
+++ b/libcaf_io/caf/io/broker.cpp
@@ -16,21 +16,6 @@
 
 namespace caf::io {
 
-void broker::initialize() {
-  auto lg = log::io::trace("");
-  init_broker();
-  auto bhvr = make_behavior();
-  if (!bhvr) {
-    log::io::debug("make_behavior() did not return a behavior: alive = {}",
-                   alive());
-  }
-  if (bhvr) {
-    // make_behavior() did return a behavior instead of using become()
-    log::io::debug("make_behavior() did return a valid behavior");
-    become(std::move(bhvr));
-  }
-}
-
 behavior broker::make_behavior() {
   behavior res;
   if (initial_behavior_fac_) {
@@ -38,6 +23,11 @@ behavior broker::make_behavior() {
     initial_behavior_fac_ = nullptr;
   }
   return res;
+}
+
+behavior broker::type_erased_initial_behavior() {
+  init_broker();
+  return make_behavior();
 }
 
 } // namespace caf::io

--- a/libcaf_io/caf/io/broker.hpp
+++ b/libcaf_io/caf/io/broker.hpp
@@ -44,15 +44,13 @@ public:
     CAF_ASSERT(sptr->hdl() == hdl);
     using trait = infer_handle_from_fun_trait_t<F>;
     using impl = typename trait::impl;
-    actor_config cfg{context()};
+    actor_config cfg{no_spawn_options, context()};
     detail::init_fun_factory<impl, F> fac;
     cfg.init_fun = fac(std::move(fun), hdl, std::forward<Ts>(xs)...);
-    auto res = this->system().spawn_class<impl, no_spawn_options>(cfg);
+    auto res = this->system().spawn_class<impl>(cfg);
     actor_cast<impl*>(res)->move_scribe(std::move(sptr));
     return res;
   }
-
-  void initialize() override;
 
   using super::super;
 
@@ -88,6 +86,9 @@ public:
 
 protected:
   virtual behavior make_behavior();
+
+private:
+  behavior type_erased_initial_behavior() final;
 };
 
 /// Convenience template alias for declaring state-based brokers.

--- a/libcaf_io/caf/io/middleman.cpp
+++ b/libcaf_io/caf/io/middleman.cpp
@@ -132,8 +132,8 @@ public:
     auto actual_port = dptr->port();
     using impl = detail::prometheus_broker;
     mpx_supervisor_ = mpx_.make_supervisor();
-    actor_config cfg{&mpx_};
-    broker_ = mpx_.system().spawn_impl<impl, hidden>(cfg, std::move(dptr));
+    actor_config cfg{hidden, &mpx_};
+    broker_ = mpx_.system().spawn_impl<impl>(cfg, std::move(dptr));
     detail::latch sync{1};
     auto run_mpx = [this, sync_ptr{&sync}] {
       auto lg = log::io::trace("");

--- a/libcaf_net/caf/net/abstract_actor_shell.cpp
+++ b/libcaf_net/caf/net/abstract_actor_shell.cpp
@@ -167,7 +167,16 @@ bool abstract_actor_shell::enqueue(mailbox_element_ptr ptr, scheduler*) {
 
 // -- overridden functions of local_actor --------------------------------------
 
-void abstract_actor_shell::launch(scheduler*, bool) {
+bool abstract_actor_shell::initialize(scheduler*) {
+  setf(is_initialized_flag);
+  return true;
+}
+
+bool abstract_actor_shell::launch_delayed() {
+  return mailbox().try_block();
+}
+
+void abstract_actor_shell::launch(caf::detail::private_thread*, scheduler*) {
   CAF_ASSERT(!getf(is_blocking_flag));
 }
 

--- a/libcaf_net/caf/net/abstract_actor_shell.hpp
+++ b/libcaf_net/caf/net/abstract_actor_shell.hpp
@@ -23,6 +23,10 @@ namespace caf::net {
 
 class CAF_NET_EXPORT abstract_actor_shell : public abstract_scheduled_actor {
 public:
+  // -- constants --------------------------------------------------------------
+
+  static constexpr auto forced_spawn_options = spawn_options::no_flags;
+
   // -- member types -----------------------------------------------------------
 
   using super = abstract_scheduled_actor;
@@ -99,7 +103,11 @@ public:
 
   // -- overridden functions of local_actor ------------------------------------
 
-  void launch(scheduler* sched, bool lazy) override;
+  bool initialize(scheduler* ctx) override;
+
+  bool launch_delayed() override;
+
+  void launch(caf::detail::private_thread* worker, scheduler* ctx) override;
 
   void on_cleanup(const error& reason) override;
 

--- a/libcaf_net/caf/net/make_actor_shell.hpp
+++ b/libcaf_net/caf/net/make_actor_shell.hpp
@@ -21,9 +21,9 @@ actor_shell_ptr_t<Handle> make_actor_shell(socket_manager* mgr) {
   using ptr_type = actor_shell_ptr_t<Handle>;
   using impl_type = typename ptr_type::element_type;
   auto& sys = mgr->mpx().system();
-  actor_config cfg;
+  actor_config cfg{no_spawn_options};
   cfg.mbox_factory = detail::actor_system_access(sys).mailbox_factory();
-  auto hdl = sys.spawn_class<impl_type, no_spawn_options>(cfg, mgr);
+  auto hdl = sys.spawn_class<impl_type>(cfg, mgr);
   auto ptr = ptr_type{actor_cast<strong_actor_ptr>(std::move(hdl))};
   ptr->set_fallback(std::move(f));
   return ptr;


### PR DESCRIPTION
When spawning an actor with the deterministic test fixture, the `detached` flag no longer has an effect and attempting to spawn a blocking actor will terminate the application.

Closes #2115.