### PR TITLE
Limit cppcheck scan to changed modules on CI

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -64,8 +64,14 @@ jobs:
               jq
       - name: Create compile database for cppcheck
         run: ./configure
-      - name: cppcheck
+      - name: Run full cppcheck on main
+        if: github.ref_name == 'main'
         run: scripts/cppcheck.sh
+      - name: Run cppcheck on modified modules
+        if: github.ref_name != 'main'
+        # note: add 'build' so the list is never empty;
+        #       the directory has auto-generated sources and is fast to scan
+        run: scripts/cppcheck.sh build $( git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -oE 'examples|libcaf_[a-z]+' | sort -u )
       - name: Upload cppcheck report
         if: always()
         uses: actions/upload-artifact@v4

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -6,6 +6,14 @@
 #
 #   scripts/cppcheck.sh
 #
+# Passing no arguments will run cppcheck on everything.
+#
+# Optionally, the script takes any number of arguments, each of which is a
+# directory to include in the scan. For example, to run cppcheck only on the
+# core and net libraries:
+#
+#   scripts/cppcheck.sh libcaf_core libcaf_net
+#
 # Requires: cppcheck, cppcheck-htmlreport (Python), jq
 # Output:   cppcheck-report.xml, cppcheck-report-html/ (HTML report)
 #
@@ -52,17 +60,44 @@ else
   jobs="$(sysctl -n hw.ncpu 2>/dev/null || echo 1)"
 fi
 
-jq '[.[] | select(
-  (.file | test("\\.test\\.(hpp|cpp)$") | not)
-  and (.file | test("/robot/") | not)
-)]' \
-  "$compileCommands" >"$filteredCompileCommands"
-
 echo "[cppcheck] Building generated sources"
 cmake --build "$buildDir" --target caf-code-gen
 
+if [ $# -gt 0 ]; then
+  echo "[cppcheck] Scanning specified directories: $@"
+  filter=""
+  for arg in "$@"; do
+    # sanitize argument to prevent jq injection
+    if [[ "$arg" =~ [^a-zA-Z0-9_./-] ]]; then
+      echo "Invalid directory argument: $arg" >&2
+      exit 1
+    fi
+    # add directory to the filter
+    filter="$filter or (.file | contains(\"$arg/\"))"
+  done
+  jq "[.[] | select(
+        (
+          (.file | (contains(\".test.hpp\") or contains(\".test.cpp\")) | not)
+           and (.file | contains(\"/robot/\") | not)
+        )
+        and ( false $filter )
+  )]" \
+    "$compileCommands" >"$filteredCompileCommands"
+else
+  echo "[cppcheck] Scanning all directories"
+  jq "[.[] | select(
+        (.file | (contains(\".test.hpp\") or contains(\".test.cpp\")) | not)
+         and (.file | contains(\"/robot/\") | not)
+      )]" \
+    "$compileCommands" >"$filteredCompileCommands"
+fi
+
+numFiles=$( jq '. | length' "$filteredCompileCommands" )
+
+echo "[cppcheck] Found $numFiles files to scan"
+
 suppressionsFile="$repoRoot/.cppcheck-suppressions"
-echo "[cppcheck] Running cppcheck (compile database: $filteredCompileCommands)"
+echo "[cppcheck] Running cppcheck with compile database: $filteredCompileCommands"
 set +e
 cppcheck \
   -j "$jobs" \
@@ -70,12 +105,7 @@ cppcheck \
   --project="$filteredCompileCommands" \
   --xml \
   --xml-version=2 \
-  --enable=all \
-  --disable=style \
-  --disable=information \
-  --suppress=functionStatic \
-  --suppress=missingIncludeSystem \
-  --suppress=unusedLabel \
+  --enable=performance,portability \
   --inline-suppr \
   --suppressions-list="$suppressionsFile" \
   --error-exitcode=7 \


### PR DESCRIPTION
A full `cppcheck` run takes about 20 Minutes on CI. However, few PRs touch all the components in CAF. So instead of doing a full scan each time, we look at the list of modified files and only select the relevant directories for `cppcheck`.

When running the pipeline for `main`, we still always do a full scan to catch regressions after merge commits early.

Closes #2294.