### PR TITLE
Backport: Fix dispose of `prefix_and_tail`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
   `from_resource()` and then connecting an observable that may cancel the flow
   mid-flow, e.g., by using `take()` (#2395).
 - Fix stalling in the flow operators `throttle_first` and `sample` (#2453).
+- Fix a bug in the `dispose` implementation of the subscription object for
+  `prefix_and_tail` that caused subscribers to not receive terminal events such
+  as `on_complete` or `on_error` (#2456).
 
 ## [1.1.0] - 2025-07-25
 

--- a/libcaf_core/caf/flow/op/prefix_and_tail.hpp
+++ b/libcaf_core/caf/flow/op/prefix_and_tail.hpp
@@ -159,7 +159,12 @@ private:
     sub_.cancel();
     if (sink_) {
       CAF_ASSERT(!out_); // Either in tail mode or in prefix mode.
-      sink_ = nullptr;
+      auto sink = std::move(sink_);
+      sink->state().listener = nullptr;
+      if (from_external)
+        sink->state().dispose();
+      else
+        sink->close();
       return;
     }
     CAF_ASSERT(out_);

--- a/libcaf_core/caf/flow/op/prefix_and_tail.test.cpp
+++ b/libcaf_core/caf/flow/op/prefix_and_tail.test.cpp
@@ -334,6 +334,31 @@ SCENARIO("disposing head_and_tail disposes the input subscription") {
   }
 }
 
+SCENARIO("disposing the prefix subscription aborts a live tail subscriber") {
+  using tuple_t = cow_tuple<cow_vector<int>, caf::flow::observable<int>>;
+  auto tail_snk
+    = coordinator()->add_child(std::in_place_type<flow::passive_observer<int>>);
+  auto got_prefix = false;
+  auto prefix_sub = //
+    coordinator()
+      ->make_observable()
+      .iota(1) //
+      .prefix_and_tail(3)
+      .for_each([&](const tuple_t& x) {
+        got_prefix = true;
+        auto [prefix, tail] = x.data();
+        check_eq(prefix, ls(1, 2, 3));
+        tail.subscribe(tail_snk->as_observer());
+      });
+  run_flows();
+  check(got_prefix);
+  check(tail_snk->subscribed());
+  prefix_sub.dispose();
+  run_flows();
+  check(tail_snk->aborted());
+  check_eq(tail_snk->err, sec::disposed);
+}
+
 SCENARIO("disposing the tail of head_and_tail disposes the operator") {
   using tuple_t = cow_tuple<cow_vector<int>, caf::flow::observable<int>>;
   GIVEN("a subscribed head_and_tail operator") {


### PR DESCRIPTION
Backport of #2457.