### PR TITLE
Redesign `actor_addr` as value type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   `abstract_actor* self` parameter. This allows us to remove weak pointers in
   the attachable implementations to avoid unnecessary increment and decrement
   operations on the reference count.
+- The class `actor_addr` has been redesigned from scratch. Prior to CAF 2.0, an
+  `actor_addr` held a weak pointer to an actor. This made it fundamentally
+  unsafe to send across the network. Since the only use case for `actor_addr` in
+  CAF is to identify an actor from an `exit_msg` or `down_msg`, we have
+  re-implemented it as a simple pair of `actor_id` and `node_id`. With this
+  change, `actor_addr` is now safe to send across the network. This change
+  should be (mostly) transparent to users with the exception of `actor_cast`,
+  which no longer can convert `actor_addr` to other actor handles.
 
 ### Deprecated
 
@@ -194,6 +202,11 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   points for the same functionality only adds redundancy.
 - Removed the `node_id::can_parse` method and the `parse` function for node IDs.
   Both are leftovers from older versions of CAF and no longer serve any purpose.
+- Related to the `actor_addr` change, we have removed the type ID for
+  `weak_actor_ptr` and inspectors no longer support `weak_actor_ptr` values.
+  This means that CAF messages may no longer contain a `weak_actor_ptr`. While
+  this is technically a breaking API change, we consider it a bug fix since
+  sending a `weak_actor_ptr` silently failed in earlier CAF versions.
 
 ## [1.1.0] - 2025-07-25
 

