### PR TITLE
Suppress style warnings in cppcheck

### DIFF
--- a/.cppcheck-suppressions
+++ b/.cppcheck-suppressions
@@ -1,70 +1,26 @@
-// types with intentionally non-explicit constructors
-noExplicitConstructor:*libcaf_core/caf/actor.hpp
-noExplicitConstructor:*libcaf_core/caf/expected.hpp
-noExplicitConstructor:*libcaf_core/caf/intrusive_cow_ptr.hpp
-noExplicitConstructor:*libcaf_core/caf/intrusive_ptr.hpp
-noExplicitConstructor:*libcaf_core/caf/result.hpp
-noExplicitConstructor:*libcaf_core/caf/placement_ptr.hpp
-noExplicitConstructor:*libcaf_core/caf/actor_addr.hpp
-noExplicitConstructor:*libcaf_net/caf/net/dsl/arg.hpp
-noExplicitConstructor:*libcaf_net/caf/net/actor_shell.hpp
-
-// our parser FSM DSL injects code that may be unreachable in some cases
-unreachableCode:*libcaf_core/caf/detail/parser/*
-unreachableCode:*libcaf_core/caf/detail/format.cpp
-unreachableCode:*libcaf_core/caf/detail/json.cpp
-
-// void-pointer arithmetic is intentional in these low-level buffers
-arithOperationsOnVoidPointer:*libcaf_core/caf/detail/ring_buffer.hpp
-arithOperationsOnVoidPointer:*libcaf_core/caf/config_option.cpp
-arithOperationsOnVoidPointer:*libcaf_io/caf/io/network/receive_buffer.hpp
-
-// some global suppressions only match in test code, which may be excluded
-unmatchedSuppression:*
-
 // false positive: cppcheck flags moved-access in chained mail() API usage
 accessMoved:*
 
 // TODO: need to be re-enabled one-by-one,
 //       see https://github.com/actor-framework/actor-framework/issues/2294
-passedByValue:*
-uninitMemberVar:*
-constParameterReference:*
-useInitializationList:*
-constVariablePointer:*
-duplInheritedMember:*
-unusedStructMember:*
-constParameterPointer:*
-missingOverride:*
-class_X_Y:*
-knownConditionTrueFalse:*
-unreadVariable:*
+arithOperationsOnVoidPointer:*
+assertWithSideEffect:*
+copyCtorPointerCopying:*
+danglingLifetime:*
 danglingTempReference:*
+derefInvalidIteratorRedundantCheck:*
+duplInheritedMember:*
+ignoredReturnValue:*
 missingReturn:*
 noCopyConstructor:*
-uninitMemberVarPrivate:*
-uselessOverride:*
+noOperatorEq:*
 operatorEqVarError:*
-unusedVariable:*
-virtualCallInConstructor:*
-assertWithSideEffect:*
-containerOutOfBounds:*
-duplicateConditionalAssign:*
+passedByValue:*
 postfixOperator:*
 returnByReference:*
 returnTempReference:*
-shadowArgument:*
 stlIfStrFind:*
-copyCtorPointerCopying:*
-cstyleCast:*
-danglingLifetime:*
-derefInvalidIteratorRedundantCheck:*
-ignoredReturnValue:*
-knownPointerToBool:*
-noConstructor:*
-noOperatorEq:*
-operatorEqMissingReturnStatement:*
-redundantAssignment:*
-redundantContinue:*
-uninitvar:*
-constParameter:*
+uninitMemberVar:*
+uninitMemberVarPrivate:*
+useInitializationList:*
+virtualCallInConstructor:*

--- a/examples/message_passing/fan_out_request.cpp
+++ b/examples/message_passing/fan_out_request.cpp
@@ -76,12 +76,12 @@ struct matrix_state {
     : self(selfptr), rows(num_rows), columns(num_columns) {
     // Spawn all cells.
     data.resize(rows);
-    std::ranges::for_each(data, [this](auto& row) {
+    for (auto& row : data) {
       row.resize(columns);
       std::ranges::generate(row, [this] {
         return self->spawn(actor_from_state<cell_state>);
       });
-    });
+    }
   }
 
   matrix::behavior_type make_behavior() {

--- a/libcaf_core/caf/actor_addr.hpp
+++ b/libcaf_core/caf/actor_addr.hpp
@@ -128,7 +128,6 @@ private:
   }
 
   CAF_DEPRECATED("construct using add_ref or adopt_ref instead")
-  // cppcheck-suppress noExplicitConstructor
   actor_addr(actor_control_block*);
 
   weak_actor_ptr ptr_;

--- a/libcaf_core/caf/behavior.hpp
+++ b/libcaf_core/caf/behavior.hpp
@@ -40,7 +40,6 @@ public:
   }
 
   /// Creates a behavior from `fun` without timeout.
-  // cppcheck-suppress noExplicitConstructor
   behavior(const message_handler& mh);
 
   /// The list of arguments can contain match expressions, message handlers,
@@ -59,7 +58,6 @@ public:
   /// Creates a behavior from `tdef` without message handler.
   template <class F>
   CAF_DEPRECATED("use idle timeouts instead of 'after >> ...'")
-  // cppcheck-suppress noExplicitConstructor
   behavior(timeout_definition<F> tdef) : impl_(detail::make_behavior(tdef)) {
     // nop
   }

--- a/libcaf_core/caf/detail/split_join.hpp
+++ b/libcaf_core/caf/detail/split_join.hpp
@@ -68,7 +68,9 @@ private:
 
 struct nop_split {
   void operator()(actor_msg_vec& xs, message& y) const {
-    std::ranges::for_each(xs, [&y](auto& x) { x.second = y; });
+    for (auto& x : xs) {
+      x.second = y;
+    }
   }
 };
 

--- a/libcaf_core/caf/error.hpp
+++ b/libcaf_core/caf/error.hpp
@@ -68,7 +68,6 @@ public:
 
   error() noexcept = default;
 
-  // cppcheck-suppress noExplicitConstructor
   error(none_t) noexcept;
 
   error(error&&) noexcept = default;
@@ -80,7 +79,6 @@ public:
   error& operator=(const error&);
 
   template <error_code_enum Enum>
-  // cppcheck-suppress noExplicitConstructor
   error(Enum code) : error(static_cast<uint8_t>(code), type_id_v<Enum>) {
     // nop
   }

--- a/libcaf_core/caf/flow/op/from_generator.hpp
+++ b/libcaf_core/caf/flow/op/from_generator.hpp
@@ -161,7 +161,6 @@ public:
 
   using super = hot<output_type>;
 
-  // cppcheck-suppress noExplicitConstructor
   from_generator(coordinator* parent, Generator gen, std::tuple<Steps...> steps)
     : super(parent), gen_(std::move(gen)), steps_(std::move(steps)) {
     // nop

--- a/libcaf_core/caf/flow/op/from_steps.hpp
+++ b/libcaf_core/caf/flow/op/from_steps.hpp
@@ -54,7 +54,6 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  // cppcheck-suppress noExplicitConstructor
   from_steps_sub(coordinator* parent, observer<output_type> out,
                  std::tuple<Steps...> steps)
     : parent_(parent), out_(std::move(out)), steps_(std::move(steps)) {
@@ -243,7 +242,6 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  // cppcheck-suppress noExplicitConstructor
   from_steps(coordinator* parent, intrusive_ptr<base<input_type>> input,
              std::tuple<Steps...> steps)
     : super(parent), input_(std::move(input)), steps_(std::move(steps)) {

--- a/libcaf_core/caf/format_string_with_location.hpp
+++ b/libcaf_core/caf/format_string_with_location.hpp
@@ -13,7 +13,6 @@ namespace caf {
 /// that have a variadic list of arguments and thus cannot use the usual way of
 /// passing in a source location via default argument.
 struct format_string_with_location {
-  // cppcheck-suppress noExplicitConstructor
   constexpr format_string_with_location(std::string_view str,
                                         const std::source_location& loc
                                         = std::source_location::current())
@@ -21,7 +20,6 @@ struct format_string_with_location {
     // nop
   }
 
-  // cppcheck-suppress noExplicitConstructor
   constexpr format_string_with_location(const char* str,
                                         const std::source_location& loc
                                         = std::source_location::current())

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -785,7 +785,6 @@ private:
   activation_result run_with_metrics(mailbox_element& x, F body) {
     if (metrics_.mailbox_time) {
       auto t0 = std::chrono::steady_clock::now();
-      // cppcheck-suppress variableScope
       auto mbox_time = x.seconds_until(t0);
       auto res = body();
       if (res != activation_result::skipped) {

--- a/libcaf_core/caf/type_id_list.cpp
+++ b/libcaf_core/caf/type_id_list.cpp
@@ -8,7 +8,6 @@
 #include "caf/detail/type_id_list_builder.hpp"
 #include "caf/message.hpp"
 
-#include <algorithm>
 #include <numeric>
 
 namespace caf {
@@ -44,9 +43,11 @@ type_id_list type_id_list::concat(std::span<type_id_list> lists) {
                                       return acc + ls.size();
                                     });
   detail::type_id_list_builder builder{total_size};
-  std::ranges::for_each(lists, [&](type_id_list ls) {
-    std::ranges::for_each(ls, [&](type_id_t id) { builder.push_back(id); });
-  });
+  for (const auto& ls : lists) {
+    for (auto id : ls) {
+      builder.push_back(id);
+    }
+  }
   return builder.move_to_list();
 }
 

--- a/libcaf_core/caf/typed_actor.hpp
+++ b/libcaf_core/caf/typed_actor.hpp
@@ -119,7 +119,6 @@ public:
   template <class... Us>
     requires detail::tl_subset_of_v<signatures,
                                     typename typed_actor<Us...>::signatures>
-  // cppcheck-suppress noExplicitConstructor
   typed_actor(const typed_actor<Us...>& other) : ptr_(other.ptr()) {
     // nop
   }
@@ -128,7 +127,6 @@ public:
   template <class T>
     requires(actor_traits<T>::is_statically_typed
              && detail::tl_subset_of_v<signatures, typename T::signatures>)
-  // cppcheck-suppress noExplicitConstructor
   typed_actor(T* ptr) : ptr_(ptr->ctrl(), add_ref) {
     CAF_ASSERT(ptr != nullptr);
   }

--- a/libcaf_core/caf/typed_actor_pointer.hpp
+++ b/libcaf_core/caf/typed_actor_pointer.hpp
@@ -28,14 +28,12 @@ public:
   template <class Supertype>
     requires detail::tl_subset_of<signatures,
                                   typename Supertype::signatures>::value
-  // cppcheck-suppress noExplicitConstructor
   typed_actor_pointer(Supertype* selfptr) : view_(selfptr) {
     // nop
   }
 
   template <class... OtherSigs>
     requires detail::tl_subset_of<signatures, type_list<OtherSigs...>>::value
-  // cppcheck-suppress noExplicitConstructor
   typed_actor_pointer(typed_actor_pointer<OtherSigs...> other)
     : view_(other.internal_ptr()) {
     // nop

--- a/libcaf_core/caf/typed_behavior.hpp
+++ b/libcaf_core/caf/typed_behavior.hpp
@@ -165,7 +165,6 @@ public:
   typed_behavior& operator=(const typed_behavior&) = default;
 
   template <class... Us>
-  // cppcheck-suppress noExplicitConstructor
   typed_behavior(const typed_behavior<Us...>& other) : bhvr_(other.unbox()) {
     using other_signatures = typename typed_behavior<Us...>::signatures;
     using m = interface_mismatch_t<other_signatures, signatures>;

--- a/libcaf_core/caf/weak_intrusive_ptr.hpp
+++ b/libcaf_core/caf/weak_intrusive_ptr.hpp
@@ -121,7 +121,6 @@ public:
   }
 
   template <detail::weak_assignable_from<managed_type, control_block_type, T> U>
-  // cppcheck-suppress noExplicitConstructor
   weak_intrusive_ptr(weak_intrusive_ptr<U> other) noexcept
     : ptr_(std::exchange(other.ptr_, nullptr)) {
     // nop
@@ -231,7 +230,6 @@ public:
   }
 
   CAF_DEPRECATED("construct using add_ref or adopt_ref instead")
-  // cppcheck-suppress noExplicitConstructor
   weak_intrusive_ptr(control_block_pointer ptr,
                      bool increase_ref_count = true) noexcept
     : ptr_(ptr) {

--- a/libcaf_io/caf/io/accept_handle.hpp
+++ b/libcaf_io/caf/io/accept_handle.hpp
@@ -32,7 +32,6 @@ public:
     // nop
   }
 
-  // cppcheck-suppress noExplicitConstructor
   constexpr accept_handle(const invalid_accept_handle_t&) {
     // nop
   }

--- a/libcaf_io/caf/io/connection_handle.hpp
+++ b/libcaf_io/caf/io/connection_handle.hpp
@@ -33,7 +33,6 @@ public:
     // nop
   }
 
-  // cppcheck-suppress noExplicitConstructor
   constexpr connection_handle(const invalid_connection_handle_t&) {
     // nop
   }

--- a/libcaf_io/caf/io/datagram_handle.hpp
+++ b/libcaf_io/caf/io/datagram_handle.hpp
@@ -33,7 +33,6 @@ public:
     // nop
   }
 
-  // cppcheck-suppress noExplicitConstructor
   constexpr datagram_handle(const invalid_datagram_handle_t&) {
     // nop
   }

--- a/libcaf_net/caf/net/lp/framing.cpp
+++ b/libcaf_net/caf/net/lp/framing.cpp
@@ -215,7 +215,6 @@ private:
   template <class T>
   bool end_message_impl() {
     using detail::to_network_order;
-    // cppcheck-suppress constVariableReference
     auto& buf = down_->output_buffer();
     CAF_ASSERT(message_offset_ < buf.size());
     auto* msg_begin = buf.data() + static_cast<ptrdiff_t>(message_offset_);

--- a/libcaf_net/caf/net/typed_actor_shell.hpp
+++ b/libcaf_net/caf/net/typed_actor_shell.hpp
@@ -161,7 +161,6 @@ public:
     // nop
   }
 
-  // cppcheck-suppress noExplicitConstructor
   typed_actor_shell_ptr(typed_actor_shell_ptr&& other) noexcept = default;
 
   typed_actor_shell_ptr& operator=(typed_actor_shell_ptr&& other) noexcept

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -71,6 +71,8 @@ cppcheck \
   --xml \
   --xml-version=2 \
   --enable=all \
+  --disable=style \
+  --disable=information \
   --suppress=functionStatic \
   --suppress=missingIncludeSystem \
   --suppress=unusedLabel \


### PR DESCRIPTION
Over the last couple iterations on `cppcheck`, it became clear that `style` warnings in cppcheck have too many false positives to be useful and some suggestions make code worse, like turning a perfectly readable for each loop into a `for_each` function call.

Revert some of the recent changes and disable the `style` category altogether in `cppcheck`.

Relates #2294.