### PR TITLE
Deprecate `abstract_mailbox::close(const error&)`

### DIFF
--- a/libcaf_core/caf/abstract_mailbox.hpp
+++ b/libcaf_core/caf/abstract_mailbox.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "caf/caf_deprecated.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/fwd.hpp"
 #include "caf/intrusive/inbox_result.hpp"
@@ -54,9 +55,12 @@ public:
   /// Closes the mailbox and discards all pending messages.
   /// @returns The number of dropped messages.
   /// @note Only the owning actor is allowed to call this function.
-  /// @note @p reason is ignored since CAF 1.10.0. A closed mailbox will always
-  ///       report @c sec::request_receiver_down.
-  virtual size_t close(const error& reason) = 0;
+  virtual size_t close() = 0;
+
+  CAF_DEPRECATED("use close() instead")
+  size_t close(const error&) {
+    return close();
+  }
 
   /// Returns the number of pending messages.
   /// @note Only the owning actor is allowed to call this function.

--- a/libcaf_core/caf/blocking_actor.cpp
+++ b/libcaf_core/caf/blocking_actor.cpp
@@ -354,7 +354,7 @@ size_t blocking_actor::attach_functor(const strong_actor_ptr& ptr) {
 }
 
 void blocking_actor::on_cleanup(const error& reason) {
-  close_mailbox(reason);
+  close_mailbox();
   on_exit();
   return super::on_cleanup(reason);
 }
@@ -364,17 +364,17 @@ void blocking_actor::unstash() {
     mailbox().push_front(mailbox_element_ptr{stashed});
 }
 
