### PR TITLE
Backport #2454: Fix credit issues in `throttle_first` and `sample`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Fix a rare crash when creating a flow from an SPSC buffer via
   `from_resource()` and then connecting an observable that may cancel the flow
   mid-flow, e.g., by using `take()` (#2395).
+- Fix stalling in the flow operators `throttle_first` and `sample` (#2453).
 
 ## [1.1.0] - 2025-07-25
 

--- a/libcaf_core/caf/flow/op/sample.hpp
+++ b/libcaf_core/caf/flow/op/sample.hpp
@@ -107,7 +107,7 @@ public:
       return;
     }
     control_sub_ = std::move(sub);
-    control_sub_.request(1);
+    request_control_token();
   }
 
   void fwd_on_complete(sample_emit_t) {
@@ -129,15 +129,19 @@ public:
       shutdown();
       return;
     }
-    if (demand_ == 0)
+    if (demand_ == 0) {
+      control_paused_ = true;
       return;
-    --demand_;
-    auto sampled = buf_.has_value();
-    if (sampled) {
+    }
+    if (demand_ > 0 && buf_.has_value()) {
+      --demand_;
       out_.on_next(*buf_);
       buf_.reset();
     }
-    control_sub_.request(1);
+    if (demand_ > 0)
+      request_control_token();
+    else
+      control_paused_ = true;
   }
 
   // -- implementation of subscription -----------------------------------------
@@ -149,9 +153,16 @@ public:
   void request(size_t n) override {
     CAF_ASSERT(out_.valid());
     demand_ += n;
+    if (n > 0 && control_paused_ && control_sub_)
+      request_control_token();
   }
 
 private:
+  void request_control_token() {
+    control_paused_ = false;
+    control_sub_.request(1);
+  }
+
   void do_dispose(bool from_external) override {
     if (!out_)
       return;
@@ -202,6 +213,9 @@ private:
 
   /// Demand signaled by the observer.
   size_t demand_ = 0;
+
+  /// Stores whether the control stream needs new credit once demand resumes.
+  bool control_paused_ = false;
 
   /// Our current state.
   /// - running: alive and ready to emit batches.

--- a/libcaf_core/caf/flow/op/sample.test.cpp
+++ b/libcaf_core/caf/flow/op/sample.test.cpp
@@ -98,6 +98,59 @@ TEST("the sample operator emits items at regular intervals") {
   }
 }
 
+SCENARIO("samples keep ticking after a zero-demand tick") {
+  GIVEN("a sample operator with a passive subscriber") {
+    auto pub = caf::flow::multicaster<int>{coordinator()};
+    auto snk = flow::make_passive_observer<int>();
+    pub.as_observable().sample(1s).subscribe(snk->as_observer());
+    run_flows();
+    WHEN("the first control tick arrives before downstream demand") {
+      pub.push(1);
+      run_flows();
+      advance_time(1s);
+      run_flows();
+      check(snk->buf.empty());
+      THEN("later demand keeps the control stream alive for future samples") {
+        snk->request(1);
+        pub.push(2);
+        run_flows();
+        advance_time(1s);
+        run_flows();
+        check_eq(snk->buf, std::vector<int>{2});
+        snk->unsubscribe();
+        run_flows();
+      }
+    }
+  }
+}
+
+SCENARIO("samples resume control tokens after zero-demand ticks") {
+  GIVEN("an initialized sample operator with counted subscriptions") {
+    auto snk = flow::make_passive_observer<int>();
+    auto out = snk->as_observer();
+    auto uut = make_counted<caf::flow::op::sample_sub<int>>(coordinator(), out);
+    out.on_subscribe(caf::flow::subscription{uut});
+    auto data_sub = make_counting_sub();
+    auto ctrl_sub = make_counting_sub();
+    uut->fwd_on_subscribe(fwd_data, caf::flow::subscription{data_sub});
+    uut->fwd_on_subscribe(fwd_ctrl, caf::flow::subscription{ctrl_sub});
+    check_eq(data_sub->demand, defaults::flow::buffer_size);
+    check_eq(ctrl_sub->demand, 1u);
+    WHEN("a control token arrives before downstream demand") {
+      uut->fwd_on_next(fwd_data, 1);
+      uut->fwd_on_next(fwd_ctrl, 0);
+      THEN("the sample requests the next control token on downstream demand") {
+        check(snk->buf.empty());
+        check_eq(ctrl_sub->demand, 1u);
+        snk->request(1);
+        check_eq(ctrl_sub->demand, 2u);
+        snk->unsubscribe();
+        run_flows();
+      }
+    }
+  }
+}
+
 TEST("the sample operator forwards errors") {
   SECTION("an observable that produces some values followed by an error") {
     auto outputs = std::make_shared<std::vector<int>>();

--- a/libcaf_core/caf/flow/op/throttle_first.hpp
+++ b/libcaf_core/caf/flow/op/throttle_first.hpp
@@ -97,8 +97,9 @@ public:
   }
 
   void fwd_on_next(throttle_first_input_t, const input_type& item) {
-    if (running() && !buf_.has_value()) {
-      buf_ = item;
+    if (running()) {
+      if (!buf_.has_value())
+        buf_ = item;
       value_sub_.request(1);
     }
   }
@@ -109,7 +110,7 @@ public:
       return;
     }
     control_sub_ = std::move(sub);
-    control_sub_.request(1);
+    request_control_token();
   }
 
   void fwd_on_complete(throttle_first_emit_t) {
@@ -131,14 +132,19 @@ public:
       shutdown();
       return;
     }
