### PR TITLE
Relax the deterministic fixture type requirements

### DIFF
--- a/libcaf_core/caf/detail/mailbox_factory.hpp
+++ b/libcaf_core/caf/detail/mailbox_factory.hpp
@@ -15,10 +15,7 @@ public:
   virtual ~mailbox_factory();
 
   /// Creates a new mailbox for `owner`.
-  virtual abstract_mailbox* make(scheduled_actor* owner) = 0;
-
-  /// Creates a new mailbox for `owner`.
-  virtual abstract_mailbox* make(blocking_actor* owner) = 0;
+  virtual abstract_mailbox* make(local_actor* owner) = 0;
 };
 
 } // namespace caf::detail

--- a/libcaf_core/caf/local_actor.cpp
+++ b/libcaf_core/caf/local_actor.cpp
@@ -162,4 +162,10 @@ disposable local_actor::do_scheduled_anon_send(strong_actor_ptr receiver,
   return {};
 }
 
+// -- miscellaneous ------------------------------------------------------------
+
+resumable* local_actor::as_resumable() noexcept {
+  return nullptr;
+}
+
 } // namespace caf

--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -285,6 +285,10 @@ public:
 
   /// @cond
 
+  /// Returns a pointer to this actor as a resumable if this actor implements
+  /// the resumable interface. Returns `nullptr` otherwise.
+  virtual resumable* as_resumable() noexcept;
+
   auto& builtin_metrics() noexcept {
     return metrics_;
   }

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -283,6 +283,10 @@ void scheduled_actor::on_cleanup(const error& reason) {
   super::on_cleanup(reason);
 }
 
+resumable* scheduled_actor::as_resumable() noexcept {
+  return this;
+}
+
 // -- overridden functions of resumable ----------------------------------------
 
 void scheduled_actor::ref_resumable() const noexcept {

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -215,6 +215,8 @@ public:
 
   void on_cleanup(const error& reason) override;
 
+  resumable* as_resumable() noexcept override;
+
   // -- overridden functions of resumable --------------------------------------
 
   void ref_resumable() const noexcept final;

--- a/libcaf_test/caf/test/fixture/deterministic.hpp
+++ b/libcaf_test/caf/test/fixture/deterministic.hpp
@@ -13,9 +13,9 @@
 #include "caf/binary_serializer.hpp"
 #include "caf/detail/concepts.hpp"
 #include "caf/detail/test_export.hpp"
+#include "caf/local_actor.hpp"
 #include "caf/mailbox_element.hpp"
 #include "caf/resumable.hpp"
-#include "caf/scheduled_actor.hpp"
 
 #include <list>
 #include <memory>
@@ -447,7 +447,7 @@ public:
   size_t mail_count();
 
   /// Returns the number of pending messages for `receiver`.
-  size_t mail_count(scheduled_actor* receiver);
+  size_t mail_count(local_actor* receiver);
 
   /// Returns the number of pending messages for `receiver`.
   size_t mail_count(const strong_actor_ptr& receiver);
@@ -650,12 +650,12 @@ public:
       return;
     }
     auto* base_ptr = actor_cast<abstract_actor*>(hdl);
-    auto* ptr = dynamic_cast<scheduled_actor*>(base_ptr);
+    auto* ptr = dynamic_cast<local_actor*>(base_ptr);
     if (ptr == nullptr) {
       return;
     }
     for (auto& event : *events_) {
-      if (event->target == ptr && event->item) {
+      if (event->target == ptr->as_resumable() && event->item) {
         fn(event->item->payload);
       }
     }


### PR DESCRIPTION
Tying the `deterministic` fixture to `scheduled_actor` is overly restrictive, since the fixture actually only needs access to the two interfaces `local_actor` and `resumable`.

By adding an `as_resumable` getter to `local_actor`, we can move up the class hierarchy to allow the fixture to work with (future) actor types that implement `resumable` without inheriting from `scheduled_actor`.