--- a/libcaf_core/CMakeLists.txt
+++ b/libcaf_core/CMakeLists.txt
@@ -168,6 +168,7 @@ caf_add_component(
     caf/detail/bounds_checker.test.cpp
     caf/detail/cleanup_and_release.cpp
     caf/detail/cleanup_and_release.test.cpp
+    caf/detail/compare.cpp
     caf/detail/config_consumer.cpp
     caf/detail/config_consumer.test.cpp
     caf/detail/counted_disposable.cpp
@@ -175,8 +176,8 @@ caf_add_component(
     caf/detail/critical.cpp
     caf/detail/current_actor.cpp
     caf/detail/daemons.cpp
-    caf/detail/default_mailbox.cpp
     caf/detail/default_actor_handle_codec.cpp
+    caf/detail/default_mailbox.cpp
     caf/detail/default_mailbox.test.cpp
     caf/detail/default_thread_count.cpp
     caf/detail/format.test.cpp

--- a/libcaf_core/caf/abstract_actor.cpp
+++ b/libcaf_core/caf/abstract_actor.cpp
@@ -114,25 +114,33 @@ void abstract_actor::del_monitor(abstract_actor* observed,
 
 // -- linking ------------------------------------------------------------------
 
-void abstract_actor::link_to(const actor_addr& other) {
-  auto lg = log::core::trace("other = {}", other);
-  link_to(actor_cast<strong_actor_ptr>(other));
-}
-
 void abstract_actor::unlink_from(const actor_addr& other) {
   auto lg = log::core::trace("other = {}", other);
-  if (!other)
+  if (other.id() == invalid_actor_id)
     return;
-  if (auto hdl = actor_cast<strong_actor_ptr>(other)) {
-    unlink_from(hdl);
+  // Try to resolve `other` to a weak pointer.
+  weak_actor_ptr other_ptr;
+  exclusive_critical_section([this, &other, &other_ptr] { //
+    internal::attachable_predicate::extractor extractor{&other, &other_ptr};
+    auto pred = internal::attachable_predicate::linked_to(&extractor);
+    std::ignore = this->attachables_.any_of(pred);
+  });
+  // If there's no link attachable for `other`, we're done.
+  if (!other_ptr) {
+    return;
+  }
+  // If `other` is still alive, unlink by calling remove_link.
+  if (auto hdl = other_ptr.lock()) {
+    CAF_ASSERT(hdl.get() != ctrl());
+    remove_link(hdl->get());
     return;
   }
   // Promoting weak to strong reference fails if-and-only-if the strong
   // reference count is already at 0 which means the other actor must have
-  // terminated. However, we call this overload automatically after receiving an
-  // exit message to clean up leftover state.
-  auto pred = internal::attachable_predicate::linked_to(other.ptr().ctrl());
-  exclusive_critical_section([this, &pred] { //
+  // terminated already. Clean up leftover state.
+  exclusive_critical_section([this, &other] { //
+    internal::attachable_predicate::extractor extractor{&other, nullptr};
+    auto pred = internal::attachable_predicate::linked_to(&extractor);
     attachables_.erase_first_if(pred);
   });
 }
@@ -161,7 +169,7 @@ actor_control_block* abstract_actor::ctrl() const {
 }
 
 actor_addr abstract_actor::address() const noexcept {
-  return actor_addr{actor_control_block::from(this), add_ref};
+  return {id(), node()};
 }
 
 abstract_actor* abstract_actor::current() noexcept {
@@ -236,7 +244,8 @@ void abstract_actor::add_link(abstract_actor* x) {
   CAF_ASSERT(x != nullptr);
   error fail_state;
   bool send_exit_immediately = false;
-  auto tmp = internal::attachable_factory::make_link(x->address());
+  auto tmp = internal::attachable_factory::make_link(
+    weak_actor_ptr{x->ctrl(), add_ref});
   joined_exclusive_critical_section(this, x, [&] {
     if (getf(is_terminated_flag)) {
       fail_state = fail_state_;
@@ -273,7 +282,8 @@ bool abstract_actor::add_backlink(abstract_actor* x) {
   }
   auto pred = internal::attachable_predicate::linked_to(x->ctrl());
   if (!attachables_.any_of(pred)) {
-    auto tmp = internal::attachable_factory::make_link(x->address());
+    auto tmp = internal::attachable_factory::make_link(
+      weak_actor_ptr{x->ctrl(), add_ref});
     attachables_.push(std::move(tmp));
     return true;
   }
@@ -290,7 +300,7 @@ bool abstract_actor::remove_backlink(abstract_actor* x) {
 void abstract_actor::clear_incoming_edges(const actor_addr& other) {
   auto lg = log::core::trace("other = {}", other);
   exclusive_critical_section([this, &other] { //
-    auto iter = incoming_edges_.find(other.ptr().ctrl());
+    auto iter = incoming_edges_.find(other);
     if (iter != incoming_edges_.end()) {
       incoming_edges_.erase(iter);
     }

--- a/libcaf_core/caf/abstract_actor.hpp
+++ b/libcaf_core/caf/abstract_actor.hpp
@@ -97,9 +97,6 @@ public:
   // -- linking ----------------------------------------------------------------
 
   /// Links this actor to `other`.
-  void link_to(const actor_addr& other);
-
-  /// Links this actor to `other`.
   template <class ActorHandle>
   void link_to(const ActorHandle& other) {
     if (other) {
@@ -108,7 +105,7 @@ public:
     }
   }
 
-  /// Unlinks this actor from `addr`.
+  /// Unlinks this actor from `other`.
   void unlink_from(const actor_addr& other);
 
   /// Links this actor to `hdl`.

--- a/libcaf_core/caf/actor.cpp
+++ b/libcaf_core/caf/actor.cpp
@@ -5,16 +5,7 @@
 #include "caf/actor.hpp"
 
 #include "caf/actor_addr.hpp"
-#include "caf/actor_proxy.hpp"
-#include "caf/deserializer.hpp"
-#include "caf/event_based_actor.hpp"
-#include "caf/local_actor.hpp"
-#include "caf/make_actor.hpp"
 #include "caf/scoped_actor.hpp"
-#include "caf/serializer.hpp"
-
-#include <cassert>
-#include <utility>
 
 namespace caf {
 
@@ -55,24 +46,15 @@ actor& actor::operator=(const scoped_actor& x) {
   return *this;
 }
 
-intptr_t actor::compare(const actor& x) const noexcept {
-  return actor_addr::compare(ptr_.get(), x.ptr_.get());
-}
-
-intptr_t actor::compare(const actor_addr& x) const noexcept {
-  return actor_addr::compare(ptr_.get(), actor_cast<actor_control_block*>(x));
-}
-
-intptr_t actor::compare(const strong_actor_ptr& x) const noexcept {
-  return actor_addr::compare(ptr_.get(), x.get());
-}
-
 void actor::swap(actor& other) noexcept {
   ptr_.swap(other.ptr_);
 }
 
 actor_addr actor::address() const noexcept {
-  return actor_cast<actor_addr>(ptr_);
+  if (ptr_) {
+    return {ptr_->id(), ptr_->node()};
+  }
+  return {};
 }
 
 bool operator==(const actor& lhs, abstract_actor* rhs) {

--- a/libcaf_core/caf/actor.hpp
+++ b/libcaf_core/caf/actor.hpp
@@ -10,18 +10,16 @@
 #include "caf/add_ref.hpp"
 #include "caf/adopt_ref.hpp"
 #include "caf/caf_deprecated.hpp"
-#include "caf/config.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/detail/comparable.hpp"
-#include "caf/detail/concepts.hpp"
+#include "caf/detail/compare.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/fwd.hpp"
-#include "caf/message.hpp"
+#include "caf/hash/fnv.hpp"
 
 #include <cstddef>
 #include <cstdint>
 #include <string>
-#include <type_traits>
 #include <utility>
 
 namespace caf {
@@ -120,11 +118,21 @@ public:
     return ptr_->get();
   }
 
-  intptr_t compare(const actor&) const noexcept;
+  intptr_t compare(const actor_control_block* other) const noexcept {
+    return detail::compare(get(), other);
+  }
 
-  intptr_t compare(const actor_addr&) const noexcept;
+  intptr_t compare(const actor& other) const noexcept {
+    return detail::compare(get(), other.get());
+  }
 
-  intptr_t compare(const strong_actor_ptr&) const noexcept;
+  intptr_t compare(const actor_addr& other) const noexcept {
+    return detail::compare(get(), other);
+  }
+
+  intptr_t compare(const strong_actor_ptr& other) const noexcept {
+    return detail::compare(get(), other.get());
+  }
 
   CAF_DEPRECATED("construct using add_ref or adopt_ref instead")
   actor(actor_control_block*, bool);
@@ -183,12 +191,16 @@ CAF_CORE_EXPORT bool operator!=(abstract_actor* lhs, const actor& rhs);
 
 } // namespace caf
 
-// allow actor to be used in hash maps
 namespace std {
+
 template <>
 struct hash<caf::actor> {
   size_t operator()(const caf::actor& ref) const noexcept {
-    return static_cast<size_t>(ref ? ref->id() : 0);
+    if (!ref) {
+      return 0;
+    }
+    return caf::hash::fnv<size_t>::compute(ref.id(), ref.node());
   }
 };
+
 } // namespace std

--- a/libcaf_core/caf/actor_addr.cpp
+++ b/libcaf_core/caf/actor_addr.cpp
@@ -4,78 +4,68 @@
 
 #include "caf/actor_addr.hpp"
 
-#include "caf/actor.hpp"
-#include "caf/config.hpp"
-#include "caf/deserializer.hpp"
-#include "caf/local_actor.hpp"
+#include "caf/abstract_actor.hpp"
+#include "caf/actor_control_block.hpp"
+#include "caf/detail/compare.hpp"
+#include "caf/detail/print.hpp"
 #include "caf/node_id.hpp"
-#include "caf/proxy_registry.hpp"
-#include "caf/serializer.hpp"
 
 namespace caf {
 
-actor_addr::actor_addr(std::nullptr_t) {
-  // nop
+actor_addr::actor_addr(actor_control_block* ptr) noexcept {
+  if (ptr != nullptr) {
+    id_ = ptr->id();
+    node_ = ptr->node();
+  }
 }
-
-actor_addr& actor_addr::operator=(std::nullptr_t) {
-  ptr_.reset();
-  return *this;
-}
-
-actor_addr::actor_addr(actor_control_block* ptr) : ptr_(ptr, add_ref) {
-  // nop
-}
-
-CAF_PUSH_DEPRECATED_WARNING
-actor_addr::actor_addr(actor_control_block* ptr, bool increase_ref_count)
-  : ptr_(ptr, increase_ref_count) {
-  // nop
-}
-CAF_POP_WARNINGS
-
-actor_addr::actor_addr(actor_control_block* ptr, add_ref_t)
-  : ptr_(ptr, add_ref) {
-  // nop
-}
-
-actor_addr::actor_addr(actor_control_block* ptr, adopt_ref_t)
-  : ptr_(ptr, adopt_ref) {
-  // nop
-}
-
-intptr_t actor_addr::compare(const actor_control_block* lhs,
-                             const actor_control_block* rhs) {
-  // invalid actors are always "less" than valid actors
-  if (lhs == nullptr)
-    return rhs != nullptr ? -1 : 0;
-  if (rhs == nullptr)
-    return 1;
-  // check for identity
-  if (lhs == rhs)
-    return 0;
-  // check for equality (a decorator is equal to the actor it represents)
-  auto x = lhs->id();
-  auto y = rhs->id();
-  if (x == y)
-    return lhs->node().compare(rhs->node());
-  return static_cast<intptr_t>(x) - static_cast<intptr_t>(y);
-}
-
 intptr_t actor_addr::compare(const actor_addr& other) const noexcept {
-  return compare(ptr_.ctrl(), other.ptr_.ctrl());
+  return detail::compare(*this, other);
+}
+
+intptr_t actor_addr::compare(const strong_actor_ptr& other) const noexcept {
+  return detail::compare(*this, other.get());
+}
+
+intptr_t actor_addr::compare(const weak_actor_ptr& other) const noexcept {
+  return detail::compare(*this, other.ctrl());
 }
 
 intptr_t actor_addr::compare(const abstract_actor* other) const noexcept {
-  return compare(ptr_.ctrl(), actor_control_block::from(other));
+  if (other) {
+    return detail::compare(*this, other->ctrl());
+  }
+  return detail::compare(*this, nullptr);
 }
 
 intptr_t actor_addr::compare(const actor_control_block* other) const noexcept {
-  return compare(ptr_.ctrl(), other);
+  return detail::compare(*this, other);
 }
 
 void actor_addr::swap(actor_addr& other) noexcept {
-  ptr_.swap(other.ptr_);
+  using std::swap;
+  swap(id_, other.id_);
+  swap(node_, other.node_);
+}
+
+std::string to_string(const actor_addr& x) {
+  std::string result;
+  append_to_string(result, x);
+  return result;
+}
+
+void append_to_string(std::string& dst, const actor_addr& addr) {
+  if (addr.id() == 0) {
+    dst += "null";
+    return;
+  }
+  using namespace std::literals;
+  auto out = std::back_inserter(dst);
+  const detail::simple_formatter<node_id> prefix;
+  out = prefix.format(addr.node(), out);
+  const auto infix = "/actor/id/"sv;
+  detail::print_iterator_adapter buf{out};
+  buf.insert(buf.end(), infix.begin(), infix.end());
+  print(buf, addr.id());
 }
 
 } // namespace caf

--- a/libcaf_core/caf/actor_addr.hpp
+++ b/libcaf_core/caf/actor_addr.hpp
@@ -4,163 +4,126 @@
 
 #pragma once
 
-#include "caf/abstract_actor.hpp"
-#include "caf/actor_control_block.hpp"
-#include "caf/add_ref.hpp"
-#include "caf/adopt_ref.hpp"
-#include "caf/caf_deprecated.hpp"
 #include "caf/detail/comparable.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/fwd.hpp"
+#include "caf/hash/fnv.hpp"
+#include "caf/node_id.hpp"
 
 #include <cstddef>
 #include <cstdint>
-#include <functional>
-#include <type_traits>
+#include <string>
+#include <utility>
 
 namespace caf {
 
-/// Stores the address of typed as well as untyped actors.
+/// Identifies an actor by its ID and the node it lives on. An `actor_addr`
+/// neither keeps the actor alive nor allows resolving it back to an actor
+/// handle. It is used as a lightweight token, e.g., in @ref down_msg and
+/// @ref exit_msg, to identify the source of the message.
 class CAF_CORE_EXPORT actor_addr
   : detail::comparable<actor_addr>,
-    detail::comparable<actor_addr, weak_actor_ptr>,
     detail::comparable<actor_addr, strong_actor_ptr>,
+    detail::comparable<actor_addr, weak_actor_ptr>,
     detail::comparable<actor_addr, abstract_actor*>,
     detail::comparable<actor_addr, actor_control_block*> {
 public:
-  // -- friend types that need access to private ctors
+  // -- constructors, destructors, and assignment operators --------------------
 
-  friend class abstract_actor;
+  actor_addr() noexcept = default;
 
-  // allow conversion via actor_cast
-  template <class, class, int>
-  friend class actor_cast_access;
+  actor_addr(actor_addr&&) noexcept = default;
 
-  // tell actor_cast which semantic this type uses
-  static constexpr bool has_weak_ptr_semantics = true;
+  actor_addr(const actor_addr&) noexcept = default;
 
-  actor_addr() = default;
-  actor_addr(actor_addr&&) = default;
-  actor_addr(const actor_addr&) = default;
-  actor_addr& operator=(actor_addr&&) = default;
-  actor_addr& operator=(const actor_addr&) = default;
+  actor_addr& operator=(actor_addr&&) noexcept = default;
 
-  actor_addr(std::nullptr_t);
+  actor_addr& operator=(const actor_addr&) noexcept = default;
 
-  actor_addr& operator=(std::nullptr_t);
+  /// Constructs an address that identifies an actor with the given ID and
+  /// node.
+  actor_addr(actor_id id, node_id node) noexcept : id_(id) {
+    // Leave the node_id default-constructed if this is the null address. This
+    // canonicalizes the representation and makes sure that there is only one
+    // representation for the null address.
+    if (id != 0 && node) {
+      node_ = std::move(node);
+    }
+  }
 
-  /// Returns the ID of this actor.
+  // -- properties -------------------------------------------------------------
+
+  /// Returns the ID of the identified actor.
   actor_id id() const noexcept {
-    return ptr_.ctrl()->id();
+    return id_;
   }
 
-  /// Returns the origin node of this actor.
-  node_id node() const noexcept {
-    return ptr_.ctrl()->node();
-  }
-
-  /// Returns the hosting actor system.
-  actor_system& home_system() const noexcept {
-    return ptr_.ctrl()->system();
+  /// Returns the origin node of the identified actor.
+  const node_id& node() const noexcept {
+    return node_;
   }
 
   /// Exchange content of `*this` and `other`.
   void swap(actor_addr& other) noexcept;
 
-  explicit operator bool() const {
-    return static_cast<bool>(ptr_);
+  CAF_DEPRECATED("an actor_addr is always valid")
+  explicit operator bool() const noexcept {
+    return id_ != 0;
   }
 
-  /// @cond
-
-  static intptr_t compare(const actor_control_block* lhs,
-                          const actor_control_block* rhs);
+  // -- comparison -------------------------------------------------------------
 
   intptr_t compare(const actor_addr& other) const noexcept;
+
+  intptr_t compare(const strong_actor_ptr& other) const noexcept;
+
+  intptr_t compare(const weak_actor_ptr& other) const noexcept;
 
   intptr_t compare(const abstract_actor* other) const noexcept;
 
   intptr_t compare(const actor_control_block* other) const noexcept;
 
-  intptr_t compare(const weak_actor_ptr& other) const noexcept {
-    return compare(other.ctrl());
-  }
-
-  intptr_t compare(const strong_actor_ptr& other) const noexcept {
-    return compare(other.get());
-  }
-
-  friend std::string to_string(const actor_addr& x) {
-    return to_string(x.ptr_);
-  }
-
-  friend void append_to_string(std::string& x, const actor_addr& y) {
-    return append_to_string(x, y.ptr_);
-  }
+  // -- friend functions -------------------------------------------------------
 
   template <class Inspector>
   friend bool inspect(Inspector& f, actor_addr& x) {
-    return f.value(x.ptr_);
+    auto canonicalize = [&x] {
+      if (x.id_ == 0 && x.node_) {
+        x.node_ = node_id{};
+      }
+      return true;
+    };
+    return f.object(x)
+      .on_load(canonicalize)
+      .fields(f.field("id", x.id_), f.field("node", x.node_));
   }
-
-  /// Releases the reference held by handle `x`. Using the
-  /// handle after invalidating it is undefined behavior.
-  friend void destroy(actor_addr& x) {
-    x.ptr_.reset();
-  }
-
-  CAF_DEPRECATED("construct using add_ref or adopt_ref instead")
-  actor_addr(actor_control_block*, bool);
-
-  actor_addr(actor_control_block*, add_ref_t);
-
-  actor_addr(actor_control_block*, adopt_ref_t);
-
-  actor_control_block* get() const noexcept {
-    return ptr_.ctrl();
-  }
-
-  const weak_actor_ptr& ptr() const noexcept {
-    return ptr_;
-  }
-
-  /// @endcond
 
 private:
-  strong_actor_ptr lock() const noexcept {
-    return ptr_.lock();
-  }
+  explicit actor_addr(actor_control_block* ptr) noexcept;
 
-  CAF_DEPRECATED("construct using add_ref or adopt_ref instead")
-  actor_addr(actor_control_block*);
-
-  weak_actor_ptr ptr_;
+  actor_id id_ = 0;
+  node_id node_;
 };
 
-inline bool operator==(const actor_addr& x, std::nullptr_t) {
-  return x.get() == nullptr;
-}
+/// @relates actor_addr
+CAF_CORE_EXPORT std::string to_string(const actor_addr& x);
 
-inline bool operator==(std::nullptr_t, const actor_addr& x) {
-  return x.get() == nullptr;
-}
-
-inline bool operator!=(const actor_addr& x, std::nullptr_t) {
-  return x.get() != nullptr;
-}
-
-inline bool operator!=(std::nullptr_t, const actor_addr& x) {
-  return x.get() != nullptr;
-}
+/// @relates actor_addr
+CAF_CORE_EXPORT void append_to_string(std::string& dst, const actor_addr& x);
 
 } // namespace caf
 
-// allow actor_addr to be used in hash maps
 namespace std {
+
 template <>
 struct hash<caf::actor_addr> {
-  size_t operator()(const caf::actor_addr& ref) const {
-    return static_cast<size_t>(ref.id());
+  size_t operator()(const caf::actor_addr& ref) const noexcept {
+    auto aid = ref.id();
+    if (aid == 0) {
+      return 0;
+    }
+    return caf::hash::fnv<size_t>::compute(aid, ref.node());
   }
 };
+
 } // namespace std

--- a/libcaf_core/caf/actor_cast.test.cpp
+++ b/libcaf_core/caf/actor_cast.test.cpp
@@ -32,201 +32,64 @@ dummy_actor::behavior_type typed_dummy_impl() {
   };
 }
 
-struct access_tag {};
-
 } // namespace
-
-namespace caf {
-
-// Abuse the fact that `actor_cast_access` has friend access to the handles.
-template <>
-class actor_cast_access<access_tag, access_tag, -1> {
-public:
-  static auto& unbox(actor& x) {
-    return x.ptr_;
-  }
-
-  template <class... Ts>
-  static auto& unbox(typed_actor<Ts...>& x) {
-    return x.ptr_;
-  }
-
-  static auto& unbox(actor_addr& x) {
-    return x.ptr_;
-  }
-};
-
-using access_t = actor_cast_access<access_tag, access_tag, -1>;
-
-} // namespace caf
 
 WITH_FIXTURE(test::fixture::deterministic) {
 
-TEST("actor_cast converts a strong pointer to a weak pointer") {
+TEST("actor_cast converts between strong and weak pointers") {
   SECTION("valid handle") {
     SECTION("actor") {
       auto hdl = sys.spawn(dummy_impl);
       auto ptr = actor_cast<weak_actor_ptr>(hdl);
-      check_eq(access_t::unbox(hdl).get(), ptr.get());
+      check_eq(hdl.compare(ptr.ctrl()), 0);
     }
     SECTION("typed_actor") {
       auto hdl = sys.spawn(typed_dummy_impl);
       auto ptr = actor_cast<weak_actor_ptr>(hdl);
-      check_eq(access_t::unbox(hdl).get(), ptr.get());
+      check_eq(hdl.compare(ptr.ctrl()), 0);
     }
   }
   SECTION("invalid handle") {
     SECTION("actor") {
       auto hdl = actor{};
       auto ptr = actor_cast<weak_actor_ptr>(hdl);
-      check_eq(ptr, nullptr);
+      check_eq(ptr.compare(nullptr), 0);
     }
     SECTION("typed_actor") {
       auto hdl = dummy_actor{};
       auto ptr = actor_cast<weak_actor_ptr>(hdl);
-      check_eq(ptr, nullptr);
+      check_eq(ptr.compare(nullptr), 0);
     }
   }
 }
 
-TEST("actor_cast converts a weak pointer to a strong pointer") {
+TEST("actor_cast converts a weak pointer back to a handle") {
   SECTION("valid handle") {
     SECTION("actor") {
       auto hdl = sys.spawn(dummy_impl);
-      auto addr = hdl.address();
-      auto hdl2 = actor_cast<actor>(addr);
-      check_eq(access_t::unbox(addr).get(), access_t::unbox(hdl2));
+      auto wptr = actor_cast<weak_actor_ptr>(hdl);
+      auto hdl2 = actor_cast<actor>(wptr);
+      check_eq(hdl.compare(wptr.ctrl()), 0);
+      check_eq(hdl2.compare(hdl), 0);
     }
     SECTION("typed_actor") {
       auto hdl = sys.spawn(typed_dummy_impl);
-      auto addr = hdl.address();
-      auto hdl2 = actor_cast<dummy_actor>(addr);
-      check_eq(access_t::unbox(addr).get(), access_t::unbox(hdl2));
+      auto wptr = actor_cast<weak_actor_ptr>(hdl);
+      auto hdl2 = actor_cast<dummy_actor>(wptr);
+      check_eq(hdl.compare(wptr.ctrl()), 0);
+      check_eq(hdl2.compare(hdl), 0);
     }
   }
   SECTION("expired handle") {
     SECTION("actor") {
-      auto addr = sys.spawn(dummy_impl).address();
-      auto hdl2 = actor_cast<actor>(addr);
-      check_eq(access_t::unbox(hdl2).get(), nullptr);
+      auto wptr = actor_cast<weak_actor_ptr>(sys.spawn(dummy_impl));
+      auto hdl2 = actor_cast<actor>(wptr);
+      check_eq(hdl2.compare(nullptr), 0);
     }
     SECTION("typed_actor") {
-      auto addr = sys.spawn(typed_dummy_impl).address();
-      auto hdl2 = actor_cast<dummy_actor>(addr);
-      check_eq(access_t::unbox(hdl2).get(), nullptr);
-    }
-  }
-  SECTION("invalid handle") {
-    SECTION("actor") {
-      auto addr = actor_addr{};
-      auto hdl2 = actor_cast<actor>(addr);
-      check_eq(access_t::unbox(hdl2).get(), nullptr);
-    }
-    SECTION("typed_actor") {
-      auto addr = actor_addr{};
-      auto hdl2 = actor_cast<dummy_actor>(addr);
-      check_eq(access_t::unbox(hdl2).get(), nullptr);
-    }
-  }
-}
-
-TEST("actor_cast converts a strong pointer to an actor_control_block*") {
-  SECTION("valid handle") {
-    SECTION("actor") {
-      auto hdl = sys.spawn(dummy_impl);
-      auto addr = hdl.address();
-      auto ptr = actor_cast<actor_control_block*>(addr);
-      check_eq(access_t::unbox(addr).get(), ptr);
-    }
-    SECTION("typed_actor") {
-      auto hdl = sys.spawn(typed_dummy_impl);
-      auto addr = hdl.address();
-      auto ptr = actor_cast<actor_control_block*>(addr);
-      check_eq(access_t::unbox(addr).get(), ptr);
-    }
-  }
-  SECTION("invalid handle") {
-    SECTION("actor") {
-      auto hdl = actor{};
-      auto addr = hdl.address();
-      auto ptr = actor_cast<actor_control_block*>(addr);
-      check_eq(ptr, nullptr);
-    }
-    SECTION("typed_actor") {
-      auto hdl = dummy_actor{};
-      auto addr = hdl.address();
-      auto ptr = actor_cast<actor_control_block*>(addr);
-      check_eq(ptr, nullptr);
-    }
-  }
-}
-
-TEST("actor_cast converts a strong pointer to an abstract_actor*") {
-  SECTION("valid handle") {
-    SECTION("actor") {
-      auto hdl = sys.spawn(dummy_impl);
-      auto addr = hdl.address();
-      auto ptr = actor_cast<abstract_actor*>(addr);
-      if (check_ne(ptr, nullptr)) {
-        check_eq(access_t::unbox(addr).get(), ptr->ctrl());
-      }
-    }
-    SECTION("typed_actor") {
-      auto hdl = sys.spawn(typed_dummy_impl);
-      auto addr = hdl.address();
-      auto ptr = actor_cast<abstract_actor*>(addr);
-      if (check_ne(ptr, nullptr)) {
-        check_eq(access_t::unbox(addr).get(), ptr->ctrl());
-      }
-    }
-  }
-  SECTION("invalid handle") {
-    SECTION("actor") {
-      auto hdl = actor{};
-      auto addr = hdl.address();
-      auto ptr = actor_cast<abstract_actor*>(addr);
-      check_eq(ptr, nullptr);
-    }
-    SECTION("typed_actor") {
-      auto hdl = dummy_actor{};
-      auto addr = hdl.address();
-      auto ptr = actor_cast<abstract_actor*>(addr);
-      check_eq(ptr, nullptr);
-    }
-  }
-}
-
-TEST("actor_cast converts a strong pointer to a local_actor*") {
-  SECTION("valid handle") {
-    SECTION("actor") {
-      auto hdl = sys.spawn(dummy_impl);
-      auto addr = hdl.address();
-      auto ptr = actor_cast<local_actor*>(addr);
-      if (check_ne(ptr, nullptr)) {
-        check_eq(access_t::unbox(addr).get(), ptr->ctrl());
-      }
-    }
-    SECTION("typed_actor") {
-      auto hdl = sys.spawn(typed_dummy_impl);
-      auto addr = hdl.address();
-      auto ptr = actor_cast<local_actor*>(addr);
-      if (check_ne(ptr, nullptr)) {
-        check_eq(access_t::unbox(addr).get(), ptr->ctrl());
-      }
-    }
-  }
-  SECTION("invalid handle") {
-    SECTION("actor") {
-      auto hdl = actor{};
-      auto addr = hdl.address();
-      auto ptr = actor_cast<local_actor*>(addr);
-      check_eq(ptr, nullptr);
-    }
-    SECTION("typed_actor") {
-      auto hdl = dummy_actor{};
-      auto addr = hdl.address();
-      auto ptr = actor_cast<local_actor*>(addr);
-      check_eq(ptr, nullptr);
+      auto wptr = actor_cast<weak_actor_ptr>(sys.spawn(typed_dummy_impl));
+      auto hdl2 = actor_cast<dummy_actor>(wptr);
+      check_eq(hdl2.compare(nullptr), 0);
     }
   }
 }
@@ -235,23 +98,23 @@ TEST("actor_cast converts a self pointer to a handle type") {
   SECTION("actor") {
     sys.spawn([this](event_based_actor* self) {
       auto hdl = actor_cast<actor>(self);
-      check_eq(self->ctrl(), access_t::unbox(hdl));
+      check_eq(hdl.compare(self->ctrl()), 0);
     });
     auto* ptr = static_cast<event_based_actor*>(nullptr);
     auto hdl = actor_cast<actor>(ptr);
-    check_eq(access_t::unbox(hdl), nullptr);
+    check_eq(hdl.compare(nullptr), 0);
   }
   SECTION("typed_actor") {
     sys.spawn([this](dummy_actor::pointer self) {
       auto hdl = actor_cast<dummy_actor>(self);
-      check_eq(self->ctrl(), access_t::unbox(hdl));
+      check_eq(hdl.compare(self->ctrl()), 0);
       return dummy_actor::behavior_type{
         [](int x) { return x; },
       };
     });
     auto* ptr = static_cast<dummy_actor::pointer>(nullptr);
     auto hdl = actor_cast<actor>(ptr);
-    check_eq(access_t::unbox(hdl), nullptr);
+    check_eq(hdl.compare(nullptr), 0);
   }
 }
 

--- a/libcaf_core/caf/actor_control_block.cpp
+++ b/libcaf_core/caf/actor_control_block.cpp
@@ -22,7 +22,7 @@
 namespace caf {
 
 actor_addr actor_control_block::address() noexcept {
-  return {this, add_ref};
+  return {id(), node()};
 }
 
 bool actor_control_block::enqueue(mailbox_element_ptr what, scheduler* sched) {
@@ -134,8 +134,12 @@ error_code<sec> save_actor(const strong_actor_ptr& storage, actor_id aid,
 namespace {
 
 void append_to_string_impl(std::string& str, const actor_control_block* ptr) {
-  detail::format_to(std::back_inserter(str), "{}",
-                    detail::formatted{ptr, policy::by_reference});
+  if (ptr) {
+    detail::format_to(std::back_inserter(str), "{}",
+                      detail::formatted{ptr, policy::by_reference});
+    return;
+  }
+  str += "null";
 }
 
 std::string to_string_impl(const actor_control_block* ptr) {

--- a/libcaf_core/caf/actor_handle_codec.cpp
+++ b/libcaf_core/caf/actor_handle_codec.cpp
@@ -14,17 +14,4 @@ actor_handle_codec::~actor_handle_codec() noexcept {
   // nop
 }
 
-bool actor_handle_codec::save(serializer& sink, const weak_actor_ptr& ptr) {
-  auto tmp = ptr.lock();
-  return save(sink, tmp);
-}
-
-bool actor_handle_codec::load(deserializer& source, weak_actor_ptr& ptr) {
-  strong_actor_ptr tmp;
-  if (!load(source, tmp))
-    return false;
-  ptr = std::move(tmp);
-  return true;
-}
-
 } // namespace caf

--- a/libcaf_core/caf/actor_handle_codec.hpp
+++ b/libcaf_core/caf/actor_handle_codec.hpp
@@ -17,10 +17,6 @@ public:
   virtual bool save(serializer& sink, const strong_actor_ptr& ptr) = 0;
 
   virtual bool load(deserializer& source, strong_actor_ptr& ptr) = 0;
-
-  bool save(serializer& sink, const weak_actor_ptr& ptr);
-
-  bool load(deserializer& source, weak_actor_ptr& ptr);
 };
 
 } // namespace caf

--- a/libcaf_core/caf/actor_pool.cpp
+++ b/libcaf_core/caf/actor_pool.cpp
@@ -101,7 +101,8 @@ actor actor_pool::make(actor_system& sys, size_t num_workers,
   for (size_t i = 0; i < num_workers; ++i) {
     auto worker = fac();
     auto* wptr = actor_cast<abstract_actor*>(worker);
-    self->add_monitor(wptr, attachable_factory::make_monitor(self->address()));
+    self->add_monitor(wptr, attachable_factory::make_monitor(
+                              weak_actor_ptr{self->ctrl(), add_ref}));
     self->workers_.push_back(std::move(worker));
   }
   return res;
@@ -168,7 +169,7 @@ bool actor_pool::filter(guard_type& guard, const strong_actor_ptr& sender,
     using factory = internal::attachable_factory;
     const auto& worker = get<2>(view);
     auto* wptr = actor_cast<abstract_actor*>(worker);
-    add_monitor(wptr, factory::make_monitor(address()));
+    add_monitor(wptr, factory::make_monitor(weak_actor_ptr{ctrl(), add_ref}));
     workers_.push_back(worker);
     return true;
   }

--- a/libcaf_core/caf/actor_system.cpp
+++ b/libcaf_core/caf/actor_system.cpp
@@ -5,6 +5,7 @@
 #include "caf/actor_system.hpp"
 
 #include "caf/actor.hpp"
+#include "caf/actor_addr.hpp"
 #include "caf/actor_companion.hpp"
 #include "caf/actor_factory.hpp"
 #include "caf/actor_registry.hpp"
@@ -860,7 +861,8 @@ void actor_system::await_running_actors_count_equal(size_t expected,
   impl_->await_running_actors_count_equal(expected, timeout);
 }
 
-void actor_system::monitor(const node_id& node, const actor_addr& observer) {
+void actor_system::monitor(const node_id& node,
+                           const strong_actor_ptr& observer) {
   // TODO: Currently does not work with other modules, in particular caf_net.
   auto mm = impl_->modules()[actor_system_module::middleman].get();
   if (mm == nullptr)

--- a/libcaf_core/caf/actor_system.hpp
+++ b/libcaf_core/caf/actor_system.hpp
@@ -157,7 +157,8 @@ public:
 
     /// Causes the module to send a `node_down_msg` to `observer` if this system
     /// loses connection to `node`.
-    virtual void monitor(const node_id& node, const actor_addr& observer) = 0;
+    virtual void monitor(const node_id& node, const strong_actor_ptr& observer)
+      = 0;
 
     /// Causes the module remove one entry for `observer` from the list of
     /// actors that receive a `node_down_msg` if this system loses connection to
@@ -304,7 +305,7 @@ public:
   /// @note Calling this function *n* times causes the system to send
   ///       `node_down_msg` *n* times to the observer. In order to not receive
   ///       the messages, the observer must call `demonitor` *n* times.
-  void monitor(const node_id& node, const actor_addr& observer);
+  void monitor(const node_id& node, const strong_actor_ptr& observer);
 
   /// Removes `observer` from the list of actors that receive a `node_down_msg`
   /// if this system loses connection to `node`.

--- a/libcaf_core/caf/attachable.cpp
+++ b/libcaf_core/caf/attachable.cpp
@@ -15,7 +15,7 @@ namespace caf::internal {
 
 class monitor_attachable : public attachable {
 public:
-  explicit monitor_attachable(actor_addr observer,
+  explicit monitor_attachable(weak_actor_ptr observer,
                               message_priority prio = message_priority::normal)
     : observer(std::move(observer)), priority(prio) {
     // nop
@@ -23,7 +23,7 @@ public:
 
   void actor_exited(abstract_actor* self, const error& rsn,
                     scheduler* sched) override {
-    if (auto sptr = actor_cast<strong_actor_ptr>(observer)) {
+    if (auto sptr = observer.lock()) {
       sptr->enqueue(make_mailbox_element(nullptr, make_message_id(priority),
                                          down_msg{self->address(), rsn}),
                     sched);
@@ -35,13 +35,13 @@ public:
   }
 
   /// Holds a weak reference to the observing actor.
-  actor_addr observer;
+  weak_actor_ptr observer;
 
   /// Defines the priority for the message.
   message_priority priority;
 };
 
-attachable_ptr attachable_factory::make_monitor(actor_addr observer,
+attachable_ptr attachable_factory::make_monitor(weak_actor_ptr observer,
                                                 message_priority prio) {
   using impl = internal::monitor_attachable;
   return std::make_unique<impl>(std::move(observer), prio);
@@ -59,7 +59,7 @@ public:
     if (!impl->set_reason(reason)) {
       return;
     }
-    if (auto sptr = actor_cast<strong_actor_ptr>(impl->observer())) {
+    if (auto sptr = impl->observer().lock()) {
       sptr->enqueue(
         make_mailbox_element(nullptr, make_message_id(), action{impl}), sched);
     }
@@ -81,14 +81,14 @@ attachable_factory::make_monitor(detail::abstract_monitor_action_ptr ptr) {
 
 class link_attachable : public attachable {
 public:
-  explicit link_attachable(actor_addr observer)
+  explicit link_attachable(weak_actor_ptr observer)
     : observer(std::move(observer)) {
     // nop
   }
 
   void actor_exited(abstract_actor* self, const error& reason,
                     scheduler* sched) override {
-    if (auto sptr = actor_cast<strong_actor_ptr>(observer)) {
+    if (auto sptr = observer.lock()) {
       sptr->enqueue(make_mailbox_element(nullptr, make_message_id(),
                                          exit_msg{self->address(), reason}),
                     sched);
@@ -100,10 +100,10 @@ public:
   }
 
   /// Holds a weak reference to the observing actor.
-  actor_addr observer;
+  weak_actor_ptr observer;
 };
 
-attachable_ptr attachable_factory::make_link(actor_addr observer) {
+attachable_ptr attachable_factory::make_link(weak_actor_ptr observer) {
   using impl = internal::link_attachable;
   return std::make_unique<impl>(std::move(observer));
 }
@@ -115,7 +115,7 @@ bool matches(const Predicate&, const Attachable&) { // fallback overload
 
 bool matches(const attachable_predicate::monitored_by_state& pred,
              const monitor_attachable& what) {
-  return pred.observer == what.observer.get();
+  return pred.observer == what.observer.ctrl();
 }
 
 bool matches(const attachable_predicate::monitored_with_callback_state& pred,
@@ -125,22 +125,33 @@ bool matches(const attachable_predicate::monitored_with_callback_state& pred,
 
 bool matches(const attachable_predicate::linked_to_state& pred,
              const link_attachable& what) {
-  return pred.observer == what.observer.get();
+  return pred.observer == what.observer.ctrl();
+}
+
+bool matches(const attachable_predicate::linked_to_state_extractor& pred,
+             const link_attachable& what) {
+  if (*pred.out->addr == what.observer) {
+    if (pred.out->result) {
+      *pred.out->result = what.observer;
+    }
+    return true;
+  }
+  return false;
 }
 
 bool matches(const attachable_predicate::observed_by_state& pred,
              const monitor_attachable& what) {
-  return pred.observer == what.observer.get();
+  return pred.observer == what.observer.ctrl();
 }
 
 bool matches(const attachable_predicate::observed_by_state& pred,
              const monitor_action_attachable& what) {
-  return pred.observer == what.impl->observer().get();
+  return pred.observer == what.impl->observer().ctrl();
 }
 
 bool matches(const attachable_predicate::observed_by_state& pred,
              const link_attachable& what) {
-  return pred.observer == what.observer.get();
+  return pred.observer == what.observer.ctrl();
 }
 
 bool attachable_predicate::operator()(const attachable& what) const {

--- a/libcaf_core/caf/blocking_actor.cpp
+++ b/libcaf_core/caf/blocking_actor.cpp
@@ -354,10 +354,6 @@ size_t blocking_actor::attach_functor(const actor& x) {
   return attach_functor(actor_cast<strong_actor_ptr>(x));
 }
 
-size_t blocking_actor::attach_functor(const actor_addr& x) {
-  return attach_functor(actor_cast<strong_actor_ptr>(x));
-}
-
 size_t blocking_actor::attach_functor(const strong_actor_ptr& ptr) {
   if (!ptr)
     return 0;

--- a/libcaf_core/caf/blocking_actor.hpp
+++ b/libcaf_core/caf/blocking_actor.hpp
@@ -404,8 +404,6 @@ private:
 
   size_t attach_functor(const actor&);
 
-  size_t attach_functor(const actor_addr&);
-
   size_t attach_functor(const strong_actor_ptr&);
 
   void unstash();

--- a/libcaf_core/caf/deserializer.cpp
+++ b/libcaf_core/caf/deserializer.cpp
@@ -73,15 +73,6 @@ bool deserializer::value(strong_actor_ptr& ptr) {
   return false;
 }
 
-bool deserializer::value(weak_actor_ptr& ptr) {
-  strong_actor_ptr tmp;
-  if (!value(tmp)) {
-    return false;
-  }
-  ptr = tmp;
-  return true;
-}
-
 bool deserializer::value(std::vector<bool>& x) {
   x.clear();
   size_t size = 0;

--- a/libcaf_core/caf/deserializer.hpp
+++ b/libcaf_core/caf/deserializer.hpp
@@ -193,9 +193,6 @@ public:
   /// @copydoc value
   bool value(strong_actor_ptr& ptr);
 
-  /// @copydoc value
-  bool value(weak_actor_ptr& ptr);
-
   virtual caf::actor_handle_codec* actor_handle_codec() = 0;
 
   /// Returns a reference to the deserializer. Convenience member function for

--- a/libcaf_core/caf/detail/compare.cpp
+++ b/libcaf_core/caf/detail/compare.cpp
@@ -1,0 +1,65 @@
+#include "caf/detail/compare.hpp"
+
+#include "caf/abstract_actor.hpp"
+#include "caf/actor.hpp"
+#include "caf/actor_addr.hpp"
+#include "caf/actor_cast.hpp"
+#include "caf/actor_control_block.hpp"
+#include "caf/node_id.hpp"
+
+namespace caf::detail {
+
+intptr_t compare(actor_id lid, const node_id& lnode, actor_id rid,
+                 const node_id& rnode) noexcept {
+  if (lid == rid) {
+    return lnode.compare(rnode);
+  }
+  return lid < rid ? -1 : 1;
+}
+
+intptr_t compare(const actor_control_block* lhs,
+                 const actor_control_block* rhs) noexcept {
+  if (lhs == rhs) {
+    return 0;
+  }
+  if (lhs) {
+    if (rhs) {
+      return compare(lhs->id(), lhs->node(), rhs->id(), rhs->node());
+    }
+    return compare(lhs->id(), lhs->node(), invalid_actor_id, node_id{});
+  }
+  if (rhs) {
+    return compare(invalid_actor_id, node_id{}, rhs->id(), rhs->node());
+  }
+  return 0;
+}
+
+intptr_t compare(const actor_control_block* lhs,
+                 const actor_addr& rhs) noexcept {
+  if (lhs) {
+    return compare(lhs->id(), lhs->node(), rhs.id(), rhs.node());
+  }
+  return compare(invalid_actor_id, node_id{}, rhs.id(), rhs.node());
+}
+
+intptr_t compare(const actor_addr& lhs,
+                 const actor_control_block* rhs) noexcept {
+  if (rhs) {
+    return compare(lhs.id(), lhs.node(), rhs->id(), rhs->node());
+  }
+  return compare(lhs.id(), lhs.node(), invalid_actor_id, node_id{});
+}
+
+intptr_t compare(const actor& lhs, const actor_control_block* rhs) noexcept {
+  return compare(actor_cast<actor_control_block*>(lhs), rhs);
+}
+
+intptr_t compare(const actor_control_block* lhs, const actor& rhs) noexcept {
+  return compare(lhs, actor_cast<actor_control_block*>(rhs));
+}
+
+intptr_t compare(const actor_addr& lhs, const actor_addr& rhs) noexcept {
+  return compare(lhs.id(), lhs.node(), rhs.id(), rhs.node());
+}
+
+} // namespace caf::detail

--- a/libcaf_core/caf/detail/compare.hpp
+++ b/libcaf_core/caf/detail/compare.hpp
@@ -1,0 +1,36 @@
+
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+#include "caf/detail/core_export.hpp"
+#include "caf/fwd.hpp"
+
+#include <cstdint>
+
+namespace caf::detail {
+
+CAF_CORE_EXPORT intptr_t compare(actor_id lid, const node_id& lnode,
+                                 actor_id rid, const node_id& rnode) noexcept;
+
+CAF_CORE_EXPORT intptr_t compare(const actor_control_block* lhs,
+                                 const actor_control_block* rhs) noexcept;
+
+CAF_CORE_EXPORT intptr_t compare(const actor_addr& lhs,
+                                 const actor_control_block* rhs) noexcept;
+
+CAF_CORE_EXPORT intptr_t compare(const actor_control_block* lhs,
+                                 const actor_addr& rhs) noexcept;
+
+CAF_CORE_EXPORT intptr_t compare(const actor& lhs,
+                                 const actor_control_block* rhs) noexcept;
+
+CAF_CORE_EXPORT intptr_t compare(const actor_control_block* lhs,
+                                 const actor& rhs) noexcept;
+
+CAF_CORE_EXPORT intptr_t compare(const actor_addr& lhs,
+                                 const actor_addr& rhs) noexcept;
+
+} // namespace caf::detail

--- a/libcaf_core/caf/detail/concepts.hpp
+++ b/libcaf_core/caf/detail/concepts.hpp
@@ -255,11 +255,6 @@ struct is_builtin_inspector_type_oracle<strong_actor_ptr, IsLoading> {
   static constexpr bool value = true;
 };
 
-template <bool IsLoading>
-struct is_builtin_inspector_type_oracle<weak_actor_ptr, IsLoading> {
-  static constexpr bool value = true;
-};
-
 template <>
 struct is_builtin_inspector_type_oracle<std::string_view, false> {
   static constexpr bool value = true;

--- a/libcaf_core/caf/detail/monitor_action.cpp
+++ b/libcaf_core/caf/detail/monitor_action.cpp
@@ -23,8 +23,8 @@ void abstract_monitor_action::deref() const noexcept {
 }
 
 void abstract_monitor_action::on_dispose() {
-  if (auto observer = actor_cast<strong_actor_ptr>(observer_)) {
-    if (auto observed = actor_cast<strong_actor_ptr>(observed_)) {
+  if (auto observer = observer_.lock()) {
+    if (auto observed = observed_.lock()) {
       auto* self = actor_cast<abstract_actor*>(observer);
       auto pred = internal::attachable_predicate::monitored_with_callback(this);
       self->del_monitor(actor_cast<abstract_actor*>(observed), pred);

--- a/libcaf_core/caf/detail/monitor_action.hpp
+++ b/libcaf_core/caf/detail/monitor_action.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "caf/action.hpp"
-#include "caf/actor_addr.hpp"
+#include "caf/actor_control_block.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/error.hpp"
 
@@ -15,7 +15,7 @@ namespace caf::detail {
 
 class CAF_CORE_EXPORT abstract_monitor_action : public action::impl {
 public:
-  abstract_monitor_action(actor_addr observer, actor_addr observed)
+  abstract_monitor_action(weak_actor_ptr observer, weak_actor_ptr observed)
     : observer_(std::move(observer)), observed_(std::move(observed)) {
     // nop
   }
@@ -28,11 +28,11 @@ public:
 
   void deref() const noexcept final;
 
-  const actor_addr& observer() const noexcept {
+  const weak_actor_ptr& observer() const noexcept {
     return observer_;
   }
 
-  const actor_addr& observed() const noexcept {
+  const weak_actor_ptr& observed() const noexcept {
     return observed_;
   }
 
@@ -41,8 +41,8 @@ protected:
 
 private:
   mutable detail::atomic_ref_count ref_count_;
-  actor_addr observer_;
-  actor_addr observed_;
+  weak_actor_ptr observer_;
+  weak_actor_ptr observed_;
 };
 
 using abstract_monitor_action_ptr = intrusive_ptr<abstract_monitor_action>;
@@ -54,7 +54,8 @@ class monitor_action : public abstract_monitor_action {
 public:
   using super = abstract_monitor_action;
 
-  explicit monitor_action(actor_addr observer, actor_addr observed, F fn)
+  explicit monitor_action(weak_actor_ptr observer, weak_actor_ptr observed,
+                          F fn)
     : super(std::move(observer), std::move(observed)),
       state_(action::state::scheduled),
       f_(function_wrapper{std::move(fn), error{}}) {

--- a/libcaf_core/caf/event_based_actor.test.cpp
+++ b/libcaf_core/caf/event_based_actor.test.cpp
@@ -188,11 +188,11 @@ SCENARIO("weak idle timeouts do not prevent actors from becoming unreachable") {
             [](const std::string&) {},
           };
         });
-        auto addr = aut.address();
+        auto wptr = actor_cast<weak_actor_ptr>(aut);
         check(has_pending_timeout());
-        check_eq(addr.get()->strong_reference_count(), 1u);
+        check_eq(wptr.ctrl()->strong_reference_count(), 1u);
         aut = nullptr;
-        check_eq(addr.get()->strong_reference_count(), 0u);
+        check_eq(wptr.ctrl()->strong_reference_count(), 0u);
         check(!has_pending_timeout());
       }
     }
@@ -206,11 +206,11 @@ SCENARIO("weak idle timeouts do not prevent actors from becoming unreachable") {
             [](const std::string&) {},
           };
         });
-        auto addr = aut.address();
+        auto wptr = actor_cast<weak_actor_ptr>(aut);
         check(has_pending_timeout());
-        check_eq(addr.get()->strong_reference_count(), 1u);
+        check_eq(wptr.ctrl()->strong_reference_count(), 1u);
         aut = nullptr;
-        check_eq(addr.get()->strong_reference_count(), 0u);
+        check_eq(wptr.ctrl()->strong_reference_count(), 0u);
         check(!has_pending_timeout());
       }
     }

--- a/libcaf_core/caf/internal/attachable_factory.hpp
+++ b/libcaf_core/caf/internal/attachable_factory.hpp
@@ -12,12 +12,12 @@ namespace caf::internal {
 class attachable_factory {
 public:
   static attachable_ptr
-  make_monitor(actor_addr observer,
+  make_monitor(weak_actor_ptr observer,
                message_priority prio = message_priority::normal);
 
   static attachable_ptr make_monitor(detail::abstract_monitor_action_ptr ptr);
 
-  static attachable_ptr make_link(actor_addr observer);
+  static attachable_ptr make_link(weak_actor_ptr observer);
 };
 
 // Note: implemented in attachable.cpp for technical reasons.

--- a/libcaf_core/caf/internal/attachable_predicate.hpp
+++ b/libcaf_core/caf/internal/attachable_predicate.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "caf/actor_addr.hpp"
 #include "caf/disposable.hpp"
 #include "caf/fwd.hpp"
 
@@ -19,6 +20,12 @@ class link_attachable;
 /// Base class for predicates operating on any of the default attachable types.
 class attachable_predicate {
 public:
+  /// Utility struct for extracting the observer from an attachable on match.
+  struct extractor {
+    const actor_addr* addr;
+    weak_actor_ptr* result;
+  };
+
   /// Predicate for checking whether an observer actor is monitoring the
   /// observed actor. Only matches monitor attachables.
   struct monitored_by_state {
@@ -36,15 +43,22 @@ public:
     const actor_control_block* observer;
   };
 
+  /// Predicate for checking whether an observer actor (identified by its
+  /// logical address) is linked to the observed actor. Only matches link
+  /// attachables.
+  struct linked_to_state_extractor {
+    extractor* out;
+  };
+
   /// Predicate for matching attachables by observer in any of the default
   /// attachable types.
   struct observed_by_state {
     const actor_control_block* observer;
   };
 
-  using impl_type
-    = std::variant<monitored_by_state, monitored_with_callback_state,
-                   linked_to_state, observed_by_state>;
+  using impl_type = std::variant<monitored_by_state,
+                                 monitored_with_callback_state, linked_to_state,
+                                 linked_to_state_extractor, observed_by_state>;
 
   impl_type impl;
 
@@ -59,6 +73,10 @@ public:
 
   static attachable_predicate linked_to(const actor_control_block* observer) {
     return {std::in_place, linked_to_state{observer}};
+  };
+
+  static attachable_predicate linked_to(extractor* out) {
+    return {std::in_place, linked_to_state_extractor{out}};
   };
 
   static attachable_predicate observed_by(const actor_control_block* observer) {

--- a/libcaf_core/caf/load_inspector_base.hpp
+++ b/libcaf_core/caf/load_inspector_base.hpp
@@ -280,10 +280,6 @@ public:
     return impl_->value(what);
   }
 
-  bool value(weak_actor_ptr& what) {
-    return impl_->value(what);
-  }
-
   bool value(std::string& what) {
     return impl_->value(what);
   }

--- a/libcaf_core/caf/local_actor.cpp
+++ b/libcaf_core/caf/local_actor.cpp
@@ -57,7 +57,7 @@ disposable local_actor::request_response_timeout(timespan timeout,
 }
 
 void local_actor::monitor(const node_id& node) {
-  system().monitor(node, address());
+  system().monitor(node, strong_actor_ptr{ctrl(), add_ref});
 }
 
 void local_actor::demonitor(const node_id& node) {
@@ -68,7 +68,8 @@ void local_actor::do_monitor(abstract_actor* ptr, message_priority priority) {
   if (ptr == nullptr)
     return;
   using factory = internal::attachable_factory;
-  add_monitor(ptr, factory::make_monitor(address(), priority));
+  add_monitor(ptr,
+              factory::make_monitor(weak_actor_ptr{ctrl(), add_ref}, priority));
 }
 
 void local_actor::do_demonitor(const strong_actor_ptr& whom) {
@@ -91,10 +92,6 @@ message_id local_actor::new_request_id(message_priority mp) noexcept {
 uint64_t local_actor::new_u64_id() noexcept {
   auto result = ++last_request_id_;
   return result.integer_value();
-}
-
-void local_actor::send_exit(const actor_addr& whom, error reason) {
-  send_exit(actor_cast<strong_actor_ptr>(whom), std::move(reason));
 }
 
 void local_actor::send_exit(const strong_actor_ptr& receiver, error reason) {

--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -139,9 +139,6 @@ public:
   // -- sending asynchronous messages ------------------------------------------
 
   /// Sends an exit message to `receiver`.
-  void send_exit(const actor_addr& receiver, error reason);
-
-  /// Sends an exit message to `receiver`.
   void send_exit(const strong_actor_ptr& receiver, error reason);
 
   /// Sends an exit message to `receiver`.
@@ -311,7 +308,7 @@ public:
   template <class ActorHandle>
   ActorHandle eval_opts(spawn_options opts, ActorHandle res) {
     if (has_link_flag(opts)) {
-      link_to(res->address());
+      link_to(res);
     }
     return res;
   }

--- a/libcaf_core/caf/mailer.test.cpp
+++ b/libcaf_core/caf/mailer.test.cpp
@@ -1070,7 +1070,8 @@ TEST("send event-based request message") {
       check_eq(*result, make_error(sec::request_timeout));
       check_eq(mail_count(), 0u);
       check_eq(num_timeouts(), 0u);
-      self->mail(exit_msg{nullptr, exit_reason::user_shutdown}).send(dummy);
+      self->mail(exit_msg{actor_addr{}, exit_reason::user_shutdown})
+        .send(dummy);
       expect<exit_msg>().to(dummy);
     }
   }
@@ -1175,7 +1176,8 @@ TEST("send event-based request message") {
       trigger_timeout();
       expect<error>().with(make_error(sec::request_timeout)).to(self_hdl);
       check_eq(*result, make_error(sec::request_timeout));
-      self->mail(exit_msg{nullptr, exit_reason::user_shutdown}).send(dummy);
+      self->mail(exit_msg{actor_addr{}, exit_reason::user_shutdown})
+        .send(dummy);
       expect<exit_msg>().to(dummy);
     }
   }
@@ -1371,7 +1373,7 @@ TEST("send event-based delayed request message with no response") {
   advance_time(1s);
   expect<error>().with(make_error(sec::request_timeout)).to(self_hdl);
   check_eq(*result, make_error(sec::request_timeout));
-  self->mail(exit_msg{nullptr, exit_reason::user_shutdown}).send(dummy);
+  self->mail(exit_msg{actor_addr{}, exit_reason::user_shutdown}).send(dummy);
   expect<exit_msg>().to(dummy);
 }
 

--- a/libcaf_core/caf/save_inspector_base.hpp
+++ b/libcaf_core/caf/save_inspector_base.hpp
@@ -220,10 +220,6 @@ public:
     return impl_->value(what);
   }
 
-  bool value(const weak_actor_ptr& what) {
-    return impl_->value(what);
-  }
-
   bool value(std::string_view what) {
     return impl_->value(what);
   }

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -558,7 +558,8 @@ public:
     }
     using impl_t = detail::monitor_action<Fn>;
     auto* observed = actor_cast<abstract_actor*>(whom);
-    auto impl = make_counted<impl_t>(address(), observed->address(),
+    auto impl = make_counted<impl_t>(weak_actor_ptr{ctrl(), add_ref},
+                                     weak_actor_ptr{observed->ctrl(), add_ref},
                                      std::move(func));
     return do_monitor(observed, std::move(impl));
   }

--- a/libcaf_core/caf/send.hpp
+++ b/libcaf_core/caf/send.hpp
@@ -36,14 +36,13 @@ namespace caf {
 /// Anonymously sends `dest` an exit message.
 template <message_priority Priority = message_priority::normal, class Handle>
 void anon_send_exit(const Handle& receiver, exit_reason reason) {
-  if constexpr (std::is_same_v<Handle, actor_addr>) {
-    anon_send_exit<Priority>(actor_cast<strong_actor_ptr>(receiver), reason);
-  } else {
-    if (receiver) {
-      auto ptr = make_mailbox_element(nullptr, make_message_id(),
-                                      exit_msg{receiver->address(), reason});
-      receiver->enqueue(std::move(ptr), nullptr);
-    }
+  static_assert(!std::is_same_v<Handle, actor_addr>,
+                "anon_send_exit no longer supports actor_addr; "
+                "use a live actor handle instead");
+  if (receiver) {
+    auto ptr = make_mailbox_element(nullptr, make_message_id(),
+                                    exit_msg{receiver->address(), reason});
+    receiver->enqueue(std::move(ptr), nullptr);
   }
 }
 

--- a/libcaf_core/caf/serializer.cpp
+++ b/libcaf_core/caf/serializer.cpp
@@ -36,11 +36,6 @@ bool serializer::value(const strong_actor_ptr& ptr) {
   return false;
 }
 
-bool serializer::value(const weak_actor_ptr& ptr) {
-  auto tmp = ptr.lock();
-  return value(tmp);
-}
-
 bool serializer::value(const std::vector<bool>& xs) {
   if (!begin_sequence(xs.size()))
     return false;

--- a/libcaf_core/caf/serializer.hpp
+++ b/libcaf_core/caf/serializer.hpp
@@ -163,8 +163,6 @@ public:
 
   bool value(const strong_actor_ptr& ptr);
 
-  bool value(const weak_actor_ptr& ptr);
-
   virtual caf::actor_handle_codec* actor_handle_codec() = 0;
 
   /// Returns a reference to the serializer. Convenience member function for

--- a/libcaf_core/caf/system_messages.test.cpp
+++ b/libcaf_core/caf/system_messages.test.cpp
@@ -16,9 +16,9 @@ WITH_FIXTURE(test::fixture::deterministic) {
 
 TEST("exit_msg is comparable") {
   SECTION("invalid actor address") {
-    auto msg1 = exit_msg{nullptr, sec::runtime_error};
-    auto msg2 = exit_msg{nullptr, sec::runtime_error};
-    auto msg3 = exit_msg{nullptr, sec::logic_error};
+    auto msg1 = exit_msg{actor_addr{}, sec::runtime_error};
+    auto msg2 = exit_msg{actor_addr{}, sec::runtime_error};
+    auto msg3 = exit_msg{actor_addr{}, sec::logic_error};
     check_eq(msg1, msg2);
     check_eq(msg2, msg1);
     check_ne(msg1, msg3);
@@ -38,16 +38,12 @@ TEST("exit_msg is comparable") {
 
 TEST("exit_msg is serializable") {
   SECTION("invalid actor address") {
-    auto msg1 = exit_msg{nullptr, sec::runtime_error};
+    auto msg1 = exit_msg{actor_addr{}, sec::runtime_error};
     auto msg2 = serialization_roundtrip(msg1);
     check_eq(msg1, msg2);
   }
   SECTION("valid actor address") {
-    // Note: serializing an actor puts it into the registry. Hence, we need to
-    //       shut down the actor manually before the end because its reference
-    //       count will not drop to zero otherwise.
     auto dummy = sys.spawn([] { return behavior{[](int) {}}; });
-    auto dummy_guard = make_actor_scope_guard(dummy);
     auto msg1 = exit_msg{dummy.address(), sec::runtime_error};
     auto msg2 = serialization_roundtrip(msg1);
     check_eq(msg1, msg2);
@@ -56,9 +52,9 @@ TEST("exit_msg is serializable") {
 
 TEST("down_msg is comparable") {
   SECTION("invalid actor address") {
-    auto msg1 = down_msg{nullptr, sec::runtime_error};
-    auto msg2 = down_msg{nullptr, sec::runtime_error};
-    auto msg3 = down_msg{nullptr, sec::logic_error};
+    auto msg1 = down_msg{actor_addr{}, sec::runtime_error};
+    auto msg2 = down_msg{actor_addr{}, sec::runtime_error};
+    auto msg3 = down_msg{actor_addr{}, sec::logic_error};
     check_eq(msg1, msg2);
     check_eq(msg2, msg1);
     check_ne(msg1, msg3);
@@ -78,17 +74,13 @@ TEST("down_msg is comparable") {
 
 TEST("down_msg is serializable") {
   SECTION("invalid actor address") {
-    auto msg1 = down_msg{nullptr, sec::runtime_error};
+    auto msg1 = down_msg{actor_addr{}, sec::runtime_error};
     auto msg2 = serialization_roundtrip(msg1);
     check_eq(msg1, msg2);
   }
   SECTION("valid actor address") {
-    // Note: serializing an actor puts it into the registry. Hence, we need to
-    //       shut down the actor manually before the end because its reference
-    //       count will not drop to zero otherwise.
     auto dummy = sys.spawn([] { return behavior{[](int) {}}; });
-    auto dummy_guard = make_actor_scope_guard(dummy);
-    auto msg1 = exit_msg{dummy.address(), sec::runtime_error};
+    auto msg1 = down_msg{dummy.address(), sec::runtime_error};
     auto msg2 = serialization_roundtrip(msg1);
     check_eq(msg1, msg2);
   }

--- a/libcaf_core/caf/type_id.hpp
+++ b/libcaf_core/caf/type_id.hpp
@@ -481,12 +481,10 @@ CAF_BEGIN_TYPE_ID_BLOCK(core_module, 0)
   CAF_ADD_TYPE_ID(core_module, (caf::unit_t))
   CAF_ADD_TYPE_ID(core_module, (caf::uri))
   CAF_ADD_TYPE_ID(core_module, (caf::uuid))
-  CAF_ADD_TYPE_ID(core_module, (caf::weak_actor_ptr))
   CAF_ADD_TYPE_ID(core_module, (std::vector<caf::actor>) )
   CAF_ADD_TYPE_ID(core_module, (std::vector<caf::actor_addr>) )
   CAF_ADD_TYPE_ID(core_module, (std::vector<caf::config_value>) )
   CAF_ADD_TYPE_ID(core_module, (std::vector<caf::strong_actor_ptr>) )
-  CAF_ADD_TYPE_ID(core_module, (std::vector<caf::weak_actor_ptr>) )
   CAF_ADD_TYPE_ID(core_module, (std::vector<std::pair<std::string, message>>) )
 
   // -- predefined atoms

--- a/libcaf_core/caf/typed_actor.hpp
+++ b/libcaf_core/caf/typed_actor.hpp
@@ -6,13 +6,14 @@
 
 #include "caf/abstract_actor.hpp"
 #include "caf/actor.hpp"
-#include "caf/actor_cast.hpp"
 #include "caf/actor_system.hpp"
 #include "caf/caf_deprecated.hpp"
 #include "caf/detail/assert.hpp"
+#include "caf/detail/compare.hpp"
 #include "caf/detail/to_statically_typed_trait.hpp"
 #include "caf/detail/type_list.hpp"
 #include "caf/fwd.hpp"
+#include "caf/hash/fnv.hpp"
 #include "caf/intrusive_ptr.hpp"
 #include "caf/stateful_actor.hpp"
 #include "caf/type_id_list.hpp"
@@ -163,7 +164,10 @@ public:
 
   /// Queries the address of the stored actor.
   actor_addr address() const noexcept {
-    return {ptr_.get(), add_ref};
+    if (ptr_) {
+      return {id(), node()};
+    }
+    return {};
   }
 
   /// Returns the ID of this actor.
@@ -200,20 +204,24 @@ public:
     return ptr_;
   }
 
-  intptr_t compare(const typed_actor& x) const noexcept {
-    return actor_addr::compare(get(), x.get());
+  intptr_t compare(const actor_control_block* other) const noexcept {
+    return detail::compare(get(), other);
   }
 
-  intptr_t compare(const actor& x) const noexcept {
-    return actor_addr::compare(get(), actor_cast<actor_control_block*>(x));
+  intptr_t compare(const typed_actor& other) const noexcept {
+    return detail::compare(get(), other.get());
   }
 
-  intptr_t compare(const actor_addr& x) const noexcept {
-    return actor_addr::compare(get(), actor_cast<actor_control_block*>(x));
+  intptr_t compare(const actor& other) const noexcept {
+    return detail::compare(get(), other);
   }
 
-  intptr_t compare(const strong_actor_ptr& x) const noexcept {
-    return actor_addr::compare(get(), actor_cast<actor_control_block*>(x));
+  intptr_t compare(const actor_addr& other) const noexcept {
+    return detail::compare(get(), other);
+  }
+
+  intptr_t compare(const strong_actor_ptr& other) const noexcept {
+    return detail::compare(get(), other.get());
   }
 
   CAF_DEPRECATED("construct using add_ref or adopt_ref instead")
@@ -277,52 +285,54 @@ private:
 
 /// @relates typed_actor
 template <class... Xs, class... Ys>
-bool operator==(const typed_actor<Xs...>& x,
-                const typed_actor<Ys...>& y) noexcept {
-  return actor_addr::compare(actor_cast<actor_control_block*>(x),
-                             actor_cast<actor_control_block*>(y))
-         == 0;
+bool operator==(const typed_actor<Xs...>& lhs,
+                const typed_actor<Ys...>& rhs) noexcept {
+  return lhs.compare(rhs) == 0;
 }
 
 /// @relates typed_actor
 template <class... Xs, class... Ys>
-bool operator!=(const typed_actor<Xs...>& x,
-                const typed_actor<Ys...>& y) noexcept {
-  return !(x == y);
+bool operator!=(const typed_actor<Xs...>& lhs,
+                const typed_actor<Ys...>& rhs) noexcept {
+  return !(lhs == rhs);
 }
 
 /// @relates typed_actor
 template <class... Xs>
-bool operator==(const typed_actor<Xs...>& x, std::nullptr_t) noexcept {
-  return actor_addr::compare(actor_cast<actor_control_block*>(x), nullptr) == 0;
+bool operator==(const typed_actor<Xs...>& lhs, std::nullptr_t) noexcept {
+  return lhs.compare(nullptr) == 0;
 }
 
 /// @relates typed_actor
 template <class... Xs>
-bool operator==(std::nullptr_t, const typed_actor<Xs...>& x) noexcept {
-  return actor_addr::compare(actor_cast<actor_control_block*>(x), nullptr) == 0;
+bool operator==(std::nullptr_t, const typed_actor<Xs...>& rhs) noexcept {
+  return rhs.compare(nullptr) == 0;
 }
 
 /// @relates typed_actor
 template <class... Xs>
-bool operator!=(const typed_actor<Xs...>& x, std::nullptr_t) noexcept {
-  return !(x == nullptr);
+bool operator!=(const typed_actor<Xs...>& lhs, std::nullptr_t) noexcept {
+  return !(lhs == nullptr);
 }
 
 /// @relates typed_actor
 template <class... Xs>
-bool operator!=(std::nullptr_t, const typed_actor<Xs...>& x) noexcept {
-  return !(x == nullptr);
+bool operator!=(std::nullptr_t, const typed_actor<Xs...>& rhs) noexcept {
+  return !(rhs == nullptr);
 }
 
 } // namespace caf
 
-// allow typed_actor to be used in hash maps
 namespace std {
+
 template <class... Sigs>
 struct hash<caf::typed_actor<Sigs...>> {
   size_t operator()(const caf::typed_actor<Sigs...>& ref) const {
-    return ref ? static_cast<size_t>(ref->id()) : 0;
+    if (!ref) {
+      return 0;
+    }
+    return caf::hash::fnv<size_t>::compute(ref.id(), ref.node());
   }
 };
+
 } // namespace std

--- a/libcaf_io/caf/io/basp_broker.cpp
+++ b/libcaf_io/caf/io/basp_broker.cpp
@@ -9,6 +9,7 @@
 #include "caf/io/middleman.hpp"
 #include "caf/io/network/interfaces.hpp"
 
+#include "caf/actor_addr.hpp"
 #include "caf/actor_from_state.hpp"
 #include "caf/actor_registry.hpp"
 #include "caf/actor_system_config.hpp"
@@ -213,7 +214,8 @@ behavior basp_broker::make_behavior() {
     },
     // received from the middleman whenever a node becomes observed by a local
     // actor
-    [this](monitor_atom, const node_id& node, const actor_addr& observer) {
+    [this](monitor_atom, const node_id& node,
+           const strong_actor_ptr& observer) {
       // Sanity checks.
       if (!observer || !node)
         return;
@@ -235,17 +237,21 @@ behavior basp_broker::make_behavior() {
         }
         return;
       }
-      std::vector<actor_addr> xs{observer};
+      std::vector<weak_actor_ptr> xs{actor_cast<weak_actor_ptr>(observer)};
       node_observers.emplace(node, std::move(xs));
     },
     // received from the middleman whenever a node becomes observed by a local
     // actor
     [this](demonitor_atom, const node_id& node, const actor_addr& observer) {
+      if (!node)
+        return;
       auto i = node_observers.find(node);
       if (i == node_observers.end())
         return;
       auto& observers = i->second;
-      auto j = std::ranges::find(observers, observer);
+      auto j = std::ranges::find_if(observers, [&](const weak_actor_ptr& w) {
+        return observer == w;
+      });
       if (j != observers.end()) {
         observers.erase(j);
         if (observers.empty())

--- a/libcaf_io/caf/io/basp_broker.hpp
+++ b/libcaf_io/caf/io/basp_broker.hpp
@@ -137,7 +137,7 @@ public:
 
   /// Keeps track of actors that wish to receive a `node_down_msg` if a
   /// particular node fails.
-  std::unordered_map<node_id, std::vector<actor_addr>> node_observers;
+  std::unordered_map<node_id, std::vector<weak_actor_ptr>> node_observers;
 
   /// Configures whether BASP automatically open new connections to optimize
   /// routing paths by forming a mesh between all nodes.

--- a/libcaf_io/caf/io/middleman.cpp
+++ b/libcaf_io/caf/io/middleman.cpp
@@ -9,6 +9,7 @@
 #include "caf/io/network/default_multiplexer.hpp"
 
 #include "caf/actor.hpp"
+#include "caf/actor_addr.hpp"
 #include "caf/actor_from_state.hpp"
 #include "caf/actor_registry.hpp"
 #include "caf/actor_system_config.hpp"
@@ -473,7 +474,7 @@ void* middleman::subtype_ptr() {
   return this;
 }
 
-void middleman::monitor(const node_id& node, const actor_addr& observer) {
+void middleman::monitor(const node_id& node, const strong_actor_ptr& observer) {
   auto basp = named_broker<basp_broker>("BASP");
   anon_mail(monitor_atom_v, node, observer).send(basp);
 }

--- a/libcaf_io/caf/io/middleman.hpp
+++ b/libcaf_io/caf/io/middleman.hpp
@@ -192,7 +192,7 @@ public:
 
   void* subtype_ptr() override;
 
-  void monitor(const node_id& node, const actor_addr& observer) override;
+  void monitor(const node_id& node, const strong_actor_ptr& observer) override;
 
   void demonitor(const node_id& node, const actor_addr& observer) override;
 

--- a/manual/core/ReferenceCounting.rst
+++ b/manual/core/ReferenceCounting.rst
@@ -113,24 +113,21 @@ track of how many references to the control block exist. The control block is
 destroyed if there are *zero* weak references to an actor (which cannot occur
 before ``strong refs`` reached *zero* as well). No cycle occurs if two actors
 keep weak references to each other, because the actor objects themselves can get
-destroyed independently from their control block.  A weak reference is only
-formed by ``actor_addr`` (see :ref:`actor-address`).
+destroyed independently from their control block. Weak references are formed by
+``weak_actor_ptr``.
 
 .. _actor-cast:
 
 Converting Actor References with ``actor_cast``
 -----------------------------------------------
 
-The function ``actor_cast`` converts between actor pointers and
-handles. The first common use case is to convert a ``strong_actor_ptr``
-to either ``actor`` or ``typed_actor<...>`` before being able
-to send messages to an actor. The second common use case is to convert
-``actor_addr`` to ``strong_actor_ptr`` to upgrade a weak
-reference to a strong reference. Note that casting ``actor_addr`` to a
-strong actor pointer or handle can result in invalid handles. The syntax for
-``actor_cast`` resembles builtin C++ casts. For example,
-``actor_cast<actor>(x)`` converts ``x`` to an handle of type
-``actor``.
+The function ``actor_cast`` converts between actor pointers and handles. The
+most common use case is to convert a ``strong_actor_ptr`` to either ``actor``
+or ``typed_actor<...>`` before being able to send messages to an actor.
+``actor_cast`` also converts to and from ``weak_actor_ptr`` when temporary weak
+references are needed. The syntax for ``actor_cast`` resembles builtin C++
+casts. For example, ``actor_cast<actor>(x)`` converts ``x`` to a handle of
+type ``actor``.
 
 .. _breaking-cycles:
 

--- a/manual/intro/Concepts.rst
+++ b/manual/intro/Concepts.rst
@@ -75,13 +75,15 @@ Address
 +++++++
 
 Each actor has a (network-wide) unique logical address. This identifier is
-represented by ``actor_addr``, which allows to identify and monitor an actor.
-Unlike other actor frameworks, CAF does *not* allow users to send messages to
+represented by ``actor_addr``, which allows to identify a (possibly already
+terminated) actor in messages such as ``down_msg`` and ``exit_msg``. Unlike
+other actor frameworks, CAF does *not* allow users to send messages to
 addresses. This limitation is due to the fact that the address does not contain
 any type information. Hence, it would not be safe to send it a message, because
 the receiving actor might use a statically typed interface that does not accept
-the given message. Because an ``actor_addr`` fills the role of an identifier, it
-has *weak reference semantics* (see :ref:`reference-counting`).
+the given message. ``actor_addr`` is a small value type composed of an
+``actor_id`` and a ``node_id``; it does not keep the actor alive nor does it
+allow upgrading to a live actor handle.
 
 .. _actor-handle:
 


### PR DESCRIPTION
The only purpose of `actor_addr` is to select actor handles that are stored as either `actor` or `typed_actor<...>`. However, internally it holds a weak pointer to the actor. At this point, only for historic reasons.

While holding a weak pointer internally works in a single-process setting, this design breaks in a distributed system. Sending a weak pointer is deeply problematic:
- remote nodes hold *strong* references to actors they are communicating with; once the remote actor terminates this reference will be dropped automatically from the registry
- when receiving a weak pointer to an unknown actor, there is no sensible thing the receiver might do other than discarding it:
  * creating a proxy would immediately expire the object again
  * there might exist weak references to the old proxy, creating a new one would mean those pointer would be unequal even though they represent the same actor
  * storing weak references in the registry would only introduce new problems w.r.t. proxy lifetimes, etc.

Since the purpose of `actor_addr` is to identify terminated actors in an `exit_msg` or `down_msg`, the much cleaner, safe alternative is to re-implement it as a simple value type holding an `actor_id` and a `node_id`: these two IDs uniquely and unambiguously identify any actor in a distributed CAF system.

Since sending weak pointers is fundamentally unsafe, we also remove the type ID for `weak_actor_ptr`.