### PR TITLE
Allow lazy template instantiation for typed actors

### DIFF
--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -7,7 +7,6 @@
 #include "caf/detail/build_config.hpp"
 #include "caf/detail/core_export.hpp"
 #include "caf/error_code_enum.hpp"
-#include "caf/typed_actor_pack.hpp"
 #include "caf/weak_intrusive_ptr_traits.hpp"
 
 #include <cstddef>
@@ -83,11 +82,11 @@ template <class...> class typed_response_promise;
 template <class, class...> class event_based_fan_out_response_handle;
 template <class, class...> class event_based_fan_out_delayed_response_handle;
 
-template <class... Ts> requires typed_actor_pack<Ts...> class typed_actor;
-template <class... Ts> requires typed_actor_pack<Ts...> class typed_actor_pointer;
-template <class... Ts> requires typed_actor_pack<Ts...> class typed_actor_view;
-template <class... Ts> requires typed_actor_pack<Ts...> class typed_behavior;
-template <class... Ts> requires typed_actor_pack<Ts...> class typed_event_based_actor;
+template <class...> class typed_actor;
+template <class...> class typed_actor_pointer;
+template <class...> class typed_actor_view;
+template <class...> class typed_behavior;
+template <class...> class typed_event_based_actor;
 
 // clang-format on
 

--- a/libcaf_core/caf/statically_typed.hpp
+++ b/libcaf_core/caf/statically_typed.hpp
@@ -4,8 +4,9 @@
 
 #pragma once
 
