### PR TITLE
Use intrusive pointers on the scheduler interface

### DIFF
--- a/libcaf_core/caf/blocking_actor.cpp
+++ b/libcaf_core/caf/blocking_actor.cpp
@@ -167,7 +167,7 @@ void blocking_actor::launch(detail::private_thread* worker, scheduler*) {
   CAF_ASSERT(worker != nullptr);
   detail::current_actor_guard ctx_guard{this};
   auto lg = log::core::trace("");
-  worker->resume(new blocking_actor_runner(this, worker));
+  worker->resume(resumable_ptr::make<blocking_actor_runner>(this, worker));
 }
 
 blocking_actor::receive_while_helper

--- a/libcaf_core/caf/detail/cleanup_and_release.cpp
+++ b/libcaf_core/caf/detail/cleanup_and_release.cpp
@@ -4,20 +4,24 @@
 
 #include "caf/detail/cleanup_and_release.hpp"
 
+#include "caf/detail/assert.hpp"
 #include "caf/resumable.hpp"
 #include "caf/scheduled_actor.hpp"
 #include "caf/scheduler.hpp"
 
+#include <vector>
+
 namespace caf::detail {
 
-void cleanup_and_release(resumable* ptr) {
+void cleanup_and_release(resumable_ptr job) {
+  CAF_ASSERT(job != nullptr);
   class dummy_scheduler : public scheduler {
   public:
-    void delay(resumable* job, uint64_t) override {
-      resumables.push_back(job);
+    void delay(resumable_ptr sub, uint64_t) override {
+      resumables.push_back(std::move(sub));
     }
-    void schedule(resumable* job, uint64_t) override {
-      resumables.push_back(job);
+    void schedule(resumable_ptr sub, uint64_t) override {
+      resumables.push_back(std::move(sub));
     }
     void start() override {
       // nop
@@ -28,17 +32,15 @@ void cleanup_and_release(resumable* ptr) {
     bool is_system_scheduler() const noexcept final {
       return true;
     }
-    std::vector<resumable*> resumables;
+    std::vector<resumable_ptr> resumables;
   };
   dummy_scheduler dummy;
-  ptr->resume(&dummy, resumable::dispose_event_id);
+  job->resume(&dummy, resumable::dispose_event_id);
   while (!dummy.resumables.empty()) {
-    auto sub = dummy.resumables.back();
+    auto sub = std::move(dummy.resumables.back());
     dummy.resumables.pop_back();
     sub->resume(&dummy, resumable::dispose_event_id);
-    intrusive_ptr_release(sub);
   }
-  intrusive_ptr_release(ptr);
 }
 
 } // namespace caf::detail

--- a/libcaf_core/caf/detail/cleanup_and_release.hpp
+++ b/libcaf_core/caf/detail/cleanup_and_release.hpp
@@ -9,6 +9,6 @@
 
 namespace caf::detail {
 
-CAF_CORE_EXPORT void cleanup_and_release(resumable*);
+CAF_CORE_EXPORT void cleanup_and_release(resumable_ptr job);
 
 } // namespace caf::detail

--- a/libcaf_core/caf/detail/cleanup_and_release.test.cpp
+++ b/libcaf_core/caf/detail/cleanup_and_release.test.cpp
@@ -47,10 +47,8 @@ struct single_mock : mock_base {
 };
 
 struct nested_mock : mock_base {
-  using child_ptr = intrusive_ptr<mock_base>;
-
   nested_mock(std::shared_ptr<std::atomic<bool>> disposed_flag,
-              std::vector<child_ptr> children)
+              std::vector<resumable_ptr> children)
     : mock_base(std::move(disposed_flag)), children(std::move(children)) {
   }
 
@@ -58,22 +56,20 @@ struct nested_mock : mock_base {
     if (event_id == resumable::dispose_event_id) {
       disposed_flag->store(true);
       for (auto& child : children) {
-        intrusive_ptr_add_ref(child.get());
-        ctx->delay(child.get(), resumable::dispose_event_id);
+        ctx->delay(child, resumable::dispose_event_id);
       }
       return;
     }
   }
 
-  std::vector<child_ptr> children;
+  std::vector<resumable_ptr> children;
 };
 
 } // namespace
 
 TEST("cleanup_and_release resumes a single resumable with dispose_event_id") {
   auto disposed = std::make_shared<std::atomic<bool>>(false);
-  auto p = make_counted<single_mock>(disposed);
-  cleanup_and_release(p.release());
+  cleanup_and_release(make_counted<single_mock>(disposed));
   check(disposed->load());
 }
 
@@ -83,12 +79,12 @@ TEST("cleanup_and_release recursively disposes nested resumables") {
   auto child1_disposed = std::make_shared<std::atomic<bool>>(false);
   auto child2_disposed = std::make_shared<std::atomic<bool>>(false);
   // Create the resumables.
-  std::vector<nested_mock::child_ptr> children;
+  std::vector<resumable_ptr> children;
   children.emplace_back(make_counted<single_mock>(child1_disposed));
   children.emplace_back(make_counted<single_mock>(child2_disposed));
   auto parent = make_counted<nested_mock>(parent_disposed, std::move(children));
   // Clean up the parent and its children.
-  cleanup_and_release(parent.release());
+  cleanup_and_release(std::move(parent));
   // Check the flags.
   check(parent_disposed->load());
   check(child1_disposed->load());

--- a/libcaf_core/caf/detail/private_thread.cpp
+++ b/libcaf_core/caf/detail/private_thread.cpp
@@ -21,7 +21,6 @@ void private_thread::run(actor_system* sys) {
     if (job) {
       CAF_ASSERT(job->pinned_scheduler() == nullptr);
       job->resume(&sys->scheduler(), resumable::default_event_id);
-      intrusive_ptr_release(job);
     }
     if (done) {
       return;
@@ -29,10 +28,10 @@ void private_thread::run(actor_system* sys) {
   }
 }
 
-void private_thread::resume(resumable* ptr) {
+void private_thread::resume(resumable_ptr job) {
   std::unique_lock<std::mutex> guard{mtx_};
   CAF_ASSERT(job_ == nullptr);
-  job_ = ptr;
+  job_ = std::move(job);
   cv_.notify_all();
 }
 
@@ -46,14 +45,13 @@ bool private_thread::stop() {
   return true;
 }
 
-std::pair<resumable*, bool> private_thread::await() {
+std::pair<resumable_ptr, bool> private_thread::await() {
   std::unique_lock<std::mutex> guard(mtx_);
   while (job_ == nullptr && !shutdown_)
     cv_.wait(guard);
-  auto ptr = job_;
-  if (ptr)
-    job_ = nullptr;
-  return {ptr, shutdown_};
+  auto job = resumable_ptr{};
+  job.swap(job_);
+  return {std::move(job), shutdown_};
 }
 
 private_thread* private_thread::launch(actor_system* sys) {

--- a/libcaf_core/caf/detail/private_thread.hpp
+++ b/libcaf_core/caf/detail/private_thread.hpp
@@ -7,6 +7,8 @@
 #include "caf/detail/core_export.hpp"
 #include "caf/detail/private_thread_pool.hpp"
 #include "caf/fwd.hpp"
+#include "caf/intrusive_ptr.hpp"
+#include "caf/resumable.hpp"
 
 #include <atomic>
 #include <condition_variable>
@@ -17,7 +19,7 @@ namespace caf::detail {
 
 class CAF_CORE_EXPORT private_thread : public private_thread_pool::node {
 public:
-  void resume(resumable* ptr);
+  void resume(resumable_ptr job);
 
   bool stop() override;
 
@@ -30,12 +32,12 @@ public:
 private:
   void run(actor_system* sys);
 
-  std::pair<resumable*, bool> await();
+  std::pair<resumable_ptr, bool> await();
 
   std::thread thread_;
   std::mutex mtx_;
   std::condition_variable cv_;
-  resumable* job_ = nullptr;
+  resumable_ptr job_;
   bool shutdown_ = false;
 };
 

--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -385,6 +385,7 @@ using weak_actor_ptr = weak_intrusive_ptr<actor_control_block>;
 
 // -- intrusive pointer aliases ------------------------------------------------
 
+using resumable_ptr = intrusive_ptr<resumable>;
 using strong_actor_ptr = intrusive_ptr<actor_control_block>;
 
 // -- unique pointer aliases ---------------------------------------------------

--- a/libcaf_core/caf/intrusive_ptr.hpp
+++ b/libcaf_core/caf/intrusive_ptr.hpp
@@ -165,6 +165,16 @@ public:
     reset(new T(std::forward<Ts>(xs)...), adopt_ref);
   }
 
+  /// Constructs an object of type `U` in an `intrusive_ptr`. This factory
+  /// function is similar to `make_counted`, but it allows passing a derived
+  /// type of `T` as the template parameter. This allows constructing an object
+  /// on a derived type while using the base type for the pointer.
+  template <class U = T, class... Ts>
+  static intrusive_ptr make(Ts&&... xs) {
+    static_assert(std::is_convertible_v<U*, T*>);
+    return {new U(std::forward<Ts>(xs)...), adopt_ref};
+  }
+
   intrusive_ptr& operator=(std::nullptr_t) noexcept {
     reset();
     return *this;

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -5,8 +5,8 @@
 #include "caf/scheduled_actor.hpp"
 
 #include "caf/action.hpp"
-#include "caf/actor_registry.hpp"
 #include "caf/actor_system_config.hpp"
+#include "caf/add_ref.hpp"
 #include "caf/anon_mail.hpp"
 #include "caf/config.hpp"
 #include "caf/defaults.hpp"
@@ -20,7 +20,6 @@
 #include "caf/detail/private_thread.hpp"
 #include "caf/detail/sync_request_bouncer.hpp"
 #include "caf/flow/observable_builder.hpp"
-#include "caf/flow/op/mcast.hpp"
 #include "caf/format_to_error.hpp"
 #include "caf/log/core.hpp"
 #include "caf/log/system.hpp"
@@ -28,7 +27,6 @@
 #include "caf/scheduler.hpp"
 #include "caf/send.hpp"
 #include "caf/stream.hpp"
-#include "caf/telemetry/metric_family_impl.hpp"
 
 using namespace std::string_literals;
 
@@ -193,13 +191,13 @@ bool scheduled_actor::enqueue(mailbox_element_ptr ptr, scheduler* sched) {
   switch (mailbox().push_back(std::move(ptr))) {
     case intrusive::inbox_result::unblocked_reader: {
       CAF_LOG_ACCEPT_EVENT(true);
-      intrusive_ptr_add_ref(ctrl());
       if (private_thread_) {
-        private_thread_->resume(this);
+        private_thread_->resume(resumable_ptr{this, add_ref});
       } else if (use_delay) {
-        sched->delay(this, resumable::default_event_id);
+        sched->delay(resumable_ptr{this, add_ref}, resumable::default_event_id);
       } else {
-        sched->schedule(this, resumable::default_event_id);
+        sched->schedule(resumable_ptr{this, add_ref},
+                        resumable::default_event_id);
       }
       return true;
     }
@@ -267,16 +265,14 @@ void scheduled_actor::launch(detail::private_thread* worker, scheduler* ctx) {
   auto lg = log::core::trace("");
   if (worker) {
     private_thread_ = worker;
-    intrusive_ptr_add_ref(ctrl());
-    private_thread_->resume(this);
+    private_thread_->resume(resumable_ptr{this, add_ref});
     return;
   }
   if (auto* pinned = pinned_scheduler()) {
     ctx = pinned;
   }
   CAF_ASSERT(ctx != nullptr);
-  intrusive_ptr_add_ref(ctrl());
-  ctx->delay(this, resumable::initialization_event_id);
+  ctx->delay(resumable_ptr{this, add_ref}, resumable::initialization_event_id);
 }
 
 void scheduled_actor::on_cleanup(const error& reason) {
@@ -374,8 +370,7 @@ void scheduled_actor::resume(scheduler* sched, uint64_t event_id) {
   using detail::actor_system_access;
   log::core::debug("max throughput reached: resume later");
   actor_system_access{home_system()}.impl()->max_throughput_reached(this);
-  intrusive_ptr_add_ref(ctrl());
-  sched->delay(this, resumable::default_event_id);
+  sched->delay(resumable_ptr{this, add_ref}, resumable::default_event_id);
 }
 
 // -- scheduler callbacks ------------------------------------------------------

--- a/libcaf_core/caf/scheduler.cpp
+++ b/libcaf_core/caf/scheduler.cpp
@@ -6,23 +6,18 @@
 
 #include "caf/actor_system.hpp"
 #include "caf/actor_system_config.hpp"
-#include "caf/blocking_actor.hpp"
-#include "caf/config.hpp"
+#include "caf/add_ref.hpp"
+#include "caf/adopt_ref.hpp"
 #include "caf/defaults.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/detail/cleanup_and_release.hpp"
 #include "caf/detail/default_thread_count.hpp"
 #include "caf/detail/double_ended_queue.hpp"
 #include "caf/logger.hpp"
-#include "caf/scheduled_actor.hpp"
-#include "caf/scoped_actor.hpp"
-#include "caf/send.hpp"
+#include "caf/resumable.hpp"
 #include "caf/thread_owner.hpp"
 
 #include <condition_variable>
-#include <fstream>
-#include <ios>
-#include <iostream>
 #include <memory>
 #include <random>
 #include <thread>
@@ -98,8 +93,6 @@ struct worker_data {
 /// Implementation of the work stealing worker class.
 class worker : public scheduler {
 public:
-  using job_ptr = resumable*;
-
   template <class SchedulerImpl>
   worker(size_t worker_id, SchedulerImpl*, const worker_data& init)
     : id_(worker_id), data_(init) {
@@ -129,14 +122,14 @@ public:
     return true;
   }
 
-  void schedule(job_ptr job, uint64_t) override {
+  void schedule(resumable_ptr job, uint64_t) override {
     CAF_ASSERT(job != nullptr);
-    data_.queue.append(job);
+    data_.queue.append(job.release());
   }
 
-  void delay(job_ptr job, uint64_t) override {
+  void delay(resumable_ptr job, uint64_t) override {
     CAF_ASSERT(job != nullptr);
-    data_.queue.prepend(job);
+    data_.queue.prepend(job.release());
   }
 
   size_t id() const {
@@ -168,7 +161,7 @@ private:
   }
 
   template <typename Parent>
-  resumable* policy_dequeue(Parent* parent) {
+  resumable_ptr policy_dequeue(Parent* parent) {
     // We wait for new jobs by polling our external queue: first, we assume an
     // active work load on the machine and perform aggressive/moderate polling
     // by using the parameters for the first two strategies. When not finding
@@ -180,11 +173,11 @@ private:
            attempt += strategy.step_size) {
         // Wait for some work to appear.
         if (auto* job = data_.queue.try_take_head(strategy.sleep_duration))
-          return job;
+          return {job, adopt_ref};
         // Try to steal every X poll attempts.
         if ((attempt % strategy.steal_interval) == 0) {
           if (auto* job = try_steal(parent))
-            return job;
+            return {job, adopt_ref};
         }
       }
     }
@@ -193,9 +186,9 @@ private:
     auto& relaxed = data_.strategies[2];
     for (;;) {
       if (auto* job = data_.queue.try_take_head(relaxed.sleep_duration))
-        return job;
+        return {job, adopt_ref};
       if (auto* job = try_steal(parent))
-        return job;
+        return {job, adopt_ref};
     }
   }
 
@@ -207,7 +200,6 @@ private:
       auto job = policy_dequeue(parent);
       CAF_ASSERT(job->pinned_scheduler() == nullptr);
       job->resume(this, resumable::default_event_id);
-      intrusive_ptr_release(job);
       if (stop_worker)
         return;
     }
@@ -254,13 +246,13 @@ public:
 
   // -- implementation of scheduler interface ----------------------------------
 
-  void schedule(resumable* ptr, uint64_t) override {
+  void schedule(resumable_ptr job, uint64_t) override {
     auto w = this->worker_by_id(next_worker++ % num_workers_);
-    w->schedule(ptr, resumable::default_event_id);
+    w->schedule(std::move(job), resumable::default_event_id);
   }
 
-  void delay(resumable* what, uint64_t) override {
-    schedule(what, resumable::default_event_id);
+  void delay(resumable_ptr what, uint64_t) override {
+    schedule(std::move(what), resumable::default_event_id);
   }
 
   void start() override {
@@ -308,10 +300,8 @@ public:
     for (size_t i = 0; i < num_workers_; ++i)
       alive_workers.insert(worker_by_id(i));
     while (!alive_workers.empty()) {
-      // Add a reference before scheduling. The worker will release this
-      // reference after processing the shutdown_helper.
-      sh.ref();
-      (*alive_workers.begin())->schedule(&sh, resumable::default_event_id);
+      (*alive_workers.begin())
+        ->schedule(resumable_ptr{&sh, add_ref}, resumable::default_event_id);
       // Since jobs can be stolen, we cannot assume that we have actually shut
       // down the worker we've enqueued sh to.
       {
@@ -329,7 +319,7 @@ public:
     for (auto& w : workers_) {
       auto next = [&] { return w->data().queue.try_take_head(); };
       for (auto job = next(); job != nullptr; job = next())
-        detail::cleanup_and_release(job);
+        detail::cleanup_and_release(resumable_ptr{job, adopt_ref});
     }
   }
 
@@ -364,8 +354,6 @@ namespace work_sharing {
 template <class Parent>
 class worker : public scheduler {
 public:
-  using job_ptr = resumable*;
-
   worker(size_t worker_id, Parent* parent) : parent_{parent}, id_(worker_id) {
     // nop
   }
@@ -389,14 +377,14 @@ public:
     return true;
   }
 
-  void schedule(job_ptr job, uint64_t) override {
+  void schedule(resumable_ptr job, uint64_t) override {
     CAF_ASSERT(job != nullptr);
-    parent_->schedule(job, resumable::default_event_id);
+    parent_->schedule(std::move(job), resumable::default_event_id);
   }
 
-  void delay(job_ptr job, uint64_t) override {
+  void delay(resumable_ptr job, uint64_t) override {
     CAF_ASSERT(job != nullptr);
-    parent_->schedule(job, resumable::default_event_id);
+    parent_->schedule(std::move(job), resumable::default_event_id);
   }
 
   size_t id() const noexcept {
@@ -416,7 +404,6 @@ private:
       CAF_ASSERT(job != nullptr);
       CAF_ASSERT(job->pinned_scheduler() == nullptr);
       job->resume(this, resumable::default_event_id);
-      intrusive_ptr_release(job);
       if (stop_worker) {
         return;
       }
@@ -439,7 +426,7 @@ public:
 
   using worker_type = worker<scheduler_impl>;
 
-  using queue_type = std::list<resumable*>;
+  using queue_type = std::list<resumable_ptr>;
 
   explicit scheduler_impl(actor_system& sys) : sys_(&sys) {
     auto& cfg = sys.config();
@@ -463,16 +450,16 @@ public:
 
   // -- implementation of scheduler interface ----------------------------------
 
-  void schedule(resumable* ptr, uint64_t) override {
+  void schedule(resumable_ptr job, uint64_t) override {
     queue_type l;
-    l.push_back(ptr);
+    l.emplace_back(std::move(job));
     std::unique_lock<std::mutex> guard(lock);
     queue.splice(queue.end(), l);
     cv.notify_one();
   }
 
-  void delay(resumable* what, uint64_t) override {
-    schedule(what, resumable::default_event_id);
+  void delay(resumable_ptr what, uint64_t) override {
+    schedule(std::move(what), resumable::default_event_id);
   }
 
   void start() override {
@@ -517,10 +504,8 @@ public:
     for (size_t i = 0; i < num_workers_; ++i)
       alive_workers.insert(worker_by_id(i));
     while (!alive_workers.empty()) {
-      // Add a reference before scheduling. The worker will release this
-      // reference after processing the shutdown_helper.
-      sh.ref();
-      (*alive_workers.begin())->schedule(&sh, resumable::default_event_id);
+      (*alive_workers.begin())
+        ->schedule(resumable_ptr{&sh, add_ref}, resumable::default_event_id);
       // Since jobs can be stolen, we cannot assume that we have actually shut
       // down the worker we've enqueued sh to.
       { // lifetime scope of guard
@@ -535,40 +520,38 @@ public:
       w->get_thread().join();
     }
     // Run cleanup code for each resumable.
-    foreach_central_resumable(detail::cleanup_and_release);
+    auto next = [&]() -> resumable_ptr {
+      std::unique_lock<std::mutex> guard(lock);
+      if (queue.empty()) {
+        return nullptr;
+      }
+      auto front = std::move(queue.front());
+      queue.pop_front();
+      return front;
+    };
+    for (auto job = next(); job != nullptr; job = next()) {
+      detail::cleanup_and_release(std::move(job));
+    }
   }
 
   bool is_system_scheduler() const noexcept final {
     return true;
   }
 
-  resumable* dequeue() {
-    std::unique_lock<std::mutex> guard(lock);
-    cv.wait(guard, [&] { return !queue.empty(); });
-    resumable* job = queue.front();
-    queue.pop_front();
-    return job;
+  resumable_ptr dequeue() {
+    resumable_ptr result;
+    {
+      std::unique_lock<std::mutex> guard(lock);
+      cv.wait(guard, [&] { return !queue.empty(); });
+      result = std::move(queue.front());
+      queue.pop_front();
+    }
+    return result;
   }
 
 private:
   worker_type* worker_by_id(size_t x) {
     return workers_[x].get();
-  }
-
-  template <class UnaryFunction>
-  void foreach_central_resumable(UnaryFunction f) {
-    auto next = [&]() -> resumable* {
-      if (queue.empty()) {
-        return nullptr;
-      }
-      auto front = queue.front();
-      queue.pop_front();
-      return front;
-    };
-    std::unique_lock<std::mutex> guard(lock);
-    for (auto job = next(); job != nullptr; job = next()) {
-      f(job);
-    }
   }
 
   /// Set of workers.

--- a/libcaf_core/caf/scheduler.hpp
+++ b/libcaf_core/caf/scheduler.hpp
@@ -27,12 +27,12 @@ public:
 
   /// Schedules @p what to run at some point in the future.
   /// @threadsafe
-  virtual void schedule(resumable* what, uint64_t event_id) = 0;
+  virtual void schedule(resumable_ptr what, uint64_t event_id) = 0;
 
   /// Delay the next execution of @p what. Unlike `schedule`, this function is
   /// not thread-safe and must be called only from the scheduler thread that is
   /// currently running.
-  virtual void delay(resumable* what, uint64_t event_id) = 0;
+  virtual void delay(resumable_ptr what, uint64_t event_id) = 0;
 
   /// Returns `true` if this scheduler is part of the default system scheduler.
   virtual bool is_system_scheduler() const noexcept = 0;

--- a/libcaf_core/caf/scheduler.test.cpp
+++ b/libcaf_core/caf/scheduler.test.cpp
@@ -7,6 +7,7 @@
 #include "caf/test/outline.hpp"
 
 #include "caf/actor_system_config.hpp"
+#include "caf/add_ref.hpp"
 #include "caf/resumable.hpp"
 
 #include <latch>
@@ -31,8 +32,7 @@ struct testee : resumable, ref_counted {
       rendezvous->count_down();
       return;
     }
-    ref();
-    ctx->delay(this, resumable::default_event_id);
+    ctx->delay(resumable_ptr{this, add_ref}, resumable::default_event_id);
   }
 
   void ref_resumable() const noexcept final {
@@ -59,46 +59,41 @@ OUTLINE("scheduling resumables") {
     WHEN("scheduling a resumable") {
       auto sys = std::make_unique<actor_system>(cfg);
       auto rendezvous = std::make_shared<std::latch>(2);
-      auto worker = make_counted<testee>(rendezvous);
-      worker->ref();
-      sys->scheduler().schedule(worker.get(), resumable::default_event_id);
+      auto uut = make_counted<testee>(rendezvous);
+      sys->scheduler().schedule(uut, resumable::default_event_id);
       THEN("expect the resumable to be executed until done") {
         rendezvous->count_down();
         rendezvous->wait();
-        check_eq(worker->runs.load(), 10u);
+        check_eq(uut->runs.load(), 10u);
       }
       AND_THEN("the scheduler releases the ref when done") {
         // Note: destroying the actor system here will cause CAF to shut down.
         //       Ultimately stopping the scheduler and releasing the references.
         sys = nullptr;
-        check_eq(worker->get_reference_count(), 1u);
+        check(uut->unique());
       }
     }
-    // TODO: Change to WHEN block after fixing issue #1776.
-    AND_WHEN("scheduling multiple resumables") {
+    WHEN("scheduling multiple resumables") {
       auto sys = std::make_unique<actor_system>(cfg);
-      auto workers = std::vector<intrusive_ptr<testee>>{};
+      auto testees = std::vector<intrusive_ptr<testee>>{};
       auto rendezvous = std::make_shared<std::latch>(11);
       for (int i = 0; i < 10; i++) {
-        workers.emplace_back(make_counted<testee>(rendezvous));
-        workers.back()->ref();
-        check_eq(workers.back()->get_reference_count(), 2u);
-        sys->scheduler().schedule(workers.back().get(),
-                                  resumable::default_event_id);
+        testees.emplace_back(make_counted<testee>(rendezvous));
+        sys->scheduler().schedule(testees.back(), resumable::default_event_id);
       }
       THEN("expect the resumables to be executed until done") {
         rendezvous->count_down();
         rendezvous->wait();
-        for (const auto& worker : workers) {
-          check_eq(worker->runs, 10u);
+        for (const auto& ptr : testees) {
+          check_eq(ptr->runs, 10u);
         }
       }
       AND_THEN("the scheduler releases the ref when done") {
         // Note: destroying the actor system here will cause CAF to shut down.
         //       Ultimately stopping the scheduler and releasing the references.
         sys = nullptr;
-        for (const auto& worker : workers)
-          check_eq(worker->get_reference_count(), 1u);
+        for (const auto& ptr : testees)
+          check(ptr->unique());
       }
     }
   }
@@ -144,27 +139,25 @@ OUTLINE("scheduling units that are awaiting") {
     cfg.set("caf.scheduler.max-throughput", 5);
     auto sys = std::make_unique<actor_system>(cfg);
     WHEN("having resumables that go to an awaiting state") {
-      auto workers = std::vector<intrusive_ptr<awaiting_testee>>{};
+      auto testees = std::vector<intrusive_ptr<awaiting_testee>>{};
       auto rendezvous = std::make_shared<std::latch>(11);
       for (int i = 0; i < 10; i++) {
-        workers.push_back(make_counted<awaiting_testee>(rendezvous));
-        workers.back()->ref();
-        sys->scheduler().schedule(workers.back().get(),
-                                  resumable::default_event_id);
+        testees.push_back(make_counted<awaiting_testee>(rendezvous));
+        sys->scheduler().schedule(testees.back(), resumable::default_event_id);
       }
       THEN("expect the resumables to be executed once") {
         rendezvous->count_down();
         rendezvous->wait();
-        for (const auto& worker : workers) {
-          check_eq(worker->runs, 1u);
+        for (const auto& uut : testees) {
+          check_eq(uut->runs, 1u);
         }
       }
       AND_THEN("the scheduler releases the ref when done") {
         // Note: destroying the actor system here will cause CAF to shut down.
         //       Ultimately stopping the scheduler and releasing the references.
         sys = nullptr;
-        for (const auto& worker : workers)
-          check_eq(worker->get_reference_count(), 1u);
+        for (const auto& uut : testees)
+          check(uut->unique());
       }
     }
   }

--- a/libcaf_io/caf/io/abstract_broker.cpp
+++ b/libcaf_io/caf/io/abstract_broker.cpp
@@ -6,6 +6,7 @@
 #include "caf/io/network/multiplexer.hpp"
 
 #include "caf/actor_system.hpp"
+#include "caf/add_ref.hpp"
 #include "caf/byte_span.hpp"
 #include "caf/config.hpp"
 #include "caf/detail/assert.hpp"
@@ -29,8 +30,7 @@ void abstract_broker::launch(caf::detail::private_thread* worker,
   backend_ = static_cast<network::multiplexer*>(ctx);
   auto lg = log::io::trace("");
   (void) worker; // Brokers run on the multiplexer.
-  intrusive_ptr_add_ref(ctrl());
-  ctx->delay(this, resumable::initialization_event_id);
+  ctx->delay(resumable_ptr{this, add_ref}, resumable::initialization_event_id);
 }
 
 void abstract_broker::on_cleanup(const error& reason) {

--- a/libcaf_io/caf/io/basp/worker.cpp
+++ b/libcaf_io/caf/io/basp/worker.cpp
@@ -7,6 +7,7 @@
 #include "caf/io/basp/message_queue.hpp"
 
 #include "caf/actor_system.hpp"
+#include "caf/add_ref.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/proxy_registry.hpp"
 #include "caf/scheduler.hpp"
@@ -36,8 +37,8 @@ void worker::launch(const node_id& last_hop, const basp::header& hdr,
   last_hop_ = last_hop;
   memcpy(&hdr_, &hdr, sizeof(basp::header));
   payload_.assign(payload.begin(), payload.end());
-  ref();
-  system_->scheduler().schedule(this, resumable::default_event_id);
+  system_->scheduler().schedule(resumable_ptr{this, add_ref},
+                                resumable::default_event_id);
 }
 
 // -- implementation of resumable ----------------------------------------------

--- a/libcaf_io/caf/io/network/default_multiplexer.cpp
+++ b/libcaf_io/caf/io/network/default_multiplexer.cpp
@@ -13,6 +13,7 @@
 #include "caf/io/network/scribe_impl.hpp"
 
 #include "caf/actor_system_config.hpp"
+#include "caf/adopt_ref.hpp"
 #include "caf/config.hpp"
 #include "caf/defaults.hpp"
 #include "caf/detail/assert.hpp"
@@ -620,7 +621,7 @@ default_multiplexer::~default_multiplexer() {
   nonblocking(pipe_.first, true);
   auto ptr = pipe_reader_.try_read_next();
   while (ptr != nullptr) {
-    detail::cleanup_and_release(ptr);
+    detail::cleanup_and_release(resumable_ptr{ptr, adopt_ref});
     ptr = pipe_reader_.try_read_next();
   }
   // do cleanup for pipe reader manually, since WSACleanup needs to happen last
@@ -632,18 +633,18 @@ default_multiplexer::~default_multiplexer() {
 #endif
 }
 
-void default_multiplexer::schedule(resumable* ptr, uint64_t) {
-  auto lg = log::io::trace("ptr = {}", ptr);
-  CAF_ASSERT(ptr != nullptr);
+void default_multiplexer::schedule(resumable_ptr job, uint64_t) {
+  auto lg = log::io::trace("ptr = {}", job.get());
+  CAF_ASSERT(job != nullptr);
   if (std::this_thread::get_id() != thread_id()) {
-    wr_dispatch_request(ptr);
+    wr_dispatch_request(job.release());
   } else {
-    internally_posted_.emplace_back(ptr, adopt_ref);
+    internally_posted_.emplace_back(std::move(job));
   }
 }
 
-void default_multiplexer::delay(resumable* ptr, uint64_t) {
-  schedule(ptr, resumable::default_event_id);
+void default_multiplexer::delay(resumable_ptr job, uint64_t) {
+  schedule(std::move(job), resumable::default_event_id);
 }
 
 scribe_ptr default_multiplexer::new_scribe(native_socket fd) {

--- a/libcaf_io/caf/io/network/default_multiplexer.hpp
+++ b/libcaf_io/caf/io/network/default_multiplexer.hpp
@@ -122,9 +122,9 @@ public:
   new_local_udp_endpoint(uint16_t port, const char* in = nullptr,
                          bool reuse_addr = false) override;
 
-  void schedule(resumable* ptr, uint64_t) override;
+  void schedule(resumable_ptr ptr, uint64_t) override;
 
-  void delay(resumable* ptr, uint64_t) override;
+  void delay(resumable_ptr ptr, uint64_t) override;
 
   explicit default_multiplexer(actor_system& sys);
 

--- a/libcaf_io/caf/io/network/multiplexer.hpp
+++ b/libcaf_io/caf/io/network/multiplexer.hpp
@@ -11,6 +11,7 @@
 #include "caf/io/network/native_socket.hpp"
 #include "caf/io/network/protocol.hpp"
 
+#include "caf/adopt_ref.hpp"
 #include "caf/detail/io_export.hpp"
 #include "caf/expected.hpp"
 #include "caf/extend.hpp"
@@ -134,7 +135,8 @@ public:
         }
       }
     };
-    delay(new impl(std::move(fun)), resumable::default_event_id);
+    delay(resumable_ptr{new impl(std::move(fun)), adopt_ref},
+          resumable::default_event_id);
   }
 
   /// Retrieves a pointer to the implementation or `nullptr` if CAF was

--- a/libcaf_test/caf/test/fixture/deterministic.cpp
+++ b/libcaf_test/caf/test/fixture/deterministic.cpp
@@ -133,8 +133,8 @@ public:
     //       `schedule`. Hence, we always return success here to make sure the
     //       actor never touches the scheduler.
     using event_t = deterministic::scheduling_event;
-    auto event = std::make_unique<event_t>(owner_->as_resumable(),
-                                           std::move(ptr));
+    auto event = std::make_unique<event_t>(
+      resumable_ptr{owner_->as_resumable(), add_ref}, std::move(ptr));
     events_->push_back(std::move(event));
     // Never return unblocked_reader: the fixture drives execution by
     // dispatching from the events list. If we reported unblocked_reader, the
@@ -144,8 +144,8 @@ public:
 
   void push_front(mailbox_element_ptr ptr) override {
     using event_t = deterministic::scheduling_event;
-    auto event = std::make_unique<event_t>(owner_->as_resumable(),
-                                           std::move(ptr));
+    auto event = std::make_unique<event_t>(
+      resumable_ptr{owner_->as_resumable(), add_ref}, std::move(ptr));
     events_->emplace_front(std::move(event));
   }
 
@@ -478,16 +478,13 @@ public:
     // nop
   }
 
-  void schedule(resumable* ptr, uint64_t) override {
+  void schedule(resumable_ptr job, uint64_t) override {
     using event_t = deterministic::scheduling_event;
-    events_->push_back(std::make_unique<event_t>(ptr, nullptr));
-    // Before calling this function, CAF *always* bumps the reference count.
-    // Hence, we need to release one reference count here.
-    intrusive_ptr_release(ptr);
+    events_->push_back(std::make_unique<event_t>(std::move(job), nullptr));
   }
 
-  void delay(resumable* what, uint64_t event_id) override {
-    schedule(what, event_id);
+  void delay(resumable_ptr what, uint64_t event_id) override {
+    schedule(std::move(what), event_id);
   }
 
   void start() override {

--- a/libcaf_test/caf/test/fixture/deterministic.hpp
+++ b/libcaf_test/caf/test/fixture/deterministic.hpp
@@ -145,8 +145,8 @@ public:
 
   /// Wraps a resumable pointer and a mailbox element pointer.
   struct scheduling_event {
-    scheduling_event(resumable* target, mailbox_element_ptr payload)
-      : target(target, add_ref), item(std::move(payload)) {
+    scheduling_event(resumable_ptr target, mailbox_element_ptr payload)
+      : target(std::move(target)), item(std::move(payload)) {
       // nop
     }
 


### PR DESCRIPTION
Using raw pointers on the scheduler interface makes it brittle and prone to error for no reason.