### PR TITLE
Enable stream socket in http::with DSL

### DIFF
--- a/libcaf_net/CMakeLists.txt
+++ b/libcaf_net/CMakeLists.txt
@@ -31,6 +31,7 @@ caf_add_component(
   SOURCES
     caf/detail/connection_acceptor.cpp
     caf/detail/connection_guard.cpp
+    caf/detail/connector.cpp
     caf/detail/flow_bridge_initializer.cpp
     caf/detail/rfc6455.cpp
     caf/detail/rfc6455.test.cpp

--- a/libcaf_net/caf/detail/connection_acceptor.hpp
+++ b/libcaf_net/caf/detail/connection_acceptor.hpp
@@ -7,6 +7,7 @@
 #include "caf/net/fwd.hpp"
 
 #include "caf/action.hpp"
+#include "caf/detail/net_export.hpp"
 #include "caf/fwd.hpp"
 
 #include <memory>

--- a/libcaf_net/caf/detail/connector.cpp
+++ b/libcaf_net/caf/detail/connector.cpp
@@ -1,0 +1,9 @@
+#include "caf/detail/connector.hpp"
+
+namespace caf::detail {
+
+connector::~connector() {
+  // nop
+}
+
+} // namespace caf::detail

--- a/libcaf_net/caf/detail/connector.hpp
+++ b/libcaf_net/caf/detail/connector.hpp
@@ -6,20 +6,21 @@
 
 #include "caf/net/stream_socket.hpp"
 
+#include "caf/detail/net_export.hpp"
 #include "caf/expected.hpp"
 #include "caf/timespan.hpp"
 
 #include <cstdint>
 #include <string>
 
-namespace caf::internal {
+namespace caf::detail {
 
 /// Abstract interface for establishing outbound TCP connections. Inject a
 /// custom implementation via `with_t::client::connector()` to intercept the
 /// connection step (e.g. in unit tests using connected socket pairs).
-class connector {
+class CAF_NET_EXPORT connector {
 public:
-  virtual ~connector() = default;
+  virtual ~connector();
 
   virtual expected<net::stream_socket>
   connect(const std::string& host, uint16_t port, timespan connection_timeout,
@@ -27,4 +28,4 @@ public:
     = 0;
 };
 
-} // namespace caf::internal
+} // namespace caf::detail

--- a/libcaf_net/caf/internal/connector.hpp
+++ b/libcaf_net/caf/internal/connector.hpp
@@ -1,0 +1,30 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+#include "caf/net/stream_socket.hpp"
+
+#include "caf/expected.hpp"
+#include "caf/timespan.hpp"
+
+#include <cstdint>
+#include <string>
+
+namespace caf::internal {
+
+/// Abstract interface for establishing outbound TCP connections. Inject a
+/// custom implementation via `with_t::client::connector()` to intercept the
+/// connection step (e.g. in unit tests using connected socket pairs).
+class connector {
+public:
+  virtual ~connector() = default;
+
+  virtual expected<net::stream_socket>
+  connect(const std::string& host, uint16_t port, timespan connection_timeout,
+          size_t max_retry_count, timespan retry_delay)
+    = 0;
+};
+
+} // namespace caf::internal

--- a/libcaf_net/caf/internal/net_config.hpp
+++ b/libcaf_net/caf/internal/net_config.hpp
@@ -16,9 +16,9 @@
 #include "caf/actor_control_block.hpp"
 #include "caf/callback.hpp"
 #include "caf/defaults.hpp"
+#include "caf/detail/connector.hpp"
 #include "caf/disposable.hpp"
 #include "caf/format_to_unexpected.hpp"
-#include "caf/internal/connector.hpp"
 #include "caf/log/net.hpp"
 #include "caf/none.hpp"
 #include "caf/uri.hpp"
@@ -364,11 +364,7 @@ public:
 
   /// Optional custom connector for establishing outbound TCP connections.
   /// When set, replaces the default `detail::tcp_try_connect` call.
-  std::unique_ptr<connector> connector_;
-
-  void set_connector(std::unique_ptr<connector> c) {
-    connector_ = std::move(c);
-  }
+  std::unique_ptr<detail::connector> connector_;
 
   virtual expected<disposable> start_client_impl(net::ssl::connection&) = 0;
 

--- a/libcaf_net/caf/internal/net_config.hpp
+++ b/libcaf_net/caf/internal/net_config.hpp
@@ -18,6 +18,7 @@
 #include "caf/defaults.hpp"
 #include "caf/disposable.hpp"
 #include "caf/format_to_unexpected.hpp"
+#include "caf/internal/connector.hpp"
 #include "caf/log/net.hpp"
 #include "caf/none.hpp"
 #include "caf/uri.hpp"
@@ -52,13 +53,13 @@ public:
     };
 
     /// Configuration for a server that uses a user-provided socket.
-    class socket {
+    class accept_socket {
     public:
-      explicit socket(net::tcp_accept_socket fd) : fd(fd) {
+      explicit accept_socket(net::tcp_accept_socket fd) : fd(fd) {
         // nop
       }
 
-      ~socket() {
+      ~accept_socket() {
         if (fd != net::invalid_socket) {
           net::close(fd);
         }
@@ -76,15 +77,58 @@ public:
       }
     };
 
+    /// Configuration for a server that handles a single connected stream
+    /// socket, for example one end of a connected socket pair.
+    class stream_socket {
+    public:
+      explicit stream_socket(net::stream_socket fd) : fd(fd) {
+        // nop
+      }
+
+      stream_socket(const stream_socket&) = delete;
+
+      stream_socket& operator=(const stream_socket&) = delete;
+
+      stream_socket(stream_socket&& other) noexcept : fd(other.fd) {
+        other.fd.id = net::invalid_socket_id;
+      }
+
+      stream_socket& operator=(stream_socket&& other) noexcept {
+        using std::swap;
+        swap(fd, other.fd);
+        return *this;
+      }
+
+      ~stream_socket() {
+        if (fd != net::invalid_socket) {
+          net::close(fd);
+        }
+      }
+
+      /// The connected stream socket.
+      net::stream_socket fd;
+
+      /// Takes ownership of the file descriptor.
+      net::stream_socket take_fd() noexcept {
+        auto result = fd;
+        fd.id = net::invalid_socket_id;
+        return result;
+      }
+    };
+
     void assign(uint16_t port, std::string&& bind_address, bool reuse_addr) {
       value.emplace<lazy>(port, std::move(bind_address), reuse_addr);
     }
 
     void assign(net::tcp_accept_socket fd) {
-      value.emplace<socket>(fd);
+      value.emplace<accept_socket>(fd);
     }
 
-    using value_t = std::variant<none_t, lazy, socket>;
+    void assign(net::stream_socket fd) {
+      value.emplace<stream_socket>(std::move(fd));
+    }
+
+    using value_t = std::variant<none_t, lazy, accept_socket, stream_socket>;
 
     value_t value;
   };
@@ -252,12 +296,14 @@ public:
 
   virtual expected<disposable> start_server_impl(net::tcp_accept_socket) = 0;
 
+  virtual expected<disposable> start_server_impl(net::stream_socket) = 0;
+
   expected<disposable> start_server(none_t) {
     return expected<disposable>{unexpect, caf::sec::logic_error,
                                 "invalid WebSocket server configuration"};
   }
 
-  expected<disposable> start_server(server_config::socket& cfg) {
+  expected<disposable> start_server(server_config::accept_socket& cfg) {
     if (ctx) {
       net::ssl::tcp_acceptor acc{cfg.take_fd(), ctx};
       return start_server_impl(acc);
@@ -273,8 +319,19 @@ public:
     if (!maybe_fd) {
       return expected<disposable>{unexpect, std::move(maybe_fd.error())};
     }
-    server_config::socket sub_cfg{*maybe_fd};
+    server_config::accept_socket sub_cfg{*maybe_fd};
     return start_server(sub_cfg);
+  }
+
+  expected<disposable> start_server(server_config::stream_socket& cfg) {
+    if (ctx) {
+      return expected<disposable>{
+        unexpect, sec::invalid_argument,
+        "cannot combine an SSL context with serving on a pre-connected stream "
+        "socket"};
+    }
+    auto fd = cfg.take_fd();
+    return start_server_impl(std::move(fd));
   }
 
   expected<disposable> start_server() {
@@ -304,6 +361,14 @@ public:
   std::string hostname;
 
   client_config client;
+
+  /// Optional custom connector for establishing outbound TCP connections.
+  /// When set, replaces the default `detail::tcp_try_connect` call.
+  std::unique_ptr<connector> connector_;
+
+  void set_connector(std::unique_ptr<connector> c) {
+    connector_ = std::move(c);
+  }
 
   virtual expected<disposable> start_client_impl(net::ssl::connection&) = 0;
 
@@ -339,12 +404,21 @@ public:
   }
 
   expected<disposable> start_client(std::string& host, uint16_t port) {
-    auto maybe_fd = detail::tcp_try_connect(host, port, connection_timeout,
-                                            max_retry_count, retry_delay);
-    if (!maybe_fd) {
-      return expected<disposable>{unexpect, std::move(maybe_fd.error())};
+    net::stream_socket fd;
+    if (connector_) {
+      auto maybe_fd = connector_->connect(host, port, connection_timeout,
+                                          max_retry_count, retry_delay);
+      if (!maybe_fd)
+        return expected<disposable>{unexpect, std::move(maybe_fd.error())};
+      fd = *maybe_fd;
+    } else {
+      auto maybe_fd = detail::tcp_try_connect(host, port, connection_timeout,
+                                              max_retry_count, retry_delay);
+      if (!maybe_fd)
+        return expected<disposable>{unexpect, std::move(maybe_fd.error())};
+      fd = *maybe_fd;
     }
-    client_config::socket sub_cfg{*maybe_fd};
+    client_config::socket sub_cfg{fd};
     hostname = std::move(host);
     return start_client(sub_cfg);
   }

--- a/libcaf_net/caf/net/fwd.hpp
+++ b/libcaf_net/caf/net/fwd.hpp
@@ -4,13 +4,11 @@
 
 #pragma once
 
-#include "caf/detail/net_export.hpp"
 #include "caf/flow/fwd.hpp"
 #include "caf/fwd.hpp"
 #include "caf/intrusive_ptr.hpp"
 #include "caf/type_id.hpp"
 
-#include <memory>
 #include <vector>
 
 namespace caf::net {
@@ -156,3 +154,9 @@ enum class format;
 enum class tls;
 
 } // namespace caf::net::ssl
+
+namespace caf::detail {
+
+class connector;
+
+} // namespace caf::detail

--- a/libcaf_net/caf/net/http/with.cpp
+++ b/libcaf_net/caf/net/http/with.cpp
@@ -11,12 +11,14 @@
 #include "caf/net/middleman.hpp"
 #include "caf/net/socket_manager.hpp"
 
+#include "caf/abstract_actor.hpp"
 #include "caf/actor_system.hpp"
 #include "caf/add_ref.hpp"
 #include "caf/defaults.hpp"
 #include "caf/detail/connection_acceptor.hpp"
 #include "caf/detail/connection_guard.hpp"
 #include "caf/internal/accept_handler.hpp"
+#include "caf/internal/connector.hpp"
 #include "caf/internal/make_transport.hpp"
 #include "caf/internal/net_config.hpp"
 #include "caf/make_counted.hpp"
@@ -113,6 +115,29 @@ private:
   action on_close_;
 };
 
+template <class Connection>
+net::socket_manager_ptr
+make_http_socket_manager(net::multiplexer* mpx, Connection conn,
+                         const std::vector<route_ptr>& routes,
+                         size_t max_consecutive_reads, size_t max_request_size,
+                         action on_close) {
+  // Create the connection guard. The router and each http::request hold a
+  // reference. When all references are released, on_close fires.
+  auto guard = make_counted<http_connection_guard>(mpx, std::move(on_close));
+  auto app = net::http::router::make(routes, std::move(guard));
+  auto serv = net::http::server::make(std::move(app));
+  serv->max_request_size(max_request_size);
+  auto transport = std::unique_ptr<net::octet_stream::transport>{};
+  if constexpr (std::is_same_v<std::decay_t<Connection>, net::ssl::connection>)
+    transport = net::ssl::transport::make(std::move(conn), std::move(serv));
+  else
+    transport = net::octet_stream::transport::make(std::move(conn),
+                                                   std::move(serv));
+  transport->max_consecutive_reads(max_consecutive_reads);
+  transport->active_policy().accept();
+  return net::socket_manager::make(mpx, std::move(transport));
+}
+
 template <class Acceptor>
 class http_conn_acceptor : public detail::connection_acceptor {
 public:
@@ -144,24 +169,10 @@ public:
     if (!conn)
       return expected<net::socket_manager_ptr>{unexpect,
                                                std::move(conn.error())};
-    // Create the connection guard. The router and each http::request hold a
-    // reference. When all references are released, on_conn_close_ fires.
     auto* mpx = parent_->mpx_ptr();
-    auto guard = make_counted<http_connection_guard>(mpx, on_conn_close_);
-    // Instantiate our protocol stack.
-    auto app = net::http::router::make(routes_, std::move(guard));
-    auto serv = net::http::server::make(std::move(app));
-    serv->max_request_size(max_request_size_);
-    auto transport = std::unique_ptr<net::octet_stream::transport>{};
-    if constexpr (std::is_same_v<std::decay_t<decltype(*conn)>,
-                                 net::ssl::connection>)
-      transport = net::ssl::transport::make(std::move(*conn), std::move(serv));
-    else
-      transport = net::octet_stream::transport::make(std::move(*conn),
-                                                     std::move(serv));
-    transport->max_consecutive_reads(max_consecutive_reads_);
-    transport->active_policy().accept();
-    auto res = net::socket_manager::make(mpx, std::move(transport));
+    auto res = make_http_socket_manager(mpx, std::move(*conn), routes_,
+                                        max_consecutive_reads_,
+                                        max_request_size_, on_conn_close_);
     mpx->watch(res->as_disposable());
     return res;
   }
@@ -200,6 +211,23 @@ make_http_conn_acceptor(net::ssl::tcp_acceptor acceptor,
                                   max_consecutive_reads, max_request_size);
 }
 
+// Builds the RFC 7230 `Host` header value from endpoint. The port is
+// omitted when it is unset, or equal to the default.
+std::string host_header_value(const uri& endpoint) {
+  const auto& scheme = endpoint.scheme();
+  auto auth = endpoint.authority();
+  if (auth.userinfo) {
+    auth.userinfo = std::nullopt; // suppress userinfo in 'Host' header field
+  }
+  if (scheme == "http" && auth.port == defaults::net::http_default_port) {
+    auth.port = 0; // suppress default HTTP port in 'Host' Header field
+  }
+  if (scheme == "https" && auth.port == defaults::net::https_default_port) {
+    auth.port = 0; // suppress default HTTPS port in 'Host' Header field
+  }
+  return to_string(auth);
+}
+
 } // namespace
 
 class with_t::config_impl : public internal::net_config {
@@ -212,8 +240,7 @@ public:
 
   using super::super;
 
-  template <class Acceptor>
-  expected<disposable> do_start_server(Acceptor& acc) {
+  expected<void> prepare_http_routes() {
     if (push) {
       auto producer = make_http_request_producer({mpx, add_ref},
                                                  push.try_open());
@@ -224,16 +251,25 @@ public:
         }
       });
       if (!new_route) {
-        return expected<disposable>{unexpect, std::move(new_route.error())};
+        return expected<void>{unexpect, std::move(new_route.error())};
       }
       routes.push_back(std::move(*new_route));
     } else if (routes.empty()) {
-      return expected<disposable>{
-        unexpect, sec::logic_error,
-        "cannot start an HTTP server without any routes"};
+      return expected<void>{unexpect, sec::logic_error,
+                            "cannot start an HTTP server without any routes"};
     }
     for (auto& ptr : routes)
       ptr->init();
+    return {};
+  }
+
+  template <class Acceptor>
+  expected<disposable> do_start_server(Acceptor& acc) {
+    auto prep = prepare_http_routes();
+    if (!prep) {
+      close(acc);
+      return expected<disposable>{unexpect, std::move(prep.error())};
+    }
     auto factory = make_http_conn_acceptor(std::move(acc), routes,
                                            max_consecutive_reads,
                                            max_request_size);
@@ -254,6 +290,34 @@ public:
 
   expected<disposable> start_server_impl(net::tcp_accept_socket acc) override {
     return do_start_server(acc);
+  }
+
+  expected<disposable> start_server_impl(net::stream_socket conn) override {
+    auto prep = prepare_http_routes();
+    if (!prep) {
+      close(conn);
+      return expected<disposable>{unexpect, std::move(prep.error())};
+    }
+    auto ptr = make_http_socket_manager(mpx, std::move(conn), routes,
+                                        max_consecutive_reads, max_request_size,
+                                        action{});
+    if (!monitored_actors.empty()) {
+      auto cb = make_action([p = ptr] { p->shutdown(); });
+      ptr->add_cleanup_listener(make_action([cb]() mutable { cb.dispose(); }));
+      auto ctx = async::execution_context_ptr{mpx, add_ref};
+      for (const auto& hdl : monitored_actors) {
+        CAF_ASSERT(hdl);
+        hdl->get()->attach_functor([ctx, cb] {
+          if (!cb.disposed())
+            ctx->schedule(cb);
+        });
+      }
+    }
+    if (mpx->start(ptr))
+      return disposable{std::move(ptr)};
+    return expected<disposable>{
+      unexpect, sec::logic_error,
+      "failed to register socket manager to net::multiplexer"};
   }
 
   template <typename Connection>
@@ -428,30 +492,15 @@ with_t::client&& with_t::client::max_retry_count(size_t value) && {
   return std::move(*this);
 }
 
+with_t::client&&
+with_t::client::connector(std::unique_ptr<internal::connector>&& c) && {
+  config_->set_connector(std::move(c));
+  return std::move(*this);
+}
+
 void with_t::client::do_add_header_field(std::string name, std::string value) {
   config_->fields.insert(std::pair{std::move(name), std::move(value)});
 }
-
-namespace {
-
-// Builds the RFC 7230 `Host` header value from @p endpoint.
-// The port is omitted when it is unset, or equal to the default (80 or 443).
-std::string host_header_value(const uri& endpoint) {
-  const auto& scheme = endpoint.scheme();
-  auto auth = endpoint.authority();
-  if (auth.userinfo) {
-    auth.userinfo = std::nullopt; // suppress userinfo in 'Host' header field
-  }
-  if (scheme == "http" && auth.port == defaults::net::http_default_port) {
-    auth.port = 0; // suppress default HTTP port in 'Host' Header field
-  }
-  if (scheme == "https" && auth.port == defaults::net::https_default_port) {
-    auth.port = 0; // suppress default HTTPS port in 'Host' Header field
-  }
-  return to_string(auth);
-}
-
-} // namespace
 
 expected<std::pair<async::future<response>, disposable>>
 with_t::client::request(http::method method, const_byte_span payload) {
@@ -462,12 +511,19 @@ with_t::client::request(http::method method, const_byte_span payload) {
     return expected<std::pair<async::future<response>, disposable>>{
       unexpect, config_->err};
   }
-  // Only connecting to an URI is enabled in the 'with' DSL.
-  using lazy_t = internal::net_config::client_config::lazy;
-  CAF_ASSERT(std::holds_alternative<lazy_t>(config_->client.value));
-  auto& lazy = std::get<lazy_t>(config_->client.value);
-  CAF_ASSERT(std::holds_alternative<uri>(lazy.server));
-  auto& endpoint = std::get<uri>(lazy.server);
+  using client_cfg = internal::net_config::client_config;
+  const uri* endpoint_ptr = nullptr;
+  if (auto* lazy = std::get_if<client_cfg::lazy>(&config_->client.value)) {
+    if (!std::holds_alternative<uri>(lazy->server)) {
+      return expected<std::pair<async::future<response>, disposable>>{
+        unexpect, sec::logic_error, "HTTP with client requires a URI endpoint"};
+    }
+    endpoint_ptr = &std::get<uri>(lazy->server);
+  } else {
+    return expected<std::pair<async::future<response>, disposable>>{
+      unexpect, sec::logic_error, "invalid HTTP with client configuration"};
+  }
+  const uri& endpoint = *endpoint_ptr;
   config_->path = endpoint.path_query_fragment();
   config_->method = method;
   config_->payload = payload;
@@ -532,6 +588,11 @@ with_t::server with_t::accept(tcp_accept_socket fd) && {
 with_t::server with_t::accept(ssl::tcp_acceptor acc) && {
   config_->ctx = acc.ctx_ptr();
   config_->server.assign(acc.fd());
+  return server{std::move(config_)};
+}
+
+with_t::server with_t::serve(net::stream_socket fd) && {
+  config_->server.assign(std::move(fd));
   return server{std::move(config_)};
 }
 

--- a/libcaf_net/caf/net/http/with.cpp
+++ b/libcaf_net/caf/net/http/with.cpp
@@ -17,8 +17,8 @@
 #include "caf/defaults.hpp"
 #include "caf/detail/connection_acceptor.hpp"
 #include "caf/detail/connection_guard.hpp"
+#include "caf/detail/connector.hpp"
 #include "caf/internal/accept_handler.hpp"
-#include "caf/internal/connector.hpp"
 #include "caf/internal/make_transport.hpp"
 #include "caf/internal/net_config.hpp"
 #include "caf/make_counted.hpp"
@@ -493,8 +493,8 @@ with_t::client&& with_t::client::max_retry_count(size_t value) && {
 }
 
 with_t::client&&
-with_t::client::connector(std::unique_ptr<internal::connector>&& c) && {
-  config_->set_connector(std::move(c));
+with_t::client::connector(std::unique_ptr<detail::connector>&& ptr) && {
+  config_->connector_ = std::move(ptr);
   return std::move(*this);
 }
 

--- a/libcaf_net/caf/net/http/with.hpp
+++ b/libcaf_net/caf/net/http/with.hpp
@@ -20,10 +20,6 @@
 #include <cstdint>
 #include <string>
 
-namespace caf::internal {
-class connector;
-} // namespace caf::internal
-
 namespace caf::net::http {
 
 /// Entry point for the `with(...)` DSL.
@@ -253,9 +249,8 @@ public:
     request(http::method method, const_byte_span payload);
 
     /// Installs a custom connector for establishing the TCP connection. This
-    /// setter is intended for unit tests only and is not part of the public
-    /// API.
-    [[nodiscard]] client&& connector(std::unique_ptr<internal::connector>&&) &&;
+    /// setter is intended for unit tests, not for production use.
+    [[nodiscard]] client&& connector(std::unique_ptr<detail::connector>&&) &&;
 
   private:
     void do_add_header_field(std::string name, std::string value);

--- a/libcaf_net/caf/net/http/with.hpp
+++ b/libcaf_net/caf/net/http/with.hpp
@@ -8,15 +8,21 @@
 #include "caf/net/http/route.hpp"
 #include "caf/net/multiplexer.hpp"
 #include "caf/net/ssl/context.hpp"
+#include "caf/net/stream_socket.hpp"
 #include "caf/net/tcp_accept_socket.hpp"
 
 #include "caf/actor_cast.hpp"
 #include "caf/callback.hpp"
 #include "caf/detail/forward_like.hpp"
 #include "caf/fwd.hpp"
+#include "caf/uri.hpp"
 
 #include <cstdint>
 #include <string>
+
+namespace caf::internal {
+class connector;
+} // namespace caf::internal
 
 namespace caf::net::http {
 
@@ -246,6 +252,11 @@ public:
     expected<std::pair<async::future<response>, disposable>>
     request(http::method method, const_byte_span payload);
 
+    /// Installs a custom connector for establishing the TCP connection. This
+    /// setter is intended for unit tests only and is not part of the public
+    /// API.
+    [[nodiscard]] client&& connector(std::unique_ptr<internal::connector>&&) &&;
+
   private:
     void do_add_header_field(std::string name, std::string value);
 
@@ -312,6 +323,12 @@ public:
   /// @param fd File descriptor for the accept socket.
   /// @returns an `server` object that will start a server on `fd`.
   [[nodiscard]] server accept(tcp_accept_socket fd) &&;
+
+  /// Creates a new server factory for an already-connected stream socket, for
+  /// example one end of a socket pair from @ref net::make_stream_socket_pair.
+  /// @param fd The stream socket that speaks HTTP to exactly one peer.
+  /// @returns a `server` object that will run the protocol on `fd`.
+  [[nodiscard]] server serve(stream_socket fd) &&;
 
   /// Creates a new server factory object for the given acceptor.
   /// @param acc The SSL acceptor for incoming TCP connections.

--- a/libcaf_net/caf/net/http/with.test.cpp
+++ b/libcaf_net/caf/net/http/with.test.cpp
@@ -15,9 +15,9 @@
 
 #include "caf/actor_system.hpp"
 #include "caf/actor_system_config.hpp"
+#include "caf/detail/connector.hpp"
 #include "caf/detail/scope_guard.hpp"
 #include "caf/fwd.hpp"
-#include "caf/internal/connector.hpp"
 #include "caf/uri.hpp"
 
 #include <chrono>
@@ -32,7 +32,7 @@ namespace {
 
 /// A connector that returns a pre-existing socket on the first connect call.
 /// Intended for unit tests that use connected socket pairs.
-class socket_connector : public internal::connector {
+class socket_connector : public detail::connector {
 public:
   explicit socket_connector(net::stream_socket fd) : fd_(fd) {
   }

--- a/libcaf_net/caf/net/http/with.test.cpp
+++ b/libcaf_net/caf/net/http/with.test.cpp
@@ -9,6 +9,7 @@
 #include "caf/net/middleman.hpp"
 #include "caf/net/socket.hpp"
 #include "caf/net/socket_guard.hpp"
+#include "caf/net/stream_socket.hpp"
 #include "caf/net/tcp_accept_socket.hpp"
 #include "caf/net/tcp_stream_socket.hpp"
 
@@ -16,6 +17,7 @@
 #include "caf/actor_system_config.hpp"
 #include "caf/detail/scope_guard.hpp"
 #include "caf/fwd.hpp"
+#include "caf/internal/connector.hpp"
 #include "caf/uri.hpp"
 
 #include <chrono>
@@ -27,6 +29,24 @@ using namespace caf;
 using namespace std::literals;
 
 namespace {
+
+/// A connector that returns a pre-existing socket on the first connect call.
+/// Intended for unit tests that use connected socket pairs.
+class socket_connector : public internal::connector {
+public:
+  explicit socket_connector(net::stream_socket fd) : fd_(fd) {
+  }
+
+  expected<net::stream_socket> connect(const std::string&, uint16_t, timespan,
+                                       size_t, timespan) override {
+    auto result = fd_;
+    fd_.id = net::invalid_socket_id;
+    return result;
+  }
+
+private:
+  net::stream_socket fd_;
+};
 
 class error_log {
 public:
@@ -350,25 +370,24 @@ TEST("GH-2226 regression") {
   check_eq(elog->errors(), std::vector<error>{});
 }
 
-// TODO: refactor the test to use a connected socket pair and improve test
-// coverage for different host formats.
-TEST("GH-2309 regression: Host header contains explicit non-default port") {
+TEST("GH-2309 Host header field in outgoing requests") {
+  auto parse_uri = [this](std::string_view sv) {
+    uri u;
+    auto err = parse(sv, u);
+    require(err.empty());
+    return u;
+  };
   caf::actor_system_config cfg;
   cfg.load<caf::net::middleman>();
   caf::actor_system sys{cfg};
-  auto acceptor = unbox(net::make_tcp_accept_socket(0));
-  auto port = unbox(net::local_port(acceptor));
-  auto uri_str = net::is_ipv4(acceptor)
-                   ? detail::format("http://127.0.0.1:{}/host-check", port)
-                   : detail::format("http://[::1]:{}/host-check", port);
-  auto expected_host = net::is_ipv4(acceptor)
-                         ? detail::format("127.0.0.1:{}", port)
-                         : detail::format("[::1]:{}", port);
+  auto fd_pair = net::make_stream_socket_pair();
+  require_has_value(fd_pair);
+  auto [server_fd, client_fd] = *fd_pair;
   std::promise<std::string> prom;
   auto host_fut = prom.get_future();
   auto hdl
     = net::http::with(sys)
-        .accept(acceptor)
+        .serve(server_fd)
         .route("/host-check", net::http::method::get,
                [prom = std::move(prom)](net::http::responder& res) mutable {
                  prom.set_value(std::string{res.header().field("Host")});
@@ -377,18 +396,47 @@ TEST("GH-2309 regression: Host header contains explicit non-default port") {
         .start();
   require_has_value(hdl);
   detail::scope_guard hdl_guard{[hdl]() mutable noexcept { hdl->dispose(); }};
-  uri endpoint;
-  require(parse(uri_str, endpoint).empty());
-  auto client_res = net::http::with(sys)
-                      .connect(endpoint)
-                      .connection_timeout(2s)
-                      .max_retry_count(1)
-                      .get();
-  require_has_value(client_res);
-  auto maybe_resp = client_res->first.get(5s);
-  require_has_value(maybe_resp);
-  check_eq(maybe_resp->code(), net::http::status::ok);
+  auto assert_request_host_is = [this, &sys, &host_fut,
+                                 client_fd](const caf::uri& uri,
+                                            std::string_view expected_host) {
+    auto client_res
+      = net::http::with(sys)
+          .connect(uri)
+          .connector(std::make_unique<socket_connector>(client_fd))
+          .connection_timeout(1s)
+          .max_retry_count(1)
+          .get();
+    require_has_value(client_res);
+    auto maybe_resp = client_res->first.get(1s);
+    require_has_value(maybe_resp);
+    require(host_fut.wait_for(1s) == std::future_status::ready);
+    check_eq(host_fut.get(), expected_host);
+  };
 
-  require(host_fut.wait_for(1s) == std::future_status::ready);
-  check_eq(host_fut.get(), expected_host);
+  SECTION("http IPv4 with non-default port") {
+    assert_request_host_is(parse_uri("http://127.0.0.1:8080/host-check"),
+                           "127.0.0.1:8080");
+  }
+  SECTION("http IPv4 omitted port") {
+    assert_request_host_is(parse_uri("http://127.0.0.1/host-check"),
+                           "127.0.0.1");
+  }
+  SECTION("http IPv4 explicit default port") {
+    assert_request_host_is(parse_uri("http://127.0.0.1:80/host-check"),
+                           "127.0.0.1");
+  }
+  SECTION("http hostname with non-default port") {
+    assert_request_host_is(parse_uri("http://api.example.org:3000/host-check"),
+                           "api.example.org:3000");
+  }
+  SECTION("http IPv6 with non-default port") {
+    assert_request_host_is(parse_uri("http://[::1]:9090/host-check"),
+                           "[::1]:9090");
+  }
+  SECTION("http IPv6 omitted port") {
+    assert_request_host_is(parse_uri("http://[::1]/host-check"), "[::1]");
+  }
+  SECTION("http IPv6 explicit default port") {
+    assert_request_host_is(parse_uri("http://[::1]:80/host-check"), "[::1]");
+  }
 }

--- a/libcaf_net/caf/net/lp/with.cpp
+++ b/libcaf_net/caf/net/lp/with.cpp
@@ -141,6 +141,14 @@ public:
     return do_start_server(acc);
   }
 
+  expected<disposable> start_server_impl(net::stream_socket conn) override {
+    close(conn);
+    return expected<disposable>{
+      unexpect, sec::invalid_argument,
+      "serving on a pre-connected stream socket is not supported for the "
+      "length-prefix framing protocol"};
+  }
+
   template <typename Connection>
   expected<disposable> do_start_client(Connection& conn) {
     auto bridge = internal::make_lp_flow_bridge(std::move(client_pull),

--- a/libcaf_net/caf/net/octet_stream/with.cpp
+++ b/libcaf_net/caf/net/octet_stream/with.cpp
@@ -143,6 +143,14 @@ public:
     return do_start_server(acc);
   }
 
+  expected<disposable> start_server_impl(net::stream_socket conn) override {
+    close(conn);
+    return expected<disposable>{
+      unexpect, sec::invalid_argument,
+      "serving on a pre-connected stream socket is not supported for octet "
+      "streams"};
+  }
+
   // state for clients
 
   template <class Connection>

--- a/libcaf_net/caf/net/web_socket/with.cpp
+++ b/libcaf_net/caf/net/web_socket/with.cpp
@@ -118,6 +118,14 @@ public:
     return do_start_server(acc);
   }
 
+  expected<disposable> start_server_impl(net::stream_socket conn) override {
+    close(conn);
+    return expected<disposable>{
+      unexpect, sec::invalid_argument,
+      "serving on a pre-connected stream socket is not supported for Web "
+      "Sockets"};
+  }
+
   // state for clients
 
   pull_t pull;


### PR DESCRIPTION
Having a regular socket be the underlying connection for the http::with DSL is useful in unit tests, as it allows us to use connected socket pairs.