### PR TITLE
Fix crash in `from_resource`

### DIFF
--- a/libcaf_core/caf/flow/generation.test.cpp
+++ b/libcaf_core/caf/flow/generation.test.cpp
@@ -317,6 +317,48 @@ SCENARIO("asynchronous buffers can generate flow items") {
   }
 }
 
+// GH-2395 had this sequence of events on from_resource_sub leading to a crash:
+// 1. `on_producer_wakeup` gets called -> schedules action A
+// 2. `request(n)` gets called (demand was 0) -> schedules action B
+// 3. action A runs -> sets `running_` back to false
+// 4. action B runs
+// 5. the observer cancels the subscription mid-batch
+// 6. do_run() still runs, yet cancel() gets called with `running_` is false
+TEST("GH-2395 regression") {
+  // Get our pull and push resources.
+  auto [pull, push] = async::make_spsc_buffer_resource<int>(50, 10);
+  // Something to write to the buffer.
+  auto producer = async::make_blocking_producer(std::move(push));
+  require(producer.has_value());
+  // An observer that will cancel on the first `on_next` call.
+  auto out = make_canceling_observer<int>(true, false);
+  // Our `from_resource_sub` for the regression test.
+  auto buf = pull.try_open();
+  using buffer_type = async::spsc_buffer<int>;
+  using impl_t = caf::flow::op::from_resource_sub<buffer_type>;
+  auto ptr = coordinator()->add_child(std::in_place_type<impl_t>, buf,
+                                      out->as_observer());
+  buf->set_consumer(ptr);
+  out->on_subscribe(subscription{ptr});
+  // Drain any scheduled action.
+  run_flows();
+  // Step 1: trigger `on_producer_wakeup` to schedule action A.
+  ptr->on_producer_wakeup();
+  // Put an action on top that will push to the buffer after action A runs.
+  coordinator()->schedule_fn([this, &producer] {
+    // Push items to the buffer so action B will call `on_next` on the observer.
+    for (int i = 0; i < 10; ++i) {
+      if (!producer->push(i)) {
+        fail("push failed");
+      }
+    }
+  });
+  // Step 2: call `request(n)` to schedule action B.
+  out->sub.request(5);
+  // Prior to the fix for GH-2395, this crashed in `observer<T>::on_next`.
+  run_flows();
+}
+
 namespace {
 
 // Generates 7 integers and then calls on_complete.

--- a/libcaf_core/caf/flow/observer.hpp
+++ b/libcaf_core/caf/flow/observer.hpp
@@ -113,16 +113,19 @@ public:
 
   /// @pre `valid()`
   void on_subscribe(subscription sub) {
+    CAF_ASSERT(pimpl_ != nullptr);
     pimpl_->on_subscribe(std::move(sub));
   }
 
   /// @pre `valid()`
   void on_batch(const async::batch& buf) {
+    CAF_ASSERT(pimpl_ != nullptr);
     pimpl_->on_batch(buf);
   }
 
   /// @pre `valid()`
   void on_next(const T& item) {
+    CAF_ASSERT(pimpl_ != nullptr);
     pimpl_->on_next(item);
   }
 

--- a/libcaf_core/caf/flow/op/from_resource.hpp
+++ b/libcaf_core/caf/flow/op/from_resource.hpp
@@ -95,7 +95,7 @@ public:
     auto lg = log::core::trace("");
     parent_->schedule_fn([ptr = strong_this()] {
       auto lg = log::core::trace("");
-      if (!ptr->disposed_) {
+      if (!ptr->disposed_ && !ptr->running_) {
         ptr->running_ = true;
         ptr->do_run();
       }

--- a/libcaf_test/caf/test/fixture/flow.hpp
+++ b/libcaf_test/caf/test/fixture/flow.hpp
@@ -151,8 +151,11 @@ public:
   class canceling_observer : public caf::flow::observer_impl_base<T> {
   public:
     explicit canceling_observer(caf::flow::coordinator* parent,
-                                bool accept_subscription)
-      : accept_subscription(accept_subscription), parent_(parent) {
+                                bool accept_subscription,
+                                bool auto_request = true)
+      : accept_subscription(accept_subscription),
+        auto_request(auto_request),
+        parent_(parent) {
       // nop
     }
 
@@ -179,7 +182,9 @@ public:
     void on_subscribe(caf::flow::subscription sub) override {
       if (accept_subscription) {
         accept_subscription = false;
-        sub.request(128);
+        if (auto_request) {
+          sub.request(128);
+        }
         this->sub = std::move(sub);
         return;
       }
@@ -190,6 +195,7 @@ public:
     int on_error_calls = 0;
     int on_complete_calls = 0;
     bool accept_subscription = false;
+    bool auto_request = false;
     caf::flow::subscription sub;
     std::vector<T> buf;
 
@@ -263,11 +269,13 @@ public:
 
   /// Returns a new canceling observer. The subscriber will either call `cancel`
   /// on its subscription immediately in `on_subscribe` or wait until the first
-  /// call to `on_next` when setting `accept_first_subscription` to `true`.
+  /// call to `on_next` when setting `accept_first` to `true`. If `auto_request`
+  /// is `true`, the observer will call `request` immediately in `on_subscribe`.
   template <class T>
-  auto make_canceling_observer(bool accept_first = false) {
+  auto
+  make_canceling_observer(bool accept_first = false, bool auto_request = true) {
     return coordinator()->add_child(std::in_place_type<canceling_observer<T>>,
-                                    accept_first);
+                                    accept_first, auto_request);
   }
 
   /// Shortcut for creating an observable error via


### PR DESCRIPTION
This was one of those "fun" one line fixes that take half a day to get there...

Fixes #2395.

This will need a backport to CAF 1.2.