### PR TITLE
Backport of removed abort() call 

### DIFF
--- a/libcaf_net/caf/net/octet_stream/transport.cpp
+++ b/libcaf_net/caf/net/octet_stream/transport.cpp
@@ -354,9 +354,13 @@ protected:
       auto delta = bytes.subspan(delta_offset_);
       auto consumed = up_->consume(bytes, delta);
       if (consumed < 0) {
-        // Negative values indicate that the application wants to close the
-        // socket. We still make sure to send any pending data before closing.
-        up_->abort(make_error(caf::sec::runtime_error, "consumed < 0"));
+        // Negative values indicate that the upper layer wants to close the
+        // connection. The upper layer has already performed its shutdown logic
+        // (e.g., WebSocket framing sends a close frame and calls
+        // down_->shutdown() before returning). Calling up_->abort() here would
+        // cause protocols like WebSocket to send a duplicate close frame. We
+        // only need to propagate the shutdown to flush the write buffer and
+        // close.
         shutdown();
         return;
       }

--- a/robot/CMakeLists.txt
+++ b/robot/CMakeLists.txt
@@ -117,7 +117,9 @@ if(TARGET CAF::net AND CAF_ENABLE_EXAMPLES)
     web-socket
     echo
     --variable BINARY_PATH:$<TARGET_FILE:echo>
-    --variable SSL_PATH:${CMAKE_CURRENT_SOURCE_DIR})
+    --variable SSL_PATH:${CMAKE_CURRENT_SOURCE_DIR}
+    --variable PYTHON:${Python_EXECUTABLE}
+    --variable CLOSE_FRAME_SCRIPT:${CMAKE_SOURCE_DIR}/scripts/websocket-close-frame-test.py)
 
   add_robot_test(
     web-socket

--- a/robot/web-socket/echo.robot
+++ b/robot/web-socket/echo.robot
@@ -9,13 +9,15 @@ Suite Setup       Start Servers
 Suite Teardown    Stop Servers
 
 *** Variables ***
-${HTTP_URL}       http://localhost:55503
-${HTTPS_URL}      https://localhost:55504
-${WS_URL}         ws://localhost:55503
-${WSS_URL}        wss://localhost:55504
-${FRAME_COUNT}    ${10}
-${BINARY_PATH}    /path/to/the/server
-${SSL_PATH}       /path/to/the/pem/files
+${HTTP_URL}              http://localhost:55503
+${HTTPS_URL}             https://localhost:55504
+${WS_URL}                ws://localhost:55503
+${WSS_URL}               wss://localhost:55504
+${FRAME_COUNT}           ${10}
+${BINARY_PATH}           /path/to/the/server
+${SSL_PATH}              /path/to/the/pem/files
+${PYTHON}                python
+${CLOSE_FRAME_SCRIPT}    /path/to/scripts/websocket-close-frame-test.py
 
 *** Test Cases ***
 Test WebSocket Server
@@ -34,6 +36,13 @@ Test WebSocket Over SSL Server
     ${result}=              WebSocketClient.Recv    ${fd}
     WebSocketClient.Close   ${fd}
     Should Be Equal         ${result}    Hello
+
+Test WebSocket Single Close Frame On Client Initiated Close
+    [Tags]      WebSocket  Regression
+    [Timeout]   10
+    ${result}=  Run Process  ${PYTHON}  ${CLOSE_FRAME_SCRIPT}  ${WS_URL}  timeout=10s
+    Should Be Equal As Integers  ${result.rc}  0
+    Log    ${result.stdout}
 
 *** Keywords ***
 Start Servers

--- a/scripts/websocket-close-frame-test.py
+++ b/scripts/websocket-close-frame-test.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+WebSocket close frame test client.
+
+Connects to a WebSocket server, sends a message, sends a close frame, then
+collects and counts all incoming frames until the connection closes. Useful for
+detecting bugs where the server sends multiple close frames instead of one.
+
+Usage:
+    python scripts/websocket-close-frame-test.py <URL>
+"""
+
+import sys
+
+try:
+    import websocket
+    from websocket import ABNF
+except ImportError:
+    print("Error: websocket-client is required. Install with: pip install websocket-client", file=sys.stderr)
+    sys.exit(2)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: websocket-close-frame-test.py <URL>", file=sys.stderr)
+        sys.exit(2)
+    url = sys.argv[1]
+    ws = websocket.WebSocket()
+    ws.settimeout(5.0)
+    try:
+        print(f"Connecting to {url}...")
+        ws.connect(url)
+        msg = "Hello"
+        print(f"Sending message: {msg!r}")
+        ws.send(msg)
+        try:
+            opcode, data = ws.recv_data(control_frame=True)
+            if opcode == ABNF.OPCODE_TEXT:
+                print(f"Received echo: {data!r}")
+            elif opcode == ABNF.OPCODE_BINARY:
+                print(f"Received binary: {data!r}")
+        except websocket.WebSocketConnectionClosedException:
+            # Connection may have been closed already; ignore.
+            pass
+        except Exception as e:
+            print(f"Unexpected error while receiving initial frame: {e}", file=sys.stderr)
+            raise
+        # Send close frame
+        print("Sending close frame...")
+        ws.send_close(status=1000, reason=b"Client closing")
+        # Collect all incoming frames until connection closes
+        close_frames = []
+        all_frames = []
+        opcode_names = {
+            ABNF.OPCODE_TEXT: "text",
+            ABNF.OPCODE_BINARY: "binary",
+            ABNF.OPCODE_CLOSE: "close",
+            ABNF.OPCODE_PING: "ping",
+            ABNF.OPCODE_PONG: "pong",
+            ABNF.OPCODE_CONT: "continuation",
+        }
+        print("Receiving frames (waiting for close)...")
+        while True:
+            try:
+                frame = ws.recv_frame()
+                all_frames.append(frame)
+                opcode_name = opcode_names.get(frame.opcode, f"unknown({frame.opcode})")
+                if frame.opcode == ABNF.OPCODE_CLOSE:
+                    close_frames.append(frame)
+                    payload = frame.data
+                    if len(payload) >= 2:
+                        status = (payload[0] << 8) | payload[1]
+                        reason = payload[2:].decode("utf-8", errors="replace") if len(payload) > 2 else ""
+                        print(f"  Close frame #{len(close_frames)}: status={status}, reason={reason!r}")
+                    else:
+                        print(f"  Close frame #{len(close_frames)}: (no status/reason)")
+                else:
+                    print(f"  {opcode_name} frame: {len(frame.data)} bytes")
+            except websocket.WebSocketConnectionClosedException:
+                break
+            except Exception as e:
+                # Connection closed or timeout
+                err_str = str(e).lower()
+                if "timed out" in err_str or "timeout" in err_str:
+                    break
+                raise
+
+        # Report results
+        print(f"Total frames received after sending close: {len(all_frames)}")
+        print(f"Close frames received: {len(close_frames)}")
+        return len(close_frames) != 1
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    finally:
+        try:
+            ws.close()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Backport of #2281. 

When WebSocket framing receives a close frame it calls abort_and_shutdown, sending a close frame via shutdown(err). Framing returns -1 from consume() to signal shutdown. Transport sees consumed < 0 and calls up_->abort(), and sends a second close frame.