### PR TITLE
Add type information to serialized caf::message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   responds with `503 Service Unavailable` when encountering backpressure from
   the consumer, i.e., if the HTTP client sends requests faster than the server
   can process them.
+- Added type information to the serialization format of `caf::message` for human
+  readable serializers (such as `json`). This representation resolves issues
+  related to `caf::message` deserialization in those formats.
 
 ### Removed
 

--- a/libcaf_core/caf/async/batch.cpp
+++ b/libcaf_core/caf/async/batch.cpp
@@ -58,7 +58,7 @@ bool batch::data::save(Inspector& sink) const {
     if (!sink.value(item_type_))
       return false;
   } else {
-    if (!sink.value(meta->type_name))
+    if (!sink.value(sink.as_serializer().resolve_type_name(item_type_)))
       return false;
   }
   if (!sink.end_field())
@@ -132,7 +132,7 @@ bool batch::load_impl(Inspector& source) {
     std::string type_name;
     if (!source.value(type_name))
       return false;
-    payload_type = query_type_id(type_name);
+    payload_type = source.resolve_type_id(type_name);
   }
   const auto* meta = detail::global_meta_object_or_null(payload_type);
   if (!meta) {

--- a/libcaf_core/caf/async/batch.cpp
+++ b/libcaf_core/caf/async/batch.cpp
@@ -4,8 +4,6 @@
 
 #include "caf/async/batch.hpp"
 
-#include "caf/binary_deserializer.hpp"
-#include "caf/binary_serializer.hpp"
 #include "caf/deserializer.hpp"
 #include "caf/detail/assert.hpp"
 #include "caf/detail/meta_object.hpp"
@@ -40,8 +38,7 @@ void dynamic_item_destructor(type_id_t item_type, size_t item_size,
 
 } // namespace
 
-template <class Inspector>
-bool batch::data::save(Inspector& sink) const {
+bool batch::data::save(serializer& sink) const {
   CAF_ASSERT(size_ > 0);
   const auto* meta = detail::global_meta_object_or_null(item_type_);
   if (!meta) {
@@ -58,7 +55,7 @@ bool batch::data::save(Inspector& sink) const {
     if (!sink.value(item_type_))
       return false;
   } else {
-    if (!sink.value(sink.as_serializer().resolve_type_name(item_type_)))
+    if (!sink.value(sink.to_type_name(item_type_)))
       return false;
   }
   if (!sink.end_field())
@@ -71,7 +68,7 @@ bool batch::data::save(Inspector& sink) const {
     return false;
   auto len = size_;
   do {
-    if (!do_save(*meta, sink.as_serializer(), ptr))
+    if (!do_save(*meta, sink, ptr))
       return false;
     ptr += item_size_;
     --len;
@@ -81,8 +78,7 @@ bool batch::data::save(Inspector& sink) const {
 
 // -- batch --------------------------------------------------------------------
 
-template <class Inspector>
-bool batch::save_impl(Inspector& sink) const {
+bool batch::save(serializer& sink) const {
   if (data_)
     return data_->save(sink);
   return sink.begin_object(type_id_v<batch>, type_name_v<batch>) //
@@ -93,15 +89,7 @@ bool batch::save_impl(Inspector& sink) const {
          && sink.end_object();
 }
 
-bool batch::save(serializer& f) const {
-  return save_impl(f);
-}
-
-bool batch::save(binary_serializer& f) const {
-  return save_impl(f);
-}
-template <class Inspector>
-bool batch::load_impl(Inspector& source) {
+bool batch::load(deserializer& source) {
   if (!source.begin_object(type_id_v<batch>, type_name_v<batch>))
     return false;
   bool type_field_present = false;
@@ -132,7 +120,7 @@ bool batch::load_impl(Inspector& source) {
     std::string type_name;
     if (!source.value(type_name))
       return false;
-    payload_type = source.resolve_type_id(type_name);
+    payload_type = source.to_type_id(type_name);
   }
   const auto* meta = detail::global_meta_object_or_null(payload_type);
   if (!meta) {
@@ -180,14 +168,6 @@ bool batch::load_impl(Inspector& source) {
   }
   data_ = std::move(ptr);
   return source.end_sequence() && source.end_field() && source.end_object();
-}
-
-bool batch::load(deserializer& f) {
-  return load_impl(f);
-}
-
-bool batch::load(binary_deserializer& f) {
-  return load_impl(f.as_deserializer());
 }
 
 } // namespace caf::async

--- a/libcaf_core/caf/async/batch.hpp
+++ b/libcaf_core/caf/async/batch.hpp
@@ -14,7 +14,6 @@
 #include "caf/type_id.hpp"
 
 #include <algorithm>
-#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -65,13 +64,9 @@ public:
     return std::span<const T>{};
   }
 
-  bool save(serializer& f) const;
+  bool save(serializer& sink) const;
 
-  bool save(binary_serializer& f) const;
-
-  bool load(deserializer& f);
-
-  bool load(binary_deserializer& f);
+  bool load(deserializer& source);
 
   void swap(batch& other) {
     data_.swap(other.data_);
@@ -174,8 +169,7 @@ private:
     // -- serialization --------------------------------------------------------
 
     /// @pre `size() > 0`
-    template <class Inspector>
-    bool save(Inspector& sink) const;
+    bool save(serializer& sink) const;
 
   private:
     mutable detail::atomic_ref_count ref_count_;

--- a/libcaf_core/caf/config_value.test.cpp
+++ b/libcaf_core/caf/config_value.test.cpp
@@ -945,7 +945,9 @@ SCENARIO("config values can parse their own to_string output") {
         CHECK_ROUNDTRIP(std::vector<int>({1, 2, 3}), "[1, 2, 3]");
         CHECK_ROUNDTRIP(my_request(1, 2), R"_({a = 1, b = 2})_");
         CHECK_ROUNDTRIP(std::make_tuple(add_atom_v, 1, 2), R"_([{}, 1, 2])_");
-        CHECK_ROUNDTRIP(make_message(add_atom_v, 1, 2), R"_([{}, 1, 2])_");
+        CHECK_ROUNDTRIP(
+          make_message(add_atom_v, 1, 2),
+          R"_({types = ["caf::add_atom", "int32_t", "int32_t"], values = [{}, 1, 2]})_");
       }
     }
   }

--- a/libcaf_core/caf/deserializer.cpp
+++ b/libcaf_core/caf/deserializer.cpp
@@ -15,7 +15,7 @@ deserializer::~deserializer() {
   // nop
 }
 
-type_id_t deserializer::resolve_type_id(std::string_view type_name) const {
+type_id_t deserializer::to_type_id(std::string_view type_name) const {
   return query_type_id(type_name);
 }
 

--- a/libcaf_core/caf/deserializer.cpp
+++ b/libcaf_core/caf/deserializer.cpp
@@ -15,6 +15,10 @@ deserializer::~deserializer() {
   // nop
 }
 
+type_id_t deserializer::resolve_type_id(std::string_view type_name) const {
+  return query_type_id(type_name);
+}
+
 bool deserializer::fetch_next_object_name(std::string_view& type_name) {
   auto t = type_id_t{};
   if (fetch_next_object_type(t)) {

--- a/libcaf_core/caf/deserializer.hpp
+++ b/libcaf_core/caf/deserializer.hpp
@@ -41,7 +41,7 @@ public:
   /// may override this to apply custom type name mappings (e.g. via a
   /// @ref type_id_mapper). The default implementation delegates to
   /// @ref query_type_id.
-  virtual type_id_t resolve_type_id(std::string_view type_name) const;
+  virtual type_id_t to_type_id(std::string_view type_name) const;
 
   // -- interface functions ----------------------------------------------------
 

--- a/libcaf_core/caf/deserializer.hpp
+++ b/libcaf_core/caf/deserializer.hpp
@@ -37,6 +37,12 @@ public:
   /// Returns whether the serialization format is human-readable.
   virtual bool has_human_readable_format() const noexcept = 0;
 
+  /// Returns the type ID for the human-readable @p type_name. Implementations
+  /// may override this to apply custom type name mappings (e.g. via a
+  /// @ref type_id_mapper). The default implementation delegates to
+  /// @ref query_type_id.
+  virtual type_id_t resolve_type_id(std::string_view type_name) const;
+
   // -- interface functions ----------------------------------------------------
 
   /// Reads run-time-type information for the next object if available.

--- a/libcaf_core/caf/json_builder.cpp
+++ b/libcaf_core/caf/json_builder.cpp
@@ -113,7 +113,7 @@ public:
       *top_ptr<key_type>() = "@type"sv;
       pop();
       CAF_ASSERT(top() == internal::json_node::element);
-      if (auto tname = resolve_type_name(id); !tname.empty()) {
+      if (auto tname = to_type_name(id); !tname.empty()) {
         top_ptr()->data = tname;
       } else {
         top_ptr()->data = name;
@@ -182,14 +182,16 @@ public:
       return false;
     }
     if (begin_key_value_pair()) {
-      if (auto tname = resolve_type_name(types[index]); !tname.empty()) {
+      const auto type = types[index];
+      if (auto tname = to_type_name(type); !tname.empty()) {
         auto& annotation = top_obj()->emplace_back();
         annotation.key = detail::json::concat({"@"sv, name, field_type_suffix_},
                                               &storage_->buf);
         annotation.val = detail::json::make_value(storage_);
         annotation.val->data = tname;
       } else {
-        err_ = make_error(sec::runtime_error, "resolve_type_name failed");
+        err_ = format_to_error(sec::runtime_error,
+                               "failed to get type name for type ID {}", type);
         return false;
       }
       CAF_ASSERT(top() == internal::json_node::key);

--- a/libcaf_core/caf/json_builder.cpp
+++ b/libcaf_core/caf/json_builder.cpp
@@ -113,7 +113,7 @@ public:
       *top_ptr<key_type>() = "@type"sv;
       pop();
       CAF_ASSERT(top() == internal::json_node::element);
-      if (auto tname = query_type_name(id); !tname.empty()) {
+      if (auto tname = resolve_type_name(id); !tname.empty()) {
         top_ptr()->data = tname;
       } else {
         top_ptr()->data = name;
@@ -182,14 +182,14 @@ public:
       return false;
     }
     if (begin_key_value_pair()) {
-      if (auto tname = query_type_name(types[index]); !tname.empty()) {
+      if (auto tname = resolve_type_name(types[index]); !tname.empty()) {
         auto& annotation = top_obj()->emplace_back();
         annotation.key = detail::json::concat({"@"sv, name, field_type_suffix_},
                                               &storage_->buf);
         annotation.val = detail::json::make_value(storage_);
         annotation.val->data = tname;
       } else {
-        err_ = make_error(sec::runtime_error, "query_type_name failed");
+        err_ = make_error(sec::runtime_error, "resolve_type_name failed");
         return false;
       }
       CAF_ASSERT(top() == internal::json_node::key);

--- a/libcaf_core/caf/json_reader.cpp
+++ b/libcaf_core/caf/json_reader.cpp
@@ -312,10 +312,15 @@ public:
     return true;
   }
 
+  type_id_t resolve_type_id(std::string_view name) const override {
+    auto id = (*mapper_)(name);
+    return id != invalid_type_id ? id : query_type_id(name);
+  }
+
   bool fetch_next_object_type(type_id_t& type) override {
     std::string_view type_name;
     if (fetch_next_object_name(type_name)) {
-      if (auto id = (*mapper_)(type_name); id != invalid_type_id) {
+      if (auto id = resolve_type_id(type_name); id != invalid_type_id) {
         type = id;
         return true;
       } else {
@@ -454,7 +459,7 @@ public:
         member != nullptr
         && member->val->data.index() != detail::json::value::null_index) {
       auto ft = field_type(top<position::object>(), name, field_type_suffix_);
-      if (auto id = (*mapper_)(ft); id != invalid_type_id) {
+      if (auto id = resolve_type_id(ft); id != invalid_type_id) {
         if (auto i = std::ranges::find(types, id); i != types.end()) {
           index = static_cast<size_t>(std::distance(types.begin(), i));
           push(member->val);

--- a/libcaf_core/caf/json_reader.cpp
+++ b/libcaf_core/caf/json_reader.cpp
@@ -312,7 +312,7 @@ public:
     return true;
   }
 
-  type_id_t resolve_type_id(std::string_view name) const override {
+  type_id_t to_type_id(std::string_view name) const override {
     auto id = (*mapper_)(name);
     return id != invalid_type_id ? id : query_type_id(name);
   }
@@ -320,7 +320,7 @@ public:
   bool fetch_next_object_type(type_id_t& type) override {
     std::string_view type_name;
     if (fetch_next_object_name(type_name)) {
-      if (auto id = resolve_type_id(type_name); id != invalid_type_id) {
+      if (auto id = to_type_id(type_name); id != invalid_type_id) {
         type = id;
         return true;
       } else {
@@ -459,7 +459,7 @@ public:
         member != nullptr
         && member->val->data.index() != detail::json::value::null_index) {
       auto ft = field_type(top<position::object>(), name, field_type_suffix_);
-      if (auto id = resolve_type_id(ft); id != invalid_type_id) {
+      if (auto id = to_type_id(ft); id != invalid_type_id) {
         if (auto i = std::ranges::find(types, id); i != types.end()) {
           index = static_cast<size_t>(std::distance(types.begin(), i));
           push(member->val);

--- a/libcaf_core/caf/json_reader.test.cpp
+++ b/libcaf_core/caf/json_reader.test.cpp
@@ -367,8 +367,9 @@ fixture::fixture() {
   add_test_case(R"_({"xs": ["x1", "x2"], "ys": ["y1", "y2"]})_",
                 dict<str_set>({{"xs", set<std::string>("x1", "x2")},
                                {"ys", set<std::string>("y1", "y2")}}));
-  add_test_case(R"_([{"@type": "my_request", "a": 1, "b": 2}])_",
-                make_message(my_request(1, 2)));
+  add_test_case(
+    R"_({"@type": "caf::message", "types": ["my_request"], "values": [{"a": 1, "b": 2}]})_",
+    make_message(my_request(1, 2)));
   add_test_case(
     R"_({"top-left":{"x":100,"y":200},"bottom-right":{"x":10,"y":20}})_",
     rectangle{{100, 200}, {10, 20}});

--- a/libcaf_core/caf/json_writer.cpp
+++ b/libcaf_core/caf/json_writer.cpp
@@ -131,21 +131,21 @@ public:
     return true;
   }
 
+  std::string_view resolve_type_name(type_id_t id) const override {
+    auto tname = (*mapper_)(id);
+    return tname.empty() ? query_type_name(id) : tname;
+  }
+
   bool begin_object(type_id_t id, std::string_view name) override {
     auto add_type_annotation = [this, id, name] {
       CAF_ASSERT(top() == internal::json_node::key);
       add(R"_("@type": )_");
       pop();
       CAF_ASSERT(top() == internal::json_node::element);
-      if (auto tname = (*mapper_)(id); !tname.empty()) {
-        add('"');
-        add(tname);
-        add('"');
-      } else {
-        add('"');
-        add(name);
-        add('"');
-      }
+      auto tname = resolve_type_name(id);
+      add('"');
+      add(tname.empty() ? name : tname);
+      add('"');
       pop();
       return true;
     };
@@ -223,14 +223,14 @@ public:
       pop();
       CAF_ASSERT(top() == internal::json_node::element);
       pop();
-      if (auto tname = (*mapper_)(types[index]); !tname.empty()) {
-        add('"');
-        add(tname);
-        add('"');
-      } else {
+      auto tname = resolve_type_name(types[index]);
+      if (tname.empty()) {
         err_ = make_error(sec::runtime_error, "failed to retrieve type name");
         return false;
       }
+      add('"');
+      add(tname);
+      add('"');
       return end_key_value_pair() && begin_field(name);
     } else {
       return false;

--- a/libcaf_core/caf/json_writer.cpp
+++ b/libcaf_core/caf/json_writer.cpp
@@ -131,7 +131,7 @@ public:
     return true;
   }
 
-  std::string_view resolve_type_name(type_id_t id) const override {
+  std::string_view to_type_name(type_id_t id) const override {
     auto tname = (*mapper_)(id);
     return tname.empty() ? query_type_name(id) : tname;
   }
@@ -142,7 +142,7 @@ public:
       add(R"_("@type": )_");
       pop();
       CAF_ASSERT(top() == internal::json_node::element);
-      auto tname = resolve_type_name(id);
+      auto tname = to_type_name(id);
       add('"');
       add(tname.empty() ? name : tname);
       add('"');
@@ -223,7 +223,7 @@ public:
       pop();
       CAF_ASSERT(top() == internal::json_node::element);
       pop();
-      auto tname = resolve_type_name(types[index]);
+      auto tname = to_type_name(types[index]);
       if (tname.empty()) {
         err_ = make_error(sec::runtime_error, "failed to retrieve type name");
         return false;

--- a/libcaf_core/caf/json_writer.test.cpp
+++ b/libcaf_core/caf/json_writer.test.cpp
@@ -286,8 +286,8 @@ SCENARIO("the JSON writer converts builtin types to strings") {
     WHEN("converting it to JSON with indentation factor 0") {
       THEN("the JSON output is a single line") {
         std::string out
-          = R"_({"@type": "caf::message", "types": ["caf::put_atom", "std::string", "int32_t"], "values": [{}, "foo", 42]})_";
-        check_eq(to_json_string(x, 0), out);
+          = R"_({"types": ["caf::put_atom", "std::string", "int32_t"], "values": [{}, "foo", 42]})_";
+        check_eq(to_json_string(x, 0, true, true), out);
       }
     }
     WHEN("converting it to JSON with indentation factor 2") {

--- a/libcaf_core/caf/json_writer.test.cpp
+++ b/libcaf_core/caf/json_writer.test.cpp
@@ -285,19 +285,26 @@ SCENARIO("the JSON writer converts builtin types to strings") {
     auto x = make_message(put_atom_v, "foo", 42);
     WHEN("converting it to JSON with indentation factor 0") {
       THEN("the JSON output is a single line") {
-        std::string out = R"_([{"@type": "caf::put_atom"}, "foo", 42])_";
+        std::string out
+          = R"_({"@type": "caf::message", "types": ["caf::put_atom", "std::string", "int32_t"], "values": [{}, "foo", 42]})_";
         check_eq(to_json_string(x, 0), out);
       }
     }
     WHEN("converting it to JSON with indentation factor 2") {
       THEN("the JSON output uses multiple lines") {
-        std::string out = R"_([
-  {
-    "@type": "caf::put_atom"
-  },
-  "foo",
-  42
-])_";
+        std::string out = R"_({
+  "@type": "caf::message",
+  "types": [
+    "caf::put_atom",
+    "std::string",
+    "int32_t"
+  ],
+  "values": [
+    {},
+    "foo",
+    42
+  ]
+})_";
         check_eq(to_json_string(x, 2), out);
       }
     }

--- a/libcaf_core/caf/message.cpp
+++ b/libcaf_core/caf/message.cpp
@@ -31,204 +31,112 @@
 namespace caf {
 
 bool message::load(deserializer& source) {
-  // For machine-to-machine data formats, we prefix the type information.
-  if (!source.has_human_readable_format()) {
-    GUARDED(source.begin_object(type_id_v<message>, "message"));
-    GUARDED(source.begin_field("types"));
-    size_t msg_size = 0;
-    GUARDED(source.begin_sequence(msg_size));
-    using uint16_limits = std::numeric_limits<uint16_t>;
-    if (msg_size > static_cast<size_t>(uint16_limits::max() - 1))
-      STOP(sec::invalid_argument, "too many types for message");
-    if (msg_size == 0) {
-      data_.reset();
-      return source.end_sequence()           //
-             && source.end_field()           //
-             && source.begin_field("values") //
-             && source.end_field()           //
-             && source.end_object();
+  GUARDED(source.begin_object(type_id_v<message>, "message"));
+  GUARDED(source.begin_field("types"));
+  size_t msg_size = 0;
+  GUARDED(source.begin_sequence(msg_size));
+  using uint16_limits = std::numeric_limits<uint16_t>;
+  if (msg_size > static_cast<size_t>(uint16_limits::max() - 1))
+    STOP(sec::invalid_argument, "too many types for message");
+  if (msg_size == 0) {
+    data_.reset();
+    return source.end_sequence()           //
+           && source.end_field()           //
+           && source.begin_field("values") //
+           && source.begin_tuple(0)        //
+           && source.end_tuple()           //
+           && source.end_field()           //
+           && source.end_object();
+  }
+  detail::type_id_list_builder ids{msg_size};
+  size_t data_size = 0;
+  if (source.has_human_readable_format()) {
+    for (size_t i = 0; i < msg_size; ++i) {
+      std::string type_name;
+      GUARDED(source.value(type_name));
+      auto type = source.resolve_type_id(type_name);
+      if (auto meta = detail::global_meta_object_or_null(type))
+        data_size += meta->padded_size;
+      else
+        STOP(sec::unknown_type, type_name);
+      ids.push_back(type);
     }
-    detail::type_id_list_builder ids{msg_size};
-    size_t data_size = 0;
+  } else {
     for (size_t i = 0; i < msg_size; ++i) {
       type_id_t id = 0;
       GUARDED(source.value(id));
       if (auto meta = detail::global_meta_object_or_null(id))
         data_size += meta->padded_size;
       else
-        STOP(sec::unknown_type);
+        STOP(sec::unknown_type, id);
       ids.push_back(id);
     }
-    GUARDED(source.end_sequence());
-    CAF_ASSERT(ids.size() == msg_size);
-    intrusive_ptr<detail::message_data> ptr;
-    if (auto vptr = malloc(sizeof(detail::message_data) + data_size)) {
-      // We don't need to worry about exceptions here: the message_data
-      // constructor as well as `move_to_list` are `noexcept`.
-      ptr.reset(new (vptr) detail::message_data(ids.move_to_list()), adopt_ref);
-    } else {
-      STOP(sec::runtime_error, "unable to allocate memory");
-    }
-    auto pos = ptr->storage();
-    auto types = ptr->types();
-    auto gmos = detail::global_meta_objects();
-    GUARDED(source.begin_field("values"));
-    GUARDED(source.begin_tuple(msg_size));
-    for (size_t i = 0; i < msg_size; ++i) {
-      auto& meta = gmos[types[i]];
-      meta.default_construct(pos);
-      ptr->inc_constructed_elements();
-      if (!meta.load(source, pos))
-        return false;
-      pos += meta.padded_size;
-    }
-    data_.reset(ptr.release(), adopt_ref);
-    return source.end_tuple() && source.end_field() && source.end_object();
   }
-  // For human-readable data formats, we serialize messages as a single list of
-  // dynamically-typed objects. This is more expensive, because we first need
-  // the full type information before we can allocate the storage. Hence, we
-  // must deserialize each element into a separate memory block first and then
-  // move them to their final destination later.
-  struct object_ptr {
-    void* obj;
-    const detail::meta_object* meta;
-    object_ptr(void* obj, const detail::meta_object* meta) noexcept
-      : obj(obj), meta(meta) {
-      // nop
-    }
-    object_ptr(object_ptr&& other) noexcept : obj(nullptr), meta(nullptr) {
-      using std::swap;
-      swap(obj, other.obj);
-      swap(meta, other.meta);
-    }
-    object_ptr& operator=(object_ptr&& other) noexcept {
-      if (this != &other) {
-        if (obj) {
-          meta->destroy(obj);
-          free(obj);
-          obj = nullptr;
-          meta = nullptr;
-        }
-        using std::swap;
-        swap(obj, other.obj);
-        swap(meta, other.meta);
-      }
-      return *this;
-    }
-    ~object_ptr() noexcept {
-      if (obj) {
-        meta->destroy(obj);
-        free(obj);
-      }
-    }
-  };
-  struct free_t {
-    void operator()(void* ptr) const noexcept {
-      return free(ptr);
-    }
-  };
-  using unique_void_ptr = std::unique_ptr<void, free_t>;
-  auto msg_size = size_t{0};
-  GUARDED(source.begin_sequence(msg_size));
-  if (msg_size > 0) {
-    // Deserialize message elements individually.
-    std::vector<object_ptr> objects;
-    detail::type_id_list_builder ids;
-    objects.reserve(msg_size);
-    auto data_size = size_t{0};
-    for (size_t i = 0; i < msg_size; ++i) {
-      auto type = type_id_t{0};
-      GUARDED(source.fetch_next_object_type(type));
-      if (auto meta_obj = detail::global_meta_object_or_null(type)) {
-        ids.push_back(type);
-        auto obj_size = meta_obj->padded_size;
-        data_size += obj_size;
-        unique_void_ptr vptr{malloc(obj_size)};
-        if (vptr == nullptr)
-          STOP(sec::runtime_error, "unable to allocate memory");
-        meta_obj->default_construct(vptr.get());
-        objects.emplace_back(vptr.release(), meta_obj);
-        if (!meta_obj->load(source, objects.back().obj))
-          return false;
-      } else {
-        STOP(sec::unknown_type);
-      }
-    }
-    GUARDED(source.end_sequence());
-    // Merge elements into a single message data object.
-    intrusive_ptr<detail::message_data> ptr;
-    if (auto vptr = malloc(sizeof(detail::message_data) + data_size)) {
-      // We don't need to worry about exceptions here: the message_data
-      // constructor as well as `move_to_list` are `noexcept`.
-      ptr.reset(new (vptr) detail::message_data(ids.move_to_list()), adopt_ref);
-    } else {
-      STOP(sec::runtime_error, "unable to allocate memory");
-    }
-    auto pos = ptr->storage();
-    for (auto& x : objects) {
-      // TODO: avoid extra copy by adding move_construct to meta objects
-      x.meta->copy_construct(pos, x.obj);
-      ptr->inc_constructed_elements();
-      pos += x.meta->padded_size;
-    }
-    data_.reset(ptr.release(), adopt_ref);
-    return true;
+  GUARDED(source.end_sequence());
+  GUARDED(source.end_field());
+  CAF_ASSERT(ids.size() == msg_size);
+  intrusive_ptr<detail::message_data> ptr;
+  if (auto vptr = malloc(sizeof(detail::message_data) + data_size)) {
+    // We don't need to worry about exceptions here: the message_data
+    // constructor as well as `move_to_list` are `noexcept`.
+    ptr.reset(new (vptr) detail::message_data(ids.move_to_list()), adopt_ref);
   } else {
-    data_.reset();
-    return source.end_sequence();
+    STOP(sec::runtime_error, "unable to allocate memory");
   }
+  auto pos = ptr->storage();
+  auto types = ptr->types();
+  auto gmos = detail::global_meta_objects();
+  GUARDED(source.begin_field("values"));
+  GUARDED(source.begin_tuple(msg_size));
+  for (size_t i = 0; i < msg_size; ++i) {
+    auto& meta = gmos[types[i]];
+    meta.default_construct(pos);
+    ptr->inc_constructed_elements();
+    if (!meta.load(source, pos))
+      return false;
+    pos += meta.padded_size;
+  }
+  data_.reset(ptr.release(), adopt_ref);
+  return source.end_tuple() && source.end_field() && source.end_object();
 }
 
 bool message::save(serializer& sink) const {
   auto gmos = detail::global_meta_objects();
-  // For machine-to-machine data formats, we prefix the type information.
-  if (!sink.has_human_readable_format()) {
-    if (data_ == nullptr) {
-      // Short-circuit empty tuples.
-      return sink.begin_object(type_id_v<message>, "message") //
-             && sink.begin_field("types")                     //
-             && sink.begin_sequence(0)                        //
-             && sink.end_sequence()                           //
-             && sink.end_field()                              //
-             && sink.begin_field("values")                    //
-             && sink.begin_tuple(0)                           //
-             && sink.end_tuple()                              //
-             && sink.end_field()                              //
-             && sink.end_object();
-    }
-    GUARDED(sink.begin_object(type_id_v<message>, "message"));
-    auto type_ids = data_->types();
-    // Write type information.
-    GUARDED(sink.begin_field("types") && sink.begin_sequence(type_ids.size()));
-    for (auto id : type_ids)
-      GUARDED(sink.value(id));
-    GUARDED(sink.end_sequence() && sink.end_field());
-    // Write elements.
-    auto storage = data_->storage();
-    GUARDED(sink.begin_field("values") && sink.begin_tuple(type_ids.size()));
-    for (auto id : type_ids) {
-      auto& meta = gmos[id];
-      GUARDED(meta.save(sink, storage));
-      storage += meta.padded_size;
-    }
-    return sink.end_tuple() && sink.end_field() && sink.end_object();
-  }
-  // For human-readable data formats, we serialize messages as a single list of
-  // dynamically-typed objects.
   if (data_ == nullptr) {
     // Short-circuit empty tuples.
-    return sink.begin_sequence(0) && sink.end_sequence();
+    return sink.begin_object(type_id_v<message>, "message") //
+           && sink.begin_field("types")                     //
+           && sink.begin_sequence(0)                        //
+           && sink.end_sequence()                           //
+           && sink.end_field()                              //
+           && sink.begin_field("values")                    //
+           && sink.begin_tuple(0)                           //
+           && sink.end_tuple()                              //
+           && sink.end_field()                              //
+           && sink.end_object();
   }
+  GUARDED(sink.begin_object(type_id_v<message>, "message"));
   auto type_ids = data_->types();
-  GUARDED(sink.begin_sequence(type_ids.size()));
+  // Write type information. This is needed for serialization round trips. Human
+  // readable formats will have human readable type information.
+  GUARDED(sink.begin_field("types") && sink.begin_sequence(type_ids.size()));
+  if (sink.has_human_readable_format()) {
+    for (auto id : type_ids)
+      GUARDED(sink.value(sink.resolve_type_name(id)));
+  } else {
+    for (auto id : type_ids)
+      GUARDED(sink.value(id));
+  }
+  GUARDED(sink.end_sequence() && sink.end_field());
+  // Write elements.
   auto storage = data_->storage();
+  GUARDED(sink.begin_field("values") && sink.begin_tuple(type_ids.size()));
   for (auto id : type_ids) {
     auto& meta = gmos[id];
     GUARDED(meta.save(sink, storage));
     storage += meta.padded_size;
   }
-  return sink.end_sequence();
+  return sink.end_tuple() && sink.end_field() && sink.end_object();
 }
 
 bool message::save(detail::stringification_inspector& sink) const {

--- a/libcaf_core/caf/message.cpp
+++ b/libcaf_core/caf/message.cpp
@@ -54,7 +54,7 @@ bool message::load(deserializer& source) {
     for (size_t i = 0; i < msg_size; ++i) {
       std::string type_name;
       GUARDED(source.value(type_name));
-      auto type = source.resolve_type_id(type_name);
+      auto type = source.to_type_id(type_name);
       if (auto meta = detail::global_meta_object_or_null(type))
         data_size += meta->padded_size;
       else
@@ -122,7 +122,7 @@ bool message::save(serializer& sink) const {
   GUARDED(sink.begin_field("types") && sink.begin_sequence(type_ids.size()));
   if (sink.has_human_readable_format()) {
     for (auto id : type_ids)
-      GUARDED(sink.value(sink.resolve_type_name(id)));
+      GUARDED(sink.value(sink.to_type_name(id)));
   } else {
     for (auto id : type_ids)
       GUARDED(sink.value(id));

--- a/libcaf_core/caf/serialization.test.cpp
+++ b/libcaf_core/caf/serialization.test.cpp
@@ -937,55 +937,55 @@ OUTLINE("serializing and then deserializing a non-empty message") {
   )_";
 }
 
-SCENARIO("caf::error round-trips through JSON") {
-  GIVEN("a json_writer and json_reader") {
-    auto sink = json_writer_wrapper{sys};
+OUTLINE("serializing and then deserializing errors") {
+  GIVEN("a <serializer>") {
+    auto sink = serializer_by_name(block_parameters<std::string>());
     WHEN("serializing an empty error") {
       auto original = error{};
-      check(inspect(sink.sink, original));
-      THEN("deserializing produces an empty error") {
-        auto source = json_reader{&sink.codec};
-        require(source.load(sink.sink.str()));
-        auto copy = make_error(sec::runtime_error);
-        check(source.apply(copy));
-        check(copy.empty());
+      std::visit([this,
+                  &original](auto& ptr) { check(ptr->sink.apply(original)); },
+                 sink);
+      THEN("deserializing the result produces the same error") {
+        auto source = make_deserializer(sink);
+        auto copy = error{};
+        std::visit([this, &copy](auto& ptr) { check(ptr->apply(copy)); },
+                   source);
+        check_eq(copy, original);
       }
     }
-    WHEN("serializing an error with a code but no context") {
+    WHEN("serializing an error that only carries an error code") {
       auto original = make_error(sec::runtime_error);
-      check(inspect(sink.sink, original));
-      THEN("deserializing produces the same error") {
-        auto source = json_reader{&sink.codec};
-        require(source.load(sink.sink.str()));
+      std::visit([this,
+                  &original](auto& ptr) { check(ptr->sink.apply(original)); },
+                 sink);
+      THEN("deserializing the result produces the same error") {
+        auto source = make_deserializer(sink);
         auto copy = error{};
-        check(source.apply(copy));
+        std::visit([this, &copy](auto& ptr) { check(ptr->apply(copy)); },
+                   source);
         check_eq(copy, original);
       }
     }
     WHEN("serializing an error that carries a string message in its context") {
-      auto original = make_error(sec::runtime_error, std::string{"oops"});
-      check(inspect(sink.sink, original));
-      THEN("the JSON context stores message types and values") {
-        auto parsed = json_value::parse(sink.sink.str());
-        require(parsed.has_value());
-        // error -> data -> context -> { types, values }
-        auto ctx = parsed->to_object()
-                     .value("data")
-                     .to_object()
-                     .value("context")
-                     .to_object();
-        check(ctx.value("types").is_array());
-        check(ctx.value("values").is_array());
-      }
-      AND_THEN("deserializing produces the same error") {
-        auto source = json_reader{&sink.codec};
-        require(source.load(sink.sink.str()));
+      auto original = make_error(sec::runtime_error, "oops");
+      std::visit([this,
+                  &original](auto& ptr) { check(ptr->sink.apply(original)); },
+                 sink);
+      THEN("deserializing the result produces the same error") {
+        auto source = make_deserializer(sink);
         auto copy = error{};
-        check(source.apply(copy));
+        std::visit([this, &copy](auto& ptr) { check(ptr->apply(copy)); },
+                   source);
         check_eq(copy, original);
       }
     }
   }
+  EXAMPLES = R"_(
+    | serializer          |
+    | binary_serializer   |
+    | json_writer         |
+    | config_value_writer |
+  )_";
 }
 
 SCENARIO("binary serializer and deserializer handle vectors of booleans") {

--- a/libcaf_core/caf/serialization.test.cpp
+++ b/libcaf_core/caf/serialization.test.cpp
@@ -13,7 +13,9 @@
 #include "caf/config_value_writer.hpp"
 #include "caf/detail/default_actor_handle_codec.hpp"
 #include "caf/init_global_meta_objects.hpp"
+#include "caf/json_object.hpp"
 #include "caf/json_reader.hpp"
+#include "caf/json_value.hpp"
 #include "caf/json_writer.hpp"
 #include "caf/raise_error.hpp"
 #include "caf/serializer.hpp"
@@ -883,6 +885,109 @@ OUTLINE("serializing a type that initializes members to a non-empty state") {
   )_";
 }
 
+OUTLINE("serializing and then deserializing an empty message") {
+  GIVEN("a <serializer>") {
+    auto sink = serializer_by_name(block_parameters<std::string>());
+    WHEN("serializing an empty message") {
+      auto val = message{};
+      std::visit([this, &val](auto& ptr) { check(ptr->sink.apply(val)); },
+                 sink);
+      THEN("deserializing the result produces an empty message again") {
+        auto source = make_deserializer(sink);
+        auto copy = make_message(int32_t{1});
+        std::visit([this, &copy](auto& ptr) { check(ptr->apply(copy)); },
+                   source);
+        check(copy.empty());
+      }
+    }
+  }
+  EXAMPLES = R"_(
+    | serializer          |
+    | binary_serializer   |
+    | json_writer         |
+    | config_value_writer |
+  )_";
+}
+
+OUTLINE("serializing and then deserializing a non-empty message") {
+  GIVEN("a <serializer>") {
+    auto sink = serializer_by_name(block_parameters<std::string>());
+    WHEN("serializing a message with builtin and custom types") {
+      auto original = make_message(std::string{"oops"}, int32_t{42},
+                                   weekday::tuesday, c_array{{1, 2, 3, 4}});
+      std::visit([this,
+                  &original](auto& ptr) { check(ptr->sink.apply(original)); },
+                 sink);
+      THEN("deserializing the result produces the same message") {
+        auto source = make_deserializer(sink);
+        auto copy = message{};
+        std::visit([this, &copy](auto& ptr) { check(ptr->apply(copy)); },
+                   source);
+        check(copy.match_elements<std::string, int32_t, weekday, c_array>());
+        check(copy.matches(std::string{"oops"}, int32_t{42}, weekday::tuesday,
+                           c_array{{1, 2, 3, 4}}));
+      }
+    }
+  }
+  EXAMPLES = R"_(
+    | serializer          |
+    | binary_serializer   |
+    | json_writer         |
+    | config_value_writer |
+  )_";
+}
+
+SCENARIO("caf::error round-trips through JSON") {
+  GIVEN("a json_writer and json_reader") {
+    auto sink = json_writer_wrapper{sys};
+    WHEN("serializing an empty error") {
+      auto original = error{};
+      check(inspect(sink.sink, original));
+      THEN("deserializing produces an empty error") {
+        auto source = json_reader{&sink.codec};
+        require(source.load(sink.sink.str()));
+        auto copy = make_error(sec::runtime_error);
+        check(source.apply(copy));
+        check(copy.empty());
+      }
+    }
+    WHEN("serializing an error with a code but no context") {
+      auto original = make_error(sec::runtime_error);
+      check(inspect(sink.sink, original));
+      THEN("deserializing produces the same error") {
+        auto source = json_reader{&sink.codec};
+        require(source.load(sink.sink.str()));
+        auto copy = error{};
+        check(source.apply(copy));
+        check_eq(copy, original);
+      }
+    }
+    WHEN("serializing an error that carries a string message in its context") {
+      auto original = make_error(sec::runtime_error, std::string{"oops"});
+      check(inspect(sink.sink, original));
+      THEN("the JSON context stores message types and values") {
+        auto parsed = json_value::parse(sink.sink.str());
+        require(parsed.has_value());
+        // error -> data -> context -> { types, values }
+        auto ctx = parsed->to_object()
+                     .value("data")
+                     .to_object()
+                     .value("context")
+                     .to_object();
+        check(ctx.value("types").is_array());
+        check(ctx.value("values").is_array());
+      }
+      AND_THEN("deserializing produces the same error") {
+        auto source = json_reader{&sink.codec};
+        require(source.load(sink.sink.str()));
+        auto copy = error{};
+        check(source.apply(copy));
+        check_eq(copy, original);
+      }
+    }
+  }
+}
+
 SCENARIO("binary serializer and deserializer handle vectors of booleans") {
   GIVEN("a binary serializer") {
     auto sink = binary_serializer_wrapper{sys};
@@ -931,6 +1036,46 @@ SCENARIO("binary serializer and deserializer handle vectors of booleans") {
         auto copy = std::vector<bool>{};
         check(source.apply(copy));
         check_eq(copy, val);
+      }
+    }
+  }
+}
+
+SCENARIO("custom type ID mapper is respected for caf::message serialization") {
+  GIVEN("a custom type ID mapper that maps 'weekday' to an alias") {
+    struct alias_mapper : type_id_mapper {
+      std::string_view operator()(type_id_t type) const override {
+        if (type == type_id_v<weekday>)
+          return "my_app.weekday";
+        return query_type_name(type);
+      }
+      type_id_t operator()(std::string_view name) const override {
+        if (name == "my_app.weekday")
+          return type_id_v<weekday>;
+        return query_type_id(name);
+      }
+    };
+    alias_mapper mapper;
+    auto wrapper = json_writer_wrapper{sys};
+    wrapper.sink.mapper(&mapper);
+    WHEN("serializing a message containing a weekday and an int32_t") {
+      auto original = make_message(weekday::tuesday, int32_t{42});
+      require(wrapper.sink.apply(original));
+      THEN("deserializing with the same mapper produces the original message") {
+        auto source = json_reader{&wrapper.codec};
+        source.mapper(&mapper);
+        require(source.load(wrapper.sink.str()));
+        auto copy = message{};
+        require(source.apply(copy));
+        require(copy.match_elements<weekday, int32_t>());
+        check(copy.matches(weekday::tuesday, int32_t{42}));
+      }
+      AND_THEN(
+        "deserializing without the mapper fails due to the unknown alias") {
+        auto source = json_reader{&wrapper.codec};
+        require(source.load(wrapper.sink.str()));
+        auto copy = message{};
+        check(!source.apply(copy));
       }
     }
   }

--- a/libcaf_core/caf/serializer.cpp
+++ b/libcaf_core/caf/serializer.cpp
@@ -14,7 +14,7 @@ serializer::~serializer() {
   // nop
 }
 
-std::string_view serializer::resolve_type_name(type_id_t id) const {
+std::string_view serializer::to_type_name(type_id_t id) const {
   return query_type_name(id);
 }
 

--- a/libcaf_core/caf/serializer.cpp
+++ b/libcaf_core/caf/serializer.cpp
@@ -6,11 +6,16 @@
 
 #include "caf/actor_control_block.hpp"
 #include "caf/actor_handle_codec.hpp"
+#include "caf/type_id.hpp"
 
 namespace caf {
 
 serializer::~serializer() {
   // nop
+}
+
+std::string_view serializer::resolve_type_name(type_id_t id) const {
+  return query_type_name(id);
 }
 
 bool serializer::begin_key_value_pair() {

--- a/libcaf_core/caf/serializer.hpp
+++ b/libcaf_core/caf/serializer.hpp
@@ -43,7 +43,7 @@ public:
   /// override this to apply custom type name mappings (e.g. via a
   /// @ref type_id_mapper). The default implementation delegates to
   /// @ref query_type_name.
-  virtual std::string_view resolve_type_name(type_id_t id) const;
+  virtual std::string_view to_type_name(type_id_t id) const;
 
   // -- interface functions ----------------------------------------------------
 

--- a/libcaf_core/caf/serializer.hpp
+++ b/libcaf_core/caf/serializer.hpp
@@ -39,6 +39,12 @@ public:
   /// Returns whether the serialization format is human-readable.
   virtual bool has_human_readable_format() const noexcept = 0;
 
+  /// Returns the human-readable type name for @p id. Implementations may
+  /// override this to apply custom type name mappings (e.g. via a
+  /// @ref type_id_mapper). The default implementation delegates to
+  /// @ref query_type_name.
+  virtual std::string_view resolve_type_name(type_id_t id) const;
+
   // -- interface functions ----------------------------------------------------
 
   /// Begins processing of an object. May save the type information to the


### PR DESCRIPTION
`caf::message` is now serialized as an object with `types` and `values` fields instead of as a bare sequence of dynamically typed values. This representation provides type information to deserializers before loading the message contents and resolves issues related to out-of-sync `caf::message::save` and `caf::message::load` format. 

Closes #2434.