### PR TITLE
Simplify `blocking_producer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   `abstract_actor* self` parameter. This allows us to remove weak pointers in
   the attachable implementations to avoid unnecessary increment and decrement
   operations on the reference count.
+- The `caf::async::producer::on_consumer_demand` callback now takes a second
+  `bool unblocked` argument. Please refer to the documentation of the `producer`
+  class for more details.
 
 ### Deprecated
 

--- a/libcaf_core/caf/async/blocking_producer.hpp
+++ b/libcaf_core/caf/async/blocking_producer.hpp
@@ -6,6 +6,7 @@
 
 #include "caf/async/producer.hpp"
 #include "caf/async/spsc_buffer.hpp"
+#include "caf/async/write_result.hpp"
 #include "caf/detail/atomic_ref_count.hpp"
 #include "caf/intrusive_ptr.hpp"
 #include "caf/make_counted.hpp"
@@ -13,7 +14,6 @@
 #include <condition_variable>
 #include <optional>
 #include <span>
-#include <type_traits>
 
 namespace caf::async {
 
@@ -32,19 +32,43 @@ public:
     }
 
     bool push(std::span<const T> items) {
-      std::unique_lock guard{mtx_};
-      while (items.size() > 0) {
-        while (demand_ == 0)
-          cv_.wait(guard);
-        if (demand_ < 0) {
-          return false;
-        } else {
-          auto n = std::min(static_cast<size_t>(demand_), items.size());
-          guard.unlock();
-          buf_->push(items.subspan(0, n));
-          guard.lock();
-          demand_ -= static_cast<ptrdiff_t>(n);
-          items = items.subspan(n);
+      // Only one thread can push at a time. The reason for this limitation is
+      // that `try_push` can return `try_again_later`, which requires a matching
+      // call to `on_consumer_demand` (or `on_consumer_cancel`) before we can
+      // call `try_push` again.
+      std::unique_lock push_guard{push_mtx_};
+      if (!buf_) {
+        return false;
+      }
+      while (!items.empty()) {
+        const auto [n, wr] = buf_->try_push(items);
+        switch (wr) {
+          case write_result::ok:
+            CAF_ASSERT(n == items.size());
+            return true;
+          case write_result::canceled:
+            return false;
+          default: { // write_result::try_again_later:
+            CAF_ASSERT(wr == write_result::try_again_later);
+            CAF_ASSERT(n < items.size());
+            if (n > 0) {
+              items = items.subspan(n);
+            }
+            // Wait until `on_consumer_cancel` changes the state to `canceled`
+            // or `on_consumer_demand` changes the state to `notified`.
+            // Note: if `try_push` returns `try_again_later`, then
+            //       `on_consumer_demand` will be called with `unblocked = true`
+            //       *once* (except when the consumer cancels).
+            std::unique_lock guard{state_mtx_};
+            while (state_ == state::idle) {
+              state_cv_.wait(guard);
+            }
+            if (state_ == state::canceled) {
+              return false;
+            }
+            CAF_ASSERT(state_ == state::notified);
+            state_ = state::idle;
+          }
         }
       }
       return true;
@@ -55,6 +79,7 @@ public:
     }
 
     void close() {
+      std::unique_lock guard{push_mtx_};
       if (buf_) {
         buf_->close();
         buf_ = nullptr;
@@ -62,6 +87,7 @@ public:
     }
 
     void abort(error reason) {
+      std::unique_lock guard{push_mtx_};
       if (buf_) {
         buf_->abort(std::move(reason));
         buf_ = nullptr;
@@ -69,8 +95,8 @@ public:
     }
 
     bool canceled() const {
-      std::unique_lock<std::mutex> guard{mtx_};
-      return demand_ == -1;
+      std::unique_lock guard{state_mtx_};
+      return state_ == state::canceled;
     }
 
     void on_consumer_ready() override {
@@ -78,18 +104,17 @@ public:
     }
 
     void on_consumer_cancel() override {
-      std::unique_lock<std::mutex> guard{mtx_};
-      demand_ = -1;
-      cv_.notify_all();
+      std::unique_lock guard{state_mtx_};
+      state_ = state::canceled;
+      state_cv_.notify_one();
     }
 
-    void on_consumer_demand(size_t demand) override {
-      std::unique_lock<std::mutex> guard{mtx_};
-      if (demand_ == 0) {
-        demand_ += static_cast<ptrdiff_t>(demand);
-        cv_.notify_all();
-      } else if (demand_ > 0) {
-        demand_ += static_cast<ptrdiff_t>(demand);
+    void on_consumer_demand(size_t, bool unblocked) override {
+      if (unblocked) {
+        std::unique_lock guard{state_mtx_};
+        CAF_ASSERT(state_ == state::idle);
+        state_ = state::notified;
+        state_cv_.notify_one();
       }
     }
 
@@ -102,11 +127,14 @@ public:
     }
 
   private:
+    enum class state { idle, notified, canceled };
+
     mutable detail::atomic_ref_count ref_count_;
     spsc_buffer_ptr<T> buf_;
-    mutable std::mutex mtx_;
-    std::condition_variable cv_;
-    ptrdiff_t demand_ = 0;
+    mutable std::mutex push_mtx_;
+    mutable std::mutex state_mtx_;
+    std::condition_variable state_cv_;
+    state state_ = state::idle;
   };
 
   using impl_ptr = intrusive_ptr<impl>;
@@ -134,19 +162,19 @@ public:
       impl_->close();
   }
 
-  /// Pushes an item to the consumer. If there is no demand by the consumer to
-  /// deliver the item, this functions blocks unconditionally.
-  /// @returns `true` if the item was delivered to the consumer or `false` if
+  /// Pushes an item to the consumer. If there is no room under the hard
+  /// buffer limit, this function blocks until space is available or the
+  /// consumer cancels.
+  /// @returns `true` if the item was delivered to the buffer or `false` if
   ///          the consumer no longer receives any additional item.
   bool push(const T& item) {
     return impl_->push(item);
   }
 
-  /// Pushes multiple items to the consumer. If there is no demand by the
-  /// consumer to deliver all items, this functions blocks unconditionally until
-  /// all items have been delivered.
-  /// @returns `true` if all items were delivered to the consumer or `false` if
-  ///          the consumer no longer receives any additional item.
+  /// Pushes multiple items to the consumer, blocking on the hard buffer limit
+  /// as needed.
+  /// @returns `true` if all items were enqueued or `false` if the consumer
+  ///          no longer receives any additional item.
   bool push(std::span<const T> items) {
     return impl_->push(items);
   }

--- a/libcaf_core/caf/async/blocking_producer.test.cpp
+++ b/libcaf_core/caf/async/blocking_producer.test.cpp
@@ -5,16 +5,23 @@
 #include "caf/async/blocking_producer.hpp"
 
 #include "caf/test/scenario.hpp"
+#include "caf/test/test.hpp"
 
 #include "caf/actor_system.hpp"
 #include "caf/actor_system_config.hpp"
+#include "caf/async/consumer.hpp"
+#include "caf/async/policy.hpp"
+#include "caf/async/spsc_buffer.hpp"
+#include "caf/detail/atomic_ref_count.hpp"
 #include "caf/event_based_actor.hpp"
 #include "caf/init_global_meta_objects.hpp"
+#include "caf/make_counted.hpp"
 #include "caf/scheduled_actor/flow.hpp"
 #include "caf/scoped_actor.hpp"
 
 #include <mutex>
 #include <thread>
+#include <vector>
 
 // Some offset to avoid collisions with other type IDs.
 CAF_BEGIN_TYPE_ID_BLOCK(blocking_producer_test, caf::first_custom_type_id + 170,
@@ -61,6 +68,42 @@ using pull_val_t = async::consumer_resource<int>;
 using push_resource_t = async::producer_resource<pull_val_t>;
 
 using pull_resource_t = async::consumer_resource<pull_val_t>;
+
+struct thread_pull_consumer : async::consumer {
+  void on_producer_ready() override {
+    // nop
+  }
+
+  void on_producer_wakeup() override {
+    // nop
+  }
+
+  void ref() const noexcept final {
+    ref_count_.inc();
+  }
+
+  void deref() const noexcept final {
+    ref_count_.dec(this);
+  }
+
+  mutable caf::detail::atomic_ref_count ref_count_;
+};
+
+struct int_observer {
+  void on_next(const int& x) {
+    out->push_back(x);
+  }
+
+  void on_error(const error&) {
+    // nop
+  }
+
+  void on_complete() {
+    // nop
+  }
+
+  std::vector<int>* out = nullptr;
+};
 
 void do_push(sync_t* sync, push_val_t push, int begin, int end) {
   auto out = async::make_blocking_producer(std::move(push));
@@ -120,6 +163,40 @@ void receiver_impl(event_based_actor* self, pull_resource_t inputs,
 } // namespace
 
 WITH_FIXTURE(fixture) {
+
+TEST("blocking producer waits when the buffer is at hard capacity") {
+  auto [rd, wr] = async::make_spsc_buffer_resource<int>(2, 1);
+  auto wbuf = wr.try_open();
+  require_ne(wbuf, nullptr);
+  auto rbuf = rd.try_open();
+  require_ne(rbuf, nullptr);
+  auto cons = make_counted<thread_pull_consumer>();
+  rbuf->set_consumer(cons);
+  async::blocking_producer<int> out{std::move(wbuf)};
+  std::vector<int> received;
+  int_observer obs{&received};
+  // Run pushes on a worker thread and pull from the main thread so a
+  // spinning consumer cannot starve the producer (and vice versa: retry with
+  // yield when `pull` returns no data yet — an open buffer may report
+  // `{true, 0}` until the producer enqueues).
+  std::thread producer([&] {
+    for (int i = 0; i < 10; ++i)
+      check(out.push(i));
+  });
+  while (received.size() < 10u) {
+    auto [ok, n] = rbuf->pull(async::delay_errors, 1, obs);
+    if (!ok)
+      break;
+    if (n == 0)
+      std::this_thread::yield();
+  }
+  producer.join();
+  if (check_eq(received.size(), 10u)) {
+    for (int i = 0; i < 10; ++i)
+      check_eq(received[static_cast<size_t>(i)], i);
+  }
+  rbuf->cancel();
+}
 
 SCENARIO("blocking producers allow threads to generate data") {
   GIVEN("a dynamic set of blocking producers") {

--- a/libcaf_core/caf/async/fwd.hpp
+++ b/libcaf_core/caf/async/fwd.hpp
@@ -10,6 +10,7 @@ namespace caf::async {
 
 // -- classes ------------------------------------------------------------------
 
+class abstract_spsc_buffer;
 class batch;
 class consumer;
 class execution_context;
@@ -40,6 +41,7 @@ class blocking_producer;
 
 // -- smart pointer aliases ----------------------------------------------------
 
+using abstract_spsc_buffer_ptr = intrusive_ptr<abstract_spsc_buffer>;
 using execution_context_ptr = intrusive_ptr<execution_context>;
 
 } // namespace caf::async

--- a/libcaf_core/caf/async/mock_producer.test.cpp
+++ b/libcaf_core/caf/async/mock_producer.test.cpp
@@ -14,7 +14,7 @@ void mock_producer::on_consumer_cancel() {
   canceled = true;
 }
 
-void mock_producer::on_consumer_demand(size_t new_demand) {
+void mock_producer::on_consumer_demand(size_t new_demand, bool) {
   demand += new_demand;
 }
 

--- a/libcaf_core/caf/async/mock_producer.test.hpp
+++ b/libcaf_core/caf/async/mock_producer.test.hpp
@@ -17,7 +17,7 @@ public:
 
   void on_consumer_cancel() override;
 
-  void on_consumer_demand(size_t new_demand) override;
+  void on_consumer_demand(size_t new_demand, bool) override;
 
   void ref() const noexcept final;
 

--- a/libcaf_core/caf/async/producer.hpp
+++ b/libcaf_core/caf/async/producer.hpp
@@ -22,7 +22,12 @@ public:
   virtual void on_consumer_cancel() = 0;
 
   /// Called to signal that the consumer requests more events.
-  virtual void on_consumer_demand(size_t demand) = 0;
+  /// @param demand The number of items that the producer may push to the buffer
+  ///               without going past its capacity.
+  /// @param unblocked `true` when a producer received `try_again_later` from
+  ///                  `try_push` prior and may now resume pushing items to the
+  ///                  buffer.
+  virtual void on_consumer_demand(size_t demand, bool unblocked) = 0;
 };
 
 /// @relates producer

--- a/libcaf_core/caf/async/producer_adapter.hpp
+++ b/libcaf_core/caf/async/producer_adapter.hpp
@@ -73,7 +73,7 @@ public:
       ctx_->schedule(do_cancel_);
     }
 
-    void on_consumer_demand(size_t) override {
+    void on_consumer_demand(size_t, bool) override {
       ctx_->schedule(do_resume_);
     }
 

--- a/libcaf_core/caf/async/spsc_buffer.hpp
+++ b/libcaf_core/caf/async/spsc_buffer.hpp
@@ -8,6 +8,7 @@
 #include "caf/async/consumer.hpp"
 #include "caf/async/policy.hpp"
 #include "caf/async/producer.hpp"
+#include "caf/async/write_result.hpp"
 #include "caf/callback.hpp"
 #include "caf/config.hpp"
 #include "caf/defaults.hpp"
@@ -25,24 +26,46 @@
 
 #include <condition_variable>
 #include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <mutex>
 #include <span>
 
 namespace caf::async {
 
-/// A Single Producer Single Consumer buffer. The buffer uses a "soft bound",
-/// which means that the producer announces a desired maximum for in-flight
-/// items that the buffer uses for its bookkeeping, but the producer may add
-/// more than that number of items. Allowing producers to go "beyond the limit"
-/// is intended for producer that transform inputs into outputs where one input
-/// event can produce multiple output items.
+/// Base class for SPSC buffers.
+class abstract_spsc_buffer : public ref_counted {
+public:
+  /// Closes the buffer by request of the producer.
+  virtual void close() = 0;
+
+  /// Closes the buffer by request of the producer and signals an error to the
+  /// consumer.
+  virtual void abort(error reason) = 0;
+
+  /// Closes the buffer by request of the consumer.
+  virtual void cancel() = 0;
+
+  /// Consumer callback for the initial handshake between producer and consumer.
+  virtual void set_consumer(consumer_ptr consumer) = 0;
+
+  /// Producer callback for the initial handshake between producer and consumer.
+  virtual void set_producer(producer_ptr producer) = 0;
+};
+
+/// A Single Producer Single Consumer buffer. The buffer uses a "soft bound"
+/// for @ref push, which means the producer may add more in-flight items than
+/// the configured capacity. Hard-capacity writers use @ref try_push: when the
+/// buffer is full, they return @ref write_result::try_again_later, set
+/// @ref flags::producer_blocked, and the next successful @ref pull / demand
+/// signals the producer with @ref producer::on_consumer_demand where the
+/// second parameter (`unblocked`) is `true`. Soft @ref push ignores that flag.
 ///
 /// Aside from providing storage, this buffer also resumes the consumer if data
 /// is available and signals demand to the producer whenever the consumer takes
 /// data out of the buffer.
 template <class T>
-class spsc_buffer : public ref_counted {
+class spsc_buffer final : public abstract_spsc_buffer {
 public:
   using value_type = T;
 
@@ -54,6 +77,9 @@ public:
     bool closed : 1;
     /// Stores whether `cancel` has been called.
     bool canceled : 1;
+    /// Set by @ref try_push when the hard capacity is reached; cleared by
+    /// @ref signal_demand when the consumer frees space and wakes the producer.
+    bool producer_blocked : 1;
   };
 
   spsc_buffer(size_t capacity, size_t min_pull_size)
@@ -89,6 +115,48 @@ public:
   /// @returns the remaining capacity after inserting the items.
   size_t push(const T& item) {
     return push(std::span{&item, 1});
+  }
+
+  /// Tries to append a span of items without exceeding the capacity.
+  /// @returns `{items.size(), write_result::ok}` if all items were appended,
+  ///          `{n, write_result::try_again_later}` if only a subset of items
+  ///          could be appended before running out of capacity, or
+  ///          `{0, write_result::canceled}` if the subscription was canceled.
+  std::pair<size_t, write_result> try_push(std::span<const T> items) {
+    if (items.empty()) {
+      return {0, write_result::ok};
+    }
+    lock_type guard{mtx_};
+    CAF_ASSERT(producer_ != nullptr);
+    CAF_ASSERT(!flags_.closed);
+    if (flags_.canceled) {
+      return {0, write_result::canceled};
+    }
+    if (capacity_ <= buf_.size()) {
+      flags_.producer_blocked = true;
+      return {0, write_result::try_again_later};
+    }
+    const auto was_empty = buf_.empty();
+    const auto available = capacity_ - buf_.size();
+    if (available >= items.size()) {
+      buf_.insert(buf_.end(), items.begin(), items.end());
+      if (was_empty && consumer_) {
+        consumer_->on_producer_wakeup();
+      }
+      return {items.size(), write_result::ok};
+    }
+    buf_.insert(buf_.end(), items.begin(), items.begin() + available);
+    flags_.producer_blocked = true;
+    if (was_empty && consumer_) {
+      consumer_->on_producer_wakeup();
+    }
+    return {available, write_result::try_again_later};
+  }
+
+  /// Tries to append a single item without exceeding the configured @ref
+  /// capacity. Unlike @ref push, this never grows past `capacity_`.
+  write_result try_push(const T& item) {
+    return try_push(std::span{&item, 1}).second;
   }
 
   /// Consumes up to `demand` items from the buffer.
@@ -131,14 +199,11 @@ public:
     return err_;
   }
 
-  /// Closes the buffer by request of the producer.
-  void close() {
+  void close() override {
     abort(error{});
   }
 
-  /// Closes the buffer by request of the producer and signals an error to the
-  /// consumer.
-  void abort(error reason) {
+  void abort(error reason) override {
     lock_type guard{mtx_};
     if (!flags_.closed) {
       flags_.closed = true;
@@ -149,8 +214,7 @@ public:
     }
   }
 
-  /// Closes the buffer by request of the consumer.
-  void cancel() {
+  void cancel() override {
     lock_type guard{mtx_};
     if (!flags_.canceled) {
       flags_.canceled = true;
@@ -160,8 +224,7 @@ public:
     }
   }
 
-  /// Consumer callback for the initial handshake between producer and consumer.
-  void set_consumer(consumer_ptr consumer) {
+  void set_consumer(consumer_ptr consumer) override {
     CAF_ASSERT(consumer != nullptr);
     lock_type guard{mtx_};
     if (consumer_)
@@ -173,8 +236,7 @@ public:
       consumer_->on_producer_wakeup();
   }
 
-  /// Producer callback for the initial handshake between producer and consumer.
-  void set_producer(producer_ptr producer) {
+  void set_producer(producer_ptr producer) override {
     CAF_ASSERT(producer != nullptr);
     lock_type guard{mtx_};
     if (producer_)
@@ -291,9 +353,19 @@ private:
   }
 
   void signal_demand(size_t new_demand) {
+    CAF_ASSERT(new_demand > 0);
     demand_ += new_demand;
-    if (demand_ >= min_pull_size_ && producer_) {
-      producer_->on_consumer_demand(demand_);
+    if (!producer_) {
+      return;
+    }
+    if (flags_.producer_blocked) {
+      flags_.producer_blocked = false;
+      producer_->on_consumer_demand(demand_, true);
+      demand_ = 0;
+      return;
+    }
+    if (demand_ >= min_pull_size_) {
+      producer_->on_consumer_demand(demand_, false);
       demand_ = 0;
     }
   }
@@ -681,7 +753,7 @@ public:
     }
   }
 
-  void on_consumer_demand(size_t demand) override {
+  void on_consumer_demand(size_t demand, bool) override {
     std::unique_lock guard{mtx_};
     if (owner_ && pending_demand_ >= 0) {
       pending_demand_ += static_cast<ptrdiff_t>(demand);

--- a/libcaf_core/caf/async/spsc_buffer.test.cpp
+++ b/libcaf_core/caf/async/spsc_buffer.test.cpp
@@ -12,6 +12,7 @@
 #include "caf/async/mock_producer.test.hpp"
 
 #include "caf/actor_from_state.hpp"
+#include "caf/async/write_result.hpp"
 #include "caf/detail/atomic_ref_count.hpp"
 #include "caf/detail/scope_guard.hpp"
 #include "caf/event_based_actor.hpp"
@@ -68,8 +69,10 @@ public:
     consumer_cancel = true;
   }
 
-  void on_consumer_demand(size_t new_demand) override {
+  void on_consumer_demand(size_t new_demand, bool unblocked) override {
     demand += new_demand;
+    if (unblocked)
+      ++unblocked_count;
   }
 
   void ref() const noexcept final {
@@ -84,6 +87,7 @@ public:
   bool consumer_ready = false;
   bool consumer_cancel = false;
   size_t demand = 0;
+  size_t unblocked_count = 0;
 };
 
 class dummy_consumer : public async::consumer {
@@ -220,6 +224,55 @@ SCENARIO("SPSC buffers may go past their capacity") {
       }
     }
   }
+}
+
+TEST("try_push enforces hard capacity and signals unblocked demand") {
+  auto prod = make_counted<dummy_producer>();
+  auto cons = make_counted<dummy_consumer>();
+  auto buf = make_counted<async::spsc_buffer<int>>(3, 2);
+  buf->set_producer(prod);
+  buf->set_consumer(cons);
+  check_eq(prod->demand, 3u);
+  check_eq(prod->unblocked_count, 0u);
+  check_eq(buf->try_push(1), async::write_result::ok);
+  check_eq(buf->try_push(2), async::write_result::ok);
+  check_eq(buf->try_push(3), async::write_result::ok);
+  check_eq(buf->try_push(4), async::write_result::try_again_later);
+  dummy_observer obs;
+  auto [ok, c] = buf->pull(async::delay_errors, 1, obs);
+  check_eq(ok, true);
+  check_eq(c, 1u);
+  check_eq(prod->unblocked_count, 1u);
+  check_eq(buf->try_push(4), async::write_result::ok);
+}
+
+TEST("try_push batch may partially fill the buffer under hard capacity") {
+  auto prod = make_counted<dummy_producer>();
+  auto cons = make_counted<dummy_consumer>();
+  auto buf = make_counted<async::spsc_buffer<int>>(3, 1);
+  buf->set_producer(prod);
+  buf->set_consumer(cons);
+  auto v = std::vector<int>{1, 2, 3, 4, 5};
+  auto [n, wr] = buf->try_push(std::span{v});
+  check_eq(n, 3u);
+  check_eq(wr, async::write_result::try_again_later);
+  dummy_observer obs;
+  std::ignore = buf->pull(async::delay_errors, 2, obs);
+  auto [n2, wr2] = buf->try_push(std::span{v}.subspan(3));
+  check_eq(n2, 2u);
+  check_eq(wr2, async::write_result::ok);
+}
+
+TEST("try_push returns canceled after cancel") {
+  auto prod = make_counted<dummy_producer>();
+  auto cons = make_counted<dummy_consumer>();
+  auto buf = make_counted<async::spsc_buffer<int>>(4, 1);
+  buf->set_producer(prod);
+  buf->set_consumer(cons);
+  buf->cancel();
+  check_eq(buf->try_push(1), async::write_result::canceled);
+  auto v = std::vector<int>{1, 2};
+  check_eq(buf->try_push(std::span{v}).second, async::write_result::canceled);
 }
 
 SCENARIO("the prioritize_errors policy skips processing of pending items") {

--- a/libcaf_core/caf/async/write_result.hpp
+++ b/libcaf_core/caf/async/write_result.hpp
@@ -12,17 +12,15 @@
 
 namespace caf::async {
 
-/// Encodes the result of an asynchronous write operation.
+/// Encodes the result of a write into an asynchronous data sink.
 enum class write_result {
-  /// Signals that the write operation succeeded.
+  /// The sink accepted all data.
   ok,
-  /// Signals that the item must be dropped because the write operation failed
-  /// with an unrecoverable error. Retries will fail with the same result. When
-  /// writing to a @ref producer_resource, this usually means the consumer
-  /// closed its end of the buffer.
-  drop,
-  /// Signals that the write operation timed out.
-  timeout,
+  /// The sink rejected some or all of the data but may accept more in the
+  /// future.
+  try_again_later,
+  /// The sink no longer accepts any data.
+  canceled,
 };
 
 /// @relates write_result

--- a/libcaf_core/caf/flow/generation.test.cpp
+++ b/libcaf_core/caf/flow/generation.test.cpp
@@ -188,14 +188,14 @@ SCENARIO("callable sources stream values generated from a function object") {
 
 SCENARIO("asynchronous buffers can generate flow items") {
   GIVEN("a background thread writing into an async buffer") {
-    auto cancelled = std::atomic<bool>{false};
-    auto producer_impl = [this, &cancelled](async::producer_resource<int> res) {
+    auto canceled = std::atomic<bool>{false};
+    auto producer_impl = [this, &canceled](async::producer_resource<int> res) {
       auto producer = async::make_blocking_producer(std::move(res));
       if (!producer)
         fail("make_blocking_producer failed");
       for (int i = 1; i <= 713; ++i) {
         if (!producer->push(i)) {
-          cancelled = true;
+          canceled = true;
           return;
         }
       }
@@ -212,7 +212,7 @@ SCENARIO("asynchronous buffers can generate flow items") {
         run_flows(2s);
         check_eq(res, iota_vec(713));
         bg_thread.join();
-        check(!cancelled);
+        check(!canceled);
       }
     }
     WHEN("reading only a subset of values from the buffer") {
@@ -227,7 +227,7 @@ SCENARIO("asynchronous buffers can generate flow items") {
         run_flows(2s);
         check_eq(res, iota_vec(20));
         bg_thread.join();
-        check(cancelled);
+        check(canceled);
       }
     }
     WHEN("canceling the subscription to the buffer") {
@@ -249,7 +249,7 @@ SCENARIO("asynchronous buffers can generate flow items") {
         run_flows();
         check(res.empty());
         bg_thread.join();
-        check(cancelled);
+        check(canceled);
       }
     }
   }

--- a/libcaf_core/caf/flow/observer.hpp
+++ b/libcaf_core/caf/flow/observer.hpp
@@ -383,7 +383,7 @@ public:
     });
   }
 
-  void on_consumer_demand(size_t demand) override {
+  void on_consumer_demand(size_t demand, bool) override {
     auto lg = log::core::trace("demand = {}", demand);
     parent_->schedule_fn([ptr{strong_this()}, demand] { //
       auto lg = log::core::trace("demand = {}", demand);

--- a/libcaf_net/caf/net/http/with.cpp
+++ b/libcaf_net/caf/net/http/with.cpp
@@ -52,7 +52,7 @@ public:
     // nop
   }
 
-  void on_consumer_demand(size_t) override {
+  void on_consumer_demand(size_t, bool) override {
     // nop
   }
 

--- a/libcaf_net/caf/net/lp/framing.cpp
+++ b/libcaf_net/caf/net/lp/framing.cpp
@@ -8,6 +8,7 @@
 
 #include "caf/async/spsc_buffer.hpp"
 #include "caf/byte_span.hpp"
+#include "caf/chunk.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/detail/network_order.hpp"
 #include "caf/error.hpp"

--- a/libcaf_net/caf/net/web_socket/acceptor.hpp
+++ b/libcaf_net/caf/net/web_socket/acceptor.hpp
@@ -6,9 +6,9 @@
 
 #include "caf/net/socket.hpp"
 #include "caf/net/socket_manager.hpp"
+#include "caf/net/web_socket/frame.hpp"
 
 #include "caf/async/spsc_buffer.hpp"
-#include "caf/callback.hpp"
 #include "caf/cow_tuple.hpp"
 #include "caf/error.hpp"
 


### PR DESCRIPTION
Refactor the SPSC buffer interface and re-implement the blocking producer to use a streamlined control flow.