### PR TITLE
Drop multiplexer dependency to the middleman

### DIFF
--- a/libcaf_net/caf/net/http/with.cpp
+++ b/libcaf_net/caf/net/http/with.cpp
@@ -8,8 +8,10 @@
 #include "caf/net/http/client.hpp"
 #include "caf/net/http/router.hpp"
 #include "caf/net/http/server.hpp"
+#include "caf/net/middleman.hpp"
 #include "caf/net/socket_manager.hpp"
 
+#include "caf/actor_system.hpp"
 #include "caf/add_ref.hpp"
 #include "caf/detail/connection_acceptor.hpp"
 #include "caf/detail/connection_guard.hpp"
@@ -465,7 +467,7 @@ with_t with(multiplexer* mpx) {
 }
 
 with_t with(actor_system& sys) {
-  return with(multiplexer::from(sys));
+  return with(sys.network_manager().mpx_ptr());
 }
 
 with_t::with_t(multiplexer* mpx) : config_(new config_impl(mpx)) {

--- a/libcaf_net/caf/net/lp/with.cpp
+++ b/libcaf_net/caf/net/lp/with.cpp
@@ -5,9 +5,11 @@
 #include "caf/net/lp/with.hpp"
 
 #include "caf/net/lp/framing.hpp"
+#include "caf/net/middleman.hpp"
 #include "caf/net/multiplexer.hpp"
 #include "caf/net/socket_manager.hpp"
 
+#include "caf/actor_system.hpp"
 #include "caf/chunk.hpp"
 #include "caf/detail/connection_acceptor.hpp"
 #include "caf/detail/critical.hpp"
@@ -268,7 +270,7 @@ with_t with(multiplexer* mpx) {
 }
 
 with_t with(actor_system& sys) {
-  return with(multiplexer::from(sys));
+  return with(sys.network_manager().mpx_ptr());
 }
 
 with_t::with_t(multiplexer* mpx) : config_(new config_impl(mpx)) {

--- a/libcaf_net/caf/net/middleman.cpp
+++ b/libcaf_net/caf/net/middleman.cpp
@@ -102,7 +102,7 @@ actor_system::global_state_guard middleman::init_host_system() {
 }
 
 middleman::middleman(actor_system& sys)
-  : sys_(sys), mpx_(multiplexer::make(this)) {
+  : sys_(sys), mpx_(multiplexer::make(&sys)) {
   // nop
 }
 

--- a/libcaf_net/caf/net/multiplexer.cpp
+++ b/libcaf_net/caf/net/multiplexer.cpp
@@ -5,7 +5,6 @@
 #include "caf/net/multiplexer.hpp"
 
 #include "caf/net/fwd.hpp"
-#include "caf/net/middleman.hpp"
 #include "caf/net/pipe_socket.hpp"
 #include "caf/net/socket.hpp"
 #include "caf/net/socket_event_layer.hpp"
@@ -152,7 +151,7 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  explicit default_multiplexer(middleman* parent) : owner_(parent) {
+  explicit default_multiplexer(actor_system* sys) : sys_(sys) {
     // nop
   }
 
@@ -178,12 +177,9 @@ public:
     return managers_.size();
   }
 
-  middleman& owner() override {
-    CAF_ASSERT(owner_ != nullptr);
-    return *owner_;
-  }
   actor_system& system() override {
-    return owner().system();
+    CAF_ASSERT(sys_ != nullptr);
+    return *sys_;
   }
 
   // -- implementation of execution_context ------------------------------------
@@ -616,8 +612,8 @@ private:
   /// Used for pushing updates to the multiplexer's thread.
   pipe_socket write_handle_;
 
-  /// Points to the owning middleman.
-  middleman* owner_;
+  /// Points to the owning actor system.
+  actor_system* sys_;
 
   /// Signals whether shutdown has been requested.
   bool shutting_down_ = false;
@@ -711,12 +707,8 @@ void multiplexer::block_sigpipe() {
 #endif
 }
 
-multiplexer_ptr multiplexer::make(middleman* parent) {
-  return make_counted<default_multiplexer>(parent);
-}
-
-multiplexer* multiplexer::from(actor_system& sys) {
-  return sys.network_manager().mpx_ptr();
+multiplexer_ptr multiplexer::make(actor_system* sys) {
+  return make_counted<default_multiplexer>(sys);
 }
 
 // -- constructors, destructors, and assignment operators ----------------------

--- a/libcaf_net/caf/net/multiplexer.hpp
+++ b/libcaf_net/caf/net/multiplexer.hpp
@@ -33,9 +33,6 @@ public:
   /// effect otherwise.
   static void block_sigpipe();
 
-  /// Returns a pointer to the multiplexer from the actor system.
-  static multiplexer* from(actor_system& sys);
-
   // -- constructors, destructors, and assignment operators --------------------
 
   ~multiplexer() override;
@@ -43,11 +40,10 @@ public:
   // -- factories --------------------------------------------------------------
 
   /// Creates a new multiplexer instance with the default implementation.
-  /// @param parent Points to the owning middleman instance. May be `nullptr`
-  ///               only for the purpose of unit testing if no @ref
-  ///               socket_manager requires access to the @ref middleman or the
-  ///               @ref actor_system.
-  static multiplexer_ptr make(middleman* parent);
+  /// @param sys Points to the owning actor system instance. May be `nullptr`
+  ///            only for the purpose of unit testing if no @ref socket_manager
+  ///            requires access to the @ref actor_system.
+  static multiplexer_ptr make(actor_system* sys);
 
   // -- initialization ---------------------------------------------------------
 
@@ -71,9 +67,6 @@ public:
 
   /// Returns the number of currently active socket managers.
   virtual size_t num_socket_managers() const noexcept = 0;
-
-  /// Returns the owning @ref middleman instance.
-  virtual middleman& owner() = 0;
 
   /// Returns the enclosing @ref actor_system.
   virtual actor_system& system() = 0;

--- a/libcaf_net/caf/net/octet_stream/with.cpp
+++ b/libcaf_net/caf/net/octet_stream/with.cpp
@@ -1,9 +1,11 @@
 #include "caf/net/octet_stream/with.hpp"
 
+#include "caf/net/middleman.hpp"
 #include "caf/net/ssl/context.hpp"
 #include "caf/net/ssl/tcp_acceptor.hpp"
 #include "caf/net/tcp_accept_socket.hpp"
 
+#include "caf/actor_system.hpp"
 #include "caf/defaults.hpp"
 #include "caf/detail/connection_acceptor.hpp"
 #include "caf/detail/critical.hpp"
@@ -285,7 +287,7 @@ with_t with(multiplexer* mpx) {
 }
 
 with_t with(actor_system& sys) {
-  return with(multiplexer::from(sys));
+  return with(sys.network_manager().mpx_ptr());
 }
 
 with_t::with_t(multiplexer* mpx) : config_(new config_impl(mpx)) {

--- a/libcaf_net/caf/net/web_socket/with.cpp
+++ b/libcaf_net/caf/net/web_socket/with.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/net/web_socket/with.hpp"
 
+#include "caf/net/middleman.hpp"
 #include "caf/net/ssl/context.hpp"
 #include "caf/net/ssl/tcp_acceptor.hpp"
 #include "caf/net/tcp_accept_socket.hpp"
@@ -11,6 +12,7 @@
 #include "caf/net/web_socket/handshake.hpp"
 #include "caf/net/web_socket/server.hpp"
 
+#include "caf/actor_system.hpp"
 #include "caf/defaults.hpp"
 #include "caf/detail/connection_acceptor.hpp"
 #include "caf/detail/ws_conn_acceptor.hpp"
@@ -292,7 +294,7 @@ with_t with(multiplexer* mpx) {
 }
 
 with_t with(actor_system& sys) {
-  return with(multiplexer::from(sys));
+  return with(sys.network_manager().mpx_ptr());
 }
 
 with_t::with_t(multiplexer* mpx) : config_(new config_impl(mpx)) {


### PR DESCRIPTION
Nothing in CAF ever calls `multiplexer::owner`, so the dependency seems accidental and/or is an oversight from earlier iterations.

It's *technically* public API, but the multiplexer really isn't a user facing API. And the fix is simply calling `system().network_manager()` instead, so it's trivial.