-    if (demand_ == 0)
+    if (demand_ == 0) {
+      control_paused_ = true;
       return;
-    --demand_;
-    if (buf_.has_value()) {
+    }
+    if (demand_ > 0 && buf_.has_value()) {
+      --demand_;
       out_.on_next(*buf_);
       buf_.reset();
     }
-    control_sub_.request(1);
+    if (demand_ > 0)
+      request_control_token();
+    else
+      control_paused_ = true;
   }
 
   // -- implementation of subscription -----------------------------------------
@@ -150,9 +156,16 @@ public:
   void request(size_t n) override {
     CAF_ASSERT(out_.valid());
     demand_ += n;
+    if (n > 0 && control_paused_ && control_sub_)
+      request_control_token();
   }
 
 private:
+  void request_control_token() {
+    control_paused_ = false;
+    control_sub_.request(1);
+  }
+
   void do_dispose(bool from_external) override {
     if (!out_)
       return;
@@ -203,6 +216,9 @@ private:
 
   /// Demand signaled by the observer.
   size_t demand_ = 0;
+
+  /// Stores whether the control stream needs new credit once demand resumes.
+  bool control_paused_ = false;
 
   /// Our current state.
   /// - running: alive and ready to emit batches.

--- a/libcaf_core/caf/flow/op/throttle_first.test.cpp
+++ b/libcaf_core/caf/flow/op/throttle_first.test.cpp
@@ -91,6 +91,58 @@ SCENARIO("the throttle_first operator emits items at regular intervals") {
   }
 }
 
