### PR TITLE
[2291] Add header fields to the http::promise to set the HTTP header fields of the response

### DIFF
--- a/libcaf_net/caf/net/http/lower_layer.cpp
+++ b/libcaf_net/caf/net/http/lower_layer.cpp
@@ -38,6 +38,18 @@ bool lower_layer::server::send_response(status code,
 }
 
 bool lower_layer::server::send_response(status code,
+                                        std::unordered_map<std::string, std::string> headers,
+                                        const_byte_span content) {
+  auto content_size = std::to_string(content.size());
+  begin_header(code);
+  for (const auto& [key: value] : headers) {
+    add_header_field(key, value);
+  }
+  add_header_field("Content-Length"sv, content_size);
+  return end_header() && send_payload(content);
+}
+
+bool lower_layer::server::send_response(status code,
                                         std::string_view content_type,
                                         std::string_view content) {
   return send_response(code, content_type, as_bytes(std::span{content}));

--- a/libcaf_net/caf/net/http/lower_layer.hpp
+++ b/libcaf_net/caf/net/http/lower_layer.hpp
@@ -71,6 +71,10 @@ public:
                      const_byte_span content);
 
   /// @copydoc send_response
+  bool send_response(status code, std::unordered_map<std::string, std::string> headers,
+                     const_byte_span content);
+
+  /// @copydoc send_response
   bool send_response(status code, std::string_view content_type,
                      std::string_view content);
 

--- a/libcaf_net/caf/net/http/responder.hpp
+++ b/libcaf_net/caf/net/http/responder.hpp
@@ -80,6 +80,14 @@ public:
     }
 
     /// Sends an HTTP response message to the client. Automatically sets the
+    /// `Content-Length` header field.
+    void respond(status code, std::unordered_map<std::string, std::string> headers,
+                 const_byte_span content) {
+      impl_->down()->send_response(code, headers, content);
+      impl_->set_completed();
+    }
+
+    /// Sends an HTTP response message to the client. Automatically sets the
     /// `Content-Type` and `Content-Length` header fields.
     void respond(status code, std::string_view content_type,
                  std::string_view content) {


### PR DESCRIPTION
In the issue[2291], user can explicitly transmit HTTP header fields by using the `respond(status code, std::unordered_map<std::string, std::string> headers, const_byte_span content)` method.