-#include <caf/fwd.hpp>
-#include <caf/type_list.hpp>
+#include "caf/fwd.hpp"
+#include "caf/type_list.hpp"
+#include "caf/typed_actor_pack.hpp"
 
 namespace caf {
 

--- a/libcaf_core/caf/typed_actor.hpp
+++ b/libcaf_core/caf/typed_actor.hpp
@@ -16,6 +16,7 @@
 #include "caf/intrusive_ptr.hpp"
 #include "caf/stateful_actor.hpp"
 #include "caf/type_id_list.hpp"
+#include "caf/typed_actor_pack.hpp"
 #include "caf/typed_actor_view_base.hpp"
 #include "caf/typed_behavior.hpp"
 
@@ -27,11 +28,12 @@ namespace caf {
 
 /// Identifies a statically typed actor.
 template <class... Ts>
-  requires typed_actor_pack<Ts...>
 class typed_actor : detail::comparable<typed_actor<Ts...>>,
                     detail::comparable<typed_actor<Ts...>, actor>,
                     detail::comparable<typed_actor<Ts...>, actor_addr>,
                     detail::comparable<typed_actor<Ts...>, strong_actor_ptr> {
+  static_assert(typed_actor_pack<Ts...>);
+
 public:
   // -- member types -----------------------------------------------------------
 
@@ -44,7 +46,6 @@ public:
   // -- friends ----------------------------------------------------------------
 
   template <class... Us>
-    requires typed_actor_pack<Us...>
   friend class typed_actor;
 
   friend class local_actor;

--- a/libcaf_core/caf/typed_actor.hpp
+++ b/libcaf_core/caf/typed_actor.hpp
@@ -32,9 +32,11 @@ class typed_actor : detail::comparable<typed_actor<Ts...>>,
                     detail::comparable<typed_actor<Ts...>, actor>,
                     detail::comparable<typed_actor<Ts...>, actor_addr>,
                     detail::comparable<typed_actor<Ts...>, strong_actor_ptr> {
+public:
+  // -- static assertions ------------------------------------------------------
+
   static_assert(typed_actor_pack<Ts...>);
 
-public:
   // -- member types -----------------------------------------------------------
 
   /// Stores the template parameter pack.

--- a/libcaf_core/caf/typed_actor.test.cpp
+++ b/libcaf_core/caf/typed_actor.test.cpp
@@ -227,6 +227,43 @@ struct t1970 {
 
 using a1970 = typed_actor<t1970>;
 
+// GH-2202 regression
+// Self-referential trait: signatures mention the actor handle being defined.
+struct ping_pong_trait {
+  using signatures = type_list<result<void>(typed_actor<ping_pong_trait>)>;
+};
+using ping_pong_actor = typed_actor<ping_pong_trait>;
+// Force full instantiation which evaluates the internal
+// static_assert(typed_actor_pack<...>);
+static_assert(std::is_same_v<ping_pong_actor::behavior_type,
+                             typed_behavior<ping_pong_trait>>);
+static_assert(
+  std::is_same_v<ping_pong_actor::signatures,
+                 type_list<result<void>(typed_actor<ping_pong_trait>)>>);
+
+// Mutually recursive traits: each signature references the other handle.
+struct ping_trait;
+struct pong_trait;
+
+struct ping_trait {
+  using signatures = type_list<result<void>(typed_actor<pong_trait>)>;
+};
+
+struct pong_trait {
+  using signatures = type_list<result<void>(typed_actor<ping_trait>)>;
+};
+
+using ping_actor = typed_actor<ping_trait>;
+using pong_actor = typed_actor<pong_trait>;
+static_assert(
+  std::is_same_v<ping_actor::behavior_type, typed_behavior<ping_trait>>);
+static_assert(
+  std::is_same_v<pong_actor::behavior_type, typed_behavior<pong_trait>>);
+static_assert(std::is_same_v<ping_actor::signatures,
+                             type_list<result<void>(typed_actor<pong_trait>)>>);
+static_assert(std::is_same_v<pong_actor::signatures,
+                             type_list<result<void>(typed_actor<ping_trait>)>>);
+
 } // namespace
 
 CAF_BEGIN_TYPE_ID_BLOCK(typed_actor_test, caf::first_custom_type_id + 130, 20)

--- a/libcaf_core/caf/typed_actor_pointer.hpp
+++ b/libcaf_core/caf/typed_actor_pointer.hpp
@@ -15,9 +15,11 @@ namespace caf {
 /// knowledge of the actual type.
 template <class... Ts>
 class typed_actor_pointer : public typed_actor_view_base {
+public:
+  // -- static assertions ------------------------------------------------------
+
   static_assert(typed_actor_pack<Ts...>);
 
-public:
   using trait = detail::to_statically_typed_trait_t<Ts...>;
 
   /// Stores the template parameter pack.

--- a/libcaf_core/caf/typed_actor_pointer.hpp
+++ b/libcaf_core/caf/typed_actor_pointer.hpp
@@ -6,6 +6,7 @@
 
 #include "caf/detail/to_statically_typed_trait.hpp"
 #include "caf/detail/type_list.hpp"
+#include "caf/typed_actor_pack.hpp"
 #include "caf/typed_actor_view.hpp"
 
 namespace caf {
@@ -13,8 +14,9 @@ namespace caf {
 /// Provides a view to an actor that implements this messaging interface without
 /// knowledge of the actual type.
 template <class... Ts>
-  requires typed_actor_pack<Ts...>
 class typed_actor_pointer : public typed_actor_view_base {
+  static_assert(typed_actor_pack<Ts...>);
+
 public:
   using trait = detail::to_statically_typed_trait_t<Ts...>;
 

--- a/libcaf_core/caf/typed_actor_view.hpp
+++ b/libcaf_core/caf/typed_actor_view.hpp
@@ -18,6 +18,7 @@
 #include "caf/scheduled_actor.hpp"
 #include "caf/stream.hpp"
 #include "caf/timespan.hpp"
+#include "caf/typed_actor_pack.hpp"
 #include "caf/typed_actor_view_base.hpp"
 #include "caf/typed_stream.hpp"
 
@@ -34,8 +35,9 @@ auto typed_actor_view_flow_access(T* self) {
 /// Decorates a pointer to a @ref scheduled_actor with a statically typed actor
 /// interface.
 template <class... Ts>
-  requires typed_actor_pack<Ts...>
 class typed_actor_view : public typed_actor_view_base {
+  static_assert(typed_actor_pack<Ts...>);
+
 public:
   using trait = detail::to_statically_typed_trait_t<Ts...>;
 

--- a/libcaf_core/caf/typed_actor_view.hpp
+++ b/libcaf_core/caf/typed_actor_view.hpp
@@ -36,9 +36,11 @@ auto typed_actor_view_flow_access(T* self) {
 /// interface.
 template <class... Ts>
 class typed_actor_view : public typed_actor_view_base {
+public:
+  // -- static assertions ------------------------------------------------------
+
   static_assert(typed_actor_pack<Ts...>);
 
-public:
   using trait = detail::to_statically_typed_trait_t<Ts...>;
 
   /// Stores the template parameter pack.

--- a/libcaf_core/caf/typed_behavior.hpp
+++ b/libcaf_core/caf/typed_behavior.hpp
@@ -149,9 +149,11 @@ constexpr partial_behavior_init_t partial_behavior_init
 
 template <class... Ts>
 class typed_behavior {
+public:
+  // -- static assertions ------------------------------------------------------
+
   static_assert(typed_actor_pack<Ts...>);
 
-public:
   // -- member types -----------------------------------------------------------
 
   using trait = detail::to_statically_typed_trait_t<Ts...>;

--- a/libcaf_core/caf/typed_behavior.hpp
+++ b/libcaf_core/caf/typed_behavior.hpp
@@ -13,6 +13,7 @@
 #include "caf/message_handler.hpp"
 #include "caf/system_messages.hpp"
 #include "caf/timespan.hpp"
+#include "caf/typed_actor_pack.hpp"
 #include "caf/unsafe_behavior_init.hpp"
 
 #include <utility>
@@ -147,8 +148,9 @@ constexpr partial_behavior_init_t partial_behavior_init
   = partial_behavior_init_t{};
 
 template <class... Ts>
-  requires typed_actor_pack<Ts...>
 class typed_behavior {
+  static_assert(typed_actor_pack<Ts...>);
+
 public:
   // -- member types -----------------------------------------------------------
 

--- a/libcaf_core/caf/typed_event_based_actor.hpp
+++ b/libcaf_core/caf/typed_event_based_actor.hpp
@@ -14,6 +14,7 @@
 #include "caf/policy/typed_event_based_requester.hpp"
 #include "caf/scheduled_actor.hpp"
 #include "caf/typed_actor.hpp"
+#include "caf/typed_actor_pack.hpp"
 #include "caf/typed_behavior.hpp"
 
 namespace caf {
@@ -22,11 +23,12 @@ namespace caf {
 /// type-checking.
 /// @extends scheduled actor
 template <class... Ts>
-  requires typed_actor_pack<Ts...>
 class typed_event_based_actor : public scheduled_actor,
                                 public statically_typed_actor_base
 
 {
+  static_assert(typed_actor_pack<Ts...>);
+
 public:
   // -- member types -----------------------------------------------------------
 

--- a/libcaf_core/caf/typed_event_based_actor.hpp
+++ b/libcaf_core/caf/typed_event_based_actor.hpp
@@ -27,9 +27,11 @@ class typed_event_based_actor : public scheduled_actor,
                                 public statically_typed_actor_base
 
 {
+public:
+  // -- static assertions ------------------------------------------------------
+
   static_assert(typed_actor_pack<Ts...>);
 
-public:
   // -- member types -----------------------------------------------------------
 
   using super = scheduled_actor;


### PR DESCRIPTION
With the `requires` clause typed actor signature checking, it became a compile time error for actors to refer to itself in it's signatures (GH-2202). This commit enables that by moves the signature checking into a static assert instead.

Closes #2202. 