-void blocking_actor::close_mailbox(const error& reason) {
+void blocking_actor::close_mailbox() {
   if (!mailbox_->closed()) {
     unstash();
-    auto dropped = mailbox_->close(reason);
+    auto dropped = mailbox_->close();
     if (dropped > 0 && metrics_.mailbox_size)
       metrics_.mailbox_size->dec(static_cast<int64_t>(dropped));
   }
 }
 
 void blocking_actor::force_close_mailbox() {
-  close_mailbox(make_error(exit_reason::unreachable));
+  close_mailbox();
 }
 
 void blocking_actor::do_unstash(mailbox_element_ptr ptr) {

--- a/libcaf_core/caf/blocking_actor.hpp
+++ b/libcaf_core/caf/blocking_actor.hpp
@@ -388,7 +388,7 @@ private:
 
   void unstash();
 
-  void close_mailbox(const error& reason);
+  void close_mailbox();
 
   void force_close_mailbox() final;
 

--- a/libcaf_core/caf/detail/default_mailbox.cpp
+++ b/libcaf_core/caf/detail/default_mailbox.cpp
@@ -48,7 +48,7 @@ bool default_mailbox::try_unblock() {
   return inbox_.try_unblock();
 }
 
-size_t default_mailbox::close(const error&) {
+size_t default_mailbox::close() {
   size_t result = 0;
   detail::sync_request_bouncer bounce;
   auto bounce_and_count = [&bounce, &result](mailbox_element* ptr) {

--- a/libcaf_core/caf/detail/default_mailbox.hpp
+++ b/libcaf_core/caf/detail/default_mailbox.hpp
@@ -41,7 +41,7 @@ public:
 
   bool try_unblock() override;
 
-  size_t close(const error&) override;
+  size_t close() override;
 
   size_t size() override;
 

--- a/libcaf_core/caf/detail/default_mailbox.test.cpp
+++ b/libcaf_core/caf/detail/default_mailbox.test.cpp
@@ -39,7 +39,7 @@ TEST("the first item unblocks the mailbox") {
 
 TEST("a closed mailbox no longer accepts new messages") {
   detail::default_mailbox uut;
-  uut.close(error{});
+  uut.close();
   check_eq(uut.push_back(make_int_msg(1)), ires::queue_closed);
 }
 

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -279,7 +279,7 @@ void scheduled_actor::on_cleanup(const error& reason) {
   awaited_responses_.clear();
   multiplexed_responses_.clear();
   cancel_flows_and_streams();
-  close_mailbox(reason);
+  close_mailbox();
   // Dispatch to parent's `on_cleanup` function.
   super::on_cleanup(reason);
 }
@@ -1218,7 +1218,7 @@ void scheduled_actor::cancel_flows_and_streams() {
   run_actions();
 }
 
-void scheduled_actor::close_mailbox(const error& reason) {
+void scheduled_actor::close_mailbox() {
   // Discard stashed messages.
   auto dropped = size_t{0};
   if (!stash_.empty()) {
@@ -1231,13 +1231,13 @@ void scheduled_actor::close_mailbox(const error& reason) {
   }
   // Clear mailbox.
   if (!mailbox().closed())
-    dropped += mailbox().close(reason);
+    dropped += mailbox().close();
   if (dropped > 0 && metrics_.mailbox_size)
     metrics_.mailbox_size->dec(static_cast<int64_t>(dropped));
 }
 
 void scheduled_actor::force_close_mailbox() {
-  close_mailbox(make_error(exit_reason::unreachable));
+  close_mailbox();
 }
 
 // -- monitoring ---------------------------------------------------------------

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -804,7 +804,7 @@ private:
 
   // -- cleanup ----------------------------------------------------------------
 
-  void close_mailbox(const error& reason);
+  void close_mailbox();
 
   void force_close_mailbox() final;
 

--- a/libcaf_net/caf/net/abstract_actor_shell.cpp
+++ b/libcaf_net/caf/net/abstract_actor_shell.cpp
@@ -182,7 +182,7 @@ void abstract_actor_shell::launch(caf::detail::private_thread*, scheduler*) {
 
 void abstract_actor_shell::on_cleanup(const error& reason) {
   auto lg = log::net::trace("reason = {}", reason);
-  close_mailbox(reason);
+  close_mailbox();
   // Detach from owner.
   {
     std::unique_lock<std::mutex> guard{loop_mtx_};
@@ -199,16 +199,16 @@ void abstract_actor_shell::do_unstash(mailbox_element_ptr ptr) {
   mailbox_.push_front(std::move(ptr));
 }
 
-void abstract_actor_shell::close_mailbox(const error& reason) {
+void abstract_actor_shell::close_mailbox() {
   if (!mailbox_.closed()) {
-    auto dropped = mailbox_.close(reason);
+    auto dropped = mailbox_.close();
     if (dropped > 0 && metrics_.mailbox_size)
       metrics_.mailbox_size->dec(static_cast<int64_t>(dropped));
   }
 }
 
 void abstract_actor_shell::force_close_mailbox() {
-  close_mailbox(make_error(exit_reason::unreachable));
+  close_mailbox();
 }
 
 flow::coordinator* abstract_actor_shell::flow_context() {

--- a/libcaf_net/caf/net/abstract_actor_shell.hpp
+++ b/libcaf_net/caf/net/abstract_actor_shell.hpp
@@ -121,7 +121,7 @@ private:
 
   void do_unstash(mailbox_element_ptr ptr) override;
 
-  void close_mailbox(const error& reason);
+  void close_mailbox();
 
   void force_close_mailbox() final;
 

--- a/libcaf_test/caf/test/fixture/deterministic.cpp
+++ b/libcaf_test/caf/test/fixture/deterministic.cpp
@@ -170,9 +170,8 @@ public:
     return true;
   }
 
-  size_t close(const error& reason) override {
+  size_t close() override {
     closed_ = true;
-    close_reason_ = reason;
     auto result = size_t{0};
     auto bounce = detail::sync_request_bouncer{};
     auto envelope = next_msg(*events_, owner_);
@@ -199,7 +198,6 @@ public:
 private:
   bool blocked_ = false;
   bool closed_ = false;
-  error close_reason_;
   deterministic::events_list_ptr events_;
   local_actor* owner_;
 };


### PR DESCRIPTION
The error reason is ignored since CAF 1.1, so we should drop it from the interface with CAF 2.0.