+SCENARIO("throttle_first keeps ticking after a zero-demand tick") {
+  GIVEN("a throttle_first operator with a passive subscriber") {
+    auto pub = caf::flow::multicaster<int>{coordinator()};
+    auto snk = flow::make_passive_observer<int>();
+    pub.as_observable().throttle_first(1s).subscribe(snk->as_observer());
+    run_flows();
+    WHEN("the first control tick arrives before downstream demand") {
+      pub.push(1);
+      run_flows();
+      advance_time(1s);
+      run_flows();
+      check(snk->buf.empty());
+      THEN("later demand keeps the control stream alive for future windows") {
+        snk->request(1);
+        advance_time(1s);
+        run_flows();
+        check_eq(snk->buf, std::vector<int>{1});
+        snk->unsubscribe();
+        run_flows();
+      }
+    }
+  }
+}
+
+SCENARIO("throttle_first resumes control tokens after zero-demand ticks") {
+  GIVEN("an initialized throttle_first operator with counted subscriptions") {
+    auto snk = flow::make_passive_observer<int>();
+    auto out = snk->as_observer();
+    auto uut = make_counted<caf::flow::op::throttle_first_sub<int>>(
+      coordinator(), out);
+    out.on_subscribe(caf::flow::subscription{uut});
+    auto data_sub = make_counting_sub();
+    auto ctrl_sub = make_counting_sub();
+    uut->fwd_on_subscribe(fwd_data, caf::flow::subscription{data_sub});
+    uut->fwd_on_subscribe(fwd_ctrl, caf::flow::subscription{ctrl_sub});
+    check_eq(data_sub->demand, defaults::flow::buffer_size);
+    check_eq(ctrl_sub->demand, 1u);
+    WHEN("a control token arrives before demand") {
+      uut->fwd_on_next(fwd_data, 1);
+      uut->fwd_on_next(fwd_ctrl, 0);
+      THEN("throttle_first requests the next control token on demand") {
+        check(snk->buf.empty());
+        check_eq(ctrl_sub->demand, 1u);
+        snk->request(1);
+        check_eq(ctrl_sub->demand, 2u);
+        snk->unsubscribe();
+        run_flows();
+      }
+    }
+  }
+}
+
 SCENARIO("the throttle_first operator forwards errors") {
   GIVEN("an observable that produces some values followed by an error") {
     WHEN("calling .throttle_first() on it") {

--- a/libcaf_core/caf/metaprogramming.test.cpp
+++ b/libcaf_core/caf/metaprogramming.test.cpp
@@ -132,7 +132,7 @@ TEST("typed_behavior_assignment") {
   // compatible handlers resulting in perfect match
   auto f1 = [=](int) { return 0.; };
   auto f2 = [=](double, double) -> result<int, int> { return {0, 0}; };
-  // incompatbile handlers
+  // incompatible handlers
   auto e1 = [=](int) { return 0.f; };
   auto e2 = [=](double, double) { return std::make_tuple(0.f, 0.f); };
   // omit one handler

--- a/libcaf_test/caf/test/fixture/flow.hpp
+++ b/libcaf_test/caf/test/fixture/flow.hpp
@@ -11,6 +11,7 @@
 #include "caf/flow/observable_builder.hpp"
 #include "caf/flow/observer.hpp"
 #include "caf/flow/scoped_coordinator.hpp"
+#include "caf/flow/subscription.hpp"
 
 #include <cstddef>
 #include <memory>
@@ -230,6 +231,36 @@ public:
     }
   };
 
+  /// A subscription that records cumulative downstream demand.
+  class counting_sub : public caf::flow::subscription::impl_base {
+  public:
+    explicit counting_sub(caf::flow::coordinator* parent) : parent_(parent) {
+      // nop
+    }
+
+    caf::flow::coordinator* parent() const noexcept override {
+      return parent_;
+    }
+
+    bool disposed() const noexcept override {
+      return disposed_;
+    }
+
+    void request(size_t n) override {
+      demand += n;
+    }
+
+    size_t demand = 0;
+
+  private:
+    void do_dispose(bool) override {
+      disposed_ = true;
+    }
+
+    caf::flow::coordinator* parent_;
+    bool disposed_ = false;
+  };
+
   // -- constructors, destructors, and assignment operators --------------------
 
   flow() {
@@ -276,6 +307,11 @@ public:
   make_canceling_observer(bool accept_first = false, bool auto_request = true) {
     return coordinator()->add_child(std::in_place_type<canceling_observer<T>>,
                                     accept_first, auto_request);
+  }
+
+  /// Returns a subscription that records cumulative demand.
+  intrusive_ptr<counting_sub> make_counting_sub() {
+    return coordinator()->add_child(std::in_place_type<counting_sub>);
   }
 
   /// Shortcut for creating an observable error via


### PR DESCRIPTION
Backport of #2454 for the CAF v1 series.