### PR TITLE
Give external access to message_rejected metrics

### DIFF
--- a/libcaf_core/caf/actor_system.cpp
+++ b/libcaf_core/caf/actor_system.cpp
@@ -954,13 +954,13 @@ void actor_system::set_node(node_id id) {
   impl_->set_node(id);
 }
 
-void actor_system::message_rejected(abstract_actor* ptr) {
-  impl_->message_rejected(ptr);
-}
-
 } // namespace caf
 
 namespace caf::detail {
+
+void actor_system_access::message_rejected(abstract_actor* ptr) {
+  sys_->impl_->message_rejected(ptr);
+}
 
 detail::daemons* actor_system_access::daemons() {
   auto ptr = sys_->impl_->modules()[actor_system_module::daemons].get();

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -105,11 +105,7 @@ public:
   friend class actor_pool;
   friend class blocking_actor;
   friend class detail::actor_system_access;
-  friend class detail::response_promise_state;
   friend class local_actor;
-  friend class net::abstract_actor_shell;
-  friend class net::middleman;
-  friend class scheduled_actor;
 
   template <class>
   friend class actor_from_state_t;
@@ -533,8 +529,6 @@ private:
   expected<strong_actor_ptr>
   dyn_spawn_impl(const std::string& name, message& args, caf::scheduler* ctx,
                  bool check_interface, const mpi* expected_ifs);
-
-  void message_rejected(abstract_actor* receiver);
 
   detail::mailbox_factory* mailbox_factory();
 

--- a/libcaf_core/caf/blocking_actor.cpp
+++ b/libcaf_core/caf/blocking_actor.cpp
@@ -6,6 +6,7 @@
 
 #include "caf/actor_system.hpp"
 #include "caf/anon_mail.hpp"
+#include "caf/detail/actor_system_access.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/detail/current_actor.hpp"
 #include "caf/detail/default_invoke_result_visitor.hpp"
@@ -67,7 +68,7 @@ bool blocking_actor::enqueue(mailbox_element_ptr ptr, scheduler*) {
   switch (mailbox().push_back(std::move(ptr))) {
     case intrusive::inbox_result::queue_closed: {
       CAF_LOG_REJECT_EVENT();
-      home_system().message_rejected(this);
+      detail::actor_system_access{home_system()}.message_rejected(this);
       if (auto* mailbox_size = metrics_.mailbox_size) {
         mailbox_size->dec();
       }

--- a/libcaf_core/caf/detail/actor_system_access.hpp
+++ b/libcaf_core/caf/detail/actor_system_access.hpp
@@ -11,7 +11,7 @@ namespace caf::detail {
 
 class daemons;
 
-/// Utility to override internal components of an actor system.
+/// Utility to access private APIs of an actor system.
 class CAF_CORE_EXPORT actor_system_access {
 public:
   explicit actor_system_access(actor_system& sys) : sys_(&sys) {
@@ -23,6 +23,8 @@ public:
   detail::mailbox_factory* mailbox_factory();
 
   detail::daemons* daemons();
+
+  void message_rejected(abstract_actor* ptr);
 
 private:
   actor_system* sys_;

--- a/libcaf_core/caf/detail/response_promise_state.cpp
+++ b/libcaf_core/caf/detail/response_promise_state.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/detail/response_promise_state.hpp"
 
+#include "caf/detail/actor_system_access.hpp"
 #include "caf/local_actor.hpp"
 #include "caf/log/core.hpp"
 #include "caf/mailbox_element.hpp"
@@ -41,7 +42,8 @@ void response_promise_state::deliver_impl(message msg) {
     auto element = make_mailbox_element(self, id.response_id(), std::move(msg));
     source->enqueue(std::move(element), selfptr->context());
   } else {
-    selfptr->home_system().message_rejected(nullptr);
+    detail::actor_system_access access{selfptr->home_system()};
+    access.message_rejected(nullptr);
   }
   cancel();
 }

--- a/libcaf_core/caf/local_actor.cpp
+++ b/libcaf_core/caf/local_actor.cpp
@@ -9,6 +9,7 @@
 #include "caf/binary_deserializer.hpp"
 #include "caf/binary_serializer.hpp"
 #include "caf/default_attachable.hpp"
+#include "caf/detail/actor_system_access.hpp"
 #include "caf/disposable.hpp"
 #include "caf/exit_reason.hpp"
 #include "caf/log/core.hpp"
@@ -146,7 +147,7 @@ void local_actor::do_anon_send(abstract_actor* receiver,
                       context());
     return;
   }
-  system().message_rejected(nullptr);
+  detail::actor_system_access{system()}.message_rejected(nullptr);
 }
 
 disposable local_actor::do_scheduled_anon_send(strong_actor_ptr receiver,
@@ -158,7 +159,7 @@ disposable local_actor::do_scheduled_anon_send(strong_actor_ptr receiver,
       timeout, receiver,
       make_mailbox_element(nullptr, make_message_id(priority), std::move(msg)));
   }
-  system().message_rejected(nullptr);
+  detail::actor_system_access{system()}.message_rejected(nullptr);
   return {};
 }
 

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -10,6 +10,7 @@
 #include "caf/anon_mail.hpp"
 #include "caf/config.hpp"
 #include "caf/defaults.hpp"
+#include "caf/detail/actor_system_access.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/detail/critical.hpp"
 #include "caf/detail/current_actor.hpp"
@@ -200,7 +201,7 @@ bool scheduled_actor::enqueue(mailbox_element_ptr ptr, scheduler* sched) {
       return true;
     default: { // intrusive::inbox_result::queue_closed
       CAF_LOG_REJECT_EVENT();
-      home_system().message_rejected(this);
+      detail::actor_system_access{home_system()}.message_rejected(this);
       if (auto* mailbox_size = metrics_.mailbox_size) {
         mailbox_size->dec();
       }

--- a/libcaf_net/caf/net/abstract_actor_shell.cpp
+++ b/libcaf_net/caf/net/abstract_actor_shell.cpp
@@ -9,6 +9,7 @@
 
 #include "caf/action.hpp"
 #include "caf/callback.hpp"
+#include "caf/detail/actor_system_access.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/detail/default_invoke_result_visitor.hpp"
 #include "caf/detail/sync_request_bouncer.hpp"
@@ -152,7 +153,7 @@ bool abstract_actor_shell::enqueue(mailbox_element_ptr ptr, scheduler*) {
       return true;
     default: { // intrusive::inbox_result::queue_closed
       CAF_LOG_REJECT_EVENT();
-      home_system().message_rejected(this);
+      detail::actor_system_access{home_system()}.message_rejected(this);
       if (auto* mailbox_size = metrics_.mailbox_size) {
         mailbox_size->dec();
       }


### PR DESCRIPTION
Give access to `message_rejected` through `actor_